### PR TITLE
clean up JSSE ProviderTest example, register wolfJSSE

### DIFF
--- a/examples/provider/ProviderTest.java
+++ b/examples/provider/ProviderTest.java
@@ -26,6 +26,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.net.ssl.SSLContext;
 
+import com.wolfssl.provider.jsse.WolfSSLProvider;
+
 /**
  * This class tests the wolfSSL provider installation.  It lists all providers
  * installed on the system, tries to look up the wolfSSL provider, and if
@@ -37,43 +39,45 @@ import javax.net.ssl.SSLContext;
  */
 public class ProviderTest {
 
-    public static void main(String args [])
+    /* Print out info about registered Security providers. Does not
+     * install wolfJSSE. If wolfJSSE has been installed at the system
+     * level, or application has installed wolfJSSE at runtime, it will
+     * show up. Otherwise will not. main() below calls this once without
+     * installing wolfJSSE explicitly, then calls again after installing
+     * wolfJSSE at runtime as the highest-level provider. */
+    public static void pollProviders()
     {
         /* Get all providers */
         Provider [] providers = Security.getProviders();
 
         System.out.println("\nAll Installed Java Security Providers:");
-        System.out.println("---------------------------------------\n");
+        System.out.println("---------------------------------------");
         for(Provider prov:providers)
         {
-            System.out.println(prov);
+            System.out.println("\t" + prov);
         }
 
-        /* Test if wolfSSL is a Provider */
-        System.out.println("\nInfo about wolfSSL Provider (wolfJSSE):");
-        System.out.println("----------------------------------------\n");
         Provider p = Security.getProvider("wolfJSSE");
         if (p == null) {
             System.out.println("No wolfJSSE provider registered in system");
         } else {
-            System.out.println("Provider:");
-            System.out.println(p);
-            System.out.println("Info:");
-            System.out.println(p.getInfo());
+            /* Test if wolfSSL is a Provider */
+            System.out.println("\nInfo about wolfSSL Provider (wolfJSSE):");
+            System.out.println("----------------------------------------");
+            System.out.println("Provider: " + p);
+            System.out.println("Info: " + p.getInfo());
             System.out.println("Services:");
             System.out.println(p.getServices());
-            System.out.println("Version:");
-            System.out.println(p.getVersion());
         }
 
         /* Test which Provider provides TLS versions */
         System.out.println("\nWhat Provider is providing TLS?");
-        System.out.println("--------------------------------\n");
+        System.out.println("--------------------------------");
         try {
             /* TLS default */
             SSLContext s = SSLContext.getInstance("TLS");
             Provider prov = s.getProvider();
-            System.out.println("SSLContext TLS Provider = " + prov);
+            System.out.println("\tSSLContext TLS Provider = " + prov);
         } catch (NoSuchAlgorithmException ex) {
             Logger.getLogger(ProviderTest.class.getName()).log(Level.SEVERE,
                              null, ex);
@@ -83,7 +87,7 @@ public class ProviderTest {
             /* TLS 1.0 - NOTE: compiled out by default in native wolfSSL */
             SSLContext s = SSLContext.getInstance("TLSv1");
             Provider prov = s.getProvider();
-            System.out.println("SSLContext TLSv1 Provider = " + prov);
+            System.out.println("\tSSLContext TLSv1 Provider = " + prov);
         } catch (NoSuchAlgorithmException ex) {
             Logger.getLogger(ProviderTest.class.getName()).log(Level.SEVERE,
                              null, ex);
@@ -93,7 +97,7 @@ public class ProviderTest {
             /* TLS 1.1 */
             SSLContext s = SSLContext.getInstance("TLSv1.1");
             Provider prov = s.getProvider();
-            System.out.println("SSLContext TLSv1.1 Provider = " + prov);
+            System.out.println("\tSSLContext TLSv1.1 Provider = " + prov);
         } catch (NoSuchAlgorithmException ex) {
             Logger.getLogger(ProviderTest.class.getName()).log(Level.SEVERE,
                              null, ex);
@@ -103,7 +107,7 @@ public class ProviderTest {
             /* TLS 1.2 */
             SSLContext s = SSLContext.getInstance("TLSv1.2");
             Provider prov = s.getProvider();
-            System.out.println("SSLContext TLSv1.2 Provider = " + prov);
+            System.out.println("\tSSLContext TLSv1.2 Provider = " + prov);
         } catch (NoSuchAlgorithmException ex) {
             Logger.getLogger(ProviderTest.class.getName()).log(Level.SEVERE,
                              null, ex);
@@ -113,12 +117,31 @@ public class ProviderTest {
             /* TLS 1.3 */
             SSLContext s = SSLContext.getInstance("TLSv1.3");
             Provider prov = s.getProvider();
-            System.out.println("SSLContext TLSv1.3 Provider = " + prov);
+            System.out.println("\tSSLContext TLSv1.3 Provider = " + prov);
 
         } catch (NoSuchAlgorithmException ex) {
             Logger.getLogger(ProviderTest.class.getName()).log(Level.SEVERE,
                              null, ex);
         }
+    }
+
+    public static void main(String args [])
+    {
+        /* Print system providers before explicit wolfJSSE install */
+        System.out.println("=================================================");
+        System.out.println("| Before installing wolfJSSE at runtime         |");
+        System.out.println("=================================================");
+        pollProviders();
+
+        /* Install wolfJSSE */
+        Security.insertProviderAt(new WolfSSLProvider(), 1);
+
+        /* Print system provider, after installing wolfJSSE */
+        System.out.println("");
+        System.out.println("=================================================");
+        System.out.println("| After installing wolfJSSE at runtime          |");
+        System.out.println("=================================================");
+        pollProviders();
     }
 }
 

--- a/examples/provider/ProviderTest.sh
+++ b/examples/provider/ProviderTest.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./lib/:/usr/local/lib
-java -classpath ./lib/wolfssl.jar:./lib/wolfssl-jsse.jar:./examples/build -Dsun.boot.library.path=./lib/ -Dwolfjsse.debug=true ProviderTest $@
+cd ./examples/build
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:../../lib/:/usr/local/lib
+java -classpath ../../lib/wolfssl.jar:../../lib/wolfssl-jsse.jar:./ -Dsun.boot.library.path=../../lib/ -Dwolfjsse.debug=true ProviderTest $@
 


### PR DESCRIPTION
This PR cleans up the JSSE ProviderTest example. Previously it only printed out providers registered at the system level. It now prints that out first, then registers wolfJSSE at runtime, then prints provider info again.

Helpful for seeing what classes wolfJSSE registers without installing at system level.