### PR TITLE
Old TLS methods need need to support NO_OLD_TLS

### DIFF
--- a/examples/Client.java
+++ b/examples/Client.java
@@ -21,7 +21,6 @@
 
 import java.io.*;
 import java.net.*;
-import java.nio.*;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CharacterCodingException;
@@ -31,8 +30,6 @@ import com.wolfssl.WolfSSLSession;
 import com.wolfssl.WolfSSLContext;
 import com.wolfssl.WolfSSLException;
 import com.wolfssl.WolfSSLJNIException;
-import com.wolfssl.WolfSSLIOSendCallback;
-import com.wolfssl.WolfSSLIORecvCallback;
 
 /* suppress SSLv3 deprecation warnings, meant for end user not examples */
 @SuppressWarnings("deprecation")

--- a/examples/MyAtomicDecCtx.java
+++ b/examples/MyAtomicDecCtx.java
@@ -19,11 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-import java.io.*;
-import java.net.*;
-import java.nio.*;
 import javax.crypto.Cipher;
-import com.wolfssl.*;
 
 class MyAtomicDecCtx
 {

--- a/examples/MyAtomicEncCtx.java
+++ b/examples/MyAtomicEncCtx.java
@@ -19,11 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-import java.io.*;
-import java.net.*;
-import java.nio.*;
 import javax.crypto.Cipher;
-import com.wolfssl.*;
 
 class MyAtomicEncCtx
 {

--- a/examples/MyDecryptVerifyCallback.java
+++ b/examples/MyDecryptVerifyCallback.java
@@ -19,9 +19,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-import java.io.*;
-import java.net.*;
-import java.nio.*;
 import java.util.*;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;

--- a/examples/MyEccSignCallback.java
+++ b/examples/MyEccSignCallback.java
@@ -19,8 +19,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-import java.io.*;
-import java.net.*;
 import java.nio.ByteBuffer;
 import com.wolfssl.*;
 import com.wolfssl.wolfcrypt.*;

--- a/examples/MyEccSignCtx.java
+++ b/examples/MyEccSignCtx.java
@@ -19,10 +19,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-import java.io.*;
-import java.net.*;
-import com.wolfssl.*;
-
 class MyEccSignCtx
 {
     /* stub for now, not needed by example ECC sign callback */

--- a/examples/MyEccVerifyCallback.java
+++ b/examples/MyEccVerifyCallback.java
@@ -19,8 +19,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-import java.io.*;
-import java.net.*;
 import java.nio.ByteBuffer;
 import com.wolfssl.*;
 import com.wolfssl.wolfcrypt.*;

--- a/examples/MyEccVerifyCtx.java
+++ b/examples/MyEccVerifyCtx.java
@@ -19,10 +19,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-import java.io.*;
-import java.net.*;
-import com.wolfssl.*;
-
 class MyEccVerifyCtx
 {
     /* stub for now, not needed by example ECC verify callback */

--- a/examples/MyGenCookieCallback.java
+++ b/examples/MyGenCookieCallback.java
@@ -19,7 +19,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-import java.io.*;
 import java.net.*;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;

--- a/examples/MyGenCookieCtx.java
+++ b/examples/MyGenCookieCtx.java
@@ -19,10 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-import java.io.*;
 import java.net.*;
-import java.nio.*;
-import com.wolfssl.*;
 
 class MyGenCookieCtx
 {

--- a/examples/MyIOCtx.java
+++ b/examples/MyIOCtx.java
@@ -21,8 +21,6 @@
 
 import java.io.*;
 import java.net.*;
-import java.nio.*;
-import com.wolfssl.*;
 
 class MyIOCtx
 {

--- a/examples/MyLoggingCallback.java
+++ b/examples/MyLoggingCallback.java
@@ -19,8 +19,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-import java.io.*;
-import java.net.*;
 import com.wolfssl.*;
 
 class MyLoggingCallback implements WolfSSLLoggingCallback

--- a/examples/MyMacEncryptCallback.java
+++ b/examples/MyMacEncryptCallback.java
@@ -19,8 +19,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-import java.io.*;
-import java.net.*;
 import java.nio.*;
 import com.wolfssl.*;
 import javax.crypto.Mac;

--- a/examples/MyPskClientCallback.java
+++ b/examples/MyPskClientCallback.java
@@ -19,9 +19,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-import java.io.*;
-import java.net.*;
-import java.nio.*;
 import com.wolfssl.*;
 
 class MyPskClientCallback implements WolfSSLPskClientCallback

--- a/examples/MyPskServerCallback.java
+++ b/examples/MyPskServerCallback.java
@@ -19,9 +19,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-import java.io.*;
-import java.net.*;
-import java.nio.*;
 import com.wolfssl.*;
 
 class MyPskServerCallback implements WolfSSLPskServerCallback

--- a/examples/MyRecvCallback.java
+++ b/examples/MyRecvCallback.java
@@ -21,7 +21,6 @@
 
 import java.io.*;
 import java.net.*;
-import java.nio.*;
 import com.wolfssl.*;
 
 class MyRecvCallback implements WolfSSLIORecvCallback

--- a/examples/MyRsaDecCallback.java
+++ b/examples/MyRsaDecCallback.java
@@ -19,8 +19,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-import java.io.*;
-import java.net.*;
 import java.nio.*;
 import com.wolfssl.*;
 import com.wolfssl.wolfcrypt.*;

--- a/examples/MyRsaDecCtx.java
+++ b/examples/MyRsaDecCtx.java
@@ -19,10 +19,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-import java.io.*;
-import java.net.*;
-import com.wolfssl.*;
-
 class MyRsaDecCtx
 {
     /* stub for now, not needed by example RSA decrypt callback */

--- a/examples/MyRsaEncCallback.java
+++ b/examples/MyRsaEncCallback.java
@@ -19,8 +19,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-import java.io.*;
-import java.net.*;
 import java.nio.*;
 import com.wolfssl.*;
 import com.wolfssl.wolfcrypt.*;

--- a/examples/MyRsaEncCtx.java
+++ b/examples/MyRsaEncCtx.java
@@ -19,10 +19,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-import java.io.*;
-import java.net.*;
-import com.wolfssl.*;
-
 class MyRsaEncCtx
 {
     /* stub for now, not needed by example RSA encrypt callback */

--- a/examples/MyRsaSignCallback.java
+++ b/examples/MyRsaSignCallback.java
@@ -19,8 +19,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-import java.io.*;
-import java.net.*;
 import java.nio.*;
 import com.wolfssl.*;
 import com.wolfssl.wolfcrypt.*;

--- a/examples/MyRsaSignCtx.java
+++ b/examples/MyRsaSignCtx.java
@@ -19,10 +19,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-import java.io.*;
-import java.net.*;
-import com.wolfssl.*;
-
 class MyRsaSignCtx
 {
     /* stub for now, not needed by example RSA sign callback */

--- a/examples/MyRsaVerifyCallback.java
+++ b/examples/MyRsaVerifyCallback.java
@@ -19,8 +19,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-import java.io.*;
-import java.net.*;
 import java.nio.*;
 import com.wolfssl.*;
 import com.wolfssl.wolfcrypt.*;

--- a/examples/MyRsaVerifyCtx.java
+++ b/examples/MyRsaVerifyCtx.java
@@ -19,10 +19,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-import java.io.*;
-import java.net.*;
-import com.wolfssl.*;
-
 class MyRsaVerifyCtx
 {
     /* stub for now, not needed by example RSA verify callback */

--- a/examples/MySendCallback.java
+++ b/examples/MySendCallback.java
@@ -21,7 +21,6 @@
 
 import java.io.*;
 import java.net.*;
-import java.nio.*;
 import com.wolfssl.*;
 
 class MySendCallback implements WolfSSLIOSendCallback

--- a/examples/Server.java
+++ b/examples/Server.java
@@ -21,7 +21,6 @@
 
 import java.io.*;
 import java.net.*;
-import java.nio.*;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CharacterCodingException;
@@ -31,8 +30,6 @@ import com.wolfssl.WolfSSLSession;
 import com.wolfssl.WolfSSLContext;
 import com.wolfssl.WolfSSLException;
 import com.wolfssl.WolfSSLJNIException;
-import com.wolfssl.WolfSSLIOSendCallback;
-import com.wolfssl.WolfSSLIORecvCallback;
 
 /* suppress SSLv3 deprecation warnings, meant for end user not examples */
 @SuppressWarnings("deprecation")

--- a/java.sh
+++ b/java.sh
@@ -6,13 +6,14 @@ ARCH=`uname -m`
 # set up Java include and library paths for OS X and Linux
 # NOTE: you may need to modify these if your platform uses different locations
 if [ "$OS" == "Darwin" ] ; then
-    javaHome=`/usr/libexec/java_home`
+    javaHome=$(/usr/libexec/java_home)
     javaIncludes="-I$javaHome/include -I$javaHome/include/darwin"
     javaLibs="-dynamiclib -framework JavaVM"
     jniLibName="libwolfssl.jnilib"
     cflags="-DHAVE_ECC"
+    fpic=""
 elif [ "$OS" == "Linux" ] ; then
-    javaHome=`echo $(dirname $(dirname $(dirname $(readlink -f $(which java)))))`
+    javaHome=$(echo $(dirname $(dirname $(dirname $(readlink -f $(which java))))))
     javaIncludes="-I$javaHome/include -I$javaHome/include/linux"
     javaLibs="-shared"
     jniLibName="libwolfSSL.so"
@@ -27,16 +28,23 @@ else
     exit
 fi
 
-# create /lib directory if doesn't exist
-if [ ! -d ./lib ]
-then
-    mkdir ./lib
+if [ "$(pkg-config --version || echo 'no pkg-config')" != "no pkg-config" ]; then
+    wolfsslcflags="$(pkg-config --cflags wolfssl)"
+    wolfssllibs="$(pkg-config --libs wolfssl)"
+else
+    wolfsslcflags=""
+    wolfssllibs="-lwolfssl"
 fi
 
-gcc -DWOLFSSL_DTLS -Wall -c $fpic $cflags ./native/com_wolfssl_WolfSSL.c -o ./native/com_wolfssl_WolfSSL.o $javaIncludes
-gcc -DWOLFSSL_DTLS -Wall -c $fpic $cflags ./native/com_wolfssl_WolfSSLSession.c -o ./native/com_wolfssl_WolfSSLSession.o $javaIncludes
-gcc -DWOLFSSL_DTLS -Wall -c $fpic $cflags ./native/com_wolfssl_WolfSSLContext.c -o ./native/com_wolfssl_WolfSSLContext.o $javaIncludes
-gcc -DWOLFSSL_DTLS -Wall -c $fpic $cflags ./native/com_wolfssl_wolfcrypt_RSA.c -o ./native/com_wolfssl_wolfcrypt_RSA.o $javaIncludes
-gcc -DWOLFSSL_DTLS -Wall -c $fpic $cflags ./native/com_wolfssl_wolfcrypt_ECC.c -o ./native/com_wolfssl_wolfcrypt_ECC.o $javaIncludes
-gcc -Wall $javaLibs $cflags -o ./lib/$jniLibName ./native/com_wolfssl_WolfSSL.o ./native/com_wolfssl_WolfSSLSession.o ./native/com_wolfssl_WolfSSLContext.o ./native/com_wolfssl_wolfcrypt_RSA.o ./native/com_wolfssl_wolfcrypt_ECC.o -lwolfssl
+# create /lib directory if doesn't exist
+mkdir -p ./lib
+
+objFiles="./native/com_wolfssl_WolfSSL.o ./native/com_wolfssl_WolfSSLSession.o ./native/com_wolfssl_WolfSSLContext.o ./native/com_wolfssl_wolfcrypt_RSA.o ./native/com_wolfssl_wolfcrypt_ECC.o"
+rm -f ${objFiles}
+gcc -DWOLFSSL_DTLS -Wall -c $fpic $cflags $wolfsslcflags ./native/com_wolfssl_WolfSSL.c -o ./native/com_wolfssl_WolfSSL.o $javaIncludes
+gcc -DWOLFSSL_DTLS -Wall -c $fpic $cflags $wolfsslcflags ./native/com_wolfssl_WolfSSLSession.c -o ./native/com_wolfssl_WolfSSLSession.o $javaIncludes
+gcc -DWOLFSSL_DTLS -Wall -c $fpic $cflags $wolfsslcflags ./native/com_wolfssl_WolfSSLContext.c -o ./native/com_wolfssl_WolfSSLContext.o $javaIncludes
+gcc -DWOLFSSL_DTLS -Wall -c $fpic $cflags $wolfsslcflags ./native/com_wolfssl_wolfcrypt_RSA.c -o ./native/com_wolfssl_wolfcrypt_RSA.o $javaIncludes
+gcc -DWOLFSSL_DTLS -Wall -c $fpic $cflags $wolfsslcflags ./native/com_wolfssl_wolfcrypt_ECC.c -o ./native/com_wolfssl_wolfcrypt_ECC.o $javaIncludes
+gcc -Wall $wolfssllibs $javaLibs $cflags $wolfsslcflags -o ./lib/$jniLibName  ${objFiles}
 

--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -83,25 +83,41 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_SSLv3_1ClientMethod
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_TLSv1_1ServerMethod
   (JNIEnv* jenv, jclass jcl)
 {
+#if !defined(NO_OLD_TLS)
     return (jlong)wolfTLSv1_server_method();
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_TLSv1_1ClientMethod
   (JNIEnv* jenv, jclass jcl)
 {
+#if !defined(NO_OLD_TLS)
     return (jlong)wolfTLSv1_client_method();
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_TLSv1_11_1ServerMethod
   (JNIEnv* jenv, jclass jcl)
 {
+#if !defined(NO_OLD_TLS)
     return (jlong)wolfTLSv1_1_server_method();
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_TLSv1_11_1ClientMethod
   (JNIEnv* jenv, jclass jcl)
 {
+#if !defined(NO_OLD_TLS)
     return (jlong)wolfTLSv1_1_client_method();
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_TLSv1_12_1ServerMethod
@@ -119,13 +135,21 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_TLSv1_12_1ClientMethod(
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_DTLSv1_1ClientMethod
   (JNIEnv* jenv, jclass jcl)
 {
+#if !defined(NO_OLD_TLS)
     return (jlong)wolfDTLSv1_client_method();
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_DTLSv1_1ServerMethod
   (JNIEnv* jenv, jclass jcl)
 {
+#if !defined(NO_OLD_TLS)
     return (jlong)wolfDTLSv1_server_method();
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_DTLSv1_12_1ClientMethod

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -21,9 +21,6 @@
 
 package com.wolfssl;
 
-import java.net.InetSocketAddress;
-import java.net.Socket;
-
 /**
  * Base class which wraps the native WolfSSL embedded SSL library.
  * This class contains library init and cleanup methods, general callback

--- a/src/java/com/wolfssl/WolfSSLContext.java
+++ b/src/java/com/wolfssl/WolfSSLContext.java
@@ -21,9 +21,6 @@
 
 package com.wolfssl;
 
-import java.net.InetSocketAddress;
-import java.net.Socket;
-import java.util.HashMap;
 import java.nio.ByteBuffer;
 
 

--- a/src/java/com/wolfssl/WolfSSLContext.java
+++ b/src/java/com/wolfssl/WolfSSLContext.java
@@ -26,8 +26,6 @@ import java.net.Socket;
 import java.util.HashMap;
 import java.nio.ByteBuffer;
 
-import com.wolfssl.WolfSSLException;
-import com.wolfssl.WolfSSLJNIException;
 
 /**
  * Wraps a native WolfSSL context object and contains methods directly related

--- a/src/java/com/wolfssl/WolfSSLPskClientCallback.java
+++ b/src/java/com/wolfssl/WolfSSLPskClientCallback.java
@@ -21,8 +21,6 @@
 
 package com.wolfssl;
 
-import java.nio.ByteBuffer;
-
 /**
  * wolfSSL PSK Client Callback Interface.
  * This interface specifies how applications should implement the PSK client

--- a/src/java/com/wolfssl/WolfSSLPskServerCallback.java
+++ b/src/java/com/wolfssl/WolfSSLPskServerCallback.java
@@ -21,8 +21,6 @@
 
 package com.wolfssl;
 
-import java.nio.ByteBuffer;
-
 /**
  * wolfSSL PSK Server Callback Interface.
  * This interface specifies how applications should implement the PSK server

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -25,8 +25,6 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.DatagramSocket;
 
-import com.wolfssl.WolfSSLException;
-import com.wolfssl.WolfSSLJNIException;
 
 /**
  * Wraps a native WolfSSL session object and contains methods directly related

--- a/src/test/com/wolfssl/WolfCryptECCTest.java
+++ b/src/test/com/wolfssl/WolfCryptECCTest.java
@@ -22,9 +22,6 @@
 package com.wolfssl;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-import static org.junit.Assert.*;
 
 import com.wolfssl.wolfcrypt.ECC;
 

--- a/src/test/com/wolfssl/WolfCryptRSATest.java
+++ b/src/test/com/wolfssl/WolfCryptRSATest.java
@@ -22,9 +22,6 @@
 package com.wolfssl;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-import static org.junit.Assert.*;
 
 import com.wolfssl.wolfcrypt.RSA;
 

--- a/src/test/com/wolfssl/WolfSSLContextTest.java
+++ b/src/test/com/wolfssl/WolfSSLContextTest.java
@@ -22,10 +22,8 @@
 package com.wolfssl;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 import static org.junit.Assert.*;
-
+import org.junit.BeforeClass;
 
 public class WolfSSLContextTest {
 
@@ -39,12 +37,21 @@ public class WolfSSLContextTest {
 
     WolfSSLContext ctx;
 
+    @BeforeClass
+    public static void loadLibrary() {
+        try {
+            WolfSSL.loadLibrary();
+        } catch (UnsatisfiedLinkError ule) {
+            fail("failed to load native JNI library");
+        }
+    }
+
     @Test
     public void testWolfSSLContext() throws WolfSSLException {
 
         System.out.println("WolfSSLContext Class");
 
-        test_WolfSSLContext_new(WolfSSL.SSLv23_ServerMethod());
+        test_WolfSSLContext_new(WolfSSL.TLSv1_2_ServerMethod());
         test_WolfSSLContext_useCertificateFile();
         test_WolfSSLContext_usePrivateKeyFile();
         test_WolfSSLContext_loadVerifyLocations();

--- a/src/test/com/wolfssl/WolfSSLContextTest.java
+++ b/src/test/com/wolfssl/WolfSSLContextTest.java
@@ -26,7 +26,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import static org.junit.Assert.*;
 
-import com.wolfssl.WolfSSL;
 
 public class WolfSSLContextTest {
 

--- a/src/test/com/wolfssl/WolfSSLSessionTest.java
+++ b/src/test/com/wolfssl/WolfSSLSessionTest.java
@@ -22,9 +22,8 @@
 package com.wolfssl;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 import static org.junit.Assert.*;
+import org.junit.BeforeClass;
 
 
 public class WolfSSLSessionTest {
@@ -40,10 +39,19 @@ public class WolfSSLSessionTest {
     WolfSSLContext ctx;
     WolfSSLSession ssl;
 
+    @BeforeClass
+    public static void loadLibrary() {
+        try {
+            WolfSSL.loadLibrary();
+        } catch (UnsatisfiedLinkError ule) {
+            fail("failed to load native JNI library");
+        }
+    }
+
     @Test
     public void testWolfSSLSession() throws WolfSSLException {
 
-        ctx = new WolfSSLContext(WolfSSL.SSLv23_ClientMethod());
+        ctx = new WolfSSLContext(WolfSSL.TLSv1_2_ClientMethod());
 
         System.out.println("WolfSSLSession Class");
 

--- a/src/test/com/wolfssl/WolfSSLSessionTest.java
+++ b/src/test/com/wolfssl/WolfSSLSessionTest.java
@@ -26,7 +26,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import static org.junit.Assert.*;
 
-import com.wolfssl.WolfSSL;
 
 public class WolfSSLSessionTest {
 

--- a/src/test/com/wolfssl/WolfSSLTest.java
+++ b/src/test/com/wolfssl/WolfSSLTest.java
@@ -27,7 +27,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import static org.junit.Assert.*;
 
-import com.wolfssl.WolfSSL;
 
 /* suppress SSLv3 deprecation warnings, meant for end user not tests */
 @SuppressWarnings("deprecation")

--- a/src/test/com/wolfssl/WolfSSLTest.java
+++ b/src/test/com/wolfssl/WolfSSLTest.java
@@ -23,8 +23,6 @@ package com.wolfssl;
 
 import org.junit.Test;
 import org.junit.BeforeClass;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 import static org.junit.Assert.*;
 
 
@@ -69,20 +67,20 @@ public class WolfSSLTest {
     }
 
     public void test_WolfSSL_Method_Allocators(WolfSSL lib) {
-        tstMethod(lib.SSLv3_ServerMethod(), "SSLv3_ServerMethod()");
-        tstMethod(lib.SSLv3_ClientMethod(), "SSLv3_ClientMethod()");
-        tstMethod(lib.TLSv1_ServerMethod(), "TLSv1_ServerMethod()");
-        tstMethod(lib.TLSv1_ClientMethod(), "TLSv1_ClientMethod()");
-        tstMethod(lib.TLSv1_1_ServerMethod(), "TLSv1_1_ServerMethod()");
-        tstMethod(lib.TLSv1_1_ClientMethod(), "TLSv1_1_ClientMethod()");
-        tstMethod(lib.TLSv1_2_ServerMethod(), "TLSv1_2_ServerMethod()");
-        tstMethod(lib.TLSv1_2_ClientMethod(), "TLSv1_2_ClientMethod()");
-        tstMethod(lib.DTLSv1_ServerMethod(), "DTLSv1_ServerMethod()");
-        tstMethod(lib.DTLSv1_ClientMethod(), "DTLSv1_ClientMethod()");
-        tstMethod(lib.DTLSv1_2_ServerMethod(), "DTLSv1_2_ServerMethod()");
-        tstMethod(lib.DTLSv1_2_ClientMethod(), "DTLSv1_2_ClientMethod()");
-        tstMethod(lib.SSLv23_ServerMethod(), "SSLv23_ServerMethod()");
-        tstMethod(lib.SSLv23_ClientMethod(), "SSLv23_ClientMethod()");
+        tstMethod(WolfSSL.SSLv3_ServerMethod(), "SSLv3_ServerMethod()");
+        tstMethod(WolfSSL.SSLv3_ClientMethod(), "SSLv3_ClientMethod()");
+        tstMethod(WolfSSL.TLSv1_ServerMethod(), "TLSv1_ServerMethod()");
+        tstMethod(WolfSSL.TLSv1_ClientMethod(), "TLSv1_ClientMethod()");
+        tstMethod(WolfSSL.TLSv1_1_ServerMethod(), "TLSv1_1_ServerMethod()");
+        tstMethod(WolfSSL.TLSv1_1_ClientMethod(), "TLSv1_1_ClientMethod()");
+        tstMethod(WolfSSL.TLSv1_2_ServerMethod(), "TLSv1_2_ServerMethod()");
+        tstMethod(WolfSSL.TLSv1_2_ClientMethod(), "TLSv1_2_ClientMethod()");
+        tstMethod(WolfSSL.DTLSv1_ServerMethod(), "DTLSv1_ServerMethod()");
+        tstMethod(WolfSSL.DTLSv1_ClientMethod(), "DTLSv1_ClientMethod()");
+        tstMethod(WolfSSL.DTLSv1_2_ServerMethod(), "DTLSv1_2_ServerMethod()");
+        tstMethod(WolfSSL.DTLSv1_2_ClientMethod(), "DTLSv1_2_ClientMethod()");
+        tstMethod(WolfSSL.SSLv23_ServerMethod(), "SSLv23_ServerMethod()");
+        tstMethod(WolfSSL.SSLv23_ClientMethod(), "SSLv23_ClientMethod()");
     }
 
     public void tstMethod(long method, String name) {


### PR DESCRIPTION
Several of the legacy SSL/TLS/DTLS methods need to support the NO_OLD_TLS configuration if WolfSSL library used was compiled without --enable-oldtls.
