### PR TITLE
SSLSocket.getSession() is expected to do handshake if not completed yet

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -935,6 +935,17 @@ public class WolfSSLSocket extends SSLSocket {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getSession()");
 
+        try {
+            /* try to do handshake if not completed yet, handles synchronization */
+            if (this.handshakeComplete == false) {
+                this.startHandshake();
+            }
+        } catch (Exception e) {
+            /* Log error, but continue. Session returned will be empty */
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                "Handshake attempt failed in SSLSocket.getSession()");
+        }
+
         return EngineHelper.getSession();
     }
 


### PR DESCRIPTION
This PR modifies the SSLSocket.getSession() method to try and do the SSL/TLS handshake if it has not yet been completed.

This matches behavior of other JSSE providers.  It seems some applications call SSLSocket.getSession() and expect the handshake to be executed at that time.