### PR TITLE
Correct behavior of WolfSSLSocket.getSoTimeout()

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -69,7 +69,6 @@ public class WolfSSLSocket extends SSLSocket {
     private Socket socket = null;
     private boolean autoClose;
     private InetSocketAddress address = null;
-    private int readTimeout = 0;
 
     private WolfSSLInputStream inStream;
     private WolfSSLOutputStream outStream;
@@ -1283,7 +1282,6 @@ public class WolfSSLSocket extends SSLSocket {
         } else {
             super.setSoTimeout(timeout);
         }
-        this.readTimeout = timeout;
     }
 
     /**
@@ -1295,7 +1293,11 @@ public class WolfSSLSocket extends SSLSocket {
      */
     @Override
     public int getSoTimeout() throws SocketException {
-        return this.readTimeout;
+        if (this.socket != null) {
+            return this.socket.getSoTimeout();
+        } else {
+            return super.getSoTimeout();
+        }
     }
 
     /**
@@ -1323,6 +1325,8 @@ public class WolfSSLSocket extends SSLSocket {
      */
     @Override
     synchronized public void close() throws IOException {
+
+        int ret;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered close()");
@@ -1353,7 +1357,11 @@ public class WolfSSLSocket extends SSLSocket {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                                      "thread got ioLock (shutdown)");
 
-                    int ret = ssl.shutdownSSL(this.readTimeout);
+                    if (this.socket != null) {
+                        ret = ssl.shutdownSSL(this.socket.getSoTimeout());
+                    } else {
+                        ret = ssl.shutdownSSL(super.getSoTimeout());
+                    }
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                             "ssl.shutdownSSL() ret = " + ret);
 
@@ -1655,9 +1663,9 @@ public class WolfSSLSocket extends SSLSocket {
                     int err;
 
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "ssl.read() socket timeout = " + socket.readTimeout);
+                        "ssl.read() socket timeout = " + socket.getSoTimeout());
 
-                    ret = ssl.read(data, len, socket.readTimeout);
+                    ret = ssl.read(data, len, socket.getSoTimeout());
                     err = ssl.getError(ret);
 
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketFactoryTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketFactoryTest.java
@@ -280,12 +280,26 @@ public class WolfSSLSocketFactoryTest {
 
                 /* Socket, String, int, boolean */
                 s = new Socket(addr, port);
+
+                /* Set timeout, to test that createSocket returns it */
+                int tmpTimeout = 15000;
+                s.setSoTimeout(tmpTimeout);
+
                 ss = (SSLSocket)sf.createSocket(s, addrStr, port, true);
                 if (ss == null) {
                     System.out.println("\t\t\t... failed");
                     fail("SSLSocketFactory.createSocket(SkSib) failed");
                     return;
                 }
+
+                /* verify getSoTimeout matches set value */
+                if (ss.getSoTimeout() != tmpTimeout) {
+                    System.out.println("\t\t\t... failed");
+                    fail("SSLSocketFactory.createSocket(SkSib) failed " +
+                         "setSoTimeout check");
+                    return;
+                }
+
                 ss.close();
                 s.close();
 


### PR DESCRIPTION
This PR corrects the behavior of WolfSSLSocket.getSoTimeout() when the WolfSSLSocket object has been created to use an inner socket.

This removes the use of the local variable "readTimeout" and instead directly uses the timeout value as received from Socket.getSoTimeout().