### PR TITLE
SSLSocketFactory.getDefault() support, WolfSSLContext getters

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLContext.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLContext.java
@@ -406,6 +406,38 @@ public class WolfSSLContext extends SSLContextSpi {
         throw new UnsupportedOperationException("Not supported by wolfJSSE");
     }
 
+    /**
+     * Returns copy of SSLParameters with default settings for this SSLContext.
+     */
+    @Override
+    protected SSLParameters engineGetDefaultSSLParameters() {
+        return WolfSSLEngineHelper.decoupleParams(this.params);
+    }
+
+    /**
+     * Returns copy of SSLParameters with max supported settings for this
+     * SSLContext.
+     */
+    @Override
+    protected SSLParameters engineGetSupportedSSLParameters() {
+        return WolfSSLEngineHelper.decoupleParams(this.params);
+    }
+
+    /* used internally by SSLSocketFactory() */
+    protected WolfSSLAuthStore getInternalAuthStore() {
+        return this.authStore;
+    }
+
+    /* used internally by SSLSocketFactory() */
+    protected SSLParameters getInternalSSLParams() {
+        return this.params;
+    }
+
+    /* used internally by SSLSocketFactory() */
+    protected com.wolfssl.WolfSSLContext getInternalWolfSSLContext() {
+        return this.ctx;
+    }
+
     public static final class TLSV1_Context extends WolfSSLContext {
         public TLSV1_Context() {
             super(TLS_VERSION.TLSv1);

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java
@@ -23,6 +23,7 @@ package com.wolfssl.provider.jsse;
 
 import java.security.Provider;
 import com.wolfssl.WolfSSL;
+import com.wolfssl.WolfSSLException;
 
 /**
  * wolfSSL JSSE Provider implementation
@@ -38,6 +39,14 @@ public final class WolfSSLProvider extends Provider {
 
         /* load native wolfSSLJNI library */
         WolfSSL.loadLibrary();
+
+        try {
+            /* initialize native wolfSSL */
+            WolfSSL sslLib = new WolfSSL();
+        } catch (WolfSSLException e) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                "Failed to initialize native wolfSSL library");
+        }
 
         /* Key Factory */
         put("KeyManagerFactory.X509",

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocketFactory.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocketFactory.java
@@ -45,6 +45,17 @@ public class WolfSSLSocketFactory extends SSLSocketFactory {
     private WolfSSLContext ctx = null;
     private SSLParameters params;
 
+    /* This constructor is used when the JSSE call
+     * SSLSocketFactory.getDefault() */
+    public WolfSSLSocketFactory() {
+        super();
+        com.wolfssl.provider.jsse.WolfSSLContext.DEFAULT_Context jsseCtx =
+            new com.wolfssl.provider.jsse.WolfSSLContext.DEFAULT_Context();
+        this.ctx = jsseCtx.getInternalWolfSSLContext();
+        this.authStore = jsseCtx.getInternalAuthStore();
+        this.params = jsseCtx.getInternalSSLParams();
+    }
+
     public WolfSSLSocketFactory(com.wolfssl.WolfSSLContext ctx,
             WolfSSLAuthStore authStore, SSLParameters params) {
         super();

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLContextTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLContextTest.java
@@ -38,6 +38,7 @@ import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.SSLSessionContext;
+import javax.net.ssl.SSLParameters;
 import java.security.Security;
 import java.security.Provider;
 import java.security.KeyStore;
@@ -270,8 +271,126 @@ public class WolfSSLContextTest {
                 /* expected */
             }
         }
-
         System.out.println("\t\t... passed");
+    }
+
+    @Test
+    public void testGetSupportedSSLParameters() throws NoSuchProviderException,
+        NoSuchAlgorithmException, IllegalStateException,
+        KeyManagementException {
+
+        System.out.print("\tgetSupportedSSLParameters()");
+
+        SSLContext ctx = null;
+
+        for (int i = 0; i < enabledProtocols.size(); i++) {
+
+            try {
+                ctx = SSLContext.getInstance(enabledProtocols.get(i),
+                        ctxProvider);
+                ctx.init(null, null, null);
+            } catch (Exception e) {
+                System.out.println("\t\t... failed");
+                fail("Failed to init SSLContext");
+                return;
+            }
+
+            /* test for UnsupportedOperationException */
+            try {
+                SSLParameters params = ctx.getSupportedSSLParameters();
+                if (params == null) {
+                    System.out.println("\t... failed");
+                    fail("Failed to valid supported SSLParameters");
+                }
+
+                /* make sure protocol list is not null */
+                String[] protocols = params.getProtocols();
+                if (protocols == null || protocols.length == 0) {
+                    System.out.println("\t... failed");
+                    fail("SSLParameters.getProtocols() returned null");
+                }
+
+                /* make sure cipher suite list is not null */
+                String[] ciphers = params.getCipherSuites();
+                if (ciphers == null || ciphers.length == 0) {
+                    System.out.println("\t... failed");
+                    fail("SSLParameters.getCipherSuites() returned null");
+                }
+
+            } catch (UnsupportedOperationException e) {
+                System.out.println("\t... failed");
+                fail("UnsupportedOperationException thrown but not expected");
+            }
+        }
+        System.out.println("\t... passed");
+    }
+
+    @Test
+    public void testGetDefaultSSLParameters() throws NoSuchProviderException,
+        NoSuchAlgorithmException, IllegalStateException,
+        KeyManagementException {
+
+        System.out.print("\tgetDefaultSSLParameters()");
+
+        SSLContext ctx = null;
+
+        for (int i = 0; i < enabledProtocols.size(); i++) {
+
+            try {
+                ctx = SSLContext.getInstance(enabledProtocols.get(i),
+                        ctxProvider);
+                ctx.init(null, null, null);
+            } catch (Exception e) {
+                System.out.println("\t\t... failed");
+                fail("Failed to init SSLContext");
+                return;
+            }
+
+            /* test for UnsupportedOperationException */
+            try {
+                SSLParameters params = ctx.getDefaultSSLParameters();
+                if (params == null) {
+                    System.out.println("\t... failed");
+                    fail("Failed to valid default SSLParameters");
+                }
+
+                /* make sure protocol list is not null */
+                String[] protocols = params.getProtocols();
+                if (protocols == null || protocols.length == 0) {
+                    System.out.println("\t... failed");
+                    fail("SSLParameters.getProtocols() returned null");
+                }
+
+                /* make sure cipher suite list is not null */
+                String[] ciphers = params.getCipherSuites();
+                if (ciphers == null || ciphers.length == 0) {
+                    System.out.println("\t... failed");
+                    fail("SSLParameters.getCipherSuites() returned null");
+                }
+
+                /* needClientAuth should default to false */
+                boolean needClientAuth = params.getNeedClientAuth();
+                if (needClientAuth == true) {
+                    System.out.println("\t... failed");
+                    fail("SSLParameters.getNeedClientAuth() should default " +
+                         "to false");
+                }
+
+                /* wantClientAuth should default to false */
+                boolean wantClientAuth = params.getWantClientAuth();
+                if (wantClientAuth == true) {
+                    System.out.println("\t... failed");
+                    fail("SSLParameters.getWantClientAuth() should default " +
+                         "to false");
+                }
+
+            } catch (UnsupportedOperationException e) {
+                System.out.println("\t... failed");
+                fail("UnsupportedOperationException thrown but not expected");
+            }
+        }
+
+        System.out.println("\t... passed");
     }
 }
 

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketFactoryTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketFactoryTest.java
@@ -149,6 +149,29 @@ public class WolfSSLSocketFactoryTest {
             SSLSocketFactory sf = ctx.getSocketFactory();
             sockFactories.add(sf);
         }
+
+        /* add default SSLSocketFactory to tests */
+        SSLSocketFactory sfDefault =
+            new com.wolfssl.provider.jsse.WolfSSLSocketFactory();
+        sockFactories.add(sfDefault);
+    }
+
+    @Test
+    public void testUseDefaultSSLSocketFactory()
+        throws NoSuchProviderException, NoSuchAlgorithmException {
+
+        /* CHRIS */
+        System.out.print("\tgetDefault()");
+
+        SSLSocketFactory sf =
+            new com.wolfssl.provider.jsse.WolfSSLSocketFactory();
+
+        if (sf == null) {
+            System.out.println("\t\t\t... failed");
+            fail("SSLSocketFactory.getDefault() failed");
+        }
+
+        System.out.println("\t\t\t... passed");
     }
 
     @Test
@@ -293,6 +316,7 @@ public class WolfSSLSocketFactoryTest {
             }
             catch (Exception e) {
                 System.out.println("\t\t\t... failed");
+                throw e;
             }
 
             /* bad arguments */


### PR DESCRIPTION
This PR includes JSSE additions:

1.  Adds support for JSSE use cases that call SSLSocketFactory.getDefault()
2.  Adds support for SSLContext.getDefaultSSLParameters()
3.  Adds support for SSLContext.getSupportedSSLParameters()
4.  Adds better native library init in WolfSSLProvider