### PR TITLE
check X509Certificate[] for null in getLocalPrincipal()

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
@@ -256,6 +256,10 @@ public class WolfSSLImplementSSLSession implements SSLSession {
         java.security.cert.X509Certificate[] certs =
                 km.getCertificateChain(authStore.getCertAlias());
 
+        if (certs == null) {
+            return null;
+        }
+
         for (i = 0; i < certs.length; i++) {
             if (certs[i].getBasicConstraints() < 0) {
                 /* is not a CA treat as end of chain */


### PR DESCRIPTION
Prevent a null pointer exception if certs is null, before calling certs.length.