### PR TITLE
Remove native wolfSSL feature dependencies

### DIFF
--- a/examples/Client.java
+++ b/examples/Client.java
@@ -340,22 +340,24 @@ public class Client {
             ssl = new WolfSSLSession(sslCtx);
 
             /* enable/load CRL functionality */
-            ret = ssl.enableCRL(WolfSSL.WOLFSSL_CRL_CHECKALL);
-            if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("failed to enable CRL check");
-                System.exit(1);
-            }
-            ret = ssl.loadCRL(crlPemDir, WolfSSL.SSL_FILETYPE_PEM, 0);
-            if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("can't load CRL, check CRL file and date " +
-                        "validity");
-                System.exit(1);
-            }
-            MyMissingCRLCallback crlCb = new MyMissingCRLCallback();
-            ret = ssl.setCRLCb(crlCb);
-            if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("can't set CRL callback");
-                System.exit(1);
+            if (WolfSSL.isEnabledCRL() == 1) {
+                ret = ssl.enableCRL(WolfSSL.WOLFSSL_CRL_CHECKALL);
+                if (ret != WolfSSL.SSL_SUCCESS) {
+                    System.out.println("failed to enable CRL check");
+                    System.exit(1);
+                }
+                ret = ssl.loadCRL(crlPemDir, WolfSSL.SSL_FILETYPE_PEM, 0);
+                if (ret != WolfSSL.SSL_SUCCESS) {
+                    System.out.println("can't load CRL, check CRL file and " +
+                            "date validity");
+                    System.exit(1);
+                }
+                MyMissingCRLCallback crlCb = new MyMissingCRLCallback();
+                ret = ssl.setCRLCb(crlCb);
+                if (ret != WolfSSL.SSL_SUCCESS) {
+                    System.out.println("can't set CRL callback");
+                    System.exit(1);
+                }
             }
 
             /* open Socket */

--- a/examples/Client.java
+++ b/examples/Client.java
@@ -82,106 +82,131 @@ public class Client {
         String host = "localhost";
         int port    =  11111;
 
-        /* pull in command line options from user */
-        for (int i = 0; i < args.length; i++)
-        {
-            String arg = args[i];
-
-            if (arg.equals("-?")) {
-                printUsage();
-
-            } else if (arg.equals("-h")) {
-                if (args.length < i+2)
-                    printUsage();
-                host = args[++i];
-
-            } else if (arg.equals("-p")) {
-                if (args.length < i+2)
-                    printUsage();
-                port = Integer.parseInt(args[++i]);
-
-            } else if (arg.equals("-v")) {
-                if (args.length < i+2)
-                    printUsage();
-                sslVersion = Integer.parseInt(args[++i]);
-                if (sslVersion < 0 || sslVersion > 3) {
-                    printUsage();
-                }
-
-            } else if (arg.equals("-l")) {
-                if (args.length < i+2)
-                    printUsage();
-                cipherList = args[++i];
-
-            } else if (arg.equals("-c")) {
-                if (args.length < i+2)
-                    printUsage();
-                clientCert = args[++i];
-
-            } else if (arg.equals("-k")) {
-                if (args.length < i+2)
-                    printUsage();
-                clientKey = args[++i];
-
-            } else if (arg.equals("-b")) {
-                if (args.length < i+2)
-                  printUsage();
-                benchmark = Integer.parseInt(args[++i]);
-                if (benchmark < 0 || benchmark > 1000000)
-                    printUsage();
-
-            } else if (arg.equals("-A")) {
-                if (args.length < i+2)
-                    printUsage();
-                caCert = args[++i];
-
-            } else if (arg.equals("-d")) {
-                verifyPeer = 0;
-
-            } else if (arg.equals("-u")) {
-                doDTLS = 1;
-
-            } else if (arg.equals("-s")) {
-                usePsk = 1;
-
-            } else if (arg.equals("-iocb")) {
-                useIOCallbacks = true;
-
-            } else if (arg.equals("-logtest")) {
-                logCallback = 1;
-
-            } else if (arg.equals("-o")) {
-                useOcsp = 1;
-
-            } else if (arg.equals("-O")) {
-                if (args.length < i+2)
-                    printUsage();
-                useOcsp = 1;
-                ocspUrl = args[++i];
-
-            } else if (arg.equals("-U")) {
-                useAtomic = 1;
-
-            } else if (arg.equals("-P")) {
-                pkCallbacks = 1;
-
-            } else {
-                printUsage();
-            }
-        }
-
-        /* sort out DTLS versus TLS versions */
-        if (doDTLS == 1) {
-            if (sslVersion == 3)
-                sslVersion = -2;
-            else
-                sslVersion = -1;
-        }
-
         try {
 
             /* load JNI library */
             WolfSSL.loadLibrary();
+
+            /* pull in command line options from user */
+            for (int i = 0; i < args.length; i++)
+            {
+                String arg = args[i];
+
+                if (arg.equals("-?")) {
+                    printUsage();
+
+                } else if (arg.equals("-h")) {
+                    if (args.length < i+2)
+                        printUsage();
+                    host = args[++i];
+
+                } else if (arg.equals("-p")) {
+                    if (args.length < i+2)
+                        printUsage();
+                    port = Integer.parseInt(args[++i]);
+
+                } else if (arg.equals("-v")) {
+                    if (args.length < i+2)
+                        printUsage();
+                    sslVersion = Integer.parseInt(args[++i]);
+                    if (sslVersion < 0 || sslVersion > 3) {
+                        printUsage();
+                    }
+
+                } else if (arg.equals("-l")) {
+                    if (args.length < i+2)
+                        printUsage();
+                    cipherList = args[++i];
+
+                } else if (arg.equals("-c")) {
+                    if (args.length < i+2)
+                        printUsage();
+                    clientCert = args[++i];
+
+                } else if (arg.equals("-k")) {
+                    if (args.length < i+2)
+                        printUsage();
+                    clientKey = args[++i];
+
+                } else if (arg.equals("-b")) {
+                    if (args.length < i+2)
+                      printUsage();
+                    benchmark = Integer.parseInt(args[++i]);
+                    if (benchmark < 0 || benchmark > 1000000)
+                        printUsage();
+
+                } else if (arg.equals("-A")) {
+                    if (args.length < i+2)
+                        printUsage();
+                    caCert = args[++i];
+
+                } else if (arg.equals("-d")) {
+                    verifyPeer = 0;
+
+                } else if (arg.equals("-u")) {
+                    doDTLS = 1;
+
+                } else if (arg.equals("-s")) {
+                    if (WolfSSL.isEnabledPSK() == 0) {
+                        System.out.println("PSK support not enabled in " +
+                                           "wolfSSL");
+                        System.exit(1);
+                    }
+                    usePsk = 1;
+
+                } else if (arg.equals("-iocb")) {
+                    useIOCallbacks = true;
+
+                } else if (arg.equals("-logtest")) {
+                    logCallback = 1;
+
+                } else if (arg.equals("-o")) {
+                    if (WolfSSL.isEnabledOCSP() == 0) {
+                        System.out.println("OCSP support not enabled in " +
+                                           "wolfSSL");
+                        System.exit(1);
+                    }
+                    useOcsp = 1;
+
+                } else if (arg.equals("-O")) {
+                    if (WolfSSL.isEnabledOCSP() == 0) {
+                        System.out.println("OCSP support not enabled in " +
+                                           "wolfSSL");
+                        System.exit(1);
+                    }
+                    if (args.length < i+2)
+                        printUsage();
+                    useOcsp = 1;
+                    ocspUrl = args[++i];
+
+                } else if (arg.equals("-U")) {
+                    if (WolfSSL.isEnabledAtomicUser() == 0) {
+                        System.out.println("Atomic User support not enabled " +
+                                           "in wolfSSL");
+                        System.exit(1);
+                    }
+                    useAtomic = 1;
+
+                } else if (arg.equals("-P")) {
+                    if (WolfSSL.isEnabledPKCallbacks() == 0) {
+                        System.out.println("Public Key callback support not " +
+                                           "enabled in wolfSSL");
+                        System.exit(1);
+                    }
+                    pkCallbacks = 1;
+
+                } else {
+                    printUsage();
+                }
+            }
+
+            /* sort out DTLS versus TLS versions */
+            if (doDTLS == 1) {
+                if (sslVersion == 3)
+                    sslVersion = -2;
+                else
+                    sslVersion = -1;
+            }
 
             /* init library */
             WolfSSL sslLib = new WolfSSL();
@@ -531,17 +556,23 @@ public class Client {
                 "../certs/ca-cert.pem");
         System.out.println("-b <num>\tBenchmark <num> connections and print" +
                 " stats");
-        System.out.println("-s\t\tUse pre shared keys");
+        if (WolfSSL.isEnabledPSK() == 1)
+            System.out.println("-s\t\tUse pre shared keys");
         System.out.println("-d\t\tDisable peer checks");
-        System.out.println("-u\t\tUse UDP DTLS, add -v 2 for DTLSv1 (default)" +
-            ", -v 3 for DTLSv1.2");
+        if (WolfSSL.isEnabledDTLS() == 1)
+            System.out.println("-u\t\tUse UDP DTLS, add -v 2 for DTLSv1 " +
+                    "(default), -v 3 for DTLSv1.2");
         System.out.println("-iocb\t\tEnable test I/O callbacks");
         System.out.println("-logtest\tEnable test logging callback");
-        System.out.println("-o\t\tPerform OCSP lookup on peer certificate");
-        System.out.println("-O <url>\tPerform OCSP lookup using <url> " +
-                "as responder");
-        System.out.println("-U\t\tEnable Atomic User Record Layer Callbacks");
-        System.out.println("-P\t\tPublic Key Callbacks");
+        if (WolfSSL.isEnabledOCSP() == 1) {
+            System.out.println("-o\t\tPerform OCSP lookup on peer certificate");
+            System.out.println("-O <url>\tPerform OCSP lookup using <url> " +
+                    "as responder");
+        }
+        if (WolfSSL.isEnabledAtomicUser() == 1)
+            System.out.println("-U\t\tEnable Atomic User Record Layer Callbacks");
+        if (WolfSSL.isEnabledPKCallbacks() == 1)
+            System.out.println("-P\t\tPublic Key Callbacks");
         System.exit(1);
     }
 

--- a/examples/Server.java
+++ b/examples/Server.java
@@ -84,100 +84,135 @@ public class Server {
         /* server info */
         int port    =  11111;
 
-        /* pull in command line options from user */
-        for (int i = 0; i < args.length; i++)
-        {
-            String arg = args[i];
-
-            if (arg.equals("-?")) {
-                printUsage();
-
-            } else if (arg.equals("-p")) {
-                if (args.length < i+2)
-                    printUsage();
-                port = Integer.parseInt(args[++i]);
-
-            } else if (arg.equals("-v")) {
-                if (args.length < i+2)
-                    printUsage();
-                sslVersion = Integer.parseInt(args[++i]);
-                if (sslVersion < 0 || sslVersion > 3) {
-                    printUsage();
-                }
-
-            } else if (arg.equals("-l")) {
-                if (args.length < i+2)
-                    printUsage();
-                cipherList = args[++i];
-
-            } else if (arg.equals("-c")) {
-                if (args.length < i+2)
-                    printUsage();
-                serverCert = args[++i];
-
-            } else if (arg.equals("-k")) {
-                if (args.length < i+2)
-                    printUsage();
-                serverKey = args[++i];
-
-            } else if (arg.equals("-A")) {
-                if (args.length < i+2)
-                    printUsage();
-                caCert = args[++i];
-
-            } else if (arg.equals("-d")) {
-                verifyPeer = 0;
-
-            } else if (arg.equals("-u")) {
-                doDTLS = 1;
-
-            } else if (arg.equals("-s")) {
-                usePsk = 1;
-
-            } else if (arg.equals("-iocb")) {
-                useIOCallbacks = true;
-
-            } else if (arg.equals("-logtest")) {
-                logCallback = 1;
-
-            } else if (arg.equals("-o")) {
-                useOcsp = 1;
-
-            } else if (arg.equals("-O")) {
-                if (args.length < i+2)
-                    printUsage();
-                useOcsp = 1;
-                ocspUrl = args[i++];
-
-            } else if (arg.equals("-U")) {
-                useAtomic = 1;
-
-            } else if (arg.equals("-P")) {
-                pkCallbacks = 1;
-
-            } else if (arg.equals("-m")) {
-                crlDirMonitor = 1;
-
-            } else if (arg.equals("-I")) {
-                sendPskIdentityHint = 0;
-
-            } else {
-                printUsage();
-            }
-        }
-
-        /* sort out DTLS versus TLS versions */
-        if (doDTLS == 1) {
-            if (sslVersion == 3)
-                sslVersion = -2;
-            else
-                sslVersion = -1;
-        }
-
         try {
 
             /* load JNI library */
             WolfSSL.loadLibrary();
+
+            /* pull in command line options from user */
+            for (int i = 0; i < args.length; i++)
+            {
+                String arg = args[i];
+
+                if (arg.equals("-?")) {
+                    printUsage();
+
+                } else if (arg.equals("-p")) {
+                    if (args.length < i+2)
+                        printUsage();
+                    port = Integer.parseInt(args[++i]);
+
+                } else if (arg.equals("-v")) {
+                    if (args.length < i+2)
+                        printUsage();
+                    sslVersion = Integer.parseInt(args[++i]);
+                    if (sslVersion < 0 || sslVersion > 3) {
+                        printUsage();
+                    }
+
+                } else if (arg.equals("-l")) {
+                    if (args.length < i+2)
+                        printUsage();
+                    cipherList = args[++i];
+
+                } else if (arg.equals("-c")) {
+                    if (args.length < i+2)
+                        printUsage();
+                    serverCert = args[++i];
+
+                } else if (arg.equals("-k")) {
+                    if (args.length < i+2)
+                        printUsage();
+                    serverKey = args[++i];
+
+                } else if (arg.equals("-A")) {
+                    if (args.length < i+2)
+                        printUsage();
+                    caCert = args[++i];
+
+                } else if (arg.equals("-d")) {
+                    verifyPeer = 0;
+
+                } else if (arg.equals("-u")) {
+                    doDTLS = 1;
+
+                } else if (arg.equals("-s")) {
+                    if (WolfSSL.isEnabledPSK() == 0) {
+                        System.out.println("PSK support not enabled in " +
+                                           "wolfSSL");
+                        System.exit(1);
+                    }
+                    usePsk = 1;
+
+                } else if (arg.equals("-iocb")) {
+                    useIOCallbacks = true;
+
+                } else if (arg.equals("-logtest")) {
+                    logCallback = 1;
+
+                } else if (arg.equals("-o")) {
+                    if (WolfSSL.isEnabledOCSP() == 0) {
+                        System.out.println("OCSP support not enabled in " +
+                                           "wolfSSL");
+                        System.exit(1);
+                    }
+                    useOcsp = 1;
+
+                } else if (arg.equals("-O")) {
+                    if (WolfSSL.isEnabledOCSP() == 0) {
+                        System.out.println("OCSP support not enabled in " +
+                                           "wolfSSL");
+                        System.exit(1);
+                    }
+                    if (args.length < i+2)
+                        printUsage();
+                    useOcsp = 1;
+                    ocspUrl = args[i++];
+
+                } else if (arg.equals("-U")) {
+                    if (WolfSSL.isEnabledAtomicUser() == 0) {
+                        System.out.println("Atomic User support not enabled " +
+                                           "in wolfSSL");
+                        System.exit(1);
+                    }
+                    useAtomic = 1;
+
+                } else if (arg.equals("-P")) {
+                    if (WolfSSL.isEnabledPKCallbacks() == 0) {
+                        System.out.println("Public Key callback support not " +
+                                           "enabled in wolfSSL");
+                        System.exit(1);
+                    }
+                    pkCallbacks = 1;
+
+                } else if (arg.equals("-m")) {
+                    if (WolfSSL.isEnabledCRLMonitor() == 0) {
+                        System.out.println("CRL monitor support not enabled " +
+                                           "in wolfSSL");
+                        System.exit(1);
+                    }
+                    crlDirMonitor = 1;
+
+                } else if (arg.equals("-I")) {
+                    if (WolfSSL.isEnabledPSK() == 0) {
+                        System.out.println("PSK support not enabled in " +
+                                           "wolfSSL");
+                        System.exit(1);
+                    }
+                    sendPskIdentityHint = 0;
+
+                } else {
+                    printUsage();
+                }
+            }
+
+            /* sort out DTLS versus TLS versions */
+            if (doDTLS == 1) {
+                if (sslVersion == 3)
+                    sslVersion = -2;
+                else
+                    sslVersion = -1;
+            }
 
             /* init library */
             WolfSSL sslLib = new WolfSSL();
@@ -558,17 +593,24 @@ public class Server {
         System.out.println("-A <file>\tCertificate Authority file,\tdefault " +
                 "../certs/client-cert.pem");
         System.out.println("-d\t\tDisable peer checks");
-        System.out.println("-s\t\tUse pre shared keys");
-        System.out.println("-u\t\tUse UDP DTLS, add -v 2 for DTLSv1 (default)" +
-            ", -v 3 for DTLSv1.2");
+        if (WolfSSL.isEnabledPSK() == 1)
+            System.out.println("-s\t\tUse pre shared keys");
+        if (WolfSSL.isEnabledDTLS() == 1)
+            System.out.println("-u\t\tUse UDP DTLS, add -v 2 for DTLSv1 (default)" +
+                ", -v 3 for DTLSv1.2");
         System.out.println("-iocb\t\tEnable test I/O callbacks");
         System.out.println("-logtest\tEnable test logging callback");
-        System.out.println("-o\t\tPerform OCSP lookup on peer certificate");
-        System.out.println("-O <url>\tPerform OCSP lookup using <url> " +
-                "as responder");
-        System.out.println("-U\t\tAtomic User Record Layer Callbacks");
-        System.out.println("-P\t\tPublic Key Callbacks");
-        System.out.println("-m\t\tEnable CRL directory monitor");
+        if (WolfSSL.isEnabledOCSP() == 1) {
+            System.out.println("-o\t\tPerform OCSP lookup on peer certificate");
+            System.out.println("-O <url>\tPerform OCSP lookup using <url> " +
+                    "as responder");
+        }
+        if (WolfSSL.isEnabledAtomicUser() == 1)
+            System.out.println("-U\t\tAtomic User Record Layer Callbacks");
+        if (WolfSSL.isEnabledPKCallbacks() == 1)
+            System.out.println("-P\t\tPublic Key Callbacks");
+        if (WolfSSL.isEnabledCRLMonitor() == 1)
+            System.out.println("-m\t\tEnable CRL directory monitor");
         System.exit(1);
     }
 

--- a/examples/Server.java
+++ b/examples/Server.java
@@ -351,38 +351,40 @@ public class Server {
                 }
 
                 /* enable/load CRL functionality */
-                ret = ssl.enableCRL(0);
-                if (ret != WolfSSL.SSL_SUCCESS) {
-                    System.out.println("failed to enable CRL, ret = "
-                            + ret);
-                    System.exit(1);
-                }
-                if (crlDirMonitor == 1) {
-                    ret = ssl.loadCRL(crlPemDir, WolfSSL.SSL_FILETYPE_PEM,
-                            (WolfSSL.WOLFSSL_CRL_MONITOR |
-                            WolfSSL.WOLFSSL_CRL_START_MON));
-                    if (ret == WolfSSL.MONITOR_RUNNING_E) {
-                        System.out.println("CRL monitor already running, " +
-                                "continuing");
-                    } else if (ret != WolfSSL.SSL_SUCCESS) {
-                        System.out.println("failed to start CRL monitor, ret = "
+                if (WolfSSL.isEnabledCRL() == 1) {
+                    ret = ssl.enableCRL(0);
+                    if (ret != WolfSSL.SSL_SUCCESS) {
+                        System.out.println("failed to enable CRL, ret = "
                                 + ret);
                         System.exit(1);
                     }
-                } else {
-                    ret = ssl.loadCRL(crlPemDir, WolfSSL.SSL_FILETYPE_PEM, 0);
+                    if (crlDirMonitor == 1) {
+                        ret = ssl.loadCRL(crlPemDir, WolfSSL.SSL_FILETYPE_PEM,
+                                (WolfSSL.WOLFSSL_CRL_MONITOR |
+                                WolfSSL.WOLFSSL_CRL_START_MON));
+                        if (ret == WolfSSL.MONITOR_RUNNING_E) {
+                            System.out.println("CRL monitor already running, " +
+                                    "continuing");
+                        } else if (ret != WolfSSL.SSL_SUCCESS) {
+                            System.out.println("failed to start CRL monitor, ret = "
+                                    + ret);
+                            System.exit(1);
+                        }
+                    } else {
+                        ret = ssl.loadCRL(crlPemDir, WolfSSL.SSL_FILETYPE_PEM, 0);
+                        if (ret != WolfSSL.SSL_SUCCESS) {
+                            System.out.println("failed to load CRL, ret = " + ret);
+                            System.exit(1);
+                        }
+                    }
+
+                    MyMissingCRLCallback crlCb = new MyMissingCRLCallback();
+                    ret = ssl.setCRLCb(crlCb);
                     if (ret != WolfSSL.SSL_SUCCESS) {
-                        System.out.println("failed to load CRL, ret = " + ret);
+                        System.out.println("failed to set CRL callback, ret = "
+                                + ret);
                         System.exit(1);
                     }
-                }
-
-                MyMissingCRLCallback crlCb = new MyMissingCRLCallback();
-                ret = ssl.setCRLCb(crlCb);
-                if (ret != WolfSSL.SSL_SUCCESS) {
-                    System.out.println("failed to set CRL callback, ret = "
-                            + ret);
-                    System.exit(1);
                 }
 
                 if (useIOCallbacks || (doDTLS == 1)) {

--- a/java.sh
+++ b/java.sh
@@ -33,10 +33,10 @@ then
     mkdir ./lib
 fi
 
-gcc -DWOLFSSL_DTLS -Wall -c $fpic $cflags ./native/com_wolfssl_WolfSSL.c -o ./native/com_wolfssl_WolfSSL.o $javaIncludes
-gcc -DWOLFSSL_DTLS -Wall -c $fpic $cflags ./native/com_wolfssl_WolfSSLSession.c -o ./native/com_wolfssl_WolfSSLSession.o $javaIncludes
-gcc -DWOLFSSL_DTLS -Wall -c $fpic $cflags ./native/com_wolfssl_WolfSSLContext.c -o ./native/com_wolfssl_WolfSSLContext.o $javaIncludes
-gcc -DWOLFSSL_DTLS -Wall -c $fpic $cflags ./native/com_wolfssl_wolfcrypt_RSA.c -o ./native/com_wolfssl_wolfcrypt_RSA.o $javaIncludes
-gcc -DWOLFSSL_DTLS -Wall -c $fpic $cflags ./native/com_wolfssl_wolfcrypt_ECC.c -o ./native/com_wolfssl_wolfcrypt_ECC.o $javaIncludes
+gcc -Wall -c $fpic $cflags ./native/com_wolfssl_WolfSSL.c -o ./native/com_wolfssl_WolfSSL.o $javaIncludes
+gcc -Wall -c $fpic $cflags ./native/com_wolfssl_WolfSSLSession.c -o ./native/com_wolfssl_WolfSSLSession.o $javaIncludes
+gcc -Wall -c $fpic $cflags ./native/com_wolfssl_WolfSSLContext.c -o ./native/com_wolfssl_WolfSSLContext.o $javaIncludes
+gcc -Wall -c $fpic $cflags ./native/com_wolfssl_wolfcrypt_RSA.c -o ./native/com_wolfssl_wolfcrypt_RSA.o $javaIncludes
+gcc -Wall -c $fpic $cflags ./native/com_wolfssl_wolfcrypt_ECC.c -o ./native/com_wolfssl_wolfcrypt_ECC.o $javaIncludes
 gcc -Wall $javaLibs $cflags -o ./lib/$jniLibName ./native/com_wolfssl_WolfSSL.o ./native/com_wolfssl_WolfSSLSession.o ./native/com_wolfssl_WolfSSLContext.o ./native/com_wolfssl_wolfcrypt_RSA.o ./native/com_wolfssl_wolfcrypt_ECC.o -lwolfssl
 

--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -119,25 +119,41 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_TLSv1_12_1ClientMethod(
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_DTLSv1_1ClientMethod
   (JNIEnv* jenv, jclass jcl)
 {
+#ifdef WOLFSSL_DTLS
     return (jlong)wolfDTLSv1_client_method();
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_DTLSv1_1ServerMethod
   (JNIEnv* jenv, jclass jcl)
 {
+#ifdef WOLFSSL_DTLS
     return (jlong)wolfDTLSv1_server_method();
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_DTLSv1_12_1ClientMethod
   (JNIEnv* jenv, jclass jcl)
 {
+#ifdef WOLFSSL_DTLS
     return (jlong)wolfDTLSv1_2_client_method();
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_DTLSv1_12_1ServerMethod
   (JNIEnv* jenv, jclass jcl)
 {
+#ifdef WOLFSSL_DTLS
     return (jlong)wolfDTLSv1_2_server_method();
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_SSLv23_1ServerMethod
@@ -293,6 +309,7 @@ void NativeLoggingCallback(const int logLevel, const char *const logMessage)
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_memsaveSessionCache
   (JNIEnv* jenv, jclass jcl, jbyteArray mem, jint sz)
 {
+#ifdef PERSIST_SESSION_CACHE
     int ret;
     int cacheSz;
     char memBuf[sz];
@@ -316,11 +333,15 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_memsaveSessionCache
     }
 
     return ret;
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_memrestoreSessionCache
   (JNIEnv* jenv, jclass jcl, jbyteArray mem, jint sz)
 {
+#ifdef PERSIST_SESSION_CACHE
     int ret;
     char memBuf[sz];
 
@@ -336,17 +357,25 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_memrestoreSessionCache
 
     ret = wolfSSL_memrestore_session_cache(memBuf, sz);
     return ret;
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getSessionCacheMemsize
   (JNIEnv* jenv, jclass jcl)
 {
+#ifdef PERSIST_SESSION_CACHE
     return wolfSSL_get_session_cache_memsize();
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSL_x509_1getDer
   (JNIEnv* jenv, jclass jcl, jlong x509)
 {
+#if defined(KEEP_PEER_CERT) || defined(SESSION_CERTS)
     int* outSz = NULL;
     const unsigned char* derCert;
     jbyteArray out = NULL;
@@ -369,6 +398,9 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSL_x509_1getDer
     } else {
         return NULL;
     }
+#else
+    return NULL;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getHmacMaxSize

--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -419,3 +419,63 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_isEnabledCRL
 #endif
 }
 
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_isEnabledCRLMonitor
+  (JNIEnv* jenv, jclass jcl)
+{
+#ifdef HAVE_CRL_MONITOR
+    return 1;
+#else
+    return 0;
+#endif
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_isEnabledOCSP
+  (JNIEnv* jenv, jclass jcl)
+{
+#ifdef HAVE_OCSP
+    return 1;
+#else
+    return 0;
+#endif
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_isEnabledPSK
+  (JNIEnv* jenv, jclass jcl)
+{
+#ifndef NO_PSK
+    return 1;
+#else
+    return 0;
+#endif
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_isEnabledDTLS
+  (JNIEnv* jenv, jclass jcl)
+{
+#ifdef WOLFSSL_DTLS
+    return 1;
+#else
+    return 0;
+#endif
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_isEnabledAtomicUser
+  (JNIEnv* jenv, jclass jcl)
+{
+#ifdef ATOMIC_USER
+    return 1;
+#else
+    return 0;
+#endif
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_isEnabledPKCallbacks
+  (JNIEnv* jenv, jclass jcl)
+{
+#ifdef HAVE_PK_CALLBACKS
+    return 1;
+#else
+    return 0;
+#endif
+}
+

--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -409,3 +409,13 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getHmacMaxSize
     return MAX_DIGEST_SIZE;
 }
 
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_isEnabledCRL
+  (JNIEnv* jenv, jclass jcl)
+{
+#ifdef HAVE_CRL
+    return 1;
+#else
+    return 0;
+#endif
+}
+

--- a/native/com_wolfssl_WolfSSL.h
+++ b/native/com_wolfssl_WolfSSL.h
@@ -399,6 +399,54 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getHmacMaxSize
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_isEnabledCRL
   (JNIEnv *, jclass);
 
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    isEnabledCRLMonitor
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_isEnabledCRLMonitor
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    isEnabledOCSP
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_isEnabledOCSP
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    isEnabledPSK
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_isEnabledPSK
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    isEnabledDTLS
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_isEnabledDTLS
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    isEnabledAtomicUser
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_isEnabledAtomicUser
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    isEnabledPKCallbacks
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_isEnabledPKCallbacks
+  (JNIEnv *, jclass);
+
 #ifdef __cplusplus
 }
 #endif

--- a/native/com_wolfssl_WolfSSL.h
+++ b/native/com_wolfssl_WolfSSL.h
@@ -391,6 +391,14 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSL_x509_1getDer
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getHmacMaxSize
   (JNIEnv *, jclass);
 
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    isEnabledCRL
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_isEnabledCRL
+  (JNIEnv *, jclass);
+
 #ifdef __cplusplus
 }
 #endif

--- a/native/com_wolfssl_WolfSSLContext.c
+++ b/native/com_wolfssl_WolfSSLContext.c
@@ -29,7 +29,10 @@
 
 /* global object refs for verify, CRL callbacks */
 static jobject g_verifyCbIfaceObj;
+
+#ifdef HAVE_CRL
 static jobject g_crlCtxCbIfaceObj;
+#endif
 
 /* custom I/O native fn prototypes */
 int  NativeIORecvCb(WOLFSSL *ssl, char *buf, int sz, void *ctx);
@@ -342,6 +345,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_memsaveCertCache
   (JNIEnv* jenv, jobject jcl, jlong ctx, jbyteArray mem, jint sz,
     jintArray used)
 {
+#ifdef PERSIST_CERT_CACHE
     int ret;
     int usedTmp;
     char memBuf[sz];
@@ -385,11 +389,15 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_memsaveCertCache
     }
 
     return ret;
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_memrestoreCertCache
   (JNIEnv* jenv, jobject jcl, jlong ctx, jbyteArray mem, jint sz)
 {
+#ifdef PERSIST_CERT_CACHE
     int ret;
     char memBuf[sz];
 
@@ -418,13 +426,20 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_memrestoreCertCache
     ret = wolfSSL_CTX_memrestore_cert_cache((WOLFSSL_CTX*)ctx, memBuf, sz);
 
     return ret;
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_getCertCacheMemsize
   (JNIEnv* jenv, jobject jcl, jlong ctx)
 {
+#ifdef PERSIST_CERT_CACHE
     /* wolfSSL checks for null pointer */
     return wolfSSL_CTX_get_cert_cache_memsize((WOLFSSL_CTX*)ctx);
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setCipherList
@@ -1046,6 +1061,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setGenCookie
         (*jenv)->ExceptionClear(jenv);
     }
 
+#ifdef WOLFSSL_DTLS
     if (ctx) {
         /* set gen cookie callback */
         wolfSSL_CTX_SetGenCookie((WOLFSSL_CTX*)ctx, NativeGenCookieCb);
@@ -1055,6 +1071,10 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setGenCookie
                 "Input WolfSSLContext object was null when setting "
                 "genCookieCb");
     }
+#else
+    (*jenv)->ThrowNew(jenv, excClass,
+            "wolfSSL not compiled with DTLS support (WOLFSSL_DTLS)");
+#endif
 }
 
 int NativeGenCookieCb(WOLFSSL *ssl, unsigned char *buf, int sz, void *ctx)
@@ -1265,24 +1285,33 @@ int NativeGenCookieCb(WOLFSSL *ssl, unsigned char *buf, int sz, void *ctx)
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_enableCRL
   (JNIEnv* jenv, jobject jcl, jlong ctx, jint options)
 {
+#ifdef HAVE_CRL
     if (!jenv || !ctx)
         return BAD_FUNC_ARG;
 
     return wolfSSL_CTX_EnableCRL((WOLFSSL_CTX*)ctx, options);
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_disableCRL
   (JNIEnv* jenv, jobject jcl, jlong ctx)
 {
+#ifdef HAVE_CRL
     if (!jenv || !ctx)
         return BAD_FUNC_ARG;
 
     return wolfSSL_CTX_DisableCRL((WOLFSSL_CTX*)ctx);
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_loadCRL
   (JNIEnv* jenv, jobject jcl, jlong ctx, jstring path, jint type, jint monitor)
 {
+#ifdef HAVE_CRL
     int ret;
     const char* crlPath;
 
@@ -1296,11 +1325,15 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_loadCRL
     (*jenv)->ReleaseStringUTFChars(jenv, path, crlPath);
 
     return ret;
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setCRLCb
   (JNIEnv* jenv, jobject jcl, jlong ctx, jobject cb)
 {
+#ifdef HAVE_CRL
     int ret = 0;
     jclass excClass;
 
@@ -1324,7 +1357,12 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setCRLCb
     ret = wolfSSL_CTX_SetCRL_Cb((WOLFSSL_CTX*)ctx, NativeCtxMissingCRLCallback);
 
     return ret;
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
+
+#ifdef HAVE_CRL
 
 void NativeCtxMissingCRLCallback(const char* url)
 {
@@ -1406,23 +1444,34 @@ void NativeCtxMissingCRLCallback(const char* url)
     }
 }
 
+#endif /* HAVE_CRL */
+
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_enableOCSP
   (JNIEnv* jenv, jobject jcl, jlong ctx, jlong options)
 {
+#ifdef HAVE_OCSP
     /* wolfSSL checks for null pointer */
     return wolfSSL_CTX_EnableOCSP((WOLFSSL_CTX*)ctx, options);
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_disableOCSP
   (JNIEnv* jenv, jobject jcl, jlong ctx)
 {
+#ifdef HAVE_OCSP
     /* wolfSSL checks for null pointer */
     return wolfSSL_CTX_DisableOCSP((WOLFSSL_CTX*)ctx);
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setOCSPOverrideUrl
   (JNIEnv* jenv, jobject jcl, jlong ctx, jstring urlString)
 {
+#ifdef HAVE_OCSP
     jint ret = 0;
     jclass excClass;
     const char* url;
@@ -1453,6 +1502,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setOCSPOverrideUrl
     (*jenv)->ReleaseStringUTFChars(jenv, urlString, url);
 
     return ret;
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setMacEncryptCb
@@ -1467,6 +1519,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setMacEncryptCb
         return;
     }
 
+#ifdef ATOMIC_USER
     if(ctx) {
         /* set MAC encrypt callback */
         wolfSSL_CTX_SetMacEncryptCb((WOLFSSL_CTX*)ctx, NativeMacEncryptCb);
@@ -1476,7 +1529,42 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setMacEncryptCb
                 "Input WolfSSLContext object was null when "
                 "setting MacEncrypt");
     }
+#else
+        (*jenv)->ThrowNew(jenv, excClass,
+                "wolfSSL not compiled with ATOMIC_USER");
+#endif
 }
+
+JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setDecryptVerifyCb
+  (JNIEnv* jenv, jobject jcl, jlong ctx)
+{
+    /* find exception class */
+    jclass excClass = (*jenv)->FindClass(jenv,
+            "com/wolfssl/WolfSSLJNIException");
+    if ((*jenv)->ExceptionOccurred(jenv)) {
+        (*jenv)->ExceptionDescribe(jenv);
+        (*jenv)->ExceptionClear(jenv);
+        return;
+    }
+
+#ifdef ATOMIC_USER
+    if(ctx) {
+        /* set decrypt/verify callback */
+        wolfSSL_CTX_SetDecryptVerifyCb((WOLFSSL_CTX*)ctx,
+                NativeDecryptVerifyCb);
+
+    } else {
+        (*jenv)->ThrowNew(jenv, excClass,
+                "Input WolfSSLContext object was null when "
+                "setting MacDecrypt");
+    }
+#else
+        (*jenv)->ThrowNew(jenv, excClass,
+                "wolfSSL not compiled with ATOMIC_USER");
+#endif /* ATOMIC_USER */
+}
+
+#ifdef ATOMIC_USER
 
 int NativeMacEncryptCb(WOLFSSL* ssl, unsigned char* macOut,
         const unsigned char* macIn, unsigned int macInSz, int macContent,
@@ -1742,30 +1830,6 @@ int NativeMacEncryptCb(WOLFSSL* ssl, unsigned char* macOut,
     return retval;
 }
 
-JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setDecryptVerifyCb
-  (JNIEnv* jenv, jobject jcl, jlong ctx)
-{
-    /* find exception class */
-    jclass excClass = (*jenv)->FindClass(jenv,
-            "com/wolfssl/WolfSSLJNIException");
-    if ((*jenv)->ExceptionOccurred(jenv)) {
-        (*jenv)->ExceptionDescribe(jenv);
-        (*jenv)->ExceptionClear(jenv);
-        return;
-    }
-
-    if(ctx) {
-        /* set decrypt/verify callback */
-        wolfSSL_CTX_SetDecryptVerifyCb((WOLFSSL_CTX*)ctx,
-                NativeDecryptVerifyCb);
-
-    } else {
-        (*jenv)->ThrowNew(jenv, excClass,
-                "Input WolfSSLContext object was null when "
-                "setting MacDecrypt");
-    }
-}
-
 int  NativeDecryptVerifyCb(WOLFSSL* ssl, unsigned char* decOut,
         const unsigned char* decIn, unsigned int decSz, int content,
         int verify, unsigned int* padSz, void* ctx)
@@ -2022,6 +2086,8 @@ int  NativeDecryptVerifyCb(WOLFSSL* ssl, unsigned char* decOut,
     return retval;
 }
 
+#endif /* ATOMIC_USER */
+
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setEccSignCb
   (JNIEnv* jenv, jobject jcl, jlong ctx)
 {
@@ -2034,6 +2100,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setEccSignCb
         return;
     }
 
+#if defined(HAVE_PK_CALLBACKS) && defined(HAVE_ECC)
     if(ctx) {
         /* set ECC sign callback */
         wolfSSL_CTX_SetEccSignCb((WOLFSSL_CTX*)ctx, NativeEccSignCb);
@@ -2043,7 +2110,14 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setEccSignCb
                 "Input WolfSSLContext object was null when setting "
                 "EccSignCb");
     }
+#else
+     (*jenv)->ThrowNew(jenv, excClass,
+             "wolfSSL not compiled with PK Callback support "
+             "(HAVE_PK_CALLBACKS)");
+#endif
 }
+
+#if defined(HAVE_PK_CALLBACKS) && defined(HAVE_ECC)
 
 int  NativeEccSignCb(WOLFSSL* ssl, const unsigned char* in, unsigned int inSz,
         unsigned char* out, unsigned int* outSz, const unsigned char* keyDer,
@@ -2311,6 +2385,8 @@ int  NativeEccSignCb(WOLFSSL* ssl, const unsigned char* in, unsigned int inSz,
     return retval;
 }
 
+#endif /* HAVE_PK_CALLBACKS */
+
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setEccVerifyCb
   (JNIEnv* jenv, jobject jcl, jlong ctx)
 {
@@ -2323,6 +2399,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setEccVerifyCb
         return;
     }
 
+#if defined(HAVE_PK_CALLBACKS) && defined(HAVE_ECC)
     if(ctx) {
         /* set ECC verify callback */
         wolfSSL_CTX_SetEccVerifyCb((WOLFSSL_CTX*)ctx, NativeEccVerifyCb);
@@ -2332,7 +2409,14 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setEccVerifyCb
                 "Input WolfSSLContext object was null when setting "
                 "EccVerifyCb");
     }
+#else
+    (*jenv)->ThrowNew(jenv, excClass,
+            "wolfSSL not compiled with PK Callback support "
+            "(HAVE_PK_CALLBACKS)");
+#endif
 }
+
+#if defined(HAVE_PK_CALLBACKS) && defined(HAVE_ECC)
 
 int  NativeEccVerifyCb(WOLFSSL* ssl, const unsigned char* sig,
         unsigned int sigSz, const unsigned char* hash, unsigned int hashSz,
@@ -2588,6 +2672,8 @@ int  NativeEccVerifyCb(WOLFSSL* ssl, const unsigned char* sig,
     return retval;
 }
 
+#endif /* HAVE_PK_CALLBACKS */
+
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setRsaSignCb
   (JNIEnv* jenv, jobject jcl, jlong ctx)
 {
@@ -2600,6 +2686,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setRsaSignCb
         return;
     }
 
+#if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
     if(ctx) {
         /* set RSA sign callback */
         wolfSSL_CTX_SetRsaSignCb((WOLFSSL_CTX*)ctx, NativeRsaSignCb);
@@ -2609,7 +2696,13 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setRsaSignCb
                 "Input WolfSSLContext object was null when setting "
                 "RsaSignCb");
     }
+#else
+    (*jenv)->ThrowNew(jenv, excClass,
+            "wolfSSL not compiled with PK Callback support and/or RSA support");
+#endif
 }
+
+#if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
 
 int  NativeRsaSignCb(WOLFSSL* ssl, const unsigned char* in, unsigned int inSz,
         unsigned char* out, unsigned int* outSz, const unsigned char* keyDer,
@@ -2882,6 +2975,8 @@ int  NativeRsaSignCb(WOLFSSL* ssl, const unsigned char* in, unsigned int inSz,
     return retval;
 }
 
+#endif /* HAVE_PK_CALLBACKS */
+
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setRsaVerifyCb
   (JNIEnv* jenv, jobject jcl, jlong ctx)
 {
@@ -2894,6 +2989,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setRsaVerifyCb
         return;
     }
 
+#if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
     if(ctx) {
         /* set RSA verify callback */
         wolfSSL_CTX_SetRsaVerifyCb((WOLFSSL_CTX*)ctx, NativeRsaVerifyCb);
@@ -2903,7 +2999,13 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setRsaVerifyCb
                 "Input WolfSSLContext object was null when setting "
                 "RsaVerifyCb");
     }
+#else
+    (*jenv)->ThrowNew(jenv, excClass,
+            "wolfSSL not compiled with PK Callback and/or RSA support");
+#endif
 }
+
+#if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
 
 int  NativeRsaVerifyCb(WOLFSSL* ssl, unsigned char* sig, unsigned int sigSz,
         unsigned char** out, const unsigned char* keyDer, unsigned int keySz,
@@ -3121,6 +3223,8 @@ int  NativeRsaVerifyCb(WOLFSSL* ssl, unsigned char* sig, unsigned int sigSz,
     return retval;
 }
 
+#endif /* HAVE_PK_CALLBACKS */
+
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setRsaEncCb
   (JNIEnv* jenv, jobject jcl, jlong ctx)
 {
@@ -3133,6 +3237,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setRsaEncCb
         return;
     }
 
+#if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
     if(ctx) {
         /* set RSA encrypt callback */
         wolfSSL_CTX_SetRsaEncCb((WOLFSSL_CTX*)ctx, NativeRsaEncCb);
@@ -3142,7 +3247,13 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setRsaEncCb
                 "Input WolfSSLContext object was null when setting "
                 "RsaEncCb");
     }
+#else
+    (*jenv)->ThrowNew(jenv, excClass,
+            "wolfSSL not compiled with PK Callback and/or RSA support");
+#endif
 }
+
+#if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
 
 int  NativeRsaEncCb(WOLFSSL* ssl, const unsigned char* in, unsigned int inSz,
         unsigned char* out, unsigned int* outSz, const unsigned char* keyDer,
@@ -3408,6 +3519,8 @@ int  NativeRsaEncCb(WOLFSSL* ssl, const unsigned char* in, unsigned int inSz,
     return retval;
 }
 
+#endif /* HAVE_PK_CALLBACKS */
+
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setRsaDecCb
   (JNIEnv* jenv, jobject jcl, jlong ctx)
 {
@@ -3420,6 +3533,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setRsaDecCb
         return;
     }
 
+#if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
     if(ctx) {
         /* set RSA encrypt callback */
         wolfSSL_CTX_SetRsaDecCb((WOLFSSL_CTX*)ctx, NativeRsaDecCb);
@@ -3429,7 +3543,13 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setRsaDecCb
                 "Input WolfSSLContext object was null when setting "
                 "RsaDecCb");
     }
+#else
+    (*jenv)->ThrowNew(jenv, excClass,
+            "wolfSSL not compiled with PK Callback and/or RSA support");
+#endif
 }
+
+#if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
 
 int  NativeRsaDecCb(WOLFSSL* ssl, unsigned char* in, unsigned int inSz,
         unsigned char** out, const unsigned char* keyDer, unsigned int keySz,
@@ -3653,6 +3773,8 @@ int  NativeRsaDecCb(WOLFSSL* ssl, unsigned char* in, unsigned int inSz,
     return retval;
 }
 
+#endif /* HAVE_PK_CALLBAKCS */
+
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setPskClientCb
   (JNIEnv* jenv, jobject jcl, jlong ctx)
 {
@@ -3665,6 +3787,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setPskClientCb
         return;
     }
 
+#ifndef NO_PSK
     if (ctx) {
         /* set PSK client callback */
         wolfSSL_CTX_set_psk_client_callback((WOLFSSL_CTX*)ctx,
@@ -3674,7 +3797,13 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setPskClientCb
                 "Input WolfSSLContext object was null when setting "
                 "NativePskClientCb");
     }
+#else
+    (*jenv)->ThrowNew(jenv, excClass,
+            "wolfSSL not compiled with PSK support");
+#endif
 }
+
+#ifndef NO_PSK
 
 unsigned int NativePskClientCb(WOLFSSL* ssl, const char* hint, char* identity,
         unsigned int id_max_len, unsigned char* key, unsigned int max_key_len)
@@ -4076,6 +4205,8 @@ unsigned int NativePskClientCb(WOLFSSL* ssl, const char* hint, char* identity,
     return retval;
 }
 
+#endif /* NO_PSK */
+
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setPskServerCb
   (JNIEnv* jenv, jobject jcl, jlong ctx)
 {
@@ -4088,6 +4219,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setPskServerCb
         return;
     }
 
+#ifndef NO_PSK
     if (ctx) {
         /* set PSK server callback */
         wolfSSL_CTX_set_psk_server_callback((WOLFSSL_CTX*)ctx,
@@ -4097,8 +4229,13 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setPskServerCb
                 "Input WolfSSLContext object was null when setting "
                 "NativePskServerCb");
     }
+#else
+    (*jenv)->ThrowNew(jenv, excClass,
+            "wolfSSL not compiled with PSK support");
+#endif
 }
 
+#ifndef NO_PSK
 unsigned int NativePskServerCb(WOLFSSL* ssl, const char* identity,
         unsigned char* key, unsigned int max_key_len)
 {
@@ -4380,9 +4517,12 @@ unsigned int NativePskServerCb(WOLFSSL* ssl, const char* identity,
     return retval;
 }
 
+#endif /* NO_PSK */
+
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_usePskIdentityHint
   (JNIEnv* jenv, jobject obj, jlong ctx, jstring hint)
 {
+#ifndef NO_PSK
     jint ret;
     const char* nativeHint;
 
@@ -4397,5 +4537,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_usePskIdentityHint
     (*jenv)->ReleaseStringUTFChars(jenv, hint, nativeHint);
 
     return ret;
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -762,9 +762,9 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_getPeerCertificate
 JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_getPeerX509Issuer
   (JNIEnv* jenv, jobject jcl, jlong ssl, jlong x509)
 {
-    jclass excClass;
 
 #if defined(KEEP_PEER_CERT) || defined(SESSION_CERTS)
+    jclass excClass;
     char* issuer;
     jstring retString;
 
@@ -794,26 +794,16 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_getPeerX509Issuer
     return retString;
 
 #else
-
-    excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-    if ((*jenv)->ExceptionOccurred(jenv)) {
-        (*jenv)->ExceptionDescribe(jenv);
-        (*jenv)->ExceptionClear(jenv);
-        return NULL;
-    }
-    (*jenv)->ThrowNew(jenv, excClass,
-            "wolfSSL not compiled with KEEP_PEER_CERT and/or SESSION_CERTS");
     return NULL;
-
 #endif
 }
 
 JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_getPeerX509Subject
   (JNIEnv* jenv, jobject jcl, jlong ssl, jlong x509)
 {
-    jclass excClass;
 
 #if defined(KEEP_PEER_CERT) || defined(SESSION_CERTS)
+    jclass excClass;
     char* subject;
     jstring retString;
 
@@ -842,25 +832,15 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_getPeerX509Subject
     return retString;
 
 #else
-
-    excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-    if ((*jenv)->ExceptionOccurred(jenv)) {
-        (*jenv)->ExceptionDescribe(jenv);
-        (*jenv)->ExceptionClear(jenv);
-        return NULL;
-    }
-    (*jenv)->ThrowNew(jenv, excClass,
-            "wolfSSL not compiled with KEEP_PEER_CERT and/or SESSION_CERTS");
     return NULL;
-
 #endif
 }
 
 JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_getPeerX509AltName
   (JNIEnv* jenv, jobject jcl, jlong ssl, jlong x509)
 {
-    jclass excClass;
 #if defined(KEEP_PEER_CERT) || defined(SESSION_CERTS)
+    jclass excClass;
     char* altname;
     jstring retString;
 
@@ -886,17 +866,7 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_getPeerX509AltName
     return retString;
 
 #else
-
-    excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-    if ((*jenv)->ExceptionOccurred(jenv)) {
-        (*jenv)->ExceptionDescribe(jenv);
-        (*jenv)->ExceptionClear(jenv);
-        return NULL;
-    }
-    (*jenv)->ThrowNew(jenv, excClass,
-            "wolfSSL not compiled with KEEP_PEER_CERT and/or SESSION_CERTS");
     return NULL;
-
 #endif
 }
 

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -28,8 +28,10 @@
 #include "com_wolfssl_globals.h"
 #include "com_wolfssl_WolfSSL.h"
 
+#ifdef HAVE_CRL
 /* global object refs for CRL callback */
 static jobject g_crlCbIfaceObj;
+#endif
 
 /* custom native fn prototypes */
 void NativeMissingCRLCallback(const char* url);
@@ -151,6 +153,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setFd(JNIEnv* jenv,
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useCertificateFile
   (JNIEnv* jenv, jobject jcl, jlong ssl, jstring file, jint format)
 {
+#ifdef OPENSSL_EXTRA
     jint ret = 0;
     const char* certFile;
 
@@ -168,11 +171,15 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useCertificateFile
     (*jenv)->ReleaseStringUTFChars(jenv, file, certFile);
 
     return ret;
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_usePrivateKeyFile
   (JNIEnv* jenv, jobject jcl, jlong ssl, jstring file, jint format)
 {
+#ifdef OPENSSL_EXTRA
     jint ret = 0;
     const char* keyFile;
 
@@ -190,11 +197,15 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_usePrivateKeyFile
     (*jenv)->ReleaseStringUTFChars(jenv, file, keyFile);
 
     return ret;
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useCertificateChainFile
   (JNIEnv* jenv, jobject jcl, jlong ssl, jstring file)
 {
+#ifdef OPENSSL_EXTRA
     jint ret = 0;
     const char* chainFile;
 
@@ -211,6 +222,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useCertificateChainFile
     (*jenv)->ReleaseStringUTFChars(jenv, file, chainFile);
 
     return ret;
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setUsingNonblock
@@ -447,6 +461,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setCipherList
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_dtlsGetCurrentTimeout
   (JNIEnv* jenv, jobject jcl, jlong ssl)
 {
+#if !defined(WOLFSSL_LEANPSK) && defined(WOLFSSL_DTLS)
     jclass excClass;
 
     if (!ssl) {
@@ -463,11 +478,15 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_dtlsGetCurrentTimeout
     }
 
     return wolfSSL_dtls_get_current_timeout((WOLFSSL*)ssl);
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_dtlsGotTimeout
   (JNIEnv* jenv, jobject jcl, jlong ssl)
 {
+#if !defined(WOLFSSL_LEANPSK) && defined(WOLFSSL_DTLS)
     jclass excClass;
 
     if (!ssl) {
@@ -484,6 +503,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_dtlsGotTimeout
     }
 
     return wolfSSL_dtls_got_timeout((WOLFSSL*)ssl);
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_dtls
@@ -716,6 +738,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_sessionReused
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_getPeerCertificate
   (JNIEnv* jenv, jobject jcl, jlong ssl)
 {
+#ifdef KEEP_PEER_CERT
     jclass excClass;
 
     if (!ssl) {
@@ -731,14 +754,20 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_getPeerCertificate
     }
 
     return (long)wolfSSL_get_peer_certificate((WOLFSSL*)ssl);
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_getPeerX509Issuer
   (JNIEnv* jenv, jobject jcl, jlong ssl, jlong x509)
 {
+    jclass excClass;
+
+#if defined(KEEP_PEER_CERT) || defined(SESSION_CERTS)
     char* issuer;
     jstring retString;
-    jclass excClass;
+
 
     if (!x509)
         return NULL;
@@ -763,14 +792,30 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_getPeerX509Issuer
     XFREE(issuer, 0, DYNAMIC_TYPE_OPENSSL);
 
     return retString;
+
+#else
+
+    excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
+    if ((*jenv)->ExceptionOccurred(jenv)) {
+        (*jenv)->ExceptionDescribe(jenv);
+        (*jenv)->ExceptionClear(jenv);
+        return NULL;
+    }
+    (*jenv)->ThrowNew(jenv, excClass,
+            "wolfSSL not compiled with KEEP_PEER_CERT and/or SESSION_CERTS");
+    return NULL;
+
+#endif
 }
 
 JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_getPeerX509Subject
   (JNIEnv* jenv, jobject jcl, jlong ssl, jlong x509)
 {
+    jclass excClass;
+
+#if defined(KEEP_PEER_CERT) || defined(SESSION_CERTS)
     char* subject;
     jstring retString;
-    jclass excClass;
 
     if (!x509)
         return NULL;
@@ -795,14 +840,29 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_getPeerX509Subject
     XFREE(subject, 0, DYNAMIC_TYPE_OPENSSL);
 
     return retString;
+
+#else
+
+    excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
+    if ((*jenv)->ExceptionOccurred(jenv)) {
+        (*jenv)->ExceptionDescribe(jenv);
+        (*jenv)->ExceptionClear(jenv);
+        return NULL;
+    }
+    (*jenv)->ThrowNew(jenv, excClass,
+            "wolfSSL not compiled with KEEP_PEER_CERT and/or SESSION_CERTS");
+    return NULL;
+
+#endif
 }
 
 JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_getPeerX509AltName
   (JNIEnv* jenv, jobject jcl, jlong ssl, jlong x509)
 {
+    jclass excClass;
+#if defined(KEEP_PEER_CERT) || defined(SESSION_CERTS)
     char* altname;
     jstring retString;
-    jclass excClass;
 
     if (!x509)
         return NULL;
@@ -824,6 +884,20 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_getPeerX509AltName
 
     retString = (*jenv)->NewStringUTF(jenv, altname);
     return retString;
+
+#else
+
+    excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
+    if ((*jenv)->ExceptionOccurred(jenv)) {
+        (*jenv)->ExceptionDescribe(jenv);
+        (*jenv)->ExceptionClear(jenv);
+        return NULL;
+    }
+    (*jenv)->ThrowNew(jenv, excClass,
+            "wolfSSL not compiled with KEEP_PEER_CERT and/or SESSION_CERTS");
+    return NULL;
+
+#endif
 }
 
 JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_getVersion
@@ -1094,6 +1168,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setGroupMessages
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_enableCRL
   (JNIEnv* jenv, jobject jcl, jlong ssl, jint options)
 {
+#ifdef HAVE_CRL
     jclass excClass;
 
     if (!jenv)
@@ -1113,11 +1188,15 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_enableCRL
     }
 
     return wolfSSL_EnableCRL((WOLFSSL*)ssl, options);
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_disableCRL
   (JNIEnv* jenv, jobject jcl, jlong ssl)
 {
+#ifdef HAVE_CRL
     jclass excClass;
 
     if (!jenv)
@@ -1137,11 +1216,15 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_disableCRL
     }
 
     return wolfSSL_DisableCRL((WOLFSSL*)ssl);
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_loadCRL
   (JNIEnv* jenv, jobject jcl, jlong ssl, jstring path, jint type, jint monitor)
 {
+#ifdef HAVE_CRL
     int ret;
     const char* crlPath;
     jclass excClass;
@@ -1169,11 +1252,15 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_loadCRL
     (*jenv)->ReleaseStringUTFChars(jenv, path, crlPath);
 
     return ret;
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setCRLCb
   (JNIEnv* jenv, jobject jcl, jlong ssl, jobject cb)
 {
+#ifdef HAVE_CRL
     int    ret = 0;
     jclass excClass;
 
@@ -1206,7 +1293,12 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setCRLCb
     ret = wolfSSL_SetCRL_Cb((WOLFSSL*)ssl, NativeMissingCRLCallback);
 
     return ret;
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
+
+#ifdef HAVE_CRL
 
 void NativeMissingCRLCallback(const char* url)
 {
@@ -1287,6 +1379,8 @@ void NativeMissingCRLCallback(const char* url)
     }
 }
 
+#endif /* HAVE_CRL */
+
 JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_cipherGetName
   (JNIEnv* jenv, jclass jcl, jlong ssl)
 {
@@ -1320,10 +1414,12 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_cipherGetName
 JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getMacSecret
   (JNIEnv* jenv, jobject jcl, jlong ssl, jint verify)
 {
+    jclass excClass;
+#ifdef ATOMIC_USER
     int macLength;
     jbyteArray retSecret;
-    jclass excClass;
     const unsigned char* secret;
+#endif
 
     /* find exception class */
     excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
@@ -1332,6 +1428,8 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getMacSecret
         (*jenv)->ExceptionClear(jenv);
         return NULL;
     }
+
+#ifdef ATOMIC_USER
 
     if (!ssl) {
         (*jenv)->ThrowNew(jenv, excClass,
@@ -1368,15 +1466,22 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getMacSecret
     } else {
         return NULL;
     }
+#else
+    (*jenv)->ThrowNew(jenv, excClass,
+        "wolfSSL not compiled with ATOMIC_USER");
+    return NULL;
+#endif
 }
 
 JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getClientWriteKey
   (JNIEnv* jenv, jobject jcl, jlong ssl)
 {
+    jclass excClass;
+#ifdef ATOMIC_USER
     int keyLength;
     jbyteArray retKey;
-    jclass excClass;
     const unsigned char* key;
+#endif
 
     /* find exception class */
     excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
@@ -1385,6 +1490,8 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getClientWriteKey
         (*jenv)->ExceptionClear(jenv);
         return NULL;
     }
+
+#ifdef ATOMIC_USER
 
     if (!ssl) {
         (*jenv)->ThrowNew(jenv, excClass,
@@ -1421,15 +1528,22 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getClientWriteKey
     } else {
         return NULL;
     }
+#else
+    (*jenv)->ThrowNew(jenv, excClass,
+        "wolfSSL not compiled with ATOMIC_USER");
+    return NULL;
+#endif
 }
 
 JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getClientWriteIV
   (JNIEnv* jenv, jobject jcl, jlong ssl)
 {
+    jclass excClass;
+#ifdef ATOMIC_USER
     jbyteArray retIV;
     const unsigned char* iv;
     int ivLength;
-    jclass excClass;
+#endif
 
     /* find exception class */
     excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
@@ -1438,6 +1552,8 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getClientWriteIV
         (*jenv)->ExceptionClear(jenv);
         return NULL;
     }
+
+#ifdef ATOMIC_USER
 
     if (!ssl) {
         (*jenv)->ThrowNew(jenv, excClass,
@@ -1474,15 +1590,22 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getClientWriteIV
     } else {
         return NULL;
     }
+#else
+    (*jenv)->ThrowNew(jenv, excClass,
+        "wolfSSL not compiled with ATOMIC_USER");
+    return NULL;
+#endif
 }
 
 JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getServerWriteKey
   (JNIEnv* jenv, jobject jcl, jlong ssl)
 {
+    jclass excClass;
+#ifdef ATOMIC_USER
     jbyteArray retKey;
     const unsigned char* key;
     int keyLength;
-    jclass excClass;
+#endif
 
     /* find exception class */
     excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
@@ -1491,6 +1614,8 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getServerWriteKey
         (*jenv)->ExceptionClear(jenv);
         return NULL;
     }
+
+#ifdef ATOMIC_USER
 
     if (!ssl) {
         (*jenv)->ThrowNew(jenv, excClass,
@@ -1527,15 +1652,22 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getServerWriteKey
     } else {
         return NULL;
     }
+#else
+    (*jenv)->ThrowNew(jenv, excClass,
+        "wolfSSL not compiled with ATOMIC_USER");
+    return NULL;
+#endif
 }
 
 JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getServerWriteIV
   (JNIEnv* jenv, jobject jcl, jlong ssl)
 {
+    jclass excClass;
+#ifdef ATOMIC_USER
     jbyteArray retIV;
     const unsigned char* iv;
     int ivLength;
-    jclass excClass;
+#endif
 
     /* find exception class */
     excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
@@ -1544,6 +1676,8 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getServerWriteIV
         (*jenv)->ExceptionClear(jenv);
         return NULL;
     }
+
+#ifdef ATOMIC_USER
 
     if (!ssl) {
         (*jenv)->ThrowNew(jenv, excClass,
@@ -1580,55 +1714,88 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getServerWriteIV
     } else {
         return NULL;
     }
+#else
+    (*jenv)->ThrowNew(jenv, excClass,
+        "wolfSSL not compiled with ATOMIC_USER");
+    return NULL;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getKeySize
   (JNIEnv* jenv, jobject jcl, jlong ssl)
 {
+#ifdef ATOMIC_USER
     /* wolfSSL checks ssl for NULL */
     return wolfSSL_GetKeySize((WOLFSSL*)ssl);
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getSide
   (JNIEnv* jenv, jobject jcl, jlong ssl)
 {
+#ifdef ATOMIC_USER
     /* wolfSSL checks ssl for NULL */
     return wolfSSL_GetSide((WOLFSSL*)ssl);
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_isTLSv1_11
   (JNIEnv* jenv, jobject jcl, jlong ssl)
 {
+#ifdef ATOMIC_USER
     /* wolfSSL checks ssl for NULL */
     return wolfSSL_IsTLSv1_1((WOLFSSL*)ssl);
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getBulkCipher
   (JNIEnv* jenv, jobject jcl, jlong ssl)
 {
+#ifdef ATOMIC_USER
     /* wolfSSL checks ssl for NULL */
     return wolfSSL_GetBulkCipher((WOLFSSL*)ssl);
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getCipherBlockSize
   (JNIEnv* jenv, jobject jcl, jlong ssl)
 {
+#ifdef ATOMIC_USER
     /* wolfSSL checks ssl for NULL */
     return wolfSSL_GetCipherBlockSize((WOLFSSL*)ssl);
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getAeadMacSize
   (JNIEnv* jenv, jobject jcl, jlong ssl)
 {
+#ifdef ATOMIC_USER
     /* wolfSSL checks ssl for NULL */
     return wolfSSL_GetAeadMacSize((WOLFSSL*)ssl);
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getHmacSize
   (JNIEnv* jenv, jobject jcl, jlong ssl)
 {
+#ifdef ATOMIC_USER
     /* wolfSSL checks ssl for NULL */
     return wolfSSL_GetHmacSize((WOLFSSL*)ssl);
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getHmacType
@@ -1641,8 +1808,12 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getHmacType
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getCipherType
   (JNIEnv* jenv, jobject jcl, jlong ssl)
 {
+#ifdef ATOMIC_USER
     /* wolfSSL checks ssl for NULL */
     return wolfSSL_GetCipherType((WOLFSSL*)ssl);
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setTlsHmacInner
@@ -1684,11 +1855,13 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setTlsHmacInner
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSignCtx
   (JNIEnv* jenv, jobject jcl, jlong ssl)
 {
-    jclass         sslClass;
     jclass         excClass;
+#if defined(HAVE_PK_CALLBACKS) && defined(HAVE_ECC)
+    jclass         sslClass;
 
     void*          eccSignCtx;
     internCtx*     myCtx;
+#endif
 
     /* find exception class in case we need it */
     excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
@@ -1697,6 +1870,8 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSignCtx
         (*jenv)->ExceptionClear(jenv);
         return;
     }
+
+#if defined(HAVE_PK_CALLBACKS) && defined(HAVE_ECC)
 
     if (!ssl) {
         (*jenv)->ThrowNew(jenv, excClass,
@@ -1745,16 +1920,23 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSignCtx
     }
 
     wolfSSL_SetEccSignCtx((WOLFSSL*) ssl, myCtx);
+#else
+    (*jenv)->ThrowNew(jenv, excClass,
+        "wolfSSL not compiled with PK Callbacks and/or ECC");
+    return;
+#endif
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccVerifyCtx
   (JNIEnv* jenv, jobject jcl, jlong ssl)
 {
-    jclass         sslClass;
     jclass         excClass;
+#if defined(HAVE_PK_CALLBACKS) && defined(HAVE_ECC)
+    jclass         sslClass;
 
     void*          eccVerifyCtx;
     internCtx*     myCtx;
+#endif
 
     /* find exception class in case we need it */
     excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
@@ -1763,6 +1945,8 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccVerifyCtx
         (*jenv)->ExceptionClear(jenv);
         return;
     }
+
+#if defined(HAVE_PK_CALLBACKS) && defined(HAVE_ECC)
 
     if (!ssl) {
         (*jenv)->ThrowNew(jenv, excClass,
@@ -1811,16 +1995,23 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccVerifyCtx
     }
 
     wolfSSL_SetEccVerifyCtx((WOLFSSL*) ssl, myCtx);
+#else
+    (*jenv)->ThrowNew(jenv, excClass,
+        "wolfSSL not compiled with PK Callbacks and/or ECC");
+    return;
+#endif
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaSignCtx
   (JNIEnv* jenv, jobject jcl, jlong ssl)
 {
-    jclass         sslClass;
     jclass         excClass;
+#if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
+    jclass         sslClass;
 
     void*          rsaSignCtx;
     internCtx*     myCtx;
+#endif
 
     /* find exception class in case we need it */
     excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
@@ -1829,6 +2020,8 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaSignCtx
         (*jenv)->ExceptionClear(jenv);
         return;
     }
+
+#if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
 
     if (!ssl) {
         (*jenv)->ThrowNew(jenv, excClass,
@@ -1877,16 +2070,23 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaSignCtx
     }
 
     wolfSSL_SetRsaSignCtx((WOLFSSL*) ssl, myCtx);
+#else
+    (*jenv)->ThrowNew(jenv, excClass,
+        "wolfSSL not compiled with PK Callbacks and/or RSA support");
+    return;
+#endif
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaVerifyCtx
   (JNIEnv* jenv, jobject jcl, jlong ssl)
 {
-    jclass         sslClass;
     jclass         excClass;
+#if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
+    jclass         sslClass;
 
     void*          rsaVerifyCtx;
     internCtx*     myCtx;
+#endif
 
     /* find exception class in case we need it */
     excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
@@ -1895,6 +2095,8 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaVerifyCtx
         (*jenv)->ExceptionClear(jenv);
         return;
     }
+
+#if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
 
     if (!ssl) {
         (*jenv)->ThrowNew(jenv, excClass,
@@ -1943,16 +2145,23 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaVerifyCtx
     }
 
     wolfSSL_SetRsaVerifyCtx((WOLFSSL*) ssl, myCtx);
+#else
+    (*jenv)->ThrowNew(jenv, excClass,
+        "wolfSSL not compiled with PK Callbacks and/or RSA support");
+    return;
+#endif
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaEncCtx
   (JNIEnv* jenv, jobject jcl, jlong ssl)
 {
-    jclass         sslClass;
     jclass         excClass;
+#if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
+    jclass         sslClass;
 
     void*          rsaEncCtx;
     internCtx*     myCtx;
+#endif
 
     /* find exception class in case we need it */
     excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
@@ -1961,6 +2170,8 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaEncCtx
         (*jenv)->ExceptionClear(jenv);
         return;
     }
+
+#if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
 
     if (!ssl) {
         (*jenv)->ThrowNew(jenv, excClass,
@@ -2009,16 +2220,23 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaEncCtx
     }
 
     wolfSSL_SetRsaEncCtx((WOLFSSL*) ssl, myCtx);
+#else
+    (*jenv)->ThrowNew(jenv, excClass,
+        "wolfSSL not compiled with PK Callbacks and/or RSA support");
+    return;
+#endif
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaDecCtx
   (JNIEnv* jenv, jobject jcl, jlong ssl)
 {
-    jclass         sslClass;
     jclass         excClass;
+#if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
+    jclass         sslClass;
 
     void*          rsaDecCtx;
     internCtx*     myCtx;
+#endif
 
     /* find exception class in case we need it */
     excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
@@ -2027,6 +2245,8 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaDecCtx
         (*jenv)->ExceptionClear(jenv);
         return;
     }
+
+#if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
 
     if (!ssl) {
         (*jenv)->ThrowNew(jenv, excClass,
@@ -2075,6 +2295,11 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaDecCtx
     }
 
     wolfSSL_SetRsaDecCtx((WOLFSSL*) ssl, myCtx);
+#else
+    (*jenv)->ThrowNew(jenv, excClass,
+        "wolfSSL not compiled with PK Callbacks and/or RSA support");
+    return;
+#endif
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setPskClientCb
@@ -2089,6 +2314,8 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setPskClientCb
         return;
     }
 
+#ifndef NO_PSK
+
     if (ssl) {
         /* set PSK client callback */
         wolfSSL_set_psk_client_callback((WOLFSSL*)ssl, NativePskClientCb);
@@ -2098,6 +2325,12 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setPskClientCb
                 "NativePskClientCb");
         return;
     }
+
+#else
+    (*jenv)->ThrowNew(jenv, excClass,
+        "wolfSSL not compiled with PSK support");
+    return;
+#endif
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setPskServerCb
@@ -2112,6 +2345,8 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setPskServerCb
         return;
     }
 
+#ifndef NO_PSK
+
     if (ssl) {
         /* set PSK server callback */
         wolfSSL_set_psk_server_callback((WOLFSSL*)ssl, NativePskServerCb);
@@ -2121,31 +2356,46 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setPskServerCb
                 "NativePskServerCb");
         return;
     }
+
+#else
+    (*jenv)->ThrowNew(jenv, excClass,
+        "wolfSSL not compiled with PSK support");
+    return;
+#endif
 }
 
 JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_getPskIdentityHint
   (JNIEnv* jenv, jobject obj, jlong ssl)
 {
+#ifndef NO_PSK
     if (!jenv || !ssl)
         return NULL;
 
     return (*jenv)->NewStringUTF(jenv,
             wolfSSL_get_psk_identity_hint((WOLFSSL*)ssl));
+#else
+    return NULL;
+#endif
 }
 
 JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_getPskIdentity
   (JNIEnv* jenv, jobject obj, jlong ssl)
 {
+#ifndef NO_PSK
     if (!jenv || !ssl)
         return NULL;
 
     return (*jenv)->NewStringUTF(jenv,
             wolfSSL_get_psk_identity((WOLFSSL*)ssl));
+#else
+    return NULL;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_usePskIdentityHint
   (JNIEnv* jenv, jobject obj, jlong ssl, jstring hint)
 {
+#ifndef NO_PSK
     jint ret;
     const char* nativeHint;
 
@@ -2159,5 +2409,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_usePskIdentityHint
     (*jenv)->ReleaseStringUTFChars(jenv, hint, nativeHint);
 
     return ret;
+#else
+    return NOT_COMPILED_IN;
+#endif
 }
 

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -587,12 +587,57 @@ public class WolfSSL {
      */
     public static native int getHmacMaxSize();
 
+    /* ------------------------- isEnabled methods -------------------------- */
+
     /**
      * Checks if CRL support is enabled in wolfSSL native library.
      *
      * @return 1 if enabled, 0 if not compiled in
      */
     public static native int isEnabledCRL();
+
+    /**
+     * Checks if CRL Monitor support is enabled in wolfSSL native library.
+     *
+     * @return 1 if enabled, 0 if not compiled in
+     */
+    public static native int isEnabledCRLMonitor();
+
+    /**
+     * Checks if OCSP support is enabled in wolfSSL native library.
+     *
+     * @return 1 if enabled, 0 if not compiled in
+     */
+    public static native int isEnabledOCSP();
+
+    /**
+     * Checks if PSK support is enabled in wolfSSL native library.
+     *
+     * @return 1 if enabled, 0 if not compiled in
+     */
+    public static native int isEnabledPSK();
+
+    /**
+     * Checks if DTLS support is enabled in wolfSSL native library.
+     *
+     * @return 1 if enabled, 0 if not compiled in
+     */
+    public static native int isEnabledDTLS();
+
+    /**
+     * Checks if Atomic User support is enabled in wolfSSL native library.
+     *
+     * @return 1 if enabled, 0 if not compiled in
+     */
+    public static native int isEnabledAtomicUser();
+
+    /**
+     * Checks if Public Key Callback support is enabled in wolfSSL
+     * native library.
+     *
+     * @return 1 if enabled, 0 if not compiled in
+     */
+    public static native int isEnabledPKCallbacks();
 
 } /* end WolfSSL */
 

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -587,5 +587,12 @@ public class WolfSSL {
      */
     public static native int getHmacMaxSize();
 
+    /**
+     * Checks if CRL support is enabled in wolfSSL native library.
+     *
+     * @return 1 if enabled, 0 if not compiled in
+     */
+    public static native int isEnabledCRL();
+
 } /* end WolfSSL */
 

--- a/src/test/com/wolfssl/WolfSSLContextTest.java
+++ b/src/test/com/wolfssl/WolfSSLContextTest.java
@@ -251,8 +251,11 @@ public class WolfSSLContextTest {
             TestPskClientCb pskClientCb = new TestPskClientCb();
             ctx.setPskClientCb(pskClientCb);
         } catch (Exception e) {
-            System.out.println("\t\t... failed");
-            e.printStackTrace();
+            if (!e.getMessage().equals("wolfSSL not compiled with PSK " +
+                        "support")) {
+                System.out.println("\t\t... failed");
+                e.printStackTrace();
+            }
         }
         System.out.println("\t\t... passed");
     }
@@ -283,8 +286,11 @@ public class WolfSSLContextTest {
             TestPskServerCb pskServerCb = new TestPskServerCb();
             ctx.setPskServerCb(pskServerCb);
         } catch (Exception e) {
-            System.out.println("\t\t... failed");
-            e.printStackTrace();
+            if (!e.getMessage().equals("wolfSSL not compiled with PSK " +
+                        "support")) {
+                System.out.println("\t\t... failed");
+                e.printStackTrace();
+            }
         }
         System.out.println("\t\t... passed");
     }
@@ -293,7 +299,8 @@ public class WolfSSLContextTest {
         System.out.print("\tusePskIdentityHint()");
         try {
             int ret = ctx.usePskIdentityHint("wolfssl hint");
-            if (ret != WolfSSL.SSL_SUCCESS) {
+            if (ret != WolfSSL.SSL_SUCCESS &&
+                ret != WolfSSL.NOT_COMPILED_IN) {
                 System.out.println("\t\t... failed");
                 fail("usePskIdentityHint failed");
             }

--- a/src/test/com/wolfssl/WolfSSLSessionTest.java
+++ b/src/test/com/wolfssl/WolfSSLSessionTest.java
@@ -132,7 +132,7 @@ public class WolfSSLSessionTest {
                 fail(name + " failed");
             }
 
-            if (result != cond)
+            if ((result != cond) && (result != WolfSSL.NOT_COMPILED_IN))
             {
                 if (func.equals("useCertificateFile")) {
                     System.out.println("\t\t... failed");
@@ -182,7 +182,7 @@ public class WolfSSLSessionTest {
         try {
 
             result = ssl.usePrivateKeyFile(filePath, type);
-            if (result != cond)
+            if ((result != cond) && (result != WolfSSL.NOT_COMPILED_IN))
             {
                 System.out.println("\t\t... failed");
                 fail(name + " failed");
@@ -227,8 +227,11 @@ public class WolfSSLSessionTest {
             TestPskClientCb pskClientCb = new TestPskClientCb();
             ssl.setPskClientCb(pskClientCb);
         } catch (Exception e) {
-            System.out.println("\t\t... failed");
-            e.printStackTrace();
+            if (!e.getMessage().equals("wolfSSL not compiled with PSK " +
+                        "support")) {
+                System.out.println("\t\t... failed");
+                e.printStackTrace();
+            }
         }
         System.out.println("\t\t... passed");
     }
@@ -259,8 +262,11 @@ public class WolfSSLSessionTest {
             TestPskServerCb pskServerCb = new TestPskServerCb();
             ssl.setPskServerCb(pskServerCb);
         } catch (Exception e) {
-            System.out.println("\t\t... failed");
-            e.printStackTrace();
+            if (!e.getMessage().equals("wolfSSL not compiled with PSK " +
+                        "support")) {
+                System.out.println("\t\t... failed");
+                e.printStackTrace();
+            }
         }
         System.out.println("\t\t... passed");
     }
@@ -269,7 +275,8 @@ public class WolfSSLSessionTest {
         System.out.print("\tusePskIdentityHint()");
         try {
             int ret = ssl.usePskIdentityHint("wolfssl hint");
-            if (ret != WolfSSL.SSL_SUCCESS) {
+            if (ret != WolfSSL.SSL_SUCCESS &&
+                ret != WolfSSL.NOT_COMPILED_IN) {
                 System.out.println("\t\t... failed");
                 fail("usePskIdentityHint failed");
             }
@@ -284,7 +291,7 @@ public class WolfSSLSessionTest {
         System.out.print("\tgetPskIdentityHint()");
         try {
             String hint = ssl.getPskIdentityHint();
-            if (!hint.equals("wolfssl hint")) {
+            if (hint != null && !hint.equals("wolfssl hint")) {
                 System.out.println("\t\t... failed");
                 fail("getPskIdentityHint failed");
             }


### PR DESCRIPTION
This pull request removes dependencies on wolfSSL native features that were requirements before (including WOLFSSL_DTLS, PERSIST_SESSION_CACHE, KEEP_PEER_CERT, SESSION_CERTS, HAVE_CRL, HAVE_OCSP, ATOMIC_USER, HAVE_PK_CALLBACKS)

It also adds methods to check if features are enabled in the native wolfSSL library.  These are used by the example client/server.