### PR TITLE
add wolfssl.debug parameter for native debug with JSSE

### DIFF
--- a/README
+++ b/README
@@ -36,6 +36,7 @@ Release X.X.X has bug fixes and new features including:
 - Conversion to use GetByteArrayElements for potential memory use savings
 - Consistently use wolfCrypt XMALLOC/XFREE for native memory allocation
 - Use javah in build.xml for older ant/Java versions without nativeheaderdir
+- Add JSSE debug logging for native wolfSSL with wolfssl.debug system parameter
 
 The wolfSSL JNI Manual is available at:
 http://www.wolfssl.com/documentation/wolfSSL-JNI-Manual.pdf. For build

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java
@@ -48,6 +48,13 @@ public final class WolfSSLProvider extends Provider {
                 "Failed to initialize native wolfSSL library");
         }
 
+        /* enable native wolfSSL debug logging, native wolfSSL must be
+         * compiled with --enable-debug */
+        String wolfsslDebug = System.getProperty("wolfssl.debug");
+        if ((wolfsslDebug != null) && (wolfsslDebug.equalsIgnoreCase("true"))) {
+            WolfSSL.debuggingON();
+        }
+
         /* Key Factory */
         put("KeyManagerFactory.X509",
                 "com.wolfssl.provider.jsse.WolfSSLKeyManager");


### PR DESCRIPTION
Adds support for a new system parameter called "wolfssl.debug".  When set to true at runtime, this will enable native wolfSSL debug logging with wolfJSSE.

For example, when running a Java app that uses wolfJSSE, and native wolfSSL has been compiled with "--enable-debug":

```
$ java -Dwolfssl.debug=true TestApp
```