### PR TITLE
fix build with DH disabled

### DIFF
--- a/README
+++ b/README
@@ -37,6 +37,9 @@ Release X.X.X has bug fixes and new features including:
 - Consistently use wolfCrypt XMALLOC/XFREE for native memory allocation
 - Use javah in build.xml for older ant/Java versions without nativeheaderdir
 - Add JSSE debug logging for native wolfSSL with wolfssl.debug system parameter
+- Add internal implementation of SSLParameters, WolfSSLParameters
+- Add client-side SNI support
+- Fix warnings when DH is disabled (--disable-dh)
 
 The wolfSSL JNI Manual is available at:
 http://www.wolfssl.com/documentation/wolfSSL-JNI-Manual.pdf. For build

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -1229,6 +1229,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setTmpDH
   (JNIEnv* jenv, jobject jcl, jlong ssl, jbyteArray p, jint pSz, jbyteArray g,
    jint gSz)
 {
+#ifndef NO_DH
     unsigned char pBuf[pSz];
     unsigned char gBuf[gSz];
     jclass excClass;
@@ -1267,12 +1268,22 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setTmpDH
     }
 
     return wolfSSL_SetTmpDH((WOLFSSL*)(uintptr_t)ssl, pBuf, pSz, gBuf, gSz);
-
+#else
+    (void)jenv;
+    (void)jcl;
+    (void)ssl;
+    (void)p;
+    (void)pSz;
+    (void)g;
+    (void)gSz;
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setTmpDHFile
   (JNIEnv* jenv, jobject jcl, jlong ssl, jstring file, jint format)
 {
+#ifndef NO_DH
     int ret;
     const char* fname;
     jclass excClass;
@@ -1302,6 +1313,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setTmpDHFile
     (*jenv)->ReleaseStringUTFChars(jenv, file, fname);
 
     return ret;
+#else
+    (void)jenv;
+    (void)jcl;
+    (void)ssl;
+    (void)file;
+    (void)format;
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useCertificateBuffer


### PR DESCRIPTION
This PR adds checks for NO_DH around DH-related functionality in native/com_wolfssl_WolfSSLSession.c.