### PR TITLE
Internal verify callback fixes and rework

### DIFF
--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -798,6 +798,10 @@ void NativeFIPSErrorCallback(const int ok, const int err,
         (*jenv)->ThrowNew(jenv, excClass,
                 "Object reference invalid in NativeFIPSErrorCallback");
     }
+#else
+    (void)ok;
+    (void)err;
+    (void)hash;
 #endif
 }
 
@@ -847,6 +851,8 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSL_getWolfCryptFIPSCoreHash
 #ifdef HAVE_FIPS
     return (*jenv)->NewStringUTF(jenv, wolfCrypt_GetCoreHash_fips());
 #else
+    (void)jenv;
+    (void)jcl;
     return NULL;
 #endif
 }

--- a/native/com_wolfssl_WolfSSLCertificate.c
+++ b/native/com_wolfssl_WolfSSLCertificate.c
@@ -332,7 +332,6 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1sign
         (*jenv)->ExceptionDescribe(jenv);
         (*jenv)->ExceptionClear(jenv);
         (*jenv)->DeleteLocalRef(jenv, ret);
-        XFREE(buf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         return NULL;
     }
 
@@ -547,7 +546,6 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1pubk
         (*jenv)->ExceptionDescribe(jenv);
         (*jenv)->ExceptionClear(jenv);
         (*jenv)->DeleteLocalRef(jenv, ret);
-        XFREE(buf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         return NULL;
     }
 

--- a/native/com_wolfssl_WolfSSLContext.c
+++ b/native/com_wolfssl_WolfSSLContext.c
@@ -324,6 +324,12 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_freeContext
     (void)jenv;
     (void)jcl;
 
+    /* release verify callback object if set */
+    if (g_verifyCbIfaceObj != NULL) {
+        (*jenv)->DeleteGlobalRef(jenv, g_verifyCbIfaceObj);
+        g_verifyCbIfaceObj = NULL;
+    }
+
     /* wolfSSL checks for null pointer */
     wolfSSL_CTX_free((WOLFSSL_CTX*)(uintptr_t)ctx);
 }
@@ -333,13 +339,23 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setVerify(JNIEnv* jenv,
 {
     (void)jcl;
 
+    if (jenv == NULL) {
+        return;
+    }
+
+    /* release verify callback object if set before */
+    if (g_verifyCbIfaceObj != NULL) {
+        (*jenv)->DeleteGlobalRef(jenv, g_verifyCbIfaceObj);
+        g_verifyCbIfaceObj = NULL;
+    }
+
     if (!callbackIface) {
         wolfSSL_CTX_set_verify((WOLFSSL_CTX*)(uintptr_t)ctx, mode, NULL);
-    } else {
-
+    }
+    else {
         /* store Java verify Interface object */
         g_verifyCbIfaceObj = (*jenv)->NewGlobalRef(jenv, callbackIface);
-        if (!g_verifyCbIfaceObj) {
+        if (g_verifyCbIfaceObj == NULL) {
             printf("error storing global callback interface\n");
         }
 

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -34,11 +34,20 @@
 /* custom I/O native fn prototypes */
 int  NativeSSLIORecvCb(WOLFSSL *ssl, char *buf, int sz, void *ctx);
 int  NativeSSLIOSendCb(WOLFSSL *ssl, char *buf, int sz, void *ctx);
-static jobject g_verifySSLCbIfaceObj;
 #ifdef HAVE_CRL
 /* global object refs for CRL callback */
 static jobject g_crlCbIfaceObj;
 #endif
+
+/* Data used per-WOLFSSL session that needs to be stored across native
+ * function calls. Stored inside WOLFSSL app data, set with
+ * wolfSSL_set_app_data(), retrieved with wolfSSL_get_app_data().
+ * Global callback objects are created with NewGlobalRef(), then freed
+ * inside freeSSL() with DeleteGlobalRef(). */
+typedef struct SSLAppData {
+    wolfSSL_Mutex* jniSessLock;      /* WOLFSSL session lock */
+    jobject* g_verifySSLCbIfaceObj;  /* Java verify callback [global ref] */
+} SSLAppData;
 
 /* custom native fn prototypes */
 void NativeMissingCRLCallback(const char* url);
@@ -52,6 +61,8 @@ int NativeSSLVerifyCallback(int preverify_ok, WOLFSSL_X509_STORE_CTX* store)
     jclass    excClass;
     jmethodID verifyMethod;
     jobjectRefType refcheck;
+    SSLAppData* appData;            /* WOLFSSL app data, stored verify cb obj */
+    jobject* g_verifySSLCbIfaceObj;  /* Global jobject, stored in app data */
 
     if (!g_vm) {
         /* we can't throw an exception yet, so just return 0 (failure) */
@@ -81,12 +92,28 @@ int NativeSSLVerifyCallback(int preverify_ok, WOLFSSL_X509_STORE_CTX* store)
         return -103;
     }
 
+    /* get app data to retrieve stored Java jobject callback object */
+    appData = (SSLAppData*)wolfSSL_get_app_data(
+                wolfSSL_X509_STORE_CTX_get_ex_data(store, 0));
+    if (appData == NULL) {
+        printf("Error getting app data from WOLFSSL\n");
+        return -105;
+    }
+
+    /* get global Java verify callback object */
+    g_verifySSLCbIfaceObj = appData->g_verifySSLCbIfaceObj;
+    if (g_verifySSLCbIfaceObj == NULL || *g_verifySSLCbIfaceObj == NULL) {
+        printf("Error getting g_verifySSLCbIfaceObj from appData\n");
+        return -106;
+    }
+
     /* check if our stored object reference is valid */
-    refcheck = (*jenv)->GetObjectRefType(jenv, g_verifySSLCbIfaceObj);
+    refcheck = (*jenv)->GetObjectRefType(jenv, *g_verifySSLCbIfaceObj);
     if (refcheck == 2) {
 
         /* lookup WolfSSLVerifyCallback class from global object ref */
-        jclass verifyClass = (*jenv)->GetObjectClass(jenv, g_verifySSLCbIfaceObj);
+        jclass verifyClass = (*jenv)->GetObjectClass(jenv,
+                                                     *g_verifySSLCbIfaceObj);
         if (!verifyClass) {
             if ((*jenv)->ExceptionOccurred(jenv)) {
                 (*jenv)->ExceptionDescribe(jenv);
@@ -95,7 +122,7 @@ int NativeSSLVerifyCallback(int preverify_ok, WOLFSSL_X509_STORE_CTX* store)
 
             (*jenv)->ThrowNew(jenv, excClass,
                 "Can't get native WolfSSLVerifyCallback class reference");
-            return -104;
+            return -107;
         }
 
         verifyMethod = (*jenv)->GetMethodID(jenv, verifyClass,
@@ -108,17 +135,17 @@ int NativeSSLVerifyCallback(int preverify_ok, WOLFSSL_X509_STORE_CTX* store)
 
             (*jenv)->ThrowNew(jenv, excClass,
                 "Error getting verifyCallback method from JNI");
-            return -105;
+            return -108;
         }
 
-        retval = (*jenv)->CallIntMethod(jenv, g_verifySSLCbIfaceObj,
+        retval = (*jenv)->CallIntMethod(jenv, *g_verifySSLCbIfaceObj,
                 verifyMethod, preverify_ok, (jlong)(uintptr_t)store);
 
         if ((*jenv)->ExceptionOccurred(jenv)) {
             /* exception occurred on the Java side during method call */
             (*jenv)->ExceptionDescribe(jenv);
             (*jenv)->ExceptionClear(jenv);
-            return -106;
+            return -109;
         }
 
     } else {
@@ -145,6 +172,7 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_newSSL
     jlong sslPtr;
     jobject* g_cachedObj;
     wolfSSL_Mutex* jniSessLock;
+    SSLAppData* appData;
 
     if (!jenv)
         return SSL_FAILURE;
@@ -175,21 +203,34 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_newSSL
             return SSL_FAILURE;
         }
 
+        appData = (SSLAppData*)XMALLOC(sizeof(SSLAppData), NULL,
+                                       DYNAMIC_TYPE_TMP_BUFFER);
+        if (appData == NULL) {
+            printf("error allocating memory in newSSL for SSLAppData\n");
+            wolfSSL_free((WOLFSSL*)(uintptr_t)sslPtr);
+            return SSL_FAILURE;
+        }
+        XMEMSET(appData, 0, sizeof(SSLAppData));
+
         /* store mutex lock in SSL app data, used for I/O and session lock.
          * This is freed in freeSSL. */
         jniSessLock = (wolfSSL_Mutex*)XMALLOC(sizeof(wolfSSL_Mutex), NULL,
                                               DYNAMIC_TYPE_TMP_BUFFER);
         if (!jniSessLock) {
             printf("error mallocing memory in newSSL for jniSessLock\n");
+            XFREE(appData, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             wolfSSL_free((WOLFSSL*)(uintptr_t)sslPtr);
             return SSL_FAILURE;
         }
 
         wc_InitMutex(jniSessLock);
+        appData->jniSessLock = jniSessLock;
+
         if (wolfSSL_set_app_data(
-                (WOLFSSL*)(uintptr_t)sslPtr, jniSessLock) != SSL_SUCCESS) {
+                (WOLFSSL*)(uintptr_t)sslPtr, appData) != SSL_SUCCESS) {
             printf("error setting WOLFSSL app data in newSSL\n");
             XFREE(jniSessLock, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(appData, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             wolfSSL_free((WOLFSSL*)(uintptr_t)sslPtr);
             return SSL_FAILURE;
         }
@@ -516,6 +557,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_connect
     int ret = 0, err = 0, sockfd = 0;
     WOLFSSL* ssl = NULL;
     wolfSSL_Mutex* jniSessLock = NULL;
+    SSLAppData* appData = NULL;
 
     (void)jcl;
 
@@ -532,9 +574,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_connect
     }
 
     /* get session mutex from SSL app data */
-    jniSessLock = (wolfSSL_Mutex*)wolfSSL_get_app_data(ssl);
+    appData = (SSLAppData*)wolfSSL_get_app_data(ssl);
+    if (appData == NULL) {
+        return WOLFSSL_FAILURE;
+    }
+
+    jniSessLock = appData->jniSessLock;
     if (jniSessLock == NULL) {
-        return SSL_FAILURE;
+        return WOLFSSL_FAILURE;
     }
 
     do {
@@ -592,6 +639,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_write(JNIEnv* jenv,
     int ret = SSL_FAILURE, err, sockfd;
     WOLFSSL* ssl = NULL;
     wolfSSL_Mutex* jniSessLock = NULL;
+    SSLAppData* appData = NULL;
 
     (void)jcl;
 
@@ -609,7 +657,12 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_write(JNIEnv* jenv,
         }
 
         /* get session mutex from SSL app data */
-        jniSessLock = (wolfSSL_Mutex*)wolfSSL_get_app_data(ssl);
+        appData = (SSLAppData*)wolfSSL_get_app_data(ssl);
+        if (appData == NULL) {
+            return WOLFSSL_FAILURE;
+        }
+
+        jniSessLock = appData->jniSessLock;
         if (jniSessLock == NULL) {
             (*jenv)->ReleaseByteArrayElements(jenv, raw, (jbyte*)data,
                     JNI_ABORT);
@@ -671,6 +724,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_read(JNIEnv* jenv,
     int size = 0, ret, err, sockfd;
     WOLFSSL* ssl = NULL;
     wolfSSL_Mutex* jniSessLock = NULL;
+    SSLAppData* appData = NULL;
 
     (void)jcl;
 
@@ -688,7 +742,12 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_read(JNIEnv* jenv,
         }
 
         /* get session mutex from SSL app data */
-        jniSessLock = (wolfSSL_Mutex*)wolfSSL_get_app_data(ssl);
+        appData = (SSLAppData*)wolfSSL_get_app_data(ssl);
+        if (appData == NULL) {
+            return WOLFSSL_FAILURE;
+        }
+
+        jniSessLock = appData->jniSessLock;
         if (jniSessLock == NULL) {
             (*jenv)->ReleaseByteArrayElements(jenv, raw, (jbyte*)data,
                     JNI_ABORT);
@@ -748,6 +807,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_accept
     int ret = 0, err, sockfd;
     WOLFSSL* ssl = NULL;
     wolfSSL_Mutex* jniSessLock = NULL;
+    SSLAppData* appData = NULL;
 
     (void)jcl;
 
@@ -764,7 +824,12 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_accept
     }
 
     /* get session mutex from SSL app data */
-    jniSessLock = (wolfSSL_Mutex*)wolfSSL_get_app_data(ssl);
+    appData = (SSLAppData*)wolfSSL_get_app_data(ssl);
+    if (appData == NULL) {
+        return WOLFSSL_FAILURE;
+    }
+
+    jniSessLock = appData->jniSessLock;
     if (jniSessLock == NULL) {
         return SSL_FAILURE;
     }
@@ -821,8 +886,9 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_freeSSL
   (JNIEnv* jenv, jobject jcl, jlong ssl)
 {
     jobject* g_cachedSSLObj;
+    jobject* g_cachedVerifyCb;
     jclass excClass;
-    wolfSSL_Mutex* jniSessLock;
+    SSLAppData* appData;
     (void)jcl;
 
     excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
@@ -839,11 +905,22 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_freeSSL
     }
 
     /* free session mutex lock */
-    jniSessLock = (wolfSSL_Mutex*)wolfSSL_get_app_data((WOLFSSL*)(uintptr_t)ssl);
-    if (jniSessLock != NULL) {
-        wc_FreeMutex(jniSessLock);
-        XFREE(jniSessLock, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        jniSessLock = NULL;
+    appData = (SSLAppData*)wolfSSL_get_app_data((WOLFSSL*)(uintptr_t)ssl);
+    if (appData != NULL) {
+        if (appData->jniSessLock != NULL) {
+            wc_FreeMutex(appData->jniSessLock);
+            XFREE(appData->jniSessLock, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            appData->jniSessLock = NULL;
+        }
+        g_cachedVerifyCb = appData->g_verifySSLCbIfaceObj;
+        if (g_cachedVerifyCb != NULL) {
+            (*jenv)->DeleteGlobalRef(jenv, (jobject)(*g_cachedVerifyCb));
+            XFREE(g_cachedVerifyCb, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            g_cachedVerifyCb = NULL;
+        }
+        /* free appData */
+        XFREE(appData, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        appData = NULL;
     }
 
     /* delete global WolfSSLSession object reference */
@@ -877,6 +954,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_shutdownSSL
     int ret = 0, err, sockfd;
     WOLFSSL* ssl = NULL;
     wolfSSL_Mutex* jniSessLock;
+    SSLAppData* appData = NULL;
     (void)jcl;
 
     if (jenv == NULL) {
@@ -892,9 +970,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_shutdownSSL
     }
 
     /* get session mutex from SSL app data */
-    jniSessLock = (wolfSSL_Mutex*)wolfSSL_get_app_data(ssl);
+    appData = (SSLAppData*)wolfSSL_get_app_data(ssl);
+    if (appData == NULL) {
+        return WOLFSSL_FAILURE;
+    }
+
+    jniSessLock = appData->jniSessLock;
     if (jniSessLock == NULL) {
-        return SSL_FAILURE;
+        return WOLFSSL_FAILURE;
     }
 
     do {
@@ -3273,23 +3356,44 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setVerify
   (JNIEnv* jenv, jobject jcl, jlong ssl, jint mode, jobject callbackIface)
 {
     (void)jcl;
+    jobject* verifyCb;
+    SSLAppData* appData;
 
     if (!jenv || !ssl)
         return;
 
     if (!callbackIface) {
         wolfSSL_set_verify((WOLFSSL*)(uintptr_t)ssl, mode, NULL);
-    } else {
-
-        /* store Java verify Interface object */
-        g_verifySSLCbIfaceObj = (*jenv)->NewGlobalRef(jenv, callbackIface);
-        if (!g_verifySSLCbIfaceObj) {
-            printf("error storing global callback interface\n");
+    }
+    else {
+        /* get app data to store verify callback jobject */
+        appData = (SSLAppData*)wolfSSL_get_app_data((WOLFSSL*)(uintptr_t)ssl);
+        if (appData == NULL) {
+            printf("Error getting app data from WOLFSSL\n");
         }
 
-        /* set verify mode, register Java callback with wolfSSL */
-        wolfSSL_set_verify((WOLFSSL*)(uintptr_t)ssl, mode,
-                           NativeSSLVerifyCallback);
+        if (appData) {
+            verifyCb = (jobject*)XMALLOC(sizeof(jobject), NULL,
+                                         DYNAMIC_TYPE_TMP_BUFFER);
+            if (verifyCb == NULL) {
+                printf("Error allocating memory for verifyCb\n");
+            }
+        }
+
+        if (appData && verifyCb) {
+            /* store Java verify Interface object */
+            *verifyCb = (*jenv)->NewGlobalRef(jenv, callbackIface);
+            if (*verifyCb == NULL) {
+                printf("error storing global callback interface\n");
+            }
+            else {
+                appData->g_verifySSLCbIfaceObj = verifyCb;
+
+                /* set verify mode, register Java callback with wolfSSL */
+                wolfSSL_set_verify((WOLFSSL*)(uintptr_t)ssl, mode,
+                                   NativeSSLVerifyCallback);
+            }
+        }
     }
 }
 

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -904,6 +904,9 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_freeSSL
     jclass excClass;
     SSLAppData* appData;
     (void)jcl;
+#if defined(HAVE_PK_CALLBACKS) && (defined(HAVE_ECC) || !defined(NO_RSA))
+    internCtx* pkCtx = NULL;
+#endif
 
     excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
 
@@ -964,6 +967,76 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_freeSSL
         g_crlCbIfaceObj = NULL;
     }
 #endif
+
+#if defined(HAVE_PK_CALLBACKS)
+    #ifdef HAVE_ECC
+        /* free ECC sign callback CTX global reference if set */
+        pkCtx = (internCtx*) wolfSSL_GetEccSignCtx((WOLFSSL*)(uintptr_t)ssl);
+        if (pkCtx != NULL) {
+            if (pkCtx->obj != NULL) {
+                (*jenv)->DeleteGlobalRef(jenv, pkCtx->obj);
+            }
+            XFREE(pkCtx, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        }
+
+        /* free ECC verify callback CTX global reference if set */
+        pkCtx = (internCtx*)wolfSSL_GetEccVerifyCtx((WOLFSSL*)(uintptr_t)ssl);
+        if (pkCtx != NULL) {
+            if (pkCtx->obj != NULL) {
+                (*jenv)->DeleteGlobalRef(jenv, pkCtx->obj);
+            }
+            XFREE(pkCtx, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        }
+
+        /* free ECC shared secret callback CTX global reference if set */
+        pkCtx = (internCtx*)wolfSSL_GetEccSharedSecretCtx(
+                                (WOLFSSL*)(uintptr_t)ssl);
+        if (pkCtx != NULL) {
+            if (pkCtx->obj != NULL) {
+                (*jenv)->DeleteGlobalRef(jenv, pkCtx->obj);
+            }
+            XFREE(pkCtx, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        }
+    #endif /* HAVE_ECC */
+
+    #ifndef NO_RSA
+        /* free RSA sign callback CTX global reference if set */
+        pkCtx = (internCtx*) wolfSSL_GetRsaSignCtx((WOLFSSL*)(uintptr_t)ssl);
+        if (pkCtx != NULL) {
+            if (pkCtx->obj != NULL) {
+                (*jenv)->DeleteGlobalRef(jenv, pkCtx->obj);
+            }
+            XFREE(pkCtx, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        }
+
+        /* free RSA verify callback CTX global reference if set */
+        pkCtx = (internCtx*)wolfSSL_GetRsaVerifyCtx((WOLFSSL*)(uintptr_t)ssl);
+        if (pkCtx != NULL) {
+            if (pkCtx->obj != NULL) {
+                (*jenv)->DeleteGlobalRef(jenv, pkCtx->obj);
+            }
+            XFREE(pkCtx, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        }
+
+        /* free RSA encrypt callback CTX global reference if set */
+        pkCtx = (internCtx*) wolfSSL_GetRsaEncCtx((WOLFSSL*)(uintptr_t)ssl);
+        if (pkCtx != NULL) {
+            if (pkCtx->obj != NULL) {
+                (*jenv)->DeleteGlobalRef(jenv, pkCtx->obj);
+            }
+            XFREE(pkCtx, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        }
+
+        /* free RSA decrypt callback CTX global reference if set */
+        pkCtx = (internCtx*) wolfSSL_GetRsaDecCtx((WOLFSSL*)(uintptr_t)ssl);
+        if (pkCtx != NULL) {
+            if (pkCtx->obj != NULL) {
+                (*jenv)->DeleteGlobalRef(jenv, pkCtx->obj);
+            }
+            XFREE(pkCtx, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        }
+    #endif /* !NO_RSA */
+#endif /* HAVE_PK_CALLBACKS */
 
     /* native cleanup */
     wolfSSL_free((WOLFSSL*)(uintptr_t)ssl);
@@ -2729,8 +2802,10 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSignCtx
     /* note: if CTX has not been set up yet, wolfSSL defaults to NULL */
     if (eccSignCtx != NULL) {
         myCtx = (internCtx*)eccSignCtx;
-        if (myCtx->active == 1) {
-            (*jenv)->DeleteGlobalRef(jenv, myCtx->obj);
+        if (myCtx != NULL) {
+            if (myCtx->active == 1) {
+                (*jenv)->DeleteGlobalRef(jenv, myCtx->obj);
+            }
             XFREE(myCtx, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         }
     }
@@ -2805,8 +2880,10 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccVerifyCtx
     /* note: if CTX has not been set up yet, wolfSSL defaults to NULL */
     if (eccVerifyCtx != NULL) {
         myCtx = (internCtx*)eccVerifyCtx;
-        if (myCtx->active == 1) {
-            (*jenv)->DeleteGlobalRef(jenv, myCtx->obj);
+        if (myCtx != NULL) {
+            if (myCtx->active == 1) {
+                (*jenv)->DeleteGlobalRef(jenv, myCtx->obj);
+            }
             XFREE(myCtx, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         }
     }
@@ -2824,7 +2901,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccVerifyCtx
 
     /* store global ref to WolfSSLSession object */
     myCtx->obj = (*jenv)->NewGlobalRef(jenv, jcl);
-    if (!myCtx->obj) {
+    if (myCtx->obj == NULL) {
         (*jenv)->ThrowNew(jenv, excClass,
                "Unable to store WolfSSLSession object as global reference");
         return;
@@ -2881,15 +2958,17 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSharedSecretCtx
     /* note: if CTX has not been set up yet, wolfSSL defaults to NULL */
     if (eccSharedSecretCtx != NULL) {
         myCtx = (internCtx*)eccSharedSecretCtx;
-        if (myCtx->active == 1) {
-            (*jenv)->DeleteGlobalRef(jenv, myCtx->obj);
+        if (myCtx != NULL) {
+            if (myCtx->active == 1) {
+                (*jenv)->DeleteGlobalRef(jenv, myCtx->obj);
+            }
             XFREE(myCtx, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         }
     }
 
     /* allocate memory for internal JNI object reference */
     myCtx = XMALLOC(sizeof(internCtx), NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    if (!myCtx) {
+    if (myCtx == NULL) {
         (*jenv)->ThrowNew(jenv, excClass,
                 "Unable to allocate memory for ECC shared secret context\n");
         return;
@@ -2900,7 +2979,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSharedSecretCtx
 
     /* store global ref to WolfSSLSession object */
     myCtx->obj = (*jenv)->NewGlobalRef(jenv, jcl);
-    if (!myCtx->obj) {
+    if (myCtx->obj == NULL) {
         (*jenv)->ThrowNew(jenv, excClass,
                "Unable to store WolfSSLSession object as global reference");
         return;
@@ -2956,15 +3035,17 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaSignCtx
     /* note: if CTX has not been set up yet, wolfSSL defaults to NULL */
     if (rsaSignCtx != NULL) {
         myCtx = (internCtx*)rsaSignCtx;
-        if (myCtx->active == 1) {
-            (*jenv)->DeleteGlobalRef(jenv, myCtx->obj);
+        if (myCtx != NULL) {
+            if (myCtx->active == 1) {
+                (*jenv)->DeleteGlobalRef(jenv, myCtx->obj);
+            }
             XFREE(myCtx, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         }
     }
 
     /* allocate memory for internal JNI object reference */
     myCtx = XMALLOC(sizeof(internCtx), NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    if (!myCtx) {
+    if (myCtx == NULL) {
         (*jenv)->ThrowNew(jenv, excClass,
                 "Unable to allocate memory for RSA sign context\n");
         return;
@@ -2975,7 +3056,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaSignCtx
 
     /* store global ref to WolfSSLSession object */
     myCtx->obj = (*jenv)->NewGlobalRef(jenv, jcl);
-    if (!myCtx->obj) {
+    if (myCtx->obj == NULL) {
         (*jenv)->ThrowNew(jenv, excClass,
                "Unable to store WolfSSLSession object as global reference");
         return;
@@ -3032,15 +3113,17 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaVerifyCtx
     /* note: if CTX has not been set up yet, wolfSSL defaults to NULL */
     if (rsaVerifyCtx != NULL) {
         myCtx = (internCtx*)rsaVerifyCtx;
-        if (myCtx->active == 1) {
-            (*jenv)->DeleteGlobalRef(jenv, myCtx->obj);
+        if (myCtx != NULL) {
+            if (myCtx->active == 1) {
+                (*jenv)->DeleteGlobalRef(jenv, myCtx->obj);
+            }
             XFREE(myCtx, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         }
     }
 
     /* allocate memory for internal JNI object reference */
     myCtx = XMALLOC(sizeof(internCtx), NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    if (!myCtx) {
+    if (myCtx == NULL) {
         (*jenv)->ThrowNew(jenv, excClass,
                 "Unable to allocate memory for RSA verify context\n");
         return;
@@ -3051,7 +3134,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaVerifyCtx
 
     /* store global ref to WolfSSLSession object */
     myCtx->obj = (*jenv)->NewGlobalRef(jenv, jcl);
-    if (!myCtx->obj) {
+    if (myCtx->obj == NULL) {
         (*jenv)->ThrowNew(jenv, excClass,
                "Unable to store WolfSSLSession object as global reference");
         return;
@@ -3107,15 +3190,17 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaEncCtx
     /* note: if CTX has not been set up yet, wolfSSL defaults to NULL */
     if (rsaEncCtx != NULL) {
         myCtx = (internCtx*)rsaEncCtx;
-        if (myCtx->active == 1) {
-            (*jenv)->DeleteGlobalRef(jenv, myCtx->obj);
+        if (myCtx != NULL) {
+            if (myCtx->active == 1) {
+                (*jenv)->DeleteGlobalRef(jenv, myCtx->obj);
+            }
             XFREE(myCtx, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         }
     }
 
     /* allocate memory for internal JNI object reference */
     myCtx = XMALLOC(sizeof(internCtx), NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    if (!myCtx) {
+    if (myCtx == NULL) {
         (*jenv)->ThrowNew(jenv, excClass,
                 "Unable to allocate memory for RSA encrypt context\n");
         return;
@@ -3126,7 +3211,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaEncCtx
 
     /* store global ref to WolfSSLSession object */
     myCtx->obj = (*jenv)->NewGlobalRef(jenv, jcl);
-    if (!myCtx->obj) {
+    if (myCtx->obj == NULL) {
         (*jenv)->ThrowNew(jenv, excClass,
                "Unable to store WolfSSLSession object as global reference");
         return;
@@ -3182,15 +3267,17 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaDecCtx
     /* note: if CTX has not been set up yet, wolfSSL defaults to NULL */
     if (rsaDecCtx != NULL) {
         myCtx = (internCtx*)rsaDecCtx;
-        if (myCtx->active == 1) {
-            (*jenv)->DeleteGlobalRef(jenv, myCtx->obj);
+        if (myCtx != NULL) {
+            if (myCtx->active == 1) {
+                (*jenv)->DeleteGlobalRef(jenv, myCtx->obj);
+            }
             XFREE(myCtx, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         }
     }
 
     /* allocate memory for internal JNI object reference */
     myCtx = XMALLOC(sizeof(internCtx), NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    if (!myCtx) {
+    if (myCtx == NULL) {
         (*jenv)->ThrowNew(jenv, excClass,
                 "Unable to allocate memory for RSA decrypt context\n");
         return;
@@ -3201,7 +3288,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaDecCtx
 
     /* store global ref to WolfSSLSession object */
     myCtx->obj = (*jenv)->NewGlobalRef(jenv, jcl);
-    if (!myCtx->obj) {
+    if (myCtx->obj == NULL) {
         (*jenv)->ThrowNew(jenv, excClass,
                "Unable to store WolfSSLSession object as global reference");
         return;

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -228,6 +228,9 @@ public class WolfSSL {
     public final static int ECDSAk   = 518;
     public final static int ED25519k = 256;
 
+    /* is this object active, or has it been cleaned up? */
+    private boolean active = false;
+
     /* ------------------------ constructors ---------------------------- */
 
     /**
@@ -256,6 +259,8 @@ public class WolfSSL {
         wolfssl_aes_ccm     = getBulkCipherAlgorithmEnumAESCCM();
         wolfssl_hc128       = getBulkCipherAlgorithmEnumHC128();
         wolfssl_rabbit      = getBulkCipherAlgorithmEnumRABBIT();
+
+        this.active = true;
     }
 
     /* ------------------- private/protected methods -------------------- */
@@ -941,6 +946,18 @@ public class WolfSSL {
      * @return an array of Strings for supported protocols
      */
     public static native String[] getProtocolsMask(long mask);
+
+    @SuppressWarnings("deprecation")
+    @Override
+    protected void finalize() throws Throwable
+    {
+        if (this.active == true) {
+            /* free resources, set state */
+            this.cleanup();
+            this.active = false;
+        }
+        super.finalize();
+    }
 
 } /* end WolfSSL */
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
@@ -24,8 +24,6 @@ import com.wolfssl.WolfSSL;
 import com.wolfssl.WolfSSLVerifyCallback;
 import com.wolfssl.WolfSSLException;
 import com.wolfssl.WolfSSLSession;
-import com.wolfssl.WolfSSLCertificate;
-import com.wolfssl.WolfSSLX509StoreCtx;
 import java.util.Arrays;
 import java.util.List;
 import java.security.cert.X509Certificate;

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
@@ -26,17 +26,22 @@ import com.wolfssl.WolfSSLJNIException;
 import com.wolfssl.WolfSSLSession;
 import java.security.Principal;
 import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateEncodingException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.io.InputStream;
+import java.io.ByteArrayInputStream;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSessionBindingEvent;
 import javax.net.ssl.SSLSessionBindingListener;
 import javax.net.ssl.SSLSessionContext;
 import javax.net.ssl.X509KeyManager;
-import javax.security.cert.*;
 
 /**
  * wolfSSL Session
@@ -234,7 +239,39 @@ public class WolfSSLImplementSSLSession implements SSLSession {
             throw new SSLPeerUnverifiedException("Error creating certificate");
         }
 
-        return new Certificate[] { cert };
+        /* convert WolfSSLX509 into X509Certificate so we can release
+         * our native memory */
+        CertificateFactory cf;
+        ByteArrayInputStream der;
+        X509Certificate exportCert;
+        try {
+            cf = CertificateFactory.getInstance("X.509");
+        } catch (CertificateException ex) {
+            cert.free();
+            throw new SSLPeerUnverifiedException(
+                    "Error getting CertificateFactory instance");
+        }
+
+        try {
+            der = new ByteArrayInputStream(cert.getEncoded());
+        } catch (CertificateEncodingException ex) {
+            cert.free();
+            throw new SSLPeerUnverifiedException(
+                    "Error getting encoded DER from WolfSSLX509 object");
+        }
+
+        try {
+            exportCert = (X509Certificate)cf.generateCertificate(der);
+        } catch (CertificateException ex) {
+            cert.free();
+            throw new SSLPeerUnverifiedException(
+                    "Error generating X509Certificdate from DER encoding");
+        }
+
+        /* release native memory */
+        cert.free();
+
+        return new Certificate[] { exportCert };
     }
 
     @Override
@@ -244,7 +281,7 @@ public class WolfSSLImplementSSLSession implements SSLSession {
     }
 
     @Override
-    public synchronized X509Certificate[] getPeerCertificateChain()
+    public synchronized javax.security.cert.X509Certificate[] getPeerCertificateChain()
         throws SSLPeerUnverifiedException {
         WolfSSLX509X x509;
 
@@ -254,7 +291,9 @@ public class WolfSSLImplementSSLSession implements SSLSession {
 
         try {
             x509 = new WolfSSLX509X(this.ssl.getPeerCertificate());
-            return new X509Certificate[]{ (X509Certificate)x509 };
+            return new javax.security.cert.X509Certificate[] {
+                (javax.security.cert.X509Certificate)x509 };
+
         } catch (IllegalStateException | WolfSSLJNIException |
                 WolfSSLException ex) {
             Logger.getLogger(
@@ -272,8 +311,13 @@ public class WolfSSLImplementSSLSession implements SSLSession {
         }
 
         try {
+            Principal peerPrincipal = null;
             WolfSSLX509 x509 = new WolfSSLX509(this.ssl.getPeerCertificate());
-            return x509.getSubjectDN();
+            peerPrincipal = x509.getSubjectDN();
+            x509.free();
+
+            return peerPrincipal;
+
         } catch (IllegalStateException | WolfSSLJNIException |
                 WolfSSLException ex) {
             Logger.getLogger(
@@ -285,23 +329,34 @@ public class WolfSSLImplementSSLSession implements SSLSession {
 
     @Override
     public Principal getLocalPrincipal() {
-        int i;
 
         X509KeyManager km = authStore.getX509KeyManager();
         java.security.cert.X509Certificate[] certs =
                 km.getCertificateChain(authStore.getCertAlias());
+        Principal localPrincipal = null;
 
         if (certs == null) {
             return null;
         }
 
-        for (i = 0; i < certs.length; i++) {
+        for (int i = 0; i < certs.length; i++) {
             if (certs[i].getBasicConstraints() < 0) {
                 /* is not a CA treat as end of chain */
-                return certs[i].getSubjectDN();
+                localPrincipal = certs[i].getSubjectDN();
+                break;
             }
         }
-        return null;
+
+        /* free native resources earlier than garbage collection if
+         * X509Certificate is WolfSSLX509 */
+        for (int i = 0; i < certs.length; i++) {
+            if (certs[i] instanceof WolfSSLX509) {
+                ((WolfSSLX509)certs[i]).free();
+            }
+        }
+
+        /* return principal, or null if not set */
+        return localPrincipal;
     }
 
     @Override

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
@@ -214,6 +214,9 @@ public class WolfSSLImplementSSLSession implements SSLSession {
             throws SSLPeerUnverifiedException {
         long x509;
         WolfSSLX509 cert;
+        CertificateFactory cf;
+        ByteArrayInputStream der;
+        X509Certificate exportCert;
 
         if (ssl == null) {
             throw new SSLPeerUnverifiedException("handshake not complete");
@@ -241,9 +244,6 @@ public class WolfSSLImplementSSLSession implements SSLSession {
 
         /* convert WolfSSLX509 into X509Certificate so we can release
          * our native memory */
-        CertificateFactory cf;
-        ByteArrayInputStream der;
-        X509Certificate exportCert;
         try {
             cf = CertificateFactory.getInstance("X.509");
         } catch (CertificateException ex) {

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLInternalVerifyCb.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLInternalVerifyCb.java
@@ -1,0 +1,103 @@
+package com.wolfssl.provider.jsse;
+
+import com.wolfssl.WolfSSL;
+import com.wolfssl.WolfSSLVerifyCallback;
+import com.wolfssl.WolfSSLException;
+import com.wolfssl.WolfSSLSession;
+import com.wolfssl.WolfSSLCertificate;
+import com.wolfssl.WolfSSLX509StoreCtx;
+import com.wolfssl.provider.jsse.WolfSSLInternalVerifyCb;
+import java.util.Arrays;
+import java.util.List;
+import java.security.cert.X509Certificate;
+import java.security.cert.CertificateException;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.X509TrustManager;
+import javax.net.ssl.SSLHandshakeException;
+import java.io.IOException;
+
+/* Internal verify callback. This is used when a user registers a
+ * TrustManager which is NOT com.wolfssl.provider.jsse.WolfSSLTrustManager
+ * and is used to call TrustManager checkClientTrusted() or
+ * checkServerTrusted(). If wolfJSSE TrustManager is used, native wolfSSL
+ * does certificate verification internally. Used by WolfSSLEngineHelper. */
+public class WolfSSLInternalVerifyCb implements WolfSSLVerifyCallback {
+
+    private X509TrustManager tm = null;
+    private boolean clientMode;
+
+    public WolfSSLInternalVerifyCb(X509TrustManager xtm, boolean client) {
+        this.tm = xtm;
+        this.clientMode = client;
+    }
+
+    public int verifyCallback(int preverify_ok, long x509StorePtr) {
+
+        WolfSSLCertificate[] certs = null;
+        X509Certificate[] x509certs = null;
+        String authType = null;
+
+        if (preverify_ok == 1) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    "Native wolfSSL peer verification passed");
+        } else {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    "WARNING: Native wolfSSL peer verification failed!");
+        }
+
+        try {
+            /* get WolfSSLCertificate[] from x509StorePtr */
+            WolfSSLX509StoreCtx store =
+                new WolfSSLX509StoreCtx(x509StorePtr);
+            certs = store.getCerts();
+
+        } catch (WolfSSLException e) {
+            /* failed to get certs from native, give app null array */
+            certs = null;
+        }
+
+        if (certs != null && certs.length > 0) {
+            try {
+                /* Convert WolfSSLCertificate[] to X509Certificate[] */
+                x509certs = new X509Certificate[certs.length];
+                for (int i = 0; i < certs.length; i++) {
+                    x509certs[i] = certs[i].getX509Certificate();
+                }
+            } catch (CertificateException | IOException ce) {
+                /* failed to get cert array, give app null array */
+                x509certs = null;
+            }
+
+            /* get authType, use first cert */
+            String sigType = certs[0].getSignatureType();
+            if (sigType.contains("RSA")) {
+                authType = "RSA";
+            } else if (sigType.contains("ECDSA")) {
+                authType = "ECDSA";
+            } else if (sigType.contains("DSA")) {
+                authType = "DSA";
+            } else if (sigType.contains("ED25519")) {
+                authType = "ED25519";
+            }
+        }
+
+
+        try {
+            /* poll TrustManager for cert verification, should throw
+             * CertificateException if verification fails */
+            if (clientMode) {
+                tm.checkServerTrusted(x509certs, authType);
+            } else {
+                tm.checkClientTrusted(x509certs, authType);
+            }
+        } catch (Exception e) {
+            /* TrustManager rejected certificate, not valid */
+            return 0;
+        }
+
+        /* continue handshake, verification succeeded */
+        return 1;
+    }
+}
+

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLInternalVerifyCb.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLInternalVerifyCb.java
@@ -80,8 +80,13 @@ public class WolfSSLInternalVerifyCb implements WolfSSLVerifyCallback {
             } else if (sigType.contains("ED25519")) {
                 authType = "ED25519";
             }
-        }
 
+            /* Free native WolfSSLCertificate memory. At this
+             * point x509certs[] is all Java managed memory now. */
+            for (int i = 0; i < certs.length; i++) {
+                certs[i].free();
+            }
+        }
 
         try {
             /* poll TrustManager for cert verification, should throw

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLInternalVerifyCb.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLInternalVerifyCb.java
@@ -1,3 +1,23 @@
+/* WolfSSLInternalVerifyCb.java
+ *
+ * Copyright (C) 2006-2021 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
 package com.wolfssl.provider.jsse;
 
 import com.wolfssl.WolfSSL;

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java
@@ -34,6 +34,10 @@ import com.wolfssl.WolfSSLFIPSErrorCallback;
  */
 public final class WolfSSLProvider extends Provider {
 
+    /* Keep one static reference to native wolfSSL library across
+     * all WolfSSLProvider objects. */
+    private static WolfSSL sslLib = null;
+
     public class JSSEFIPSErrorCallback implements WolfSSLFIPSErrorCallback {
         public void errorCallback(int ok, int err, String hash) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
@@ -75,7 +79,7 @@ public final class WolfSSLProvider extends Provider {
 
         try {
             /* initialize native wolfSSL */
-            WolfSSL sslLib = new WolfSSL();
+            sslLib = new WolfSSL();
         } catch (WolfSSLException e) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                 "Failed to initialize native wolfSSL library");

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSNIServerName.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSNIServerName.java
@@ -62,6 +62,10 @@ public abstract class WolfSSLSNIServerName
     }
 
     public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        }
+
         if (!(other instanceof WolfSSLSNIServerName)) {
             return false;
         }

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -1371,6 +1371,12 @@ public class WolfSSLSocket extends SSLSocket {
 
                 synchronized (handshakeLock) {
                     this.connectionClosed = true;
+
+                    /* Connection is closed, free native WOLFSSL session
+                     * to release native memory earlier than garbage collector
+                     * might with finalize(). */
+                    this.ssl.freeSSL();
+                    this.ssl = null;
                 }
             }
 
@@ -1396,6 +1402,8 @@ public class WolfSSLSocket extends SSLSocket {
 
         } catch (IllegalStateException e) {
             throw new IOException(e);
+        } catch (WolfSSLJNIException jnie) {
+            throw new IOException(jnie);
         }
     }
 

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLX509Test.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLX509Test.java
@@ -486,7 +486,9 @@ public class WolfSSLX509Test {
                fail("failed to get cert string");
            }
 
-           /* check encoding can be parsed (throws exception if not) */
+           /* check encoding can be parsed (throws exception if not).
+            * Use WolfSSLX509 for tests below to ensure we are using our
+            * implementation of X509Certificate. */
            WolfSSLX509 tmp;
            tmp = new WolfSSLX509(peer.getEncoded());
            tmp = new WolfSSLX509(x509.getEncoded());
@@ -499,7 +501,7 @@ public class WolfSSLX509Test {
            }
 
            try {
-               x509.getIssuerUniqueID();
+               tmp.getIssuerUniqueID();
                error("\t\t... failed: A test case for getIssuerUniqueID is needed");
                fail("getIssuerUniqueID implemented without test case");
            } catch (Exception ex) {
@@ -507,7 +509,7 @@ public class WolfSSLX509Test {
            }
 
            try {
-               x509.getSubjectUniqueID();
+               tmp.getSubjectUniqueID();
                error("\t\t... failed: A test case for getSubjectUniqueID is needed");
                fail("getSubjectUniqueID implemented without test case");
            } catch (Exception ex) {
@@ -515,7 +517,7 @@ public class WolfSSLX509Test {
            }
 
            try {
-               x509.getSigAlgParams();
+               tmp.getSigAlgParams();
                error("\t\t... failed: A test case for getSigAlgParams is needed");
                fail("getSigAlgParams implemented without test case");
            } catch (Exception ex) {


### PR DESCRIPTION
Changes and fixes in this PR are related to memory use optimization and memory cleanup:
- Fixes a memory leak when users/applications used a custom X509TrustManager and wolfJSSE created a native global reference for WolfSSLInternalVerifyCb object (https://github.com/wolfSSL/wolfssljni/pull/69/commits/96f365a5e02f04222d1be4be7b01482b223a4ee2).
- Adds support for multiple simultaneous WOLFSSL sessions registering a custom X509TrustManager concurrently.  Previously the JNI native code maintained one global reference to a WolfSSLInternalVerifyCb object.  This meant that a single WolfSSLSession could have the callback registered.  This PR stores the global native WolfSSLInternalVerifyCb reference inside each native WOLFSSL session structure, thus making it possible for each WolfSSLSession to register it's own X509TrustManager without conflicting and overwriting the single global instance (https://github.com/wolfSSL/wolfssljni/pull/69/commits/96f365a5e02f04222d1be4be7b01482b223a4ee2).
- Adds call to WolfSSL.cleanup() inside WolfSSL.finalize() to call wolfSSL_Cleanup() when done with WolfSSL object (https://github.com/wolfSSL/wolfssljni/pull/69/commits/4216f2676eba6b3ddccee07082fd58351431099e).
- When a WolfSSLSocket is closed (close()), release the native memory held by the WOLFSSL object.  This is done by calling freeSSL() inside close().  freeSSL() is also called by the finalize() method of WolfSSLSocket, but this approach will free the native memory sooner than waiting for the garbage collector (https://github.com/wolfSSL/wolfssljni/pull/69/commits/ceb837afe7bddf626407e623fe006702d8a435bc).
- Be more diligent about freeing native certificate memory used by WolfSSLCertificate objects when possible (https://github.com/wolfSSL/wolfssljni/pull/69/commits/848309613571751b6d03534de780350b154e1659).
- Release native logging callback with DeleteGlobalRef() when wolfSSL_Cleanup() is called (https://github.com/wolfSSL/wolfssljni/pull/69/commits/b7b61407d36898eef00b63fe3eb93720ddfe1168).
- Release native wolfCrypt FIPS callback with DeleteGlobalRef() when wolfSSL_Cleanup() is called. Only affects FIPS builds with **HAVE_FIPS** defined (https://github.com/wolfSSL/wolfssljni/pull/69/commits/e7a24de557847467fab77c230e45d62f5b24958a).
- Release WOLFSSL_CTX level Java verify callback object with DeleteGlobalRef() when wolfSSL_CTX_free() is called. Only affects JNI-only users registering verify callback at CTX level. Does not affect JSSE users, as callback is registered per-WOLFSSL session in JSSE (https://github.com/wolfSSL/wolfssljni/pull/69/commits/90d5d477cc30b8c43c8c0cc756042ff348246908).
- Release WOLFSSL_CTX level Java CRL callback object with DeleteGlobalRef() when wolfSSL_CTX_free() is called. Only affects JNI-only users registering CRL callback at the CTX level. Does not affect JSSE users (https://github.com/wolfSSL/wolfssljni/pull/69/commits/86aae3a6e865bcc1f8361a129a5b7ad8f7ea31db).
- When doing native WOLFSSL session creation and setup, make sure to call DeleteGlobalRef() in error cases (https://github.com/wolfSSL/wolfssljni/pull/69/commits/32b1083f68ca873897a563a17134bbf7c3180e34).
- Release WOLFSSL JNI global CRL callback object with DeleteGlobalRef() when calling wolfSSL_free() if it has been registered. Only applies to JNI users, not JSSE-only. JSSE does not register CRL callbacks (https://github.com/wolfSSL/wolfssljni/pull/69/commits/84f7f5e46bea8108eb552f763b85cc2a7bebce2d).
- Release WOLFSSL public key callback JNI global references with DeleteGlobalRef() when calling wolfSSL_free(). Only applies to JNI users who have registered their own public key callback classes (https://github.com/wolfSSL/wolfssljni/pull/69/commits/8a8231411533564196d9405e3807c941e2ee44d9).
- Remove two duplicate / extraneous XFREE calls in WolfSSLCertificate.c (https://github.com/wolfSSL/wolfssljni/pull/69/commits/d522902cac8bec3f6610314eca1c15a8c0e0446a).
- Fix unused variable warnings when HAVE_FIPS is not defined (https://github.com/wolfSSL/wolfssljni/pull/69/commits/589e628d8188b6633d73fd414cdd3fdf86224199).
- Change the WolfSSL class variable in WolfSSLProvider to be a static class variable. This will use only one shared WolfSSL object across all WolfSSLProvider objects. We should only keep one WolfSSL object if possible since this object is responsible for initializing the library proper (ie: calling wolfSSL_Init()). (https://github.com/wolfSSL/wolfssljni/pull/69/commits/92aa334b4d7a626a1d5c44fd7d9f6cd68a085b5d).

This PR was rebased on master to include additional fixes from:
- https://github.com/wolfSSL/wolfssljni/pull/70