### PR TITLE
catch IllegalStateException in WolfSSLContext cleanup()

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLContext.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLContext.java
@@ -452,8 +452,13 @@ public class WolfSSLContext extends SSLContextSpi {
 
     protected void cleanup() {
         if (this.ctx != null) {
-            this.ctx.free();
-            this.ctx = null;
+            try {
+                this.ctx.free();
+                this.ctx = null;
+            } catch (IllegalStateException e) {
+                /* ctx already freed */
+                this.ctx = null;
+            }
         }
     }
 


### PR DESCRIPTION
In case the underlying WolfSSLContext has already been freed, have cleanup() catch the IllegalStateException to prevent users from seeing it pop up.