### PR TITLE
WolfSSLSocket, WolfSSLTrustX509 fixes

### DIFF
--- a/native/com_wolfssl_WolfSSLCertificate.c
+++ b/native/com_wolfssl_WolfSSLCertificate.c
@@ -707,10 +707,13 @@ JNIEXPORT jbooleanArray JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1k
 JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1extension
   (JNIEnv* jenv, jclass jcl, jlong x509, jstring oidIn)
 {
-    int nid = 0, idx = 0;
+    int nid = 0;
     jbyteArray ret = NULL;
     const char* oid = NULL;
+#if LIBWOLFSSL_VERSION_HEX >= 0x04002000
+    int idx = 0;
     WOLFSSL_X509_EXTENSION* ext = NULL;
+#endif
     WOLFSSL_ASN1_OBJECT* obj = NULL;
 #if LIBWOLFSSL_VERSION_HEX < 0x04002000
     void* sk = NULL;

--- a/native/com_wolfssl_WolfSSLSession.h
+++ b/native/com_wolfssl_WolfSSLSession.h
@@ -98,10 +98,10 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_write
 /*
  * Class:     com_wolfssl_WolfSSLSession
  * Method:    read
- * Signature: (J[BI)I
+ * Signature: (J[BII)I
  */
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_read
-  (JNIEnv *, jobject, jlong, jbyteArray, jint);
+  (JNIEnv *, jobject, jlong, jbyteArray, jint, jint);
 
 /*
  * Class:     com_wolfssl_WolfSSLSession
@@ -122,10 +122,10 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_freeSSL
 /*
  * Class:     com_wolfssl_WolfSSLSession
  * Method:    shutdownSSL
- * Signature: (J)I
+ * Signature: (JI)I
  */
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_shutdownSSL
-  (JNIEnv *, jobject, jlong);
+  (JNIEnv *, jobject, jlong, jint);
 
 /*
  * Class:     com_wolfssl_WolfSSLSession

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -623,6 +623,7 @@ public class WolfSSLSession {
      * @param data  buffer where the data read from the SSL connection
      *              will be placed.
      * @param sz    number of bytes to read into <b><code>data</code></b>
+     * @param timeout read timeout, milliseconds.
      * @return      the number of bytes read upon success. <code>SSL_FAILURE
      *              </code> will be returned upon failure which may be caused
      *              by either a clean (close notify alert) shutdown or just
@@ -766,6 +767,8 @@ public class WolfSSLSession {
      * to <code>getError()</code> will yield either <b>SSL_ERROR_WANT_READ</b>
      * or <b>SSL_ERROR_WANT_WRITE</b>. The calling process must then repeat
      * the call to <code>shutdownSSL()</code> when the underlying I/O is ready.
+     *
+     * @param timeout read timeout, milliseconds.
      *
      * @return <code>SSL_SUCCESS</code> on success,
      *         <code>SSL_FATAL_ERROR</code> upon failure. Call <code>

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
@@ -255,7 +255,7 @@ public class WolfSSLEngineHelper {
             String list;
             StringBuilder sb = new StringBuilder();
 
-            if (suites == null) {
+            if (suites == null || suites.length == 0) {
                 /* use default cipher suites */
                 return;
             }
@@ -265,12 +265,14 @@ public class WolfSSLEngineHelper {
                 sb.append(":");
             }
 
-            /* remove last : */
-            sb.deleteCharAt(sb.length() - 1);
-            list = sb.toString();
-            if (this.ssl.setCipherList(list) != WolfSSL.SSL_SUCCESS) {
-                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "error setting cipher list " + list);
+            if (sb.length() > 0) {
+                /* remove last : */
+                sb.deleteCharAt(sb.length() - 1);
+                list = sb.toString();
+                if (this.ssl.setCipherList(list) != WolfSSL.SSL_SUCCESS) {
+                    WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                            "error setting cipher list " + list);
+                }
             }
 
         } catch (IllegalStateException e) {

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -932,6 +932,17 @@ public class WolfSSLSocket extends SSLSocket {
             "entered close()");
 
         try {
+
+            /* Check if underlying Socket is still open before closing,
+             * in case application calls SSLSocket.close() multiple times */
+            synchronized (handshakeLock) {
+                if (this.connectionClosed == true || super.isClosed()) {
+                    WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                        "Socket already closed, skipping TLS shutdown");
+                    return;
+                }
+            }
+
             if (ssl != null) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                         "shutting down SSL/TLS connection");

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -1163,16 +1163,16 @@ public class WolfSSLSocket extends SSLSocket {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                                  "thread got readLock");
 
-                /* do handshake if not completed yet, handles synchronization */
-                if (socket.handshakeComplete == false) {
-                    socket.startHandshake();
-                }
-
                 /* check if connection has already been closed/shutdown */
                 synchronized (socket.handshakeLock) {
                     if (socket.connectionClosed == true) {
                         throw new SocketException("Connection already shutdown");
                     }
+                }
+
+                /* do handshake if not completed yet, handles synchronization */
+                if (socket.handshakeComplete == false) {
+                    socket.startHandshake();
                 }
 
                 if (b.length == 0 || len == 0) {
@@ -1279,16 +1279,16 @@ public class WolfSSLSocket extends SSLSocket {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                                  "thread got writeLock");
 
-                /* do handshake if not completed yet, handles synchronization */
-                if (socket.handshakeComplete == false) {
-                    socket.startHandshake();
-                }
-
                 /* check if connection has already been closed/shutdown */
                 synchronized (socket.handshakeLock) {
                     if (socket.connectionClosed == true) {
                         throw new SocketException("Connection already shutdown");
                     }
+                }
+
+                /* do handshake if not completed yet, handles synchronization */
+                if (socket.handshakeComplete == false) {
+                    socket.startHandshake();
                 }
 
                 if (off < 0 || len < 0 || (off + len) > b.length) {

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocketFactory.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocketFactory.java
@@ -53,7 +53,6 @@ public class WolfSSLSocketFactory extends SSLSocketFactory {
     /* This constructor is used when the JSSE call
      * SSLSocketFactory.getDefault() */
     public WolfSSLSocketFactory() {
-        super();
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "created new default WolfSSLSocketFactory");
@@ -70,7 +69,6 @@ public class WolfSSLSocketFactory extends SSLSocketFactory {
 
     public WolfSSLSocketFactory(com.wolfssl.WolfSSLContext ctx,
             WolfSSLAuthStore authStore, WolfSSLParameters params) {
-        super();
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "created new WolfSSLSocketFactory");

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocketFactory.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocketFactory.java
@@ -45,6 +45,11 @@ public class WolfSSLSocketFactory extends SSLSocketFactory {
     private com.wolfssl.provider.jsse.WolfSSLContext jsseCtx = null;
     private WolfSSLParameters params;
 
+    /* Defer creation and initialization of DEFAULT Context until used,
+     * to remove creation logic from constructor */
+    private int isDefault = 0;
+    private int isDefaultInitialized = 0;
+
     /* This constructor is used when the JSSE call
      * SSLSocketFactory.getDefault() */
     public WolfSSLSocketFactory() {
@@ -53,10 +58,14 @@ public class WolfSSLSocketFactory extends SSLSocketFactory {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "created new default WolfSSLSocketFactory");
 
-        this.jsseCtx = new com.wolfssl.provider.jsse.WolfSSLContext.DEFAULT_Context();
-        this.ctx = jsseCtx.getInternalWolfSSLContext();
-        this.authStore = jsseCtx.getInternalAuthStore();
-        this.params = jsseCtx.getInternalSSLParams();
+        this.isDefault = 1;
+        this.isDefaultInitialized = 0;
+
+        /* initialize later on first use */
+        this.jsseCtx = null;
+        this.ctx = null;
+        this.authStore = null;
+        this.params = null;
     }
 
     public WolfSSLSocketFactory(com.wolfssl.WolfSSLContext ctx,
@@ -69,6 +78,27 @@ public class WolfSSLSocketFactory extends SSLSocketFactory {
         this.ctx = ctx;
         this.authStore = authStore;
         this.params = params;
+    }
+
+    /**
+     * Private internal function to create and initialize default context
+     * and set ctx, authStore, and params from it.
+     */
+    private void initDefaultContext() {
+        if (this.isDefault == 1 && this.isDefaultInitialized == 0) {
+
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                "creating and initializing DEFAULT_Context");
+
+            this.jsseCtx =
+                new com.wolfssl.provider.jsse.WolfSSLContext.DEFAULT_Context();
+            this.ctx = jsseCtx.getInternalWolfSSLContext();
+            this.authStore = jsseCtx.getInternalAuthStore();
+            this.params = jsseCtx.getInternalSSLParams();
+
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                "DEFAULT_Context created and initialized");
+        }
     }
 
     /**
@@ -111,6 +141,8 @@ public class WolfSSLSocketFactory extends SSLSocketFactory {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered createSocket()");
 
+        initDefaultContext();
+
         return new WolfSSLSocket(ctx, authStore, params, true);
     }
 
@@ -130,6 +162,8 @@ public class WolfSSLSocketFactory extends SSLSocketFactory {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered createSocket(InetAddress host, int port)");
+
+        initDefaultContext();
 
         return new WolfSSLSocket(ctx, authStore, params, true, host, port);
     }
@@ -155,6 +189,8 @@ public class WolfSSLSocketFactory extends SSLSocketFactory {
             "entered createSocket(InetAddress host, port: " + port + ", " +
             "InetAddress localAddress, localPort: " + localPort + ")");
 
+        initDefaultContext();
+
         return new WolfSSLSocket(ctx, authStore, params,
             true, address, port, localAddress, localPort);
     }
@@ -175,6 +211,8 @@ public class WolfSSLSocketFactory extends SSLSocketFactory {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered createSocket(host: " + host + ", port: " + port + ")");
+
+        initDefaultContext();
 
         return new WolfSSLSocket(ctx, authStore, params, true, host, port);
     }
@@ -199,6 +237,8 @@ public class WolfSSLSocketFactory extends SSLSocketFactory {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered createSocket(host: " + host + ", port: " + port +
             ", InetAddress localHost, localPort: " + localPort + ")");
+
+        initDefaultContext();
 
         return new WolfSSLSocket(ctx, authStore, params,
             true, host, port, localHost, localPort);
@@ -225,6 +265,8 @@ public class WolfSSLSocketFactory extends SSLSocketFactory {
             "entered createSocket(Socket s, host: " + host + ", port: " +
             port + ", autoClose: " + String.valueOf(autoClose) + ")");
 
+        initDefaultContext();
+
         return new WolfSSLSocket(ctx, authStore, params,
             true, s, host, port, autoClose);
     }
@@ -250,6 +292,8 @@ public class WolfSSLSocketFactory extends SSLSocketFactory {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered createSocket(Socket s, InputStream consumed, autoClose: "
             + String.valueOf(autoClose) + ")");
+
+        initDefaultContext();
 
         return new WolfSSLSocket(ctx, authStore, params, s,
             consumed, autoClose);


### PR DESCRIPTION
This PR contains four fixes:

- In WolfSSLInputStream/OutputStream, check if the connection has already been closed before trying to complete the handshake
- In WolfSSLEngineHelper.setLocalCiphers(), add length check to StringBuilder before modifying. Prevents StringIndexOutOfBoundsException.
- Add support for setSoTimeout() in WolfSSLSocket.  If called by an application, this timeout value will get used in select() calls made by socket SSL_read() and SSL_shutdown() operations.
- Adjust WolfSSLTrustX509.certManagerVerify() to verify and load intermediate chain certs before verifying peer.
- In WolfSSLSocket.close(), first check to see if close() has already been called before by checking if the underlying Socket has been closed.  If it has been closed, there is no reason to call SSL_shutdown() and close() again, and may only cause timeout/performance issues.