### PR TITLE
Fix Atomic User callback registration in examples

### DIFF
--- a/examples/Client.java
+++ b/examples/Client.java
@@ -334,6 +334,14 @@ public class Client {
                 System.out.println("Registered I/O callbacks");
             }
 
+            /* register atomic record layer callbacks, ctx setup later */
+            if (useAtomic == 1) {
+                MyMacEncryptCallback mecb = new MyMacEncryptCallback();
+                MyDecryptVerifyCallback dvcb = new MyDecryptVerifyCallback();
+                sslCtx.setMacEncryptCb(mecb);
+                sslCtx.setDecryptVerifyCb(dvcb);
+            }
+
             if (benchmark != 0) {
                 int times = benchmark;
                 int i = 0;
@@ -436,13 +444,9 @@ public class Client {
             }
 
             if (useAtomic == 1) {
-                /* register atomic record layer callbacks */
-                MyMacEncryptCallback mecb = new MyMacEncryptCallback();
-                MyDecryptVerifyCallback dvcb = new MyDecryptVerifyCallback();
+                /* register atomic record layer callback user contexts */
                 MyAtomicEncCtx encCtx = new MyAtomicEncCtx();
                 MyAtomicDecCtx decCtx = new MyAtomicDecCtx();
-                sslCtx.setMacEncryptCb(mecb);
-                sslCtx.setDecryptVerifyCb(dvcb);
                 ssl.setMacEncryptCtx(encCtx);
                 ssl.setDecryptVerifyCtx(decCtx);
             }

--- a/examples/MyDecryptVerifyCallback.java
+++ b/examples/MyDecryptVerifyCallback.java
@@ -41,6 +41,7 @@ class MyDecryptVerifyCallback implements WolfSSLDecryptVerifyCallback
         int ivExtra  = 0;
         long pad     = 0;
         long padByte = 0;
+        String hmacString;
         String tlsStr   = "TLS";
         byte[] keyBytes = null;
         byte[] ivBytes  = null;
@@ -113,18 +114,32 @@ class MyDecryptVerifyCallback implements WolfSSLDecryptVerifyCallback
 
             ssl.setTlsHmacInner(myInner, macInSz, macContent, macVerify);
             int hmacType = ssl.getHmacType();
-            if (hmacType != WolfSSL.SHA) {
-                System.out.println("MyMacEncryptCallback example only "
-                        + "supports SHA1");
-                return -1;
+
+            switch (hmacType) {
+                case WolfSSL.SHA:
+                    hmacString = "HmacSHA1";
+                    break;
+                case WolfSSL.SHA256:
+                    hmacString = "HmacSHA256";
+                    break;
+                case WolfSSL.SHA384:
+                    hmacString = "HmacSHA384";
+                    break;
+                case WolfSSL.SHA512:
+                    hmacString = "HmacSHA512";
+                    break;
+                default:
+                    System.out.println("Unsupported HMAC hash type in " +
+                            "MyDecryptVerifyCallback");
+                    return -1;
             }
 
             /* get Hmac SHA-1 key */
             SecretKeySpec signingKey = new SecretKeySpec(
-                    ssl.getMacSecret(macVerify), "HmacSHA1");
+                    ssl.getMacSecret(macVerify), hmacString);
 
             /* get Hmac SHA-1 instance and initialize with signing key */
-            Mac mac = Mac.getInstance("HmacSHA1");
+            Mac mac = Mac.getInstance(hmacString);
             mac.init(signingKey);
 
             /* get tmp array for encrypted MAC */

--- a/examples/Server.java
+++ b/examples/Server.java
@@ -353,6 +353,15 @@ public class Server {
                 }
             }
 
+            /* register atomic record layer callbacks, ctx setup later */
+            if (useAtomic == 1) {
+                MyMacEncryptCallback mecb = new MyMacEncryptCallback();
+                MyDecryptVerifyCallback dvcb =
+                    new MyDecryptVerifyCallback();
+                sslCtx.setMacEncryptCb(mecb);
+                sslCtx.setDecryptVerifyCb(dvcb);
+            }
+
             /* create server socket, later if DTLS */
             if (doDTLS == 0) {
                 serverSocket = new ServerSocket(port);
@@ -467,14 +476,9 @@ public class Server {
                 }
 
                 if (useAtomic == 1) {
-                    /* register atomic record layer callbacks */
-                    MyMacEncryptCallback mecb = new MyMacEncryptCallback();
-                    MyDecryptVerifyCallback dvcb =
-                        new MyDecryptVerifyCallback();
+                    /* register atomic record layer callback user contexts */
                     MyAtomicEncCtx encCtx = new MyAtomicEncCtx();
                     MyAtomicDecCtx decCtx = new MyAtomicDecCtx();
-                    sslCtx.setMacEncryptCb(mecb);
-                    sslCtx.setDecryptVerifyCb(dvcb);
                     ssl.setMacEncryptCtx(encCtx);
                     ssl.setDecryptVerifyCtx(decCtx);
                 }

--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -60,6 +60,95 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSL_nativeFree
         free((void*)ptr);
 }
 
+/* functions to return BulkCipherAlgorithm enum values from ./wolfssl/ssl.h  */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumNULL
+  (JNIEnv* jenv, jclass jcl)
+{
+    return wolfssl_cipher_null;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumRC4
+  (JNIEnv* jenv, jclass jcl)
+{
+    return wolfssl_rc4;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumRC2
+  (JNIEnv* jenv, jclass jcl)
+{
+    return wolfssl_rc2;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumDES
+  (JNIEnv* jenv, jclass jcl)
+{
+    return wolfssl_des;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnum3DES
+  (JNIEnv* jenv, jclass jcl)
+{
+    return wolfssl_triple_des;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumDES40
+  (JNIEnv* jenv, jclass jcl)
+{
+    return wolfssl_des40;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumIDEA
+  (JNIEnv* jenv, jclass jcl)
+{
+#ifdef HAVE_IDEA
+    return wolfssl_idea;
+#else
+    return NOT_COMPILED_IN;
+#endif
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumAES
+  (JNIEnv* jenv, jclass jcl)
+{
+    return wolfssl_aes;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumAESGCM
+  (JNIEnv* jenv, jclass jcl)
+{
+    return wolfssl_aes_gcm;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumAESCCM
+  (JNIEnv* jenv, jclass jcl)
+{
+    return wolfssl_aes_ccm;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumCHACHA
+  (JNIEnv* jenv, jclass jcl)
+{
+    return wolfssl_chacha;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumCAMELLIA
+  (JNIEnv* jenv, jclass jcl)
+{
+    return wolfssl_camellia;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumHC128
+  (JNIEnv* jenv, jclass jcl)
+{
+    return wolfssl_hc128;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumRABBIT
+  (JNIEnv* jenv, jclass jcl)
+{
+    return wolfssl_rabbit;
+}
+
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_SSLv3_1ServerMethod
   (JNIEnv* jenv, jclass jcl)
 {

--- a/native/com_wolfssl_WolfSSL.h
+++ b/native/com_wolfssl_WolfSSL.h
@@ -105,30 +105,6 @@ extern "C" {
 #define com_wolfssl_WolfSSL_WOLFSSL_AEAD_TYPE 4L
 #undef com_wolfssl_WolfSSL_WOLFSSL_TLS_HMAC_INNER_SZ
 #define com_wolfssl_WolfSSL_WOLFSSL_TLS_HMAC_INNER_SZ 13L
-#undef com_wolfssl_WolfSSL_wolfssl_cipher_null
-#define com_wolfssl_WolfSSL_wolfssl_cipher_null 0L
-#undef com_wolfssl_WolfSSL_wolfssl_rc4
-#define com_wolfssl_WolfSSL_wolfssl_rc4 1L
-#undef com_wolfssl_WolfSSL_wolfssl_rc2
-#define com_wolfssl_WolfSSL_wolfssl_rc2 2L
-#undef com_wolfssl_WolfSSL_wolfssl_des
-#define com_wolfssl_WolfSSL_wolfssl_des 3L
-#undef com_wolfssl_WolfSSL_wolfssl_triple_des
-#define com_wolfssl_WolfSSL_wolfssl_triple_des 4L
-#undef com_wolfssl_WolfSSL_wolfssl_des40
-#define com_wolfssl_WolfSSL_wolfssl_des40 5L
-#undef com_wolfssl_WolfSSL_wolfssl_idea
-#define com_wolfssl_WolfSSL_wolfssl_idea 6L
-#undef com_wolfssl_WolfSSL_wolfssl_aes
-#define com_wolfssl_WolfSSL_wolfssl_aes 7L
-#undef com_wolfssl_WolfSSL_wolfssl_aes_gcm
-#define com_wolfssl_WolfSSL_wolfssl_aes_gcm 8L
-#undef com_wolfssl_WolfSSL_wolfssl_aes_ccm
-#define com_wolfssl_WolfSSL_wolfssl_aes_ccm 9L
-#undef com_wolfssl_WolfSSL_wolfssl_hc128
-#define com_wolfssl_WolfSSL_wolfssl_hc128 10L
-#undef com_wolfssl_WolfSSL_wolfssl_rabbit
-#define com_wolfssl_WolfSSL_wolfssl_rabbit 11L
 #undef com_wolfssl_WolfSSL_GEN_COOKIE_E
 #define com_wolfssl_WolfSSL_GEN_COOKIE_E -277L
 #undef com_wolfssl_WolfSSL_SSL_SENT_SHUTDOWN
@@ -198,6 +174,118 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_init
  */
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSL_nativeFree
   (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getBulkCipherAlgorithmEnumNULL
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumNULL
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getBulkCipherAlgorithmEnumRC4
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumRC4
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getBulkCipherAlgorithmEnumRC2
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumRC2
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getBulkCipherAlgorithmEnumDES
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumDES
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getBulkCipherAlgorithmEnum3DES
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnum3DES
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getBulkCipherAlgorithmEnumDES40
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumDES40
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getBulkCipherAlgorithmEnumIDEA
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumIDEA
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getBulkCipherAlgorithmEnumAES
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumAES
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getBulkCipherAlgorithmEnumAESGCM
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumAESGCM
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getBulkCipherAlgorithmEnumAESCCM
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumAESCCM
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getBulkCipherAlgorithmEnumCHACHA
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumCHACHA
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getBulkCipherAlgorithmEnumCAMELLIA
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumCAMELLIA
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getBulkCipherAlgorithmEnumHC128
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumHC128
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getBulkCipherAlgorithmEnumRABBIT
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumRABBIT
+  (JNIEnv *, jclass);
 
 /*
  * Class:     com_wolfssl_WolfSSL

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -136,18 +136,18 @@ public class WolfSSL {
     public final static int WOLFSSL_TLS_HMAC_INNER_SZ = 13;
 
     /* GetBulkCipher enum, pulled in from ssl.h for Atomic Record layer */
-    public final static int wolfssl_cipher_null = 0;
-    public final static int wolfssl_rc4         = 1;
-    public final static int wolfssl_rc2         = 2;
-    public final static int wolfssl_des         = 3;
-    public final static int wolfssl_triple_des  = 4;
-    public final static int wolfssl_des40       = 5;
-    public final static int wolfssl_idea        = 6;
-    public final static int wolfssl_aes         = 7;
-    public final static int wolfssl_aes_gcm     = 8;
-    public final static int wolfssl_aes_ccm     = 9;
-    public final static int wolfssl_hc128       = 10;
-    public final static int wolfssl_rabbit      = 11;
+    public static int wolfssl_cipher_null;
+    public static int wolfssl_rc4;
+    public static int wolfssl_rc2;
+    public static int wolfssl_des;
+    public static int wolfssl_triple_des;
+    public static int wolfssl_des40;
+    public static int wolfssl_idea;
+    public static int wolfssl_aes;
+    public static int wolfssl_aes_gcm;
+    public static int wolfssl_aes_ccm;
+    public static int wolfssl_hc128;
+    public static int wolfssl_rabbit;
 
     /* wolfSSL error codes, pulled in from wolfssl/error.h wolfSSL_ErrorCodes */
     public final static int GEN_COOKIE_E    =   -277;
@@ -224,6 +224,20 @@ public class WolfSSL {
             throw new WolfSSLException("Failed to initialize wolfSSL library: "
                     + ret);
         }
+
+        /* initialize enum values */
+        wolfssl_aes         = getBulkCipherAlgorithmEnumAES();
+        wolfssl_cipher_null = getBulkCipherAlgorithmEnumNULL();
+        wolfssl_rc4         = getBulkCipherAlgorithmEnumRC4();
+        wolfssl_rc2         = getBulkCipherAlgorithmEnumRC2();
+        wolfssl_des         = getBulkCipherAlgorithmEnumDES();
+        wolfssl_triple_des  = getBulkCipherAlgorithmEnumDES();
+        wolfssl_des40       = getBulkCipherAlgorithmEnumDES40();
+        wolfssl_idea        = getBulkCipherAlgorithmEnumIDEA();
+        wolfssl_aes_gcm     = getBulkCipherAlgorithmEnumAESGCM();
+        wolfssl_aes_ccm     = getBulkCipherAlgorithmEnumAESCCM();
+        wolfssl_hc128       = getBulkCipherAlgorithmEnumHC128();
+        wolfssl_rabbit      = getBulkCipherAlgorithmEnumRABBIT();
     }
 
     /* ------------------- private/protected methods -------------------- */
@@ -231,6 +245,21 @@ public class WolfSSL {
     private native int init();
 
     static native void nativeFree(long ptr);
+
+    static native int getBulkCipherAlgorithmEnumNULL();
+    static native int getBulkCipherAlgorithmEnumRC4();
+    static native int getBulkCipherAlgorithmEnumRC2();
+    static native int getBulkCipherAlgorithmEnumDES();
+    static native int getBulkCipherAlgorithmEnum3DES();
+    static native int getBulkCipherAlgorithmEnumDES40();
+    static native int getBulkCipherAlgorithmEnumIDEA();
+    static native int getBulkCipherAlgorithmEnumAES();
+    static native int getBulkCipherAlgorithmEnumAESGCM();
+    static native int getBulkCipherAlgorithmEnumAESCCM();
+    static native int getBulkCipherAlgorithmEnumCHACHA();
+    static native int getBulkCipherAlgorithmEnumCAMELLIA();
+    static native int getBulkCipherAlgorithmEnumHC128();
+    static native int getBulkCipherAlgorithmEnumRABBIT();
 
     /* ------------------------- Java methods --------------------------- */
 


### PR DESCRIPTION
This PR:

- Fixes the registration of atomic user callbacks in the example client and server
- Switches WolfSSL.java to get the BulkCipherAlgorithm enum values dynamically (since the native code enums can change due to ifdef configuration)
- Allows additional non-SHA1 Hmac types to be used in the atomic user callback examples.  They previously only supported HmacSHA1.