### PR TITLE
free WolfSSLCertificate in WolfSSLTrustManager when done with it

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLTrustManager.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLTrustManager.java
@@ -187,6 +187,7 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
                             }
 
                             byte[] derArray = certPem.getDer();
+                            certPem.free();
                             ByteArrayInputStream bis =
                                 new ByteArrayInputStream(derArray);
                             Certificate tmpCert = null;


### PR DESCRIPTION
On Android, when loading trusted system certificates, we should free the WolfSSLCertificate explicitly after we are finished with it.