### PR TITLE
Prep for 1.4.0 Release

### DIFF
--- a/README
+++ b/README
@@ -12,7 +12,27 @@ when running java.sh. In this case, you should modify java.sh to match
 your environment.
 
 
-wolfSSL JNI Release 1.3.0 (12/04/2015)
+wolfSSL JNI Release 1.4.0 (11/16/2018)
+
+Release 1.4.0 has bug fixes and new features including:
+
+- Better support for conditional native wolfSSL feature dependencies
+- Adds methods for checking if native features are enabled
+- Optional method for loading native JNI library from a specific path
+- TLS 1.0 functions are compiled out unless WOLFSSL_ALLOW_TLSV10 is defined
+- Wrapper for native wolfCrypt ECC shared secret public key callback
+- Allow other HmacSHA* hash types to be used in Atomic User callback examples
+- Error string buffer size set to use WOLFSSL_MAX_ERROR_SZ
+- Fix for RSA doSign() output length
+- Fix for I/O, Atomic User, and Public Key callback registration in examples
+- Updated example key and certificate files
+
+The wolfSSL JNI Manual is available at:
+http://www.wolfssl.com/documentation/wolfSSL-JNI-Manual.pdf. For build
+instructions and more detailed comments, please check the manual.
+
+
+************ wolfSSL JNI Release 1.3.0 (12/04/2015)
 
 Release 1.3.0 has bug fixes and new features including:
 

--- a/examples/Client.java
+++ b/examples/Client.java
@@ -1,6 +1,6 @@
 /* Client.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/examples/MyAtomicDecCtx.java
+++ b/examples/MyAtomicDecCtx.java
@@ -1,6 +1,6 @@
 /* MyAtomicDecCtx.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/examples/MyAtomicEncCtx.java
+++ b/examples/MyAtomicEncCtx.java
@@ -1,6 +1,6 @@
 /* MyAtomicEncContext.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/examples/MyDecryptVerifyCallback.java
+++ b/examples/MyDecryptVerifyCallback.java
@@ -1,6 +1,6 @@
 /* MyDecryptVerifyCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/examples/MyEccSharedSecretCallback.java
+++ b/examples/MyEccSharedSecretCallback.java
@@ -1,6 +1,6 @@
 /* MyEccSharedSecretCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/examples/MyEccSharedSecretCtx.java
+++ b/examples/MyEccSharedSecretCtx.java
@@ -1,6 +1,6 @@
 /* MyEccSharedSecretCtx.java
  *
- * Copyright (C) 2006-2016 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/examples/MyEccSignCallback.java
+++ b/examples/MyEccSignCallback.java
@@ -1,6 +1,6 @@
 /* MyEccSignCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/examples/MyEccSignCtx.java
+++ b/examples/MyEccSignCtx.java
@@ -1,6 +1,6 @@
 /* MyEccSignCtx.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/examples/MyEccVerifyCallback.java
+++ b/examples/MyEccVerifyCallback.java
@@ -1,6 +1,6 @@
 /* MyEccVerifyCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/examples/MyEccVerifyCtx.java
+++ b/examples/MyEccVerifyCtx.java
@@ -1,6 +1,6 @@
 /* MyEccVerifyCtx.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/examples/MyGenCookieCallback.java
+++ b/examples/MyGenCookieCallback.java
@@ -1,6 +1,6 @@
 /* MyGenCookieCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/examples/MyGenCookieCtx.java
+++ b/examples/MyGenCookieCtx.java
@@ -1,6 +1,6 @@
 /* MyGenCookieCtx.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/examples/MyIOCtx.java
+++ b/examples/MyIOCtx.java
@@ -1,6 +1,6 @@
 /* MyIOCtx.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/examples/MyLoggingCallback.java
+++ b/examples/MyLoggingCallback.java
@@ -1,6 +1,6 @@
 /* MyLoggingCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/examples/MyMacEncryptCallback.java
+++ b/examples/MyMacEncryptCallback.java
@@ -1,6 +1,6 @@
 /* MyMacEncryptCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/examples/MyMissingCRLCallback.java
+++ b/examples/MyMissingCRLCallback.java
@@ -1,6 +1,6 @@
 /* MyMissingCRLCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/examples/MyPskClientCallback.java
+++ b/examples/MyPskClientCallback.java
@@ -1,6 +1,6 @@
 /* MyPskClientCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/examples/MyPskServerCallback.java
+++ b/examples/MyPskServerCallback.java
@@ -1,6 +1,6 @@
 /* MyPskServerCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/examples/MyRecvCallback.java
+++ b/examples/MyRecvCallback.java
@@ -1,6 +1,6 @@
 /* MyRecvCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/examples/MyRsaDecCallback.java
+++ b/examples/MyRsaDecCallback.java
@@ -1,6 +1,6 @@
 /* MyRsaDecCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/examples/MyRsaDecCtx.java
+++ b/examples/MyRsaDecCtx.java
@@ -1,6 +1,6 @@
 /* MyRsaDecCtx.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/examples/MyRsaEncCallback.java
+++ b/examples/MyRsaEncCallback.java
@@ -1,6 +1,6 @@
 /* MyRsaEncCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/examples/MyRsaEncCtx.java
+++ b/examples/MyRsaEncCtx.java
@@ -1,6 +1,6 @@
 /* MyRsaEncCtx.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/examples/MyRsaSignCallback.java
+++ b/examples/MyRsaSignCallback.java
@@ -1,6 +1,6 @@
 /* MyRsaSignCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/examples/MyRsaSignCtx.java
+++ b/examples/MyRsaSignCtx.java
@@ -1,6 +1,6 @@
 /* MyRsaSignCtx.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/examples/MyRsaVerifyCallback.java
+++ b/examples/MyRsaVerifyCallback.java
@@ -1,6 +1,6 @@
 /* MyRsaVerifyCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/examples/MyRsaVerifyCtx.java
+++ b/examples/MyRsaVerifyCtx.java
@@ -1,6 +1,6 @@
 /* MyRsaVerifyCtx.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/examples/MySendCallback.java
+++ b/examples/MySendCallback.java
@@ -1,6 +1,6 @@
 /* MySendCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/examples/Server.java
+++ b/examples/Server.java
@@ -1,6 +1,6 @@
 /* Server.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/examples/VerifyCallback.java
+++ b/examples/VerifyCallback.java
@@ -1,6 +1,6 @@
 /* VerifyCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/examples/certs/ca-cert.pem
+++ b/examples/certs/ca-cert.pem
@@ -1,13 +1,12 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number:
-            b7:b6:90:33:66:1b:6b:23
+        Serial Number: 9727763710660753659 (0x86fff58e10deb8fb)
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: C=US, ST=Montana, L=Bozeman, O=Sawtooth, OU=Consulting, CN=www.wolfssl.com/emailAddress=info@wolfssl.com
         Validity
-            Not Before: Aug 11 20:07:37 2016 GMT
-            Not After : May  8 20:07:37 2019 GMT
+            Not Before: Apr 13 15:23:09 2018 GMT
+            Not After : Jan  7 15:23:09 2021 GMT
         Subject: C=US, ST=Montana, L=Bozeman, O=Sawtooth, OU=Consulting, CN=www.wolfssl.com/emailAddress=info@wolfssl.com
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
@@ -38,32 +37,32 @@ Certificate:
             X509v3 Authority Key Identifier: 
                 keyid:27:8E:67:11:74:C3:26:1D:3F:ED:33:63:B3:A4:D8:1D:30:E5:E8:D5
                 DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
-                serial:B7:B6:90:33:66:1B:6B:23
+                serial:86:FF:F5:8E:10:DE:B8:FB
 
             X509v3 Basic Constraints: 
                 CA:TRUE
     Signature Algorithm: sha256WithRSAEncryption
-         0e:93:48:44:4a:72:96:60:71:25:82:a9:2c:ca:60:5b:f2:88:
-         3e:cf:11:74:5a:11:4a:dc:d9:d8:f6:58:2c:05:d3:56:d9:e9:
-         8f:37:ef:8e:3e:3b:ff:22:36:00:ca:d8:e2:96:3f:a7:d1:ed:
-         1f:de:7a:b0:d7:8f:36:bd:41:55:1e:d4:b9:86:3b:87:25:69:
-         35:60:48:d6:e4:5a:94:ce:a2:fa:70:38:36:c4:85:b4:4b:23:
-         fe:71:9e:2f:db:06:c7:b5:9c:21:f0:3e:7c:eb:91:f8:5c:09:
-         fd:84:43:a4:b3:4e:04:0c:22:31:71:6a:48:c8:ab:bb:e8:ce:
-         fa:67:15:1a:3a:82:98:43:33:b5:0e:1f:1e:89:f8:37:de:1b:
-         e6:b5:a0:f4:a2:8b:b7:1c:90:ba:98:6d:94:21:08:80:5d:f3:
-         bf:66:ad:c9:72:28:7a:6a:48:ee:cf:63:69:31:8c:c5:8e:66:
-         da:4b:78:65:e8:03:3a:4b:f8:cc:42:54:d3:52:5c:2d:04:ae:
-         26:87:e1:7e:40:cb:45:41:16:4b:6e:a3:2e:4a:76:bd:29:7f:
-         1c:53:37:06:ad:e9:5b:6a:d6:b7:4e:94:a2:7c:e8:ac:4e:a6:
-         50:3e:2b:32:9e:68:42:1b:e4:59:67:61:ea:c7:9a:51:9c:1c:
-         55:a3:77:76
+         9e:28:88:72:00:ca:e6:e7:97:ca:c1:f1:1f:9e:12:b2:b8:c7:
+         51:ea:28:e1:36:b5:2d:e6:2f:08:23:cb:a9:4a:87:25:c6:5d:
+         89:45:ea:f5:00:98:ac:76:fb:1b:af:f0:ce:64:9e:da:08:bf:
+         b6:eb:b4:b5:0c:a0:e7:f6:47:59:1c:61:cf:2e:0e:58:a4:82:
+         ac:0f:3f:ec:c4:ae:80:f7:b0:8a:1e:85:41:e8:ff:fe:fe:4f:
+         1a:24:d5:49:fa:fb:fe:5e:e5:d3:91:0e:4f:4e:0c:21:51:71:
+         83:04:6b:62:7b:4f:59:76:48:81:1e:b4:f7:04:47:8a:91:57:
+         a3:11:a9:f2:20:b4:78:33:62:3d:b0:5e:0d:f9:86:38:82:da:
+         a1:98:8d:19:06:87:21:39:b7:02:f7:da:7d:58:ba:52:15:d8:
+         3b:c9:7b:58:34:a0:c7:e2:7c:a9:83:13:e1:b6:ec:01:bf:52:
+         33:0b:c4:fe:43:d3:c6:a4:8e:2f:87:7f:7a:44:ea:ca:53:6c:
+         85:ed:65:76:73:31:03:4e:ea:bd:35:54:13:f3:64:87:6b:df:
+         34:dd:34:a1:88:3b:db:4d:af:1b:64:90:92:71:30:8e:c8:cc:
+         e5:60:24:af:31:16:39:33:91:50:f9:ab:68:42:74:7a:35:d9:
+         dd:c8:c4:52
 -----BEGIN CERTIFICATE-----
-MIIEqjCCA5KgAwIBAgIJALe2kDNmG2sjMA0GCSqGSIb3DQEBCwUAMIGUMQswCQYD
+MIIEqjCCA5KgAwIBAgIJAIb/9Y4Q3rj7MA0GCSqGSIb3DQEBCwUAMIGUMQswCQYD
 VQQGEwJVUzEQMA4GA1UECAwHTW9udGFuYTEQMA4GA1UEBwwHQm96ZW1hbjERMA8G
 A1UECgwIU2F3dG9vdGgxEzARBgNVBAsMCkNvbnN1bHRpbmcxGDAWBgNVBAMMD3d3
 dy53b2xmc3NsLmNvbTEfMB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbTAe
-Fw0xNjA4MTEyMDA3MzdaFw0xOTA1MDgyMDA3MzdaMIGUMQswCQYDVQQGEwJVUzEQ
+Fw0xODA0MTMxNTIzMDlaFw0yMTAxMDcxNTIzMDlaMIGUMQswCQYDVQQGEwJVUzEQ
 MA4GA1UECAwHTW9udGFuYTEQMA4GA1UEBwwHQm96ZW1hbjERMA8GA1UECgwIU2F3
 dG9vdGgxEzARBgNVBAsMCkNvbnN1bHRpbmcxGDAWBgNVBAMMD3d3dy53b2xmc3Ns
 LmNvbTEfMB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbTCCASIwDQYJKoZI
@@ -77,11 +76,11 @@ XDjNdyXvvYB1U5Q8PcpjW58VtdMdEy8Z0TzbdjrMuH3J5cLX2kBv2CHccxtCLVOc
 J45nEXTDJh0/7TNjs6TYHTDl6NWhgZqkgZcwgZQxCzAJBgNVBAYTAlVTMRAwDgYD
 VQQIDAdNb250YW5hMRAwDgYDVQQHDAdCb3plbWFuMREwDwYDVQQKDAhTYXd0b290
 aDETMBEGA1UECwwKQ29uc3VsdGluZzEYMBYGA1UEAwwPd3d3LndvbGZzc2wuY29t
-MR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tggkAt7aQM2YbayMwDAYD
-VR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEADpNIREpylmBxJYKpLMpgW/KI
-Ps8RdFoRStzZ2PZYLAXTVtnpjzfvjj47/yI2AMrY4pY/p9HtH956sNePNr1BVR7U
-uYY7hyVpNWBI1uRalM6i+nA4NsSFtEsj/nGeL9sGx7WcIfA+fOuR+FwJ/YRDpLNO
-BAwiMXFqSMiru+jO+mcVGjqCmEMztQ4fHon4N94b5rWg9KKLtxyQuphtlCEIgF3z
-v2atyXIoempI7s9jaTGMxY5m2kt4ZegDOkv4zEJU01JcLQSuJofhfkDLRUEWS26j
-Lkp2vSl/HFM3Bq3pW2rWt06UonzorE6mUD4rMp5oQhvkWWdh6seaUZwcVaN3dg==
+MR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tggkAhv/1jhDeuPswDAYD
+VR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAniiIcgDK5ueXysHxH54SsrjH
+Ueoo4Ta1LeYvCCPLqUqHJcZdiUXq9QCYrHb7G6/wzmSe2gi/tuu0tQyg5/ZHWRxh
+zy4OWKSCrA8/7MSugPewih6FQej//v5PGiTVSfr7/l7l05EOT04MIVFxgwRrYntP
+WXZIgR609wRHipFXoxGp8iC0eDNiPbBeDfmGOILaoZiNGQaHITm3AvfafVi6UhXY
+O8l7WDSgx+J8qYMT4bbsAb9SMwvE/kPTxqSOL4d/ekTqylNshe1ldnMxA07qvTVU
+E/Nkh2vfNN00oYg7202vG2SQknEwjsjM5WAkrzEWOTORUPmraEJ0ejXZ3cjEUg==
 -----END CERTIFICATE-----

--- a/examples/certs/client-cert.pem
+++ b/examples/certs/client-cert.pem
@@ -1,13 +1,12 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number:
-            b9:bc:90:ed:ad:aa:0a:8c
+        Serial Number: 12305170416376042871 (0xaac4bf4c50bd5577)
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: C=US, ST=Montana, L=Bozeman, O=wolfSSL_2048, OU=Programming-2048, CN=www.wolfssl.com/emailAddress=info@wolfssl.com
         Validity
-            Not Before: Aug 11 20:07:37 2016 GMT
-            Not After : May  8 20:07:37 2019 GMT
+            Not Before: Apr 13 15:23:09 2018 GMT
+            Not After : Jan  7 15:23:09 2021 GMT
         Subject: C=US, ST=Montana, L=Bozeman, O=wolfSSL_2048, OU=Programming-2048, CN=www.wolfssl.com/emailAddress=info@wolfssl.com
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
@@ -38,32 +37,32 @@ Certificate:
             X509v3 Authority Key Identifier: 
                 keyid:33:D8:45:66:D7:68:87:18:7E:54:0D:70:27:91:C7:26:D7:85:65:C0
                 DirName:/C=US/ST=Montana/L=Bozeman/O=wolfSSL_2048/OU=Programming-2048/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
-                serial:B9:BC:90:ED:AD:AA:0A:8C
+                serial:AA:C4:BF:4C:50:BD:55:77
 
             X509v3 Basic Constraints: 
                 CA:TRUE
     Signature Algorithm: sha256WithRSAEncryption
-         33:85:08:b4:58:0e:a2:00:03:74:de:77:fb:d1:2b:76:9c:97:
-         90:20:21:a2:e8:2e:22:50:26:04:76:ba:5b:47:79:e5:52:f7:
-         c4:0d:79:ff:62:3f:05:7c:c3:08:6c:e0:b7:81:d0:ce:c6:c9:
-         46:b9:8e:4b:5f:56:79:4b:13:b6:d1:6b:66:4b:ce:00:0d:e3:
-         76:5e:fb:cb:b5:5d:12:31:05:f1:bb:39:f6:86:90:ca:92:56:
-         a4:a0:75:21:b6:1d:4c:96:c3:45:eb:5a:91:94:32:d3:59:b8:
-         c9:73:1f:03:a9:81:63:e0:43:c0:1e:c8:65:be:3b:a7:53:c3:
-         44:ff:b3:fb:47:84:a8:b6:9d:00:d5:6b:ae:87:f8:bb:35:b2:
-         6c:66:0b:11:ee:6f:fe:12:ed:59:79:f1:3e:f2:d3:61:27:8b:
-         95:7e:99:75:8d:a4:9f:34:85:f1:25:4d:48:1e:9b:6b:70:f6:
-         66:cc:56:b1:a3:02:52:8a:7c:aa:af:07:da:97:c6:0c:a5:8f:
-         ed:cb:f5:d8:04:5d:97:0a:5d:5a:2b:49:f5:bd:93:e5:23:9b:
-         99:b5:0c:ff:0c:7e:38:82:b2:6e:ab:8a:c9:a7:45:ab:d6:d7:
-         93:35:70:07:7e:c8:3d:a5:fe:33:8f:d9:85:c0:c7:5a:02:e4:
-         7c:d6:35:9e
+         80:52:54:61:2a:77:80:53:44:a9:80:6d:45:ff:0d:25:7d:1a:
+         8f:23:93:53:74:35:12:6f:f0:2e:20:ea:ed:80:63:69:88:e6:
+         0c:a1:49:30:e0:82:db:68:0f:7e:84:ac:ff:ff:7b:42:fa:7e:
+         2f:b2:52:9f:d2:79:5e:35:12:27:36:bc:df:96:58:44:96:55:
+         c8:4a:94:02:5f:4a:9d:dc:d3:3a:f7:6d:ac:8b:79:6e:fc:be:
+         8f:23:58:6a:8a:f5:38:0a:42:f6:98:74:88:53:2e:02:af:e1:
+         0e:be:6f:cc:74:33:7c:ec:b4:cb:a7:49:6d:82:42:4f:eb:73:
+         29:c3:32:00:2b:15:f8:88:7a:8f:6d:20:1b:ae:65:5f:c5:d0:
+         8a:d1:e2:64:6d:a3:a8:fe:64:e1:a9:5b:e6:d0:23:d6:02:72:
+         5a:ec:03:8e:87:67:19:8d:e4:a8:99:15:c1:3d:91:48:99:8d:
+         fe:ae:1c:bf:f6:28:1b:45:be:ad:ef:72:83:9a:f6:c7:3b:51:
+         a3:6e:7a:73:bd:83:aa:97:fd:63:b4:f4:6b:1c:14:81:9a:ef:
+         14:24:d3:e1:8b:f4:04:04:84:54:0f:61:a2:a8:f2:50:37:0c:
+         17:0c:bc:e0:c2:84:85:f4:0b:ae:00:ca:9f:27:e2:44:4f:15:
+         0b:8b:1d:b4
 -----BEGIN CERTIFICATE-----
-MIIEyjCCA7KgAwIBAgIJALm8kO2tqgqMMA0GCSqGSIb3DQEBCwUAMIGeMQswCQYD
+MIIEyjCCA7KgAwIBAgIJAKrEv0xQvVV3MA0GCSqGSIb3DQEBCwUAMIGeMQswCQYD
 VQQGEwJVUzEQMA4GA1UECAwHTW9udGFuYTEQMA4GA1UEBwwHQm96ZW1hbjEVMBMG
 A1UECgwMd29sZlNTTF8yMDQ4MRkwFwYDVQQLDBBQcm9ncmFtbWluZy0yMDQ4MRgw
 FgYDVQQDDA93d3cud29sZnNzbC5jb20xHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29s
-ZnNzbC5jb20wHhcNMTYwODExMjAwNzM3WhcNMTkwNTA4MjAwNzM3WjCBnjELMAkG
+ZnNzbC5jb20wHhcNMTgwNDEzMTUyMzA5WhcNMjEwMTA3MTUyMzA5WjCBnjELMAkG
 A1UEBhMCVVMxEDAOBgNVBAgMB01vbnRhbmExEDAOBgNVBAcMB0JvemVtYW4xFTAT
 BgNVBAoMDHdvbGZTU0xfMjA0ODEZMBcGA1UECwwQUHJvZ3JhbW1pbmctMjA0ODEY
 MBYGA1UEAwwPd3d3LndvbGZzc2wuY29tMR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdv
@@ -78,11 +77,11 @@ xybXhWXAMIHTBgNVHSMEgcswgciAFDPYRWbXaIcYflQNcCeRxybXhWXAoYGkpIGh
 MIGeMQswCQYDVQQGEwJVUzEQMA4GA1UECAwHTW9udGFuYTEQMA4GA1UEBwwHQm96
 ZW1hbjEVMBMGA1UECgwMd29sZlNTTF8yMDQ4MRkwFwYDVQQLDBBQcm9ncmFtbWlu
 Zy0yMDQ4MRgwFgYDVQQDDA93d3cud29sZnNzbC5jb20xHzAdBgkqhkiG9w0BCQEW
-EGluZm9Ad29sZnNzbC5jb22CCQC5vJDtraoKjDAMBgNVHRMEBTADAQH/MA0GCSqG
-SIb3DQEBCwUAA4IBAQAzhQi0WA6iAAN03nf70St2nJeQICGi6C4iUCYEdrpbR3nl
-UvfEDXn/Yj8FfMMIbOC3gdDOxslGuY5LX1Z5SxO20WtmS84ADeN2XvvLtV0SMQXx
-uzn2hpDKklakoHUhth1MlsNF61qRlDLTWbjJcx8DqYFj4EPAHshlvjunU8NE/7P7
-R4Sotp0A1Wuuh/i7NbJsZgsR7m/+Eu1ZefE+8tNhJ4uVfpl1jaSfNIXxJU1IHptr
-cPZmzFaxowJSinyqrwfal8YMpY/ty/XYBF2XCl1aK0n1vZPlI5uZtQz/DH44grJu
-q4rJp0Wr1teTNXAHfsg9pf4zj9mFwMdaAuR81jWe
+EGluZm9Ad29sZnNzbC5jb22CCQCqxL9MUL1VdzAMBgNVHRMEBTADAQH/MA0GCSqG
+SIb3DQEBCwUAA4IBAQCAUlRhKneAU0SpgG1F/w0lfRqPI5NTdDUSb/AuIOrtgGNp
+iOYMoUkw4ILbaA9+hKz//3tC+n4vslKf0nleNRInNrzfllhEllXISpQCX0qd3NM6
+922si3lu/L6PI1hqivU4CkL2mHSIUy4Cr+EOvm/MdDN87LTLp0ltgkJP63MpwzIA
+KxX4iHqPbSAbrmVfxdCK0eJkbaOo/mThqVvm0CPWAnJa7AOOh2cZjeSomRXBPZFI
+mY3+rhy/9igbRb6t73KDmvbHO1GjbnpzvYOql/1jtPRrHBSBmu8UJNPhi/QEBIRU
+D2GiqPJQNwwXDLzgwoSF9AuuAMqfJ+JETxULix20
 -----END CERTIFICATE-----

--- a/examples/certs/crl/cliCrl.pem
+++ b/examples/certs/crl/cliCrl.pem
@@ -2,38 +2,41 @@ Certificate Revocation List (CRL):
         Version 2 (0x1)
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: /C=US/ST=Montana/L=Bozeman/O=wolfSSL_2048/OU=Programming-2048/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
-        Last Update: Aug 11 20:07:38 2016 GMT
-        Next Update: May  8 20:07:38 2019 GMT
+        Last Update: May 29 22:47:57 2018 GMT
+        Next Update: Jan  7 22:47:57 2021 GMT
         CRL extensions:
             X509v3 CRL Number: 
-                3
-No Revoked Certificates.
+                6
+Revoked Certificates:
+    Serial Number: 02
+        Revocation Date: May 29 22:47:57 2018 GMT
     Signature Algorithm: sha256WithRSAEncryption
-         14:85:d5:c8:db:62:74:48:94:5e:dc:52:0f:5e:43:8b:29:83:
-         32:e0:7a:4c:5c:76:e3:7e:c1:87:74:40:b2:6f:f8:33:4c:2c:
-         32:08:f0:5f:d9:85:b3:20:05:34:5d:15:4d:ba:45:bc:2d:9c:
-         ae:40:d0:d8:9a:b3:a1:4f:0b:94:ce:c4:23:c6:bf:a2:f8:a6:
-         02:4c:6d:ad:5a:59:b3:83:55:dd:37:91:f6:75:d4:6f:83:5f:
-         1c:29:94:cd:01:09:dc:38:d8:6c:c0:9f:1e:76:9d:f9:8f:70:
-         0d:48:e5:99:82:90:3a:36:f1:33:17:69:73:8a:ee:a7:22:4c:
-         58:93:a1:dc:59:b9:44:8f:88:99:0b:c4:d3:74:aa:02:9a:84:
-         36:48:d8:a0:05:73:bc:14:32:1e:76:23:85:c5:94:56:b2:2c:
-         61:3b:07:d7:bd:0c:27:f7:d7:23:40:bd:0c:6c:c7:e0:f7:28:
-         74:67:98:20:93:72:16:b6:6e:67:3f:9e:c9:34:c5:64:09:bf:
-         b1:ab:87:0c:80:b6:1f:89:d8:0e:67:c2:c7:19:df:ee:9f:b2:
-         e6:fb:64:3d:82:7a:47:e2:8d:a3:93:1d:29:f6:94:db:83:2f:
-         b6:0a:a0:da:77:e3:56:ec:d7:d2:22:3c:88:4d:4a:87:de:b5:
-         1c:eb:7b:08
+         7b:c2:9a:bc:3a:b4:15:d0:fc:7c:8c:cd:da:23:30:08:7b:2d:
+         8e:a7:2a:d7:e0:2e:c7:a6:2b:54:c9:0b:2f:d6:52:6c:98:c6:
+         2a:fb:5d:68:0f:43:26:d6:c6:63:8c:79:1f:53:df:55:a9:64:
+         88:da:da:09:49:90:11:dd:d2:43:87:14:f7:54:37:8d:57:52:
+         72:af:56:0a:cf:93:f1:46:fa:ed:f8:cd:af:a9:9e:26:ec:45:
+         e3:ec:3f:ed:7e:48:10:cf:3a:94:45:8f:24:e0:e6:41:2e:1e:
+         bf:11:a9:4b:d3:d9:b3:1e:95:5b:6b:9b:68:18:a3:74:08:a6:
+         87:b2:f3:a8:9a:33:5b:8b:97:09:16:72:68:8b:52:a2:79:2a:
+         e7:b5:aa:17:4e:b3:99:60:8f:30:35:c0:19:6a:0f:1a:23:b9:
+         bc:5a:8c:99:0e:cd:e4:bd:a3:6e:47:5e:e9:c1:53:97:40:ec:
+         56:0b:24:cf:e5:7f:aa:1e:62:4d:46:a1:21:85:c7:b8:1b:74:
+         d4:03:52:d7:50:58:70:e0:db:03:66:ef:77:cc:6d:1e:a1:4d:
+         84:45:c5:c2:15:d0:88:76:73:44:be:7b:8b:f2:94:b6:5b:99:
+         d4:69:7e:0f:4a:4e:90:ed:a9:b8:19:92:e1:b5:64:75:56:26:
+         f9:c1:2f:06
 -----BEGIN X509 CRL-----
-MIIB+DCB4QIBATANBgkqhkiG9w0BAQsFADCBnjELMAkGA1UEBhMCVVMxEDAOBgNV
+MIICDjCB9wIBATANBgkqhkiG9w0BAQsFADCBnjELMAkGA1UEBhMCVVMxEDAOBgNV
 BAgMB01vbnRhbmExEDAOBgNVBAcMB0JvemVtYW4xFTATBgNVBAoMDHdvbGZTU0xf
 MjA0ODEZMBcGA1UECwwQUHJvZ3JhbW1pbmctMjA0ODEYMBYGA1UEAwwPd3d3Lndv
-bGZzc2wuY29tMR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tFw0xNjA4
-MTEyMDA3MzhaFw0xOTA1MDgyMDA3MzhaoA4wDDAKBgNVHRQEAwIBAzANBgkqhkiG
-9w0BAQsFAAOCAQEAFIXVyNtidEiUXtxSD15DiymDMuB6TFx2437Bh3RAsm/4M0ws
-MgjwX9mFsyAFNF0VTbpFvC2crkDQ2JqzoU8LlM7EI8a/ovimAkxtrVpZs4NV3TeR
-9nXUb4NfHCmUzQEJ3DjYbMCfHnad+Y9wDUjlmYKQOjbxMxdpc4rupyJMWJOh3Fm5
-RI+ImQvE03SqApqENkjYoAVzvBQyHnYjhcWUVrIsYTsH170MJ/fXI0C9DGzH4Pco
-dGeYIJNyFrZuZz+eyTTFZAm/sauHDIC2H4nYDmfCxxnf7p+y5vtkPYJ6R+KNo5Md
-KfaU24Mvtgqg2nfjVuzX0iI8iE1Kh961HOt7CA==
+bGZzc2wuY29tMR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tFw0xODA1
+MjkyMjQ3NTdaFw0yMTAxMDcyMjQ3NTdaMBQwEgIBAhcNMTgwNTI5MjI0NzU3WqAO
+MAwwCgYDVR0UBAMCAQYwDQYJKoZIhvcNAQELBQADggEBAHvCmrw6tBXQ/HyMzdoj
+MAh7LY6nKtfgLsemK1TJCy/WUmyYxir7XWgPQybWxmOMeR9T31WpZIja2glJkBHd
+0kOHFPdUN41XUnKvVgrPk/FG+u34za+pnibsRePsP+1+SBDPOpRFjyTg5kEuHr8R
+qUvT2bMelVtrm2gYo3QIpoey86iaM1uLlwkWcmiLUqJ5Kue1qhdOs5lgjzA1wBlq
+DxojubxajJkOzeS9o25HXunBU5dA7FYLJM/lf6oeYk1GoSGFx7gbdNQDUtdQWHDg
+2wNm73fMbR6hTYRFxcIV0Ih2c0S+e4vylLZbmdRpfg9KTpDtqbgZkuG1ZHVWJvnB
+LwY=
 -----END X509 CRL-----

--- a/examples/certs/crl/crl.pem
+++ b/examples/certs/crl/crl.pem
@@ -2,40 +2,40 @@ Certificate Revocation List (CRL):
         Version 2 (0x1)
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: /C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
-        Last Update: Aug 11 20:07:38 2016 GMT
-        Next Update: May  8 20:07:38 2019 GMT
+        Last Update: May 29 22:47:57 2018 GMT
+        Next Update: Jan  7 22:47:57 2021 GMT
         CRL extensions:
             X509v3 CRL Number: 
-                1
+                2
 Revoked Certificates:
     Serial Number: 02
-        Revocation Date: Aug 11 20:07:38 2016 GMT
+        Revocation Date: May 29 22:47:57 2018 GMT
     Signature Algorithm: sha256WithRSAEncryption
-         35:c6:7f:57:9a:e5:86:5a:15:1a:e2:e5:2b:9f:54:79:2a:58:
-         51:a2:12:0c:4e:53:58:eb:99:e3:c2:ee:2b:d7:23:e4:3c:4d:
-         0a:ab:ae:71:9b:ce:b1:c1:75:a1:b6:e5:32:5f:10:b0:72:28:
-         2e:74:b1:99:dd:47:53:20:f6:9a:83:5c:bd:20:b0:aa:df:32:
-         f6:95:54:98:9e:59:96:55:7b:0a:74:be:94:66:44:b7:32:82:
-         f0:eb:16:f8:30:86:16:9f:73:43:98:82:b5:5e:ad:58:c0:c8:
-         79:da:ad:b1:b4:d7:fb:34:c1:cc:3a:67:af:a4:56:5a:70:5c:
-         2d:1f:73:16:78:92:01:06:e3:2c:fb:f1:ba:d5:8f:f9:be:dd:
-         e1:4a:ce:de:ca:e6:2d:96:09:24:06:40:9e:10:15:2e:f2:cd:
-         85:d6:84:88:db:9c:4a:7b:75:7a:06:0e:40:02:20:60:7e:91:
-         f7:92:53:1e:34:7a:ea:ee:df:e7:cd:a8:9e:a6:61:b4:56:50:
-         4d:dc:b1:78:0d:86:cf:45:c3:a6:0a:b9:88:2c:56:a7:b1:d3:
-         d3:0d:44:aa:93:a4:05:4d:ce:9f:01:b0:c6:1e:e4:ea:6b:92:
-         6f:93:dd:98:cf:fb:1d:06:72:ac:d4:99:e7:f2:b4:11:57:bd:
-         9d:63:e5:dc
+         6b:c1:26:13:77:62:8e:4e:a9:e5:87:b6:f6:66:c8:1f:cc:6a:
+         20:94:f0:f6:a5:c6:b7:aa:03:b7:60:cf:74:16:5e:2f:c6:10:
+         8c:82:c9:31:da:20:23:c0:9e:f0:64:4b:cc:d8:6c:ec:57:1a:
+         5c:27:ec:36:db:64:f0:28:b2:34:33:d2:aa:1b:55:e7:4a:1f:
+         c2:51:e9:b8:32:a8:be:53:ee:21:65:f7:c5:92:d0:0d:98:db:
+         65:50:7f:35:98:21:5b:52:a0:1e:ce:79:af:66:de:55:81:11:
+         0f:b0:8d:20:a8:48:f3:ff:ca:99:69:04:d8:c6:ec:98:de:8b:
+         56:e1:53:cf:0b:da:47:91:9e:27:ff:d2:2d:a3:65:61:80:89:
+         64:20:65:12:41:ce:8e:c8:55:a5:90:8d:fa:02:45:6b:28:6e:
+         28:ab:5a:94:c3:49:37:d0:b1:8e:d1:3b:9f:da:7e:36:73:d9:
+         8d:a5:60:97:71:51:6f:7b:88:90:84:14:0a:50:31:3c:e1:63:
+         d6:dd:26:e9:f5:63:b2:ae:54:4e:8f:80:aa:2b:4c:94:ab:08:
+         16:03:b0:31:3a:16:f3:c6:20:0a:00:c9:52:7c:88:72:23:8d:
+         80:c9:98:45:c3:44:1e:84:99:b8:53:1e:67:23:bc:aa:80:f6:
+         77:58:0a:7a
 -----BEGIN X509 CRL-----
 MIICBDCB7QIBATANBgkqhkiG9w0BAQsFADCBlDELMAkGA1UEBhMCVVMxEDAOBgNV
 BAgMB01vbnRhbmExEDAOBgNVBAcMB0JvemVtYW4xETAPBgNVBAoMCFNhd3Rvb3Ro
 MRMwEQYDVQQLDApDb25zdWx0aW5nMRgwFgYDVQQDDA93d3cud29sZnNzbC5jb20x
-HzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20XDTE2MDgxMTIwMDczOFoX
-DTE5MDUwODIwMDczOFowFDASAgECFw0xNjA4MTEyMDA3MzhaoA4wDDAKBgNVHRQE
-AwIBATANBgkqhkiG9w0BAQsFAAOCAQEANcZ/V5rlhloVGuLlK59UeSpYUaISDE5T
-WOuZ48LuK9cj5DxNCquucZvOscF1obblMl8QsHIoLnSxmd1HUyD2moNcvSCwqt8y
-9pVUmJ5ZllV7CnS+lGZEtzKC8OsW+DCGFp9zQ5iCtV6tWMDIedqtsbTX+zTBzDpn
-r6RWWnBcLR9zFniSAQbjLPvxutWP+b7d4UrO3srmLZYJJAZAnhAVLvLNhdaEiNuc
-Snt1egYOQAIgYH6R95JTHjR66u7f582onqZhtFZQTdyxeA2Gz0XDpgq5iCxWp7HT
-0w1EqpOkBU3OnwGwxh7k6muSb5PdmM/7HQZyrNSZ5/K0EVe9nWPl3A==
+HzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20XDTE4MDUyOTIyNDc1N1oX
+DTIxMDEwNzIyNDc1N1owFDASAgECFw0xODA1MjkyMjQ3NTdaoA4wDDAKBgNVHRQE
+AwIBAjANBgkqhkiG9w0BAQsFAAOCAQEAa8EmE3dijk6p5Ye29mbIH8xqIJTw9qXG
+t6oDt2DPdBZeL8YQjILJMdogI8Ce8GRLzNhs7FcaXCfsNttk8CiyNDPSqhtV50of
+wlHpuDKovlPuIWX3xZLQDZjbZVB/NZghW1KgHs55r2beVYERD7CNIKhI8//KmWkE
+2MbsmN6LVuFTzwvaR5GeJ//SLaNlYYCJZCBlEkHOjshVpZCN+gJFayhuKKtalMNJ
+N9CxjtE7n9p+NnPZjaVgl3FRb3uIkIQUClAxPOFj1t0m6fVjsq5UTo+AqitMlKsI
+FgOwMToW88YgCgDJUnyIciONgMmYRcNEHoSZuFMeZyO8qoD2d1gKeg==
 -----END X509 CRL-----

--- a/examples/certs/crl/crl.revoked
+++ b/examples/certs/crl/crl.revoked
@@ -2,43 +2,43 @@ Certificate Revocation List (CRL):
         Version 2 (0x1)
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: /C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
-        Last Update: Aug 11 20:07:38 2016 GMT
-        Next Update: May  8 20:07:38 2019 GMT
+        Last Update: May 29 22:47:57 2018 GMT
+        Next Update: Jan  7 22:47:57 2021 GMT
         CRL extensions:
             X509v3 CRL Number: 
-                2
+                3
 Revoked Certificates:
     Serial Number: 01
-        Revocation Date: Aug 11 20:07:38 2016 GMT
+        Revocation Date: May 29 22:47:57 2018 GMT
     Serial Number: 02
-        Revocation Date: Aug 11 20:07:38 2016 GMT
+        Revocation Date: May 29 22:47:57 2018 GMT
     Signature Algorithm: sha256WithRSAEncryption
-         91:67:3d:34:8f:85:87:cd:11:0f:e2:af:cd:77:3f:d8:f2:15:
-         cb:c3:0d:49:02:87:13:f5:82:9e:a9:6f:ed:6a:aa:28:b7:6c:
-         61:7b:ac:90:d0:e5:a1:3d:80:2c:31:6f:4e:0b:e9:9a:44:db:
-         6b:24:71:34:9f:d1:51:53:8a:bd:bd:1c:20:e0:96:73:7b:29:
-         1c:e3:56:97:46:a2:5e:db:ae:fe:1f:4a:c1:5c:5b:30:74:a4:
-         70:dc:7e:70:7f:42:9f:48:d3:99:16:ff:34:f9:a7:db:ad:3d:
-         bc:a6:9d:ee:6a:ed:e7:e0:2f:ef:24:ab:4c:9b:44:d8:fc:1c:
-         48:9f:f4:3c:14:f3:6c:a2:0f:a7:93:00:32:29:96:7e:98:5d:
-         c9:85:fa:94:4c:e2:03:7e:fb:bf:f0:0e:93:52:3b:8a:e1:43:
-         fe:3f:f2:57:02:21:e8:ff:43:da:3e:f0:3d:1a:eb:96:7a:0a:
-         d8:27:56:e2:30:2a:3c:a3:93:ff:1e:3f:98:6b:4e:ea:78:90:
-         8b:d7:24:0a:98:b8:c1:e8:f5:02:d2:18:07:17:c3:6c:b5:db:
-         a7:61:c5:5d:8e:36:80:f5:aa:c1:a7:5b:66:4a:dd:17:62:da:
-         80:70:83:4d:69:fa:c4:f4:2d:27:90:8d:7f:28:34:19:e0:a3:
-         8a:6b:73:55
+         b4:bb:8c:be:03:d7:e3:38:93:ef:31:1c:11:a4:de:77:9a:5d:
+         11:4c:5c:e4:7b:e5:c7:ac:6a:b4:bc:2a:f9:5a:01:bd:72:20:
+         77:b6:46:4b:8c:c3:25:d7:c4:a6:39:fe:cf:9a:99:9d:af:02:
+         3e:15:fe:38:b2:04:7e:99:74:63:61:07:8e:8e:f7:23:b4:96:
+         b8:85:2f:01:cb:e6:e4:c3:3d:cb:31:e7:60:38:02:3b:8a:da:
+         15:d2:37:34:8b:da:3d:c7:c8:0d:f6:1f:da:f5:ac:66:a1:0d:
+         22:73:a5:78:76:88:04:ec:7c:80:8b:a0:99:40:4b:56:aa:aa:
+         8e:01:7b:66:b7:6e:9e:5b:82:e7:4c:9d:99:27:8f:cb:cb:26:
+         c1:38:ed:bc:3c:e5:07:79:0b:79:7c:29:60:08:72:01:fc:9a:
+         2a:60:7e:93:f3:a8:a5:29:93:58:e6:8d:2f:6a:02:d5:70:7e:
+         cc:fd:69:6f:b4:09:60:c0:da:bb:ca:b1:e1:e2:91:85:9c:a3:
+         46:73:99:19:4d:77:e5:1c:80:33:04:34:5d:c1:e3:88:6d:b1:
+         10:6c:79:9a:dd:e9:ac:d8:82:f6:0d:f0:7c:4b:de:fd:f1:17:
+         04:54:8e:56:ec:3c:79:06:17:30:42:39:d5:98:0d:bb:78:b3:
+         9f:4e:5b:87
 -----BEGIN X509 CRL-----
 MIICGTCCAQECAQEwDQYJKoZIhvcNAQELBQAwgZQxCzAJBgNVBAYTAlVTMRAwDgYD
 VQQIDAdNb250YW5hMRAwDgYDVQQHDAdCb3plbWFuMREwDwYDVQQKDAhTYXd0b290
 aDETMBEGA1UECwwKQ29uc3VsdGluZzEYMBYGA1UEAwwPd3d3LndvbGZzc2wuY29t
-MR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tFw0xNjA4MTEyMDA3Mzha
-Fw0xOTA1MDgyMDA3MzhaMCgwEgIBARcNMTYwODExMjAwNzM4WjASAgECFw0xNjA4
-MTEyMDA3MzhaoA4wDDAKBgNVHRQEAwIBAjANBgkqhkiG9w0BAQsFAAOCAQEAkWc9
-NI+Fh80RD+KvzXc/2PIVy8MNSQKHE/WCnqlv7WqqKLdsYXuskNDloT2ALDFvTgvp
-mkTbayRxNJ/RUVOKvb0cIOCWc3spHONWl0aiXtuu/h9KwVxbMHSkcNx+cH9Cn0jT
-mRb/NPmn2609vKad7mrt5+Av7ySrTJtE2PwcSJ/0PBTzbKIPp5MAMimWfphdyYX6
-lEziA377v/AOk1I7iuFD/j/yVwIh6P9D2j7wPRrrlnoK2CdW4jAqPKOT/x4/mGtO
-6niQi9ckCpi4wej1AtIYBxfDbLXbp2HFXY42gPWqwadbZkrdF2LagHCDTWn6xPQt
-J5CNfyg0GeCjimtzVQ==
+MR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tFw0xODA1MjkyMjQ3NTda
+Fw0yMTAxMDcyMjQ3NTdaMCgwEgIBARcNMTgwNTI5MjI0NzU3WjASAgECFw0xODA1
+MjkyMjQ3NTdaoA4wDDAKBgNVHRQEAwIBAzANBgkqhkiG9w0BAQsFAAOCAQEAtLuM
+vgPX4ziT7zEcEaTed5pdEUxc5Hvlx6xqtLwq+VoBvXIgd7ZGS4zDJdfEpjn+z5qZ
+na8CPhX+OLIEfpl0Y2EHjo73I7SWuIUvAcvm5MM9yzHnYDgCO4raFdI3NIvaPcfI
+DfYf2vWsZqENInOleHaIBOx8gIugmUBLVqqqjgF7ZrdunluC50ydmSePy8smwTjt
+vDzlB3kLeXwpYAhyAfyaKmB+k/OopSmTWOaNL2oC1XB+zP1pb7QJYMDau8qx4eKR
+hZyjRnOZGU135RyAMwQ0XcHjiG2xEGx5mt3prNiC9g3wfEve/fEXBFSOVuw8eQYX
+MEI51ZgNu3izn05bhw==
 -----END X509 CRL-----

--- a/examples/certs/crl/eccCliCRL.pem
+++ b/examples/certs/crl/eccCliCRL.pem
@@ -2,23 +2,25 @@ Certificate Revocation List (CRL):
         Version 2 (0x1)
     Signature Algorithm: ecdsa-with-SHA256
         Issuer: /C=US/ST=Oregon/L=Salem/O=Client ECC/OU=Fast/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
-        Last Update: Aug 11 20:07:38 2016 GMT
-        Next Update: May  8 20:07:38 2019 GMT
+        Last Update: May 29 22:47:57 2018 GMT
+        Next Update: Jan  7 22:47:57 2021 GMT
         CRL extensions:
             X509v3 CRL Number: 
-                4
-No Revoked Certificates.
+                7
+Revoked Certificates:
+    Serial Number: 02
+        Revocation Date: May 29 22:47:57 2018 GMT
     Signature Algorithm: ecdsa-with-SHA256
-         30:45:02:20:05:17:4f:0c:42:51:f6:f5:a3:2e:52:3e:e3:f4:
-         ed:99:ca:4d:16:75:f7:80:9d:7a:cf:64:5e:ec:cd:9d:f0:86:
-         02:21:00:e0:38:31:16:e2:ab:e4:d5:4b:cd:67:2f:e1:f0:e5:
-         ac:f2:8a:4b:03:9b:f1:69:60:2c:bf:dc:02:11:e8:71:f7
+         30:44:02:20:7b:58:a3:78:b4:fa:98:8b:bb:ce:83:a0:36:ee:
+         d5:69:ac:d2:8b:f6:67:86:c3:1d:44:2a:58:28:de:29:3e:d8:
+         02:20:5a:56:34:28:7f:2b:75:0e:81:7f:80:2b:53:6c:13:e5:
+         d8:3a:2d:68:78:8d:c3:d6:e6:39:11:82:ee:ed:1f:5b
 -----BEGIN X509 CRL-----
-MIIBJjCBzQIBATAKBggqhkjOPQQDAjCBjTELMAkGA1UEBhMCVVMxDzANBgNVBAgM
+MIIBOzCB4wIBATAKBggqhkjOPQQDAjCBjTELMAkGA1UEBhMCVVMxDzANBgNVBAgM
 Bk9yZWdvbjEOMAwGA1UEBwwFU2FsZW0xEzARBgNVBAoMCkNsaWVudCBFQ0MxDTAL
 BgNVBAsMBEZhc3QxGDAWBgNVBAMMD3d3dy53b2xmc3NsLmNvbTEfMB0GCSqGSIb3
-DQEJARYQaW5mb0B3b2xmc3NsLmNvbRcNMTYwODExMjAwNzM4WhcNMTkwNTA4MjAw
-NzM4WqAOMAwwCgYDVR0UBAMCAQQwCgYIKoZIzj0EAwIDSAAwRQIgBRdPDEJR9vWj
-LlI+4/TtmcpNFnX3gJ16z2Re7M2d8IYCIQDgODEW4qvk1UvNZy/h8OWs8opLA5vx
-aWAsv9wCEehx9w==
+DQEJARYQaW5mb0B3b2xmc3NsLmNvbRcNMTgwNTI5MjI0NzU3WhcNMjEwMTA3MjI0
+NzU3WjAUMBICAQIXDTE4MDUyOTIyNDc1N1qgDjAMMAoGA1UdFAQDAgEHMAoGCCqG
+SM49BAMCA0cAMEQCIHtYo3i0+piLu86DoDbu1Wms0ov2Z4bDHUQqWCjeKT7YAiBa
+VjQofyt1DoF/gCtTbBPl2DotaHiNw9bmORGC7u0fWw==
 -----END X509 CRL-----

--- a/examples/certs/crl/eccSrvCRL.pem
+++ b/examples/certs/crl/eccSrvCRL.pem
@@ -2,23 +2,25 @@ Certificate Revocation List (CRL):
         Version 2 (0x1)
     Signature Algorithm: ecdsa-with-SHA256
         Issuer: /C=US/ST=Washington/L=Seattle/O=Eliptic/OU=ECC/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
-        Last Update: Aug 11 20:07:38 2016 GMT
-        Next Update: May  8 20:07:38 2019 GMT
+        Last Update: May 29 22:47:57 2018 GMT
+        Next Update: Jan  7 22:47:57 2021 GMT
         CRL extensions:
             X509v3 CRL Number: 
-                5
-No Revoked Certificates.
+                8
+Revoked Certificates:
+    Serial Number: 02
+        Revocation Date: May 29 22:47:57 2018 GMT
     Signature Algorithm: ecdsa-with-SHA256
-         30:46:02:21:00:dd:0a:1e:ff:5b:19:4e:40:a1:a8:65:b3:48:
-         fb:2b:a0:e5:6b:c4:27:31:2b:0b:1e:8c:c2:12:f5:74:74:c2:
-         5b:02:21:00:f9:67:2e:5c:26:7b:14:a1:16:db:d4:7d:b1:a9:
-         75:c7:5f:db:6f:c9:57:12:9b:44:99:40:71:70:7d:f9:b6:c8
+         30:44:02:20:17:18:ac:ac:96:28:7b:87:6a:d4:10:03:df:d8:
+         34:23:33:67:ed:ad:20:df:ab:da:a9:7c:f4:61:c0:d1:d5:4b:
+         02:20:74:47:c1:26:c7:8c:92:f3:7c:c2:91:96:26:91:90:ff:
+         d2:23:b8:dc:e9:62:f9:d2:19:18:11:94:e5:b2:ff:85
 -----BEGIN X509 CRL-----
-MIIBKTCBzwIBATAKBggqhkjOPQQDAjCBjzELMAkGA1UEBhMCVVMxEzARBgNVBAgM
+MIIBPTCB5QIBATAKBggqhkjOPQQDAjCBjzELMAkGA1UEBhMCVVMxEzARBgNVBAgM
 Cldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxEDAOBgNVBAoMB0VsaXB0aWMx
 DDAKBgNVBAsMA0VDQzEYMBYGA1UEAwwPd3d3LndvbGZzc2wuY29tMR8wHQYJKoZI
-hvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tFw0xNjA4MTEyMDA3MzhaFw0xOTA1MDgy
-MDA3MzhaoA4wDDAKBgNVHRQEAwIBBTAKBggqhkjOPQQDAgNJADBGAiEA3Qoe/1sZ
-TkChqGWzSPsroOVrxCcxKwsejMIS9XR0wlsCIQD5Zy5cJnsUoRbb1H2xqXXHX9tv
-yVcSm0SZQHFwffm2yA==
+hvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tFw0xODA1MjkyMjQ3NTdaFw0yMTAxMDcy
+MjQ3NTdaMBQwEgIBAhcNMTgwNTI5MjI0NzU3WqAOMAwwCgYDVR0UBAMCAQgwCgYI
+KoZIzj0EAwIDRwAwRAIgFxisrJYoe4dq1BAD39g0IzNn7a0g36vaqXz0YcDR1UsC
+IHRHwSbHjJLzfMKRliaRkP/SI7jc6WL50hkYEZTlsv+F
 -----END X509 CRL-----

--- a/examples/certs/server-cert.pem
+++ b/examples/certs/server-cert.pem
@@ -5,8 +5,8 @@ Certificate:
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: C=US, ST=Montana, L=Bozeman, O=Sawtooth, OU=Consulting, CN=www.wolfssl.com/emailAddress=info@wolfssl.com
         Validity
-            Not Before: Aug 11 20:07:37 2016 GMT
-            Not After : May  8 20:07:37 2019 GMT
+            Not Before: Apr 13 15:23:10 2018 GMT
+            Not After : Jan  7 15:23:10 2021 GMT
         Subject: C=US, ST=Montana, L=Bozeman, O=wolfSSL, OU=Support, CN=www.wolfssl.com/emailAddress=info@wolfssl.com
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
@@ -37,32 +37,32 @@ Certificate:
             X509v3 Authority Key Identifier: 
                 keyid:27:8E:67:11:74:C3:26:1D:3F:ED:33:63:B3:A4:D8:1D:30:E5:E8:D5
                 DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
-                serial:B7:B6:90:33:66:1B:6B:23
+                serial:86:FF:F5:8E:10:DE:B8:FB
 
             X509v3 Basic Constraints: 
                 CA:TRUE
     Signature Algorithm: sha256WithRSAEncryption
-         51:fe:2a:df:07:7e:43:ca:66:8d:15:c4:2b:db:57:b2:06:6d:
-         0d:90:66:ff:a5:24:9c:14:ef:81:f2:a4:ab:99:a9:6a:49:20:
-         a5:d2:71:e7:1c:3c:99:07:c7:47:fc:e8:96:b4:f5:42:30:ce:
-         39:01:4b:d1:c2:e8:bc:95:84:87:ce:55:5d:97:9f:cf:78:f3:
-         56:9b:a5:08:6d:ac:f6:a5:5c:c4:ef:3e:2a:39:a6:48:26:29:
-         7b:2d:e0:cd:a6:8c:57:48:0b:bb:31:32:c2:bf:d9:43:4c:47:
-         25:18:81:a8:c9:33:82:41:9b:ba:61:86:d7:84:93:17:24:25:
-         36:ca:4d:63:6b:4f:95:79:d8:60:e0:1e:f5:ac:c1:8a:a1:b1:
-         7e:85:8e:87:20:2f:08:31:ad:5e:c6:4a:c8:61:f4:9e:07:1e:
-         a2:22:ed:73:7c:85:ee:fa:62:dc:50:36:aa:fd:c7:9d:aa:18:
-         04:fb:ea:cc:2c:68:9b:b3:a9:c2:96:d8:c1:cc:5a:7e:f7:0d:
-         9e:08:e0:9d:29:8b:84:46:8f:d3:91:6a:b5:b8:7a:5c:cc:4f:
-         55:01:b8:9a:48:a0:94:43:ca:25:47:52:0a:f7:f4:be:b0:d1:
-         71:6d:a5:52:4a:65:50:b2:ad:4e:1d:e0:6c:01:d8:fb:43:80:
-         e6:e4:0c:37
+         b4:54:60:ad:a0:03:32:de:02:7f:21:4a:81:c6:ed:cd:cd:d8:
+         12:8a:c0:ba:82:5b:75:ad:54:e3:7c:80:6a:ac:2e:6c:20:4e:
+         be:4d:82:a7:47:13:5c:f4:c6:6a:2b:10:99:58:de:ab:6b:7c:
+         22:05:c1:83:9d:cb:ff:3c:e4:2d:57:6a:a6:96:df:d3:c1:68:
+         e3:d2:c6:83:4b:97:e2:c6:32:0e:be:c4:03:b9:07:8a:5b:b8:
+         84:ba:c5:39:3f:1c:58:a7:55:d7:f0:9b:e8:d2:45:b9:e3:83:
+         2e:ee:b6:71:56:b9:3a:ee:3f:27:d8:77:e8:fb:44:48:65:27:
+         47:4c:fb:fe:72:c3:ac:05:7b:1d:cb:eb:5e:65:9a:ab:02:e4:
+         88:5b:3b:8b:0b:c7:cc:a9:a6:8b:e1:87:b0:19:1a:0c:28:58:
+         6f:99:52:7e:ed:b0:3a:68:3b:8c:0a:08:74:72:ab:b9:09:c5:
+         ed:04:7e:6f:0b:1c:09:21:d0:cd:7f:f9:c4:5e:27:20:e4:85:
+         73:52:05:d2:ba:f8:d5:8f:41:cc:23:2e:12:6d:bc:31:98:e7:
+         63:a3:8e:26:cd:e8:2b:88:ee:e2:fe:3a:74:52:34:0e:fd:12:
+         e5:5e:69:50:20:31:34:e4:31:f1:e7:e4:5b:03:13:da:ac:41:
+         6c:e7:cf:2b
 -----BEGIN CERTIFICATE-----
 MIIEnjCCA4agAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlDELMAkGA1UEBhMCVVMx
 EDAOBgNVBAgMB01vbnRhbmExEDAOBgNVBAcMB0JvemVtYW4xETAPBgNVBAoMCFNh
 d3Rvb3RoMRMwEQYDVQQLDApDb25zdWx0aW5nMRgwFgYDVQQDDA93d3cud29sZnNz
-bC5jb20xHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wHhcNMTYwODEx
-MjAwNzM3WhcNMTkwNTA4MjAwNzM3WjCBkDELMAkGA1UEBhMCVVMxEDAOBgNVBAgM
+bC5jb20xHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wHhcNMTgwNDEz
+MTUyMzEwWhcNMjEwMTA3MTUyMzEwWjCBkDELMAkGA1UEBhMCVVMxEDAOBgNVBAgM
 B01vbnRhbmExEDAOBgNVBAcMB0JvemVtYW4xEDAOBgNVBAoMB3dvbGZTU0wxEDAO
 BgNVBAsMB1N1cHBvcnQxGDAWBgNVBAMMD3d3dy53b2xmc3NsLmNvbTEfMB0GCSqG
 SIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEP
@@ -76,24 +76,23 @@ sxEyyZKYhOLJ+NA7bgNCyh8OjjwwgckGA1UdIwSBwTCBvoAUJ45nEXTDJh0/7TNj
 s6TYHTDl6NWhgZqkgZcwgZQxCzAJBgNVBAYTAlVTMRAwDgYDVQQIDAdNb250YW5h
 MRAwDgYDVQQHDAdCb3plbWFuMREwDwYDVQQKDAhTYXd0b290aDETMBEGA1UECwwK
 Q29uc3VsdGluZzEYMBYGA1UEAwwPd3d3LndvbGZzc2wuY29tMR8wHQYJKoZIhvcN
-AQkBFhBpbmZvQHdvbGZzc2wuY29tggkAt7aQM2YbayMwDAYDVR0TBAUwAwEB/zAN
-BgkqhkiG9w0BAQsFAAOCAQEAUf4q3wd+Q8pmjRXEK9tXsgZtDZBm/6UknBTvgfKk
-q5mpakkgpdJx5xw8mQfHR/zolrT1QjDOOQFL0cLovJWEh85VXZefz3jzVpulCG2s
-9qVcxO8+KjmmSCYpey3gzaaMV0gLuzEywr/ZQ0xHJRiBqMkzgkGbumGG14STFyQl
-NspNY2tPlXnYYOAe9azBiqGxfoWOhyAvCDGtXsZKyGH0ngceoiLtc3yF7vpi3FA2
-qv3HnaoYBPvqzCxom7OpwpbYwcxafvcNngjgnSmLhEaP05Fqtbh6XMxPVQG4mkig
-lEPKJUdSCvf0vrDRcW2lUkplULKtTh3gbAHY+0OA5uQMNw==
+AQkBFhBpbmZvQHdvbGZzc2wuY29tggkAhv/1jhDeuPswDAYDVR0TBAUwAwEB/zAN
+BgkqhkiG9w0BAQsFAAOCAQEAtFRgraADMt4CfyFKgcbtzc3YEorAuoJbda1U43yA
+aqwubCBOvk2Cp0cTXPTGaisQmVjeq2t8IgXBg53L/zzkLVdqppbf08Fo49LGg0uX
+4sYyDr7EA7kHilu4hLrFOT8cWKdV1/Cb6NJFueODLu62cVa5Ou4/J9h36PtESGUn
+R0z7/nLDrAV7HcvrXmWaqwLkiFs7iwvHzKmmi+GHsBkaDChYb5lSfu2wOmg7jAoI
+dHKruQnF7QR+bwscCSHQzX/5xF4nIOSFc1IF0rr41Y9BzCMuEm28MZjnY6OOJs3o
+K4ju4v46dFI0Dv0S5V5pUCAxNOQx8efkWwMT2qxBbOfPKw==
 -----END CERTIFICATE-----
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number:
-            b7:b6:90:33:66:1b:6b:23
+        Serial Number: 9727763710660753659 (0x86fff58e10deb8fb)
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: C=US, ST=Montana, L=Bozeman, O=Sawtooth, OU=Consulting, CN=www.wolfssl.com/emailAddress=info@wolfssl.com
         Validity
-            Not Before: Aug 11 20:07:37 2016 GMT
-            Not After : May  8 20:07:37 2019 GMT
+            Not Before: Apr 13 15:23:09 2018 GMT
+            Not After : Jan  7 15:23:09 2021 GMT
         Subject: C=US, ST=Montana, L=Bozeman, O=Sawtooth, OU=Consulting, CN=www.wolfssl.com/emailAddress=info@wolfssl.com
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
@@ -124,32 +123,32 @@ Certificate:
             X509v3 Authority Key Identifier: 
                 keyid:27:8E:67:11:74:C3:26:1D:3F:ED:33:63:B3:A4:D8:1D:30:E5:E8:D5
                 DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
-                serial:B7:B6:90:33:66:1B:6B:23
+                serial:86:FF:F5:8E:10:DE:B8:FB
 
             X509v3 Basic Constraints: 
                 CA:TRUE
     Signature Algorithm: sha256WithRSAEncryption
-         0e:93:48:44:4a:72:96:60:71:25:82:a9:2c:ca:60:5b:f2:88:
-         3e:cf:11:74:5a:11:4a:dc:d9:d8:f6:58:2c:05:d3:56:d9:e9:
-         8f:37:ef:8e:3e:3b:ff:22:36:00:ca:d8:e2:96:3f:a7:d1:ed:
-         1f:de:7a:b0:d7:8f:36:bd:41:55:1e:d4:b9:86:3b:87:25:69:
-         35:60:48:d6:e4:5a:94:ce:a2:fa:70:38:36:c4:85:b4:4b:23:
-         fe:71:9e:2f:db:06:c7:b5:9c:21:f0:3e:7c:eb:91:f8:5c:09:
-         fd:84:43:a4:b3:4e:04:0c:22:31:71:6a:48:c8:ab:bb:e8:ce:
-         fa:67:15:1a:3a:82:98:43:33:b5:0e:1f:1e:89:f8:37:de:1b:
-         e6:b5:a0:f4:a2:8b:b7:1c:90:ba:98:6d:94:21:08:80:5d:f3:
-         bf:66:ad:c9:72:28:7a:6a:48:ee:cf:63:69:31:8c:c5:8e:66:
-         da:4b:78:65:e8:03:3a:4b:f8:cc:42:54:d3:52:5c:2d:04:ae:
-         26:87:e1:7e:40:cb:45:41:16:4b:6e:a3:2e:4a:76:bd:29:7f:
-         1c:53:37:06:ad:e9:5b:6a:d6:b7:4e:94:a2:7c:e8:ac:4e:a6:
-         50:3e:2b:32:9e:68:42:1b:e4:59:67:61:ea:c7:9a:51:9c:1c:
-         55:a3:77:76
+         9e:28:88:72:00:ca:e6:e7:97:ca:c1:f1:1f:9e:12:b2:b8:c7:
+         51:ea:28:e1:36:b5:2d:e6:2f:08:23:cb:a9:4a:87:25:c6:5d:
+         89:45:ea:f5:00:98:ac:76:fb:1b:af:f0:ce:64:9e:da:08:bf:
+         b6:eb:b4:b5:0c:a0:e7:f6:47:59:1c:61:cf:2e:0e:58:a4:82:
+         ac:0f:3f:ec:c4:ae:80:f7:b0:8a:1e:85:41:e8:ff:fe:fe:4f:
+         1a:24:d5:49:fa:fb:fe:5e:e5:d3:91:0e:4f:4e:0c:21:51:71:
+         83:04:6b:62:7b:4f:59:76:48:81:1e:b4:f7:04:47:8a:91:57:
+         a3:11:a9:f2:20:b4:78:33:62:3d:b0:5e:0d:f9:86:38:82:da:
+         a1:98:8d:19:06:87:21:39:b7:02:f7:da:7d:58:ba:52:15:d8:
+         3b:c9:7b:58:34:a0:c7:e2:7c:a9:83:13:e1:b6:ec:01:bf:52:
+         33:0b:c4:fe:43:d3:c6:a4:8e:2f:87:7f:7a:44:ea:ca:53:6c:
+         85:ed:65:76:73:31:03:4e:ea:bd:35:54:13:f3:64:87:6b:df:
+         34:dd:34:a1:88:3b:db:4d:af:1b:64:90:92:71:30:8e:c8:cc:
+         e5:60:24:af:31:16:39:33:91:50:f9:ab:68:42:74:7a:35:d9:
+         dd:c8:c4:52
 -----BEGIN CERTIFICATE-----
-MIIEqjCCA5KgAwIBAgIJALe2kDNmG2sjMA0GCSqGSIb3DQEBCwUAMIGUMQswCQYD
+MIIEqjCCA5KgAwIBAgIJAIb/9Y4Q3rj7MA0GCSqGSIb3DQEBCwUAMIGUMQswCQYD
 VQQGEwJVUzEQMA4GA1UECAwHTW9udGFuYTEQMA4GA1UEBwwHQm96ZW1hbjERMA8G
 A1UECgwIU2F3dG9vdGgxEzARBgNVBAsMCkNvbnN1bHRpbmcxGDAWBgNVBAMMD3d3
 dy53b2xmc3NsLmNvbTEfMB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbTAe
-Fw0xNjA4MTEyMDA3MzdaFw0xOTA1MDgyMDA3MzdaMIGUMQswCQYDVQQGEwJVUzEQ
+Fw0xODA0MTMxNTIzMDlaFw0yMTAxMDcxNTIzMDlaMIGUMQswCQYDVQQGEwJVUzEQ
 MA4GA1UECAwHTW9udGFuYTEQMA4GA1UEBwwHQm96ZW1hbjERMA8GA1UECgwIU2F3
 dG9vdGgxEzARBgNVBAsMCkNvbnN1bHRpbmcxGDAWBgNVBAMMD3d3dy53b2xmc3Ns
 LmNvbTEfMB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbTCCASIwDQYJKoZI
@@ -163,11 +162,11 @@ XDjNdyXvvYB1U5Q8PcpjW58VtdMdEy8Z0TzbdjrMuH3J5cLX2kBv2CHccxtCLVOc
 J45nEXTDJh0/7TNjs6TYHTDl6NWhgZqkgZcwgZQxCzAJBgNVBAYTAlVTMRAwDgYD
 VQQIDAdNb250YW5hMRAwDgYDVQQHDAdCb3plbWFuMREwDwYDVQQKDAhTYXd0b290
 aDETMBEGA1UECwwKQ29uc3VsdGluZzEYMBYGA1UEAwwPd3d3LndvbGZzc2wuY29t
-MR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tggkAt7aQM2YbayMwDAYD
-VR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEADpNIREpylmBxJYKpLMpgW/KI
-Ps8RdFoRStzZ2PZYLAXTVtnpjzfvjj47/yI2AMrY4pY/p9HtH956sNePNr1BVR7U
-uYY7hyVpNWBI1uRalM6i+nA4NsSFtEsj/nGeL9sGx7WcIfA+fOuR+FwJ/YRDpLNO
-BAwiMXFqSMiru+jO+mcVGjqCmEMztQ4fHon4N94b5rWg9KKLtxyQuphtlCEIgF3z
-v2atyXIoempI7s9jaTGMxY5m2kt4ZegDOkv4zEJU01JcLQSuJofhfkDLRUEWS26j
-Lkp2vSl/HFM3Bq3pW2rWt06UonzorE6mUD4rMp5oQhvkWWdh6seaUZwcVaN3dg==
+MR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tggkAhv/1jhDeuPswDAYD
+VR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAniiIcgDK5ueXysHxH54SsrjH
+Ueoo4Ta1LeYvCCPLqUqHJcZdiUXq9QCYrHb7G6/wzmSe2gi/tuu0tQyg5/ZHWRxh
+zy4OWKSCrA8/7MSugPewih6FQej//v5PGiTVSfr7/l7l05EOT04MIVFxgwRrYntP
+WXZIgR609wRHipFXoxGp8iC0eDNiPbBeDfmGOILaoZiNGQaHITm3AvfafVi6UhXY
+O8l7WDSgx+J8qYMT4bbsAb9SMwvE/kPTxqSOL4d/ekTqylNshe1ldnMxA07qvTVU
+E/Nkh2vfNN00oYg7202vG2SQknEwjsjM5WAkrzEWOTORUPmraEJ0ejXZ3cjEUg==
 -----END CERTIFICATE-----

--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -1,6 +1,6 @@
 /* com_wolfssl_WolfSSL.c
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/native/com_wolfssl_WolfSSLContext.c
+++ b/native/com_wolfssl_WolfSSLContext.c
@@ -1,6 +1,6 @@
 /* com_wolfssl_WolfSSLContext.c
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -1,6 +1,6 @@
 /* com_wolfssl_WolfSSLSession.c
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/native/com_wolfssl_globals.h
+++ b/native/com_wolfssl_globals.h
@@ -1,6 +1,6 @@
 /* com_wolfssl_globals.c
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/native/com_wolfssl_wolfcrypt_ECC.c
+++ b/native/com_wolfssl_wolfcrypt_ECC.c
@@ -1,6 +1,6 @@
 /* com_wolfssl_wolfcrypt_ECC.c
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/native/com_wolfssl_wolfcrypt_EccKey.c
+++ b/native/com_wolfssl_wolfcrypt_EccKey.c
@@ -1,6 +1,6 @@
 /* com_wolfssl_wolfcrypt_EccKey.c
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/native/com_wolfssl_wolfcrypt_RSA.c
+++ b/native/com_wolfssl_wolfcrypt_RSA.c
@@ -1,6 +1,6 @@
 /* com_wolfssl_wolfcrypt_RSA.c
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -1,6 +1,6 @@
 /* WolfSSL.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/src/java/com/wolfssl/WolfSSLContext.java
+++ b/src/java/com/wolfssl/WolfSSLContext.java
@@ -1,6 +1,6 @@
 /* WolfSSLContext.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/src/java/com/wolfssl/WolfSSLDecryptVerifyCallback.java
+++ b/src/java/com/wolfssl/WolfSSLDecryptVerifyCallback.java
@@ -1,6 +1,6 @@
 /* WolfSSLDecryptVerifyCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/src/java/com/wolfssl/WolfSSLEccSharedSecretCallback.java
+++ b/src/java/com/wolfssl/WolfSSLEccSharedSecretCallback.java
@@ -1,6 +1,6 @@
 /* WolfSSLEccSharedSecretCallback.java
  *
- * Copyright (C) 2006-2016 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/src/java/com/wolfssl/WolfSSLEccSignCallback.java
+++ b/src/java/com/wolfssl/WolfSSLEccSignCallback.java
@@ -1,6 +1,6 @@
 /* WolfSSLEccSignCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/src/java/com/wolfssl/WolfSSLEccVerifyCallback.java
+++ b/src/java/com/wolfssl/WolfSSLEccVerifyCallback.java
@@ -1,6 +1,6 @@
 /* WolfSSLEccVerifyCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/src/java/com/wolfssl/WolfSSLException.java
+++ b/src/java/com/wolfssl/WolfSSLException.java
@@ -1,6 +1,6 @@
 /* WolfSSLException.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/src/java/com/wolfssl/WolfSSLGenCookieCallback.java
+++ b/src/java/com/wolfssl/WolfSSLGenCookieCallback.java
@@ -1,6 +1,6 @@
 /* WolfSSLGenCookieCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/src/java/com/wolfssl/WolfSSLIORecvCallback.java
+++ b/src/java/com/wolfssl/WolfSSLIORecvCallback.java
@@ -1,6 +1,6 @@
 /* WolfSSLIORecvCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/src/java/com/wolfssl/WolfSSLIOSendCallback.java
+++ b/src/java/com/wolfssl/WolfSSLIOSendCallback.java
@@ -1,6 +1,6 @@
 /* WolfSSLIOSendCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/src/java/com/wolfssl/WolfSSLJNIException.java
+++ b/src/java/com/wolfssl/WolfSSLJNIException.java
@@ -1,6 +1,6 @@
 /* WolfSSLJNIException.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/src/java/com/wolfssl/WolfSSLLoggingCallback.java
+++ b/src/java/com/wolfssl/WolfSSLLoggingCallback.java
@@ -1,6 +1,6 @@
 /* WolfSSLLoggingCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/src/java/com/wolfssl/WolfSSLMacEncryptCallback.java
+++ b/src/java/com/wolfssl/WolfSSLMacEncryptCallback.java
@@ -1,6 +1,6 @@
 /* WolfSSLMacEncryptCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/src/java/com/wolfssl/WolfSSLMissingCRLCallback.java
+++ b/src/java/com/wolfssl/WolfSSLMissingCRLCallback.java
@@ -1,6 +1,6 @@
 /* WolfSSLMissingCRLCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/src/java/com/wolfssl/WolfSSLPskClientCallback.java
+++ b/src/java/com/wolfssl/WolfSSLPskClientCallback.java
@@ -1,6 +1,6 @@
 /* WolfSSLPskClientCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/src/java/com/wolfssl/WolfSSLPskServerCallback.java
+++ b/src/java/com/wolfssl/WolfSSLPskServerCallback.java
@@ -1,6 +1,6 @@
 /* WolfSSLPskServerCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/src/java/com/wolfssl/WolfSSLRsaDecCallback.java
+++ b/src/java/com/wolfssl/WolfSSLRsaDecCallback.java
@@ -1,6 +1,6 @@
 /* WolfSSLRsaDecCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/src/java/com/wolfssl/WolfSSLRsaEncCallback.java
+++ b/src/java/com/wolfssl/WolfSSLRsaEncCallback.java
@@ -1,6 +1,6 @@
 /* WolfSSLRsaEncCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/src/java/com/wolfssl/WolfSSLRsaSignCallback.java
+++ b/src/java/com/wolfssl/WolfSSLRsaSignCallback.java
@@ -1,6 +1,6 @@
 /* WolfSSLRsaSignCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/src/java/com/wolfssl/WolfSSLRsaVerifyCallback.java
+++ b/src/java/com/wolfssl/WolfSSLRsaVerifyCallback.java
@@ -1,6 +1,6 @@
 /* WolfSSLRsaVerifyCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -1,6 +1,6 @@
 /* WolfSSLSession.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/src/java/com/wolfssl/WolfSSLVerifyCallback.java
+++ b/src/java/com/wolfssl/WolfSSLVerifyCallback.java
@@ -1,6 +1,6 @@
 /* WolfSSLVerifyCallback.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/src/java/com/wolfssl/wolfcrypt/ECC.java
+++ b/src/java/com/wolfssl/wolfcrypt/ECC.java
@@ -1,6 +1,6 @@
 /* ECC.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/src/java/com/wolfssl/wolfcrypt/EccKey.java
+++ b/src/java/com/wolfssl/wolfcrypt/EccKey.java
@@ -1,6 +1,6 @@
 /* EccKey.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/src/java/com/wolfssl/wolfcrypt/RSA.java
+++ b/src/java/com/wolfssl/wolfcrypt/RSA.java
@@ -1,6 +1,6 @@
 /* RSA.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/src/test/com/wolfssl/WolfCryptECCTest.java
+++ b/src/test/com/wolfssl/WolfCryptECCTest.java
@@ -1,6 +1,6 @@
 /* WolfCryptECCTest.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/src/test/com/wolfssl/WolfCryptRSATest.java
+++ b/src/test/com/wolfssl/WolfCryptRSATest.java
@@ -1,6 +1,6 @@
 /* WolfCryptRSATest.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/src/test/com/wolfssl/WolfSSLContextTest.java
+++ b/src/test/com/wolfssl/WolfSSLContextTest.java
@@ -1,6 +1,6 @@
 /* WolfSSLContextTest.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/src/test/com/wolfssl/WolfSSLSessionTest.java
+++ b/src/test/com/wolfssl/WolfSSLSessionTest.java
@@ -1,6 +1,6 @@
 /* WolfSSLSessionTest.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/src/test/com/wolfssl/WolfSSLTest.java
+++ b/src/test/com/wolfssl/WolfSSLTest.java
@@ -1,6 +1,6 @@
 /* WolfSSLTest.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/src/test/com/wolfssl/WolfSSLTestSuite.java
+++ b/src/test/com/wolfssl/WolfSSLTestSuite.java
@@ -1,6 +1,6 @@
 /* WolfSSLTestSuite.java
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *


### PR DESCRIPTION
- Update copyright to 2018
- Update README notes for 1.4.0
- Update example certs/keys from current wolfSSL