### PR TITLE
register wolfJSSE as first Security provider in unit tests

### DIFF
--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLContextTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLContextTest.java
@@ -77,7 +77,7 @@ public class WolfSSLContextTest {
         System.out.println("WolfSSLContext Class");
 
         /* install wolfJSSE provider at runtime */
-        Security.addProvider(new WolfSSLProvider());
+        Security.insertProviderAt(new WolfSSLProvider(), 1);
 
         Provider p = Security.getProvider("wolfJSSE");
         assertNotNull(p);

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineTest.java
@@ -73,7 +73,7 @@ public class WolfSSLEngineTest {
         System.out.println("WolfSSLEngine Class");
 
         /* install wolfJSSE provider at runtime */
-        Security.addProvider(new WolfSSLProvider());
+        Security.insertProviderAt(new WolfSSLProvider(), 1);
 
         Provider p = Security.getProvider("wolfJSSE");
         assertNotNull(p);

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLKeyX509Test.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLKeyX509Test.java
@@ -52,7 +52,7 @@ public class WolfSSLKeyX509Test {
         System.out.println("WolfSSLKeyX509 Class");
 
         /* install wolfJSSE provider at runtime */
-        Security.addProvider(new WolfSSLProvider());
+        Security.insertProviderAt(new WolfSSLProvider(), 1);
 
         Provider p = Security.getProvider("wolfJSSE");
         assertNotNull(p);

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLServerSocketFactoryTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLServerSocketFactoryTest.java
@@ -84,7 +84,7 @@ public class WolfSSLServerSocketFactoryTest {
         System.out.println("WolfSSLServerSocketFactory Class");
 
         /* install wolfJSSE provider at runtime */
-        Security.addProvider(new WolfSSLProvider());
+        Security.insertProviderAt(new WolfSSLProvider(), 1);
 
         Provider p = Security.getProvider("wolfJSSE");
         assertNotNull(p);

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLServerSocketTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLServerSocketTest.java
@@ -97,7 +97,7 @@ public class WolfSSLServerSocketTest {
         tf = new WolfSSLTestFactory();
 
         /* install wolfJSSE provider at runtime */
-        Security.addProvider(new WolfSSLProvider());
+        Security.insertProviderAt(new WolfSSLProvider(), 1);
 
         Provider p = Security.getProvider("wolfJSSE");
         assertNotNull(p);

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSessionTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSessionTest.java
@@ -61,7 +61,7 @@ public class WolfSSLSessionTest {
         System.out.println("WolfSSLImplementSSLSession Class");
 
         /* install wolfJSSE provider at runtime */
-        Security.addProvider(new WolfSSLProvider());
+        Security.insertProviderAt(new WolfSSLProvider(), 1);
 
         Provider p = Security.getProvider("wolfJSSE");
         assertNotNull(p);

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketFactoryTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketFactoryTest.java
@@ -90,7 +90,7 @@ public class WolfSSLSocketFactoryTest {
         System.out.println("WolfSSLSocketFactory Class");
 
         /* install wolfJSSE provider at runtime */
-        Security.addProvider(new WolfSSLProvider());
+        Security.insertProviderAt(new WolfSSLProvider(), 1);
 
         Provider p = Security.getProvider("wolfJSSE");
         assertNotNull(p);

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
@@ -123,7 +123,7 @@ public class WolfSSLSocketTest {
         tf = new WolfSSLTestFactory();
 
         /* install wolfJSSE provider at runtime */
-        Security.addProvider(new WolfSSLProvider());
+        Security.insertProviderAt(new WolfSSLProvider(), 1);
 
         Provider p = Security.getProvider("wolfJSSE");
         assertNotNull(p);

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLTrustX509Test.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLTrustX509Test.java
@@ -58,7 +58,7 @@ public class WolfSSLTrustX509Test {
         System.out.println("WolfSSLTrustX509 Class");
 
         /* install wolfJSSE provider at runtime */
-        Security.addProvider(new WolfSSLProvider());
+        Security.insertProviderAt(new WolfSSLProvider(), 1);
 
         Provider p = Security.getProvider("wolfJSSE");
         assertNotNull(p);

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLX509Test.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLX509Test.java
@@ -71,7 +71,7 @@ public class WolfSSLX509Test {
         System.out.println("WolfSSLX509 Class");
 
                 /* install wolfJSSE provider at runtime */
-        Security.addProvider(new WolfSSLProvider());
+        Security.insertProviderAt(new WolfSSLProvider(), 1);
 
 
         Provider p = Security.getProvider("wolfJSSE");


### PR DESCRIPTION
This PR changes how wolfJSSE is registered as a Security Provider in our junit tests.  Previously we were using "Security.addProvider()", but on some systems this does not register wolfJSSE as the highest priority Provider.  Using "Security.insertProviderAt()" instead allows us to explicitly register wolfJSSE as the first priority provider.