### PR TITLE
Add wrappers to get FIPS verifyCore hash (FIPS error callback, or directly)

### DIFF
--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -26,6 +26,9 @@
 #include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/hmac.h>
 #include <wolfssl/wolfcrypt/asn_public.h>
+#ifdef HAVE_FIPS
+    #include <wolfssl/wolfcrypt/fips_test.h>
+#endif
 
 #include "com_wolfssl_globals.h"
 #include "com_wolfssl_WolfSSL.h"
@@ -35,6 +38,11 @@ JavaVM*  g_vm;
 
 /* global object refs for logging callbacks */
 static jobject g_loggingCbIfaceObj;
+
+#ifdef HAVE_FIPS
+/* global object ref for FIPS error callback */
+static jobject g_fipsCbIfaceObj;
+#endif
 
 /* custom native fn prototypes */
 void NativeLoggingCallback(const int logLevel, const char *const logMessage);
@@ -676,6 +684,138 @@ void NativeLoggingCallback(const int logLevel, const char *const logMessage)
         (*jenv)->ThrowNew(jenv, excClass,
                 "Object reference invalid in NativeLoggingCallback");
     }
+}
+
+void NativeFIPSErrorCallback(const int ok, const int err,
+                             const char* const hash)
+{
+#ifdef HAVE_FIPS
+    JNIEnv*   jenv;
+    jint      vmret  = 0;
+    jclass    excClass;
+    jmethodID errorMethod;
+    jobjectRefType refcheck;
+
+    /* get JNIEnv from JavaVM */
+    vmret = (int)((*g_vm)->GetEnv(g_vm, (void**) &jenv, JNI_VERSION_1_6));
+    if (vmret == JNI_EDETACHED) {
+#ifdef __ANDROID__
+        vmret = (*g_vm)->AttachCurrentThread(g_vm, &jenv, NULL);
+#else
+        vmret = (*g_vm)->AttachCurrentThread(g_vm, (void**) &jenv, NULL);
+#endif
+        if (vmret) {
+            printf("Failed to attach JNIEnv to thread\n");
+        }
+    } else if (vmret != JNI_OK) {
+        printf("Unable to get JNIEnv from JavaVM\n");
+    }
+
+    /* find exception class */
+    excClass = (*jenv)->FindClass(jenv, "java/lang/Exception");
+    if ((*jenv)->ExceptionOccurred(jenv)) {
+        (*jenv)->ExceptionDescribe(jenv);
+        (*jenv)->ExceptionClear(jenv);
+        return;
+    }
+
+    /* check if our stored object reference is valid */
+    refcheck = (*jenv)->GetObjectRefType(jenv, g_fipsCbIfaceObj);
+    if (refcheck == 2) {
+
+        /* lookup WolfSSLLoggingCallback class from global object ref */
+        jclass fipsCbClass = (*jenv)->GetObjectClass(jenv, g_fipsCbIfaceObj);
+        if (!fipsCbClass) {
+            if ((*jenv)->ExceptionOccurred(jenv)) {
+                (*jenv)->ExceptionDescribe(jenv);
+                (*jenv)->ExceptionClear(jenv);
+            }
+
+            (*jenv)->ThrowNew(jenv, excClass,
+                "Can't get native WolfSSLFIPSErrorCallback class reference");
+            return;
+        }
+
+        errorMethod = (*jenv)->GetMethodID(jenv, fipsCbClass,
+                                            "errorCallback",
+                                            "(IILjava/lang/String;)V");
+        if (errorMethod == 0) {
+            if ((*jenv)->ExceptionOccurred(jenv)) {
+                (*jenv)->ExceptionDescribe(jenv);
+                (*jenv)->ExceptionClear(jenv);
+            }
+            (*jenv)->ThrowNew(jenv, excClass,
+                "Error getting errorCallback method from JNI");
+            return;
+        }
+
+        /* create jstring from char* */
+        jstring hashString = (*jenv)->NewStringUTF(jenv, hash);
+
+        (*jenv)->CallVoidMethod(jenv, g_fipsCbIfaceObj, errorMethod,
+                ok, err, hashString);
+
+        if ((*jenv)->ExceptionOccurred(jenv)) {
+            (*jenv)->ExceptionDescribe(jenv);
+            (*jenv)->ExceptionClear(jenv);
+
+            (*jenv)->ThrowNew(jenv, excClass,
+                    "Error calling FIPS error callback from JNI");
+            return;
+        }
+
+    } else {
+        if ((*jenv)->ExceptionOccurred(jenv)) {
+            (*jenv)->ExceptionDescribe(jenv);
+            (*jenv)->ExceptionClear(jenv);
+        }
+
+        (*jenv)->ThrowNew(jenv, excClass,
+                "Object reference invalid in NativeFIPSErrorCallback");
+    }
+#endif
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_setFIPSCb
+  (JNIEnv* jenv, jclass jcl, jobject callback)
+{
+    int ret = SSL_SUCCESS;
+    (void)jcl;
+
+#ifdef HAVE_FIPS
+    if (jenv == NULL || callback == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    /* store Java FIPS callback Interface object */
+    g_fipsCbIfaceObj = (*jenv)->NewGlobalRef(jenv, callback);
+    if (!g_fipsCbIfaceObj) {
+        printf("error storing global wolfCrypt FIP callback interface\n");
+        return SSL_FAILURE;
+    }
+
+    /* register NativeFIPSErrorCallback, wraps Java callback */
+    ret = wolfCrypt_SetCb_fips(NativeFIPSErrorCallback);
+    if (ret == 0) {
+        ret = SSL_SUCCESS;
+    }
+#else
+    (void)jenv;
+    (void)callback;
+    /* simply return SSL_SUCCESS if not compiled in / not FIPS lib */
+#endif
+
+    return ret;
+}
+
+JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSL_getWolfCryptFIPSCoreHash
+  (JNIEnv* jenv, jclass jcl)
+{
+#ifdef HAVE_FIPS
+    return (*jenv)->NewStringUTF(jenv, wolfCrypt_GetCoreHash_fips());
+#else
+    return NULL;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_memsaveSessionCache

--- a/native/com_wolfssl_WolfSSL.h
+++ b/native/com_wolfssl_WolfSSL.h
@@ -589,6 +589,22 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_setLoggingCb
 
 /*
  * Class:     com_wolfssl_WolfSSL
+ * Method:    setFIPSCb
+ * Signature: (Lcom/wolfssl/WolfSSLFIPSErrorCallback;)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_setFIPSCb
+  (JNIEnv *, jclass, jobject);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getWolfCryptFIPSCoreHash
+ * Signature: ()Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSL_getWolfCryptFIPSCoreHash
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
  * Method:    memsaveSessionCache
  * Signature: ([BI)I
  */

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -731,8 +731,9 @@ public class WolfSSL {
      * library.
      *
      * @param cb    Callback to be used for wolfCrypt FIPS verifyCore errors
-     * @return      <b><code>SSL_SUCCESS</code></b> on success, negative
-     *              on error.
+     * @return      <b><code>SSL_SUCCESS</code></b> on success,
+     *              <b><code>NOT_COMPILED_IN</code></b> if not using wolfCrypt
+     *              FIPS library distribution, or negative on error.
      */
     public final static native int setFIPSCb(WolfSSLFIPSErrorCallback cb);
 

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -726,6 +726,30 @@ public class WolfSSL {
     public final static native int setLoggingCb(WolfSSLLoggingCallback cb);
 
     /**
+     * Registers the callback to be used for wolfCrypt FIPS verifyCore error.
+     * This method is a NOOP if called when not using a wolfCrypt FIPS
+     * library.
+     *
+     * @param cb    Callback to be used for wolfCrypt FIPS verifyCore errors
+     * @return      <b><code>SSL_SUCCESS</code></b> on success, negative
+     *              on error.
+     */
+    public final static native int setFIPSCb(WolfSSLFIPSErrorCallback cb);
+
+
+    /**
+     * Returns the current verifyCore hash from wolfCrypt FIPS, from
+     * native wolfcrypt/src/fips_test.c, verifyCore[] array.
+     *
+     * NOTE: this method returns NULL if not used with a wolfCrypt FIPS
+     * library.
+     *
+     * @return current verifyCore hash from wolfCrypt FIPS, or NULL
+     *         if called when not using a wolfCrypt FIPS library.
+     */
+    public final static native String getWolfCryptFIPSCoreHash();
+
+    /**
      * Persists session cache to memory buffer.
      * This method can be used to persist the current session cache to a
      * memory buffer for storage. The cache can be loaded back into wolfSSL

--- a/src/java/com/wolfssl/WolfSSLFIPSErrorCallback.java
+++ b/src/java/com/wolfssl/WolfSSLFIPSErrorCallback.java
@@ -1,0 +1,52 @@
+/* WolfSSLFIPSErrorCallback.java
+ *
+ * Copyright (C) 2006-2021 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+package com.wolfssl;
+
+/**
+ * wolfSSL/wolfCrypt FIPS Error Interface.
+ * This interface specifies how applications should implement the wolfCrypt
+ * FIPS error callback, which will be called if the FIPS self tests fail,
+ * including if the power-on integrtiy check verifyCore comparison fails.
+ * <p>
+ * After implementing this interface, it should be passed as a parameter
+ * to the {@link WolfSSL#setFIPSCb(WolfSSLFIPSErrorCallback)
+ * WolfSSL.setFIPSCb()} method to be registered with the native wolfSSL
+ * library.
+ *
+ * @author  wolfSSL
+ * @version 1.0, May 2021
+ */
+public interface WolfSSLFIPSErrorCallback {
+
+    /**
+     * wolfCrypt FIPS error callback.
+     * This method is called when wolfCrypt FIPS power-on self tests fail,
+     * and can be used to retreive the correct FIPS verifyCore hash that
+     * needs to be updated in the native ./wolfcrypt/src/fips_test.c file.
+     *
+     * @param ok    FIPS status ok, 0 for not ok, 1 for ok
+     * @param err   wolfCrypt FIPS error code
+     * @param hash  Expected wolfCrypt FIPS verifyCore hash value
+     */
+    public void errorCallback(int ok, int err, String hash);
+}
+

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java
@@ -57,10 +57,21 @@ public final class WolfSSLProvider extends Provider {
         /* load native wolfSSLJNI library */
         WolfSSL.loadLibrary();
 
-        /* Register wolfCrypt FIPS error callback.
-         * Used for FIPS builds to output correct verifyCore hash to
-         * logging mechanism. NOOP for non-FIPS wolfCrypt installs */
-        WolfSSL.setFIPSCb(new JSSEFIPSErrorCallback());
+        /* Register wolfCrypt FIPS error callback. Used for FIPS builds to
+         * output correct verifyCore hash to logging mechanism. */
+        int rc = WolfSSL.setFIPSCb(new JSSEFIPSErrorCallback());
+        if (rc != WolfSSL.SSL_SUCCESS) {
+            if (rc == WolfSSL.NOT_COMPILED_IN) {
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    "FIPS callback not set, not using wolfCrypt FIPS");
+            } else {
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    "Error setting wolfCrypt FIPS Callback, ret = " + rc);
+            }
+        } else {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                "Registered wolfCrypt FIPS error callback");
+        }
 
         try {
             /* initialize native wolfSSL */


### PR DESCRIPTION
This PR wraps native wolfCrypt_SetCb_fips() and wolfCrypt_GetCoreHash_fips(), so that wolfCrypt FIPS users can get/see the verifyCore hash needed to update in fips_test.c.

Two new methods are added to the WolfSSL class to be used for non-JSSE consumers:
- `public final static native int setFIPSCb(WolfSSLFIPSErrorCallback cb);`
- `public final static native String getWolfCryptFIPSCoreHash();`

For wolfJSSE users, WolfSSLProvider automatically registers an internal WolfSSLFIPSErrorCallback in WolfSSLProvider.java when the provider is initialized.  This will automatically set up the FIPS error callback for JSSE users, and they will see output from the callback show up in the debug log.

To see the debug output of wolfJSSE, the `wolfjsse.debug` system property needs to be set to `true` (ie: `-Dwolfjsse.debug=true`).