### PR TITLE
WolfSSLSocketFactory, WolfSSLContext fixes

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLContext.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLContext.java
@@ -322,7 +322,7 @@ public class WolfSSLContext extends SSLContextSpi {
     protected SSLSocketFactory engineGetSocketFactory()
         throws IllegalStateException {
 
-        if (authStore == null) {
+        if (this.ctx == null || this.authStore == null) {
             throw new IllegalStateException("SSLContext must be initialized " +
                 "before use, please call init()");
         }
@@ -339,7 +339,7 @@ public class WolfSSLContext extends SSLContextSpi {
     protected SSLServerSocketFactory engineGetServerSocketFactory()
         throws IllegalStateException {
 
-        if (authStore == null) {
+        if (this.ctx == null || this.authStore == null) {
             throw new IllegalStateException("SSLContext must be initialized " +
                 "before use, please call init()");
         }
@@ -357,7 +357,7 @@ public class WolfSSLContext extends SSLContextSpi {
     protected SSLEngine engineCreateSSLEngine()
         throws IllegalStateException {
 
-        if (authStore == null) {
+        if (this.ctx == null || this.authStore == null) {
             throw new IllegalStateException("SSLContext must be initialized " +
                 "before use, please call init()");
         }
@@ -381,7 +381,7 @@ public class WolfSSLContext extends SSLContextSpi {
     protected SSLEngine engineCreateSSLEngine(String host, int port)
         throws IllegalStateException {
 
-        if (authStore == null) {
+        if (this.ctx == null || this.authStore == null) {
             throw new IllegalStateException("SSLContext must be initialized " +
                 "before use, please call init()");
         }
@@ -450,22 +450,12 @@ public class WolfSSLContext extends SSLContextSpi {
         return this.ctx;
     }
 
-    protected void cleanup() {
-        if (this.ctx != null) {
-            try {
-                this.ctx.free();
-                this.ctx = null;
-            } catch (IllegalStateException e) {
-                /* ctx already freed */
-                this.ctx = null;
-            }
-        }
-    }
-
     @SuppressWarnings("deprecation")
     @Override
     protected void finalize() throws Throwable {
-        this.cleanup();
+        if (this.ctx != null) {
+            this.ctx = null;
+        }
         super.finalize();
     }
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLContext.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLContext.java
@@ -473,25 +473,11 @@ public class WolfSSLContext extends SSLContextSpi {
         public TLSV1_Context() {
             super(TLS_VERSION.TLSv1);
         }
-
-        @SuppressWarnings("deprecation")
-        @Override
-        protected void finalize() throws Throwable {
-            this.cleanup();
-            super.finalize();
-        }
     }
 
     public static final class TLSV11_Context extends WolfSSLContext {
         public TLSV11_Context() {
             super(TLS_VERSION.TLSv1_1);
-        }
-
-        @SuppressWarnings("deprecation")
-        @Override
-        protected void finalize() throws Throwable {
-            this.cleanup();
-            super.finalize();
         }
     }
 
@@ -499,38 +485,17 @@ public class WolfSSLContext extends SSLContextSpi {
         public TLSV12_Context() {
             super(TLS_VERSION.TLSv1_2);
         }
-
-        @SuppressWarnings("deprecation")
-        @Override
-        protected void finalize() throws Throwable {
-            this.cleanup();
-            super.finalize();
-        }
     }
 
     public static final class TLSV13_Context extends WolfSSLContext {
         public TLSV13_Context() {
             super(TLS_VERSION.TLSv1_3);
         }
-
-        @SuppressWarnings("deprecation")
-        @Override
-        protected void finalize() throws Throwable {
-            this.cleanup();
-            super.finalize();
-        }
     }
 
     public static final class TLSV23_Context extends WolfSSLContext {
         public TLSV23_Context() {
             super(TLS_VERSION.SSLv23);
-        }
-
-        @SuppressWarnings("deprecation")
-        @Override
-        protected void finalize() throws Throwable {
-            this.cleanup();
-            super.finalize();
         }
     }
 
@@ -542,13 +507,6 @@ public class WolfSSLContext extends SSLContextSpi {
             } catch (Exception e) {
                 /* TODO: log this */
             }
-        }
-
-        @SuppressWarnings("deprecation")
-        @Override
-        protected void finalize() throws Throwable {
-            this.cleanup();
-            super.finalize();
         }
     }
 }

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocketFactory.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocketFactory.java
@@ -43,14 +43,14 @@ public class WolfSSLSocketFactory extends SSLSocketFactory {
 
     private WolfSSLAuthStore authStore = null;
     private com.wolfssl.WolfSSLContext ctx = null;
+    private com.wolfssl.provider.jsse.WolfSSLContext jsseCtx = null;
     private SSLParameters params;
 
     /* This constructor is used when the JSSE call
      * SSLSocketFactory.getDefault() */
     public WolfSSLSocketFactory() {
         super();
-        com.wolfssl.provider.jsse.WolfSSLContext.DEFAULT_Context jsseCtx =
-            new com.wolfssl.provider.jsse.WolfSSLContext.DEFAULT_Context();
+        this.jsseCtx = new com.wolfssl.provider.jsse.WolfSSLContext.DEFAULT_Context();
         this.ctx = jsseCtx.getInternalWolfSSLContext();
         this.authStore = jsseCtx.getInternalAuthStore();
         this.params = jsseCtx.getInternalSSLParams();


### PR DESCRIPTION
This PR:

1) Fixes how WolfSSLSocketFactory stores the DEFAULT_Context reference.  Previously the reference lost scope after the constructor exited.

2) Removes unnecessary finalize() methods in WolfSSLContext inner classes.  The outer WolfSSLContext finalize() will always be called when an inner class goes out of scope and is garbage collected.

3)  Changes com.wolfssl.provider.jsse.WolfSSLContext finalizer so that it does not free the underlying com.wolfssl.WolfSSLContext.  Some objects/classes may still hold references to the underlying WolfSSLContext which they need.  The underlying WolfSSLContext will be freed by its own finalize() method when needed.