### PR TITLE
prevent NullPointerException in WolfSSLParameters.getCipherSuites()

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLParameters.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLParameters.java
@@ -67,6 +67,9 @@ final class WolfSSLParameters {
     }
 
     String[] getCipherSuites() {
+        if (this.cipherSuites == null) {
+            return null;
+        }
         return this.cipherSuites.clone();
     }
 
@@ -81,6 +84,9 @@ final class WolfSSLParameters {
     }
 
     synchronized String[] getProtocols() {
+        if (this.protocols == null) {
+            return null;
+        }
         return this.protocols.clone();
     }
 
@@ -182,6 +188,9 @@ final class WolfSSLParameters {
     }
 
     String[] getApplicationProtocols() {
+        if (this.applicationProtocols == null) {
+            return null;
+        }
         return this.applicationProtocols.clone();
     }
 


### PR DESCRIPTION
Fixes potential NullPointerException in getCipherSuites(), getProtocols(), and getApplicationProtocols() when clone() would have been called on a null object.