### PR TITLE
remove try/catch block from finalize methods

### DIFF
--- a/src/java/com/wolfssl/WolfSSLContext.java
+++ b/src/java/com/wolfssl/WolfSSLContext.java
@@ -1544,17 +1544,12 @@ public class WolfSSLContext {
     @Override
     protected void finalize() throws Throwable
     {
-        try {
-            if (this.active == true) {
-                /* free resources, set state */
-                this.free();
-                this.active = false;
-            }
-        } catch (Throwable t) {
-            throw t;
-        } finally {
-            super.finalize();
+        if (this.active == true) {
+            /* free resources, set state */
+            this.free();
+            this.active = false;
         }
+        super.finalize();
     }
 
 } /* end WolfSSLContext */

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -2109,17 +2109,12 @@ public class WolfSSLSession {
     @Override
     protected void finalize() throws Throwable
     {
-        try {
-            if (this.active == true) {
-                /* free resources, set state */
-                this.freeSSL();
-                this.active = false;
-            }
-        } catch (Throwable t) {
-            throw t;
-        } finally {
-            super.finalize();
+        if (this.active == true) {
+            /* free resources, set state */
+            this.freeSSL();
+            this.active = false;
         }
+        super.finalize();
     }
 
 } /* end WolfSSLSession */


### PR DESCRIPTION
The try/catch/finalize block is not necessary in these two methods, as the finalize() method already throws "Throwable".