### PR TITLE
add build of tests and examples seperate from build of jar

### DIFF
--- a/README
+++ b/README
@@ -12,6 +12,12 @@ If your Java install location is different, this could lead to an error
 when running java.sh. In this case, you should modify java.sh to match
 your environment.
 
+Build options are :
+- ant build (only builds the jar necessary for an app to use)
+- ant test  (builds the jar and tests then runs the tests, requires JUNIT setup)
+- ant examples (builds the jar and example cases)
+- ant clean   (cleans all)
+
 
 wolfSSL JNI Release X.X.X (TBD)
 
@@ -26,6 +32,7 @@ Release X.X.X has bug fixes and new features including:
 - Add JNI wrapper for wolfSSL_get_ciphers_iana()
 - Update build.xml to use nativeheaderdir instead of javah target
 - Update tests to use junit-4.13-beta-2 / hamcrest-all-1.3
+- Update to build, now ant build does not build and run tests / examples
 
 The wolfSSL JNI Manual is available at:
 http://www.wolfssl.com/documentation/wolfSSL-JNI-Manual.pdf. For build

--- a/build.xml
+++ b/build.xml
@@ -71,7 +71,7 @@
         </delete>
     </target>
 
-    <target name="build" depends="init, compile, jar, jar-jsse, javadoc, examples, test"/>
+    <target name="build" depends="init, compile, jar, jar-jsse, javadoc"/>
     <target name="build-jacoco" depends="init, compile, jar, jar-jsse, javadoc, examples, test-jacoco, coverage-report"/>
 
     <target name="compile">
@@ -118,7 +118,7 @@
         <javadoc sourcepath="${src.dir}" destdir="${doc.dir}"/>
     </target>
 
-    <target name="examples">
+    <target name="examples" depends="build">
         <javac srcdir="${examples.dir}"
                destdir="${examples.build.dir}"
                debug="${java.debug}"
@@ -133,7 +133,7 @@
         </javac>
     </target>
 
-    <target name="build-test">
+    <target name="build-test" depends="build">
         <javac srcdir="${test.dir}"
                destdir="${test.build.dir}"
                debug="${java.debug}"

--- a/build.xml
+++ b/build.xml
@@ -39,7 +39,7 @@
         <fileset dir="${lib.dir}" includes="*.jar">
             <include name="wolfssl.jar"/>
         </fileset>
-        <fileset dir="${env.JUNIT_HOME}">
+        <fileset dir="${env.JUNIT_HOME}" erroronmissingdir="false">
             <include name="${junit4}"/>
         </fileset>
     </path>


### PR DESCRIPTION
Separate build of tests and examples from main jar. This helps by not stopping the build of the main code source if JUNIT is not setup in the exact way that build.xml expects on the system.

Build options
- ant build
- ant examples
- ant test