### PR TITLE
add finalize() methods for WolfSSLCertManager, WolfSSLCertificate

### DIFF
--- a/src/java/com/wolfssl/WolfSSLCertManager.java
+++ b/src/java/com/wolfssl/WolfSSLCertManager.java
@@ -87,4 +87,16 @@ public class WolfSSLCertManager {
         /* free Java resources */
         this.active = false;
     }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    protected void finalize() throws Throwable
+    {
+        if (this.active == true) {
+            /* free resources, set state */
+            this.free();
+            this.active = false;
+        }
+        super.finalize();
+    }
 }

--- a/src/java/com/wolfssl/WolfSSLCertificate.java
+++ b/src/java/com/wolfssl/WolfSSLCertificate.java
@@ -391,4 +391,16 @@ public class WolfSSLCertificate {
         /* free Java resources */
         this.active = false;
     }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    protected void finalize() throws Throwable
+    {
+        if (this.active == true) {
+            /* free resources, set state */
+            this.free();
+            this.active = false;
+        }
+        super.finalize();
+    }
 }


### PR DESCRIPTION
This PR adds finalize() methods to the WolfSSLCertManager and WolfSSLCertificate classes, to protect against any cases where users might not call free() explicitly.