### PR TITLE
fix on TLS version filter

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLContext.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLContext.java
@@ -82,20 +82,16 @@ public class WolfSSLContext extends SSLContextSpi {
         method = WolfSSL.NOT_COMPILED_IN;
         switch (this.currentVersion) {
             case TLSv1:
-                if((ctxAttr.noOptions & WolfSSL.SSL_OP_NO_TLSv1) == 0)
-                    method = WolfSSL.TLSv1_Method();
+                method = WolfSSL.TLSv1_Method();
                 break;
             case TLSv1_1:
-                if((ctxAttr.noOptions & WolfSSL.SSL_OP_NO_TLSv1_1) == 0)
-                    method = WolfSSL.TLSv1_1_Method();
+                method = WolfSSL.TLSv1_1_Method();
                 break;
             case TLSv1_2:
-                if((ctxAttr.noOptions & WolfSSL.SSL_OP_NO_TLSv1_2) == 0)
-                    method = WolfSSL.TLSv1_2_Method();
+                method = WolfSSL.TLSv1_2_Method();
                 break;
             case TLSv1_3:
-                if((ctxAttr.noOptions & WolfSSL.SSL_OP_NO_TLSv1_3) == 0)
-                    method = WolfSSL.TLSv1_3_Method();
+                method = WolfSSL.TLSv1_3_Method();
                 break;
             case SSLv23:
                 method = WolfSSL.SSLv23_Method();

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
@@ -175,10 +175,7 @@ public class WolfSSLEngineHelper {
 
     /* gets all supported protocols */
     protected String[] getAllProtocols() {
-        if(ssl != null)
-            return WolfSSL.getProtocolsMask(ssl.getOptions());
-        else
-            return WolfSSL.getProtocols();
+        return WolfSSL.getProtocols();
     }
 
     protected void setUseClientMode(boolean mode)

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLServerSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLServerSocket.java
@@ -138,7 +138,7 @@ public class WolfSSLServerSocket extends SSLServerSocket {
 
     @Override
     public String[] getSupportedProtocols() {
-        return WolfSSL.getProtocols();
+        return params.getProtocols();
     }
 
     @Override
@@ -160,11 +160,7 @@ public class WolfSSLServerSocket extends SSLServerSocket {
 
         /* sanitize protocol array for unsupported strings */
         List<String> supported;
-        if(context != null)
-            supported = Arrays.asList(
-                            WolfSSL.getProtocolsMask(context.getOptions()));
-        else
-            supported = Arrays.asList(WolfSSL.getProtocols());
+        supported = Arrays.asList(WolfSSL.getProtocols());
                 
         for (int i = 0; i < protocols.length; i++) {
             if (!supported.contains(protocols[i])) {


### PR DESCRIPTION
- callback filter is effective after creating context in createCtx
- getAllProtocols to get built in protocols
- getSupportedProtocols to get protocols after the filter

