### PR TITLE
synchronize class free() calls that access native cleanup functions

### DIFF
--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -243,6 +243,11 @@ public class WolfSSL {
     /* is this object active, or has it been cleaned up? */
     private boolean active = false;
 
+    /* ---------------------------- locks ------------------------------- */
+
+    /* lock for cleanup */
+    final private Object cleanupLock = new Object();
+
     /* ------------------------ constructors ---------------------------- */
 
     /**
@@ -978,10 +983,12 @@ public class WolfSSL {
     @Override
     protected void finalize() throws Throwable
     {
-        if (this.active == true) {
-            /* free resources, set state */
-            this.cleanup();
-            this.active = false;
+        synchronized(cleanupLock) {
+            if (this.active == true) {
+                /* free resources, set state */
+                this.cleanup();
+                this.active = false;
+            }
         }
         super.finalize();
     }

--- a/src/java/com/wolfssl/WolfSSLCertManager.java
+++ b/src/java/com/wolfssl/WolfSSLCertManager.java
@@ -140,7 +140,7 @@ public class WolfSSLCertManager {
      * @throws IllegalStateException WolfSSLContext has been freed
      * @see         WolfSSLSession#freeSSL()
      */
-    public void free() throws IllegalStateException {
+    public synchronized void free() throws IllegalStateException {
 
         if (this.active == false)
             throw new IllegalStateException("Object has been freed");

--- a/src/java/com/wolfssl/WolfSSLCertificate.java
+++ b/src/java/com/wolfssl/WolfSSLCertificate.java
@@ -453,7 +453,7 @@ public class WolfSSLCertificate {
      *
      * @throws IllegalStateException WolfSSLCertificate has been freed
      */
-    public void free() throws IllegalStateException {
+    public synchronized void free() throws IllegalStateException {
 
         if (this.active == false)
             throw new IllegalStateException("Object has been freed");

--- a/src/java/com/wolfssl/WolfSSLContext.java
+++ b/src/java/com/wolfssl/WolfSSLContext.java
@@ -600,7 +600,7 @@ public class WolfSSLContext {
      * @throws IllegalStateException WolfSSLContext has been freed
      * @see         WolfSSLSession#freeSSL()
      */
-    public void free() throws IllegalStateException {
+    public synchronized void free() throws IllegalStateException {
 
         if (this.active == false)
             throw new IllegalStateException("Object has been freed");

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -697,7 +697,7 @@ public class WolfSSLSession {
      * @see    WolfSSLContext#newContext(long)
      * @see    WolfSSLContext#free()
      */
-    public void freeSSL()
+    public synchronized void freeSSL()
         throws IllegalStateException, WolfSSLJNIException {
 
         if (this.active == false)


### PR DESCRIPTION
This PR adds synchronization to class cleanup/free routines so that only one thread can enter the respective free() at a time.  Could prevent a scenario where multiple threads call native free() functions at the same time on the same pointer.