### PR TITLE
Add support for SSLEngine.getApplicationProtocol()

### DIFF
--- a/native/com_wolfssl_WolfSSL.h
+++ b/native/com_wolfssl_WolfSSL.h
@@ -87,6 +87,14 @@ extern "C" {
 #define com_wolfssl_WolfSSL_WOLFSSL_OCSP_URL_OVERRIDE 1L
 #undef com_wolfssl_WolfSSL_WOLFSSL_OCSP_NO_NONCE
 #define com_wolfssl_WolfSSL_WOLFSSL_OCSP_NO_NONCE 2L
+#undef com_wolfssl_WolfSSL_WOLFSSL_ALPN_NO_MATCH
+#define com_wolfssl_WolfSSL_WOLFSSL_ALPN_NO_MATCH 0L
+#undef com_wolfssl_WolfSSL_WOLFSSL_ALPN_MATCH
+#define com_wolfssl_WolfSSL_WOLFSSL_ALPN_MATCH 1L
+#undef com_wolfssl_WolfSSL_WOLFSSL_ALPN_CONTINUE_ON_MISMATCH
+#define com_wolfssl_WolfSSL_WOLFSSL_ALPN_CONTINUE_ON_MISMATCH 2L
+#undef com_wolfssl_WolfSSL_WOLFSSL_ALPN_FAILED_ON_MISMATCH
+#define com_wolfssl_WolfSSL_WOLFSSL_ALPN_FAILED_ON_MISMATCH 4L
 #undef com_wolfssl_WolfSSL_WOLFSSL_CBIO_ERR_GENERAL
 #define com_wolfssl_WolfSSL_WOLFSSL_CBIO_ERR_GENERAL -1L
 #undef com_wolfssl_WolfSSL_WOLFSSL_CBIO_ERR_WANT_READ

--- a/native/com_wolfssl_WolfSSLSession.h
+++ b/native/com_wolfssl_WolfSSLSession.h
@@ -719,6 +719,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_sslSetAlpnProtos
 JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_sslGet0AlpnSelected
   (JNIEnv *, jobject, jlong);
 
+/*
+ * Class:     com_wolfssl_WolfSSLSession
+ * Method:    useALPN
+ * Signature: (JLjava/lang/String;I)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useALPN
+  (JNIEnv *, jobject, jlong, jstring, jint);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -187,9 +187,13 @@ public class WolfSSL {
     public final static int WOLFSSL_OCSP_NO_NONCE     = 2;
 
     /* ALPN definitions from ssl.h */
+    /** ALPN: no match found */
     public final static int WOLFSSL_ALPN_NO_MATCH = 0;
+    /** ALPN: found match */
     public final static int WOLFSSL_ALPN_MATCH    = 1;
+    /** ALPN: continue on protocol mismatch */
     public final static int WOLFSSL_ALPN_CONTINUE_ON_MISMATCH = 2;
+    /** ALPN: failed on protocol mismatch */
     public final static int WOLFSSL_ALPN_FAILED_ON_MISMATCH   = 4;
 
     /* I/O callback default errors, pulled from wolfssl/ssl.h IOerrors */

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -186,6 +186,12 @@ public class WolfSSL {
     /** CertManager: disable sending OCSP nonce */
     public final static int WOLFSSL_OCSP_NO_NONCE     = 2;
 
+    /* ALPN definitions from ssl.h */
+    public final static int WOLFSSL_ALPN_NO_MATCH = 0;
+    public final static int WOLFSSL_ALPN_MATCH    = 1;
+    public final static int WOLFSSL_ALPN_CONTINUE_ON_MISMATCH = 2;
+    public final static int WOLFSSL_ALPN_FAILED_ON_MISMATCH   = 4;
+
     /* I/O callback default errors, pulled from wolfssl/ssl.h IOerrors */
     /** I/O callback error: general error */
     public final static int WOLFSSL_CBIO_ERR_GENERAL    = -1;

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -2840,10 +2840,18 @@ public class WolfSSLSession {
      */
     public String getAlpnSelectedString() throws IllegalStateException {
 
+        byte[] alpnSelectedBytes = null;
+
         if (this.active == false)
             throw new IllegalStateException("Object has been freed");
 
-        return new String(getAlpnSelected(), StandardCharsets.UTF_8);
+        alpnSelectedBytes = getAlpnSelected();
+
+        if (alpnSelectedBytes != null) {
+            return new String(alpnSelectedBytes, StandardCharsets.UTF_8);
+        } else {
+            return null;
+        }
     }
 
     /**

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -25,6 +25,8 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.DatagramSocket;
 import java.net.SocketTimeoutException;
+import java.lang.StringBuilder;
+import java.nio.charset.StandardCharsets;
 
 import com.wolfssl.WolfSSLException;
 import com.wolfssl.WolfSSLJNIException;
@@ -276,6 +278,7 @@ public class WolfSSLSession {
     private native int gotCloseNotify(long ssl);
     private native int sslSetAlpnProtos(long ssl, byte[] alpnProtos);
     private native byte[] sslGet0AlpnSelected(long ssl);
+    private native int useALPN(long ssl, String protocols, int options);
 
     /* ------------------- session-specific methods --------------------- */
 
@@ -2753,16 +2756,19 @@ public class WolfSSLSession {
     }
 
     /**
-     * Set ALPN extension protocol for this session.
-     * Calls native SSL_set_alpn_protos() at native level. Format starts with
+     * Set ALPN extension protocol for this session from encoded byte array.
+     * Calls SSL_set_alpn_protos() at native level. Format starts with
      * length, where length does not include length byte itself. Example format:
      *
      * byte[] p = "http/1.1".getBytes();
      *
+     * Unless this input format is explicitly needed, useALPN(String[], int)
+     * will likely be easier to use.
+     *
      * @param alpnProtos ALPN protocols, encoded as byte array vector
-     * @return WolfSSL.SSL_SUCCESS on success, otherwise negative.
+     * @return WolfSSL.SSL_SUCCESS on success, otherwise negative on error.
      */
-    public int setAlpnProtos(byte[] alpnProtos) throws IllegalStateException {
+    public int useALPN(byte[] alpnProtos) throws IllegalStateException {
 
         if (this.active == false)
             throw new IllegalStateException("Object has been freed");
@@ -2771,10 +2777,48 @@ public class WolfSSLSession {
     }
 
     /**
+     * Set ALPN extension protocol for this session from String array.
+     * Calls native wolfSSL_useALPN(), where protocols should be a String
+     * array of ALPN protocols. At the native JNI level, this is converted to
+     * a comma-delimited list of prototocls and passed to native wolfSSL.
+     *
+     * This method is similar to useALPN(byte[]), but accepts a String array
+     * and calls a different native wolfSSL API for ALPN use.
+     *
+     * @param protocols Array of ALPN protocol Strings
+     * @param options Options to control behavior of ALPN failure mode.
+     *                Possible options include:
+     *                    WolfSSL.WOLFSSL_ALPN_CONTINUE_ON_MISMATCH
+     *                    WolfSSL.WOLFSSL_ALPN_FAILED_ON_MISMATCH
+     * @return WolfSSL.SSL_SUCCESS on success, otherwise negative on error.
+     *
+     */
+    public int useALPN(String[] protocols, int options) {
+
+        /* all protocols, comma delimited */
+        StringBuilder allProtocols = new StringBuilder();
+
+        if (this.active == false)
+            throw new IllegalStateException("Object has been freed");
+
+        if (protocols == null) {
+            return WolfSSL.BAD_FUNC_ARG;
+        }
+
+        for (int i = 0; i < protocols.length; i++) {
+            if (i != 0) {
+                allProtocols.append(",");
+            }
+            allProtocols.append(protocols[i]);
+        }
+
+        return useALPN(getSessionPtr(), allProtocols.toString(), options);
+    }
+
+    /**
      * Get the ALPN protocol selected by the client/server for this session.
      *
-     * @return byte array representation of selected protocol, starting with
-     *         length byte. Length does not include length byte itself.
+     * @return byte array representation of selected protocol.
      * @throws IllegalStateException WolfSSLSession has been freed
      */
     public byte[] getAlpnSelected() throws IllegalStateException {
@@ -2783,6 +2827,23 @@ public class WolfSSLSession {
             throw new IllegalStateException("Object has been freed");
 
         return sslGet0AlpnSelected(getSessionPtr());
+    }
+
+    /**
+     * Get the ALPN protocol selected by the client/server for this session.
+     *
+     * Same behavior as getAlpnSelected(), but returns a String instead of a
+     * byte array.
+     *
+     * @return String of the selected ALPN protocol
+     * @throws IllegalStateException WolfSSLSession has been freed
+     */
+    public String getAlpnSelectedString() throws IllegalStateException {
+
+        if (this.active == false)
+            throw new IllegalStateException("Object has been freed");
+
+        return new String(getAlpnSelected(), StandardCharsets.UTF_8);
     }
 
     /**

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
@@ -545,6 +545,10 @@ public class WolfSSLEngine extends SSLEngine {
         return EngineHelper.getEnableSessionCreation();
     }
 
+    public String getApplicationProtocol() {
+        return EngineHelper.getAlpnSelectedProtocolString();
+    }
+
     /**
      * Set the SSLParameters for this SSLSocket.
      *

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
@@ -370,6 +370,12 @@ public class WolfSSLEngineHelper {
         return null;
     }
 
+    /**
+     * Get selected ALPN protocol string
+     *
+     * @return String representation of selected ALPN protocol or null
+     *         if handshake has not finished
+     */
     protected String getAlpnSelectedProtocolString() {
         if (ssl.handshakeDone()) {
             String proto = ssl.getAlpnSelectedString();

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
@@ -358,12 +358,26 @@ public class WolfSSLEngineHelper {
     /**
      * Get selected ALPN protocol
      *
+     * Used by some versions of Android, non-standard ALPN API.
+     *
      * @return encoded byte array for selected ALPN protocol or null if
      *         handshake has not finished
      */
     protected byte[] getAlpnSelectedProtocol() {
         if (ssl.handshakeDone()) {
             return ssl.getAlpnSelected();
+        }
+        return null;
+    }
+
+    protected String getAlpnSelectedProtocolString() {
+        if (ssl.handshakeDone()) {
+            String proto = ssl.getAlpnSelectedString();
+
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                "selected ALPN protocol = " + proto);
+
+            return proto;
         }
         return null;
     }
@@ -577,13 +591,51 @@ public class WolfSSLEngineHelper {
 
     /* Set the ALPN to be used for this session */
     private void setLocalAlpnProtocols() {
-        byte[] alpnProtos = this.params.getAlpnProtos();
 
-        if (alpnProtos != null) {
+        /* ALPN protocol list could be stored in either of the following,
+         * depending on what platform/JDK we are being used on:
+         *     this.params.getAlpnProtos() or
+         *     this.params.getApplicationProtocols()
+         * For example, Conscrypt consumers on older Android versions with
+         * JDK 7 will be in params.getAlpnProtos(). JDK versions > 8, with
+         * support for params.getApplicationProtocols() will likely use that
+         * instead. */
+
+        int i;
+        byte[] alpnProtos = this.params.getAlpnProtos();
+        String[] applicationProtocols = this.params.getApplicationProtocols();
+
+        if ((alpnProtos != null && alpnProtos.length > 0) &&
+            (applicationProtocols != null && applicationProtocols.length > 0)) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "Setting ALPN protocols for WOLFSSL session");
-            this.ssl.setAlpnProtos(alpnProtos);
-        } else {
+                "ALPN protocols found in both params.getAlpnProtos() and " +
+                "params.getApplicationProtocols()");
+        }
+
+        /* try to set from byte[] first, then overwrite with String[] if
+         * both have been set */
+        if (alpnProtos != null && alpnProtos.length > 0) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                "Setting ALPN protocols for WOLFSSL session from byte[" +
+                alpnProtos.length + "]");
+            this.ssl.useALPN(alpnProtos);
+        }
+
+        if (applicationProtocols != null && applicationProtocols.length > 0) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                "Setting Application Protocols for WOLFSSL session " +
+                "from String[]:");
+            for (i = 0; i < applicationProtocols.length; i++) {
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    "\t" + i + ": " + applicationProtocols[i]);
+            }
+
+            /* continue on mismatch */
+            this.ssl.useALPN(applicationProtocols,
+                             WolfSSL.WOLFSSL_ALPN_CONTINUE_ON_MISMATCH);
+        }
+
+        if (alpnProtos == null && applicationProtocols == null) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                 "No ALPN protocols set, not setting for this WOLFSSL session");
         }

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLParametersHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLParametersHelper.java
@@ -33,6 +33,8 @@ public class WolfSSLParametersHelper
 {
     private static Method getServerNames = null;
     private static Method setServerNames = null;
+    private static Method getApplicationProtocols = null;
+    private static Method setApplicationProtocols = null;
 
     /** Default WolfSSLParametersHelper constructor */
     public WolfSSLParametersHelper() { }
@@ -58,6 +60,12 @@ public class WolfSSLParametersHelper
                                 continue;
                             case "setServerNames":
                                 setServerNames = m;
+                                continue;
+                            case "getApplicationProtocols":
+                                getApplicationProtocols = m;
+                                continue;
+                            case "setApplicationProtocols":
+                                setApplicationProtocols = m;
                                 continue;
                             default:
                                 continue;
@@ -100,7 +108,7 @@ public class WolfSSLParametersHelper
         /* Methods added as of JDK 1.8, older JDKs will not have them. Using
          * Java reflection to detect availability. */
 
-        if (setServerNames != null) {
+        if (setServerNames != null || setApplicationProtocols != null) {
 
             try {
                 /* load WolfSSLJDK8Helper at runtime, not compiled on older JDKs */
@@ -110,9 +118,16 @@ public class WolfSSLParametersHelper
                 paramList[0] = javax.net.ssl.SSLParameters.class;
                 paramList[1] = java.lang.reflect.Method.class;
                 paramList[2] = com.wolfssl.provider.jsse.WolfSSLParameters.class;
+                Method mth = null;
 
-                Method mth = cls.getDeclaredMethod("setServerNames", paramList);
-                mth.invoke(obj, ret, setServerNames, in);
+                if (setServerNames != null) {
+                    mth = cls.getDeclaredMethod("setServerNames", paramList);
+                    mth.invoke(obj, ret, setServerNames, in);
+                }
+                if (setApplicationProtocols != null) {
+                    mth = cls.getDeclaredMethod("setApplicationProtocols", paramList);
+                    mth.invoke(obj, ret, setServerNames, in);
+                }
 
             } catch (Exception e) {
                 /* ignore, class not found */
@@ -124,7 +139,6 @@ public class WolfSSLParametersHelper
          * with newer versions of SSLParameters, but will need to be added
          * conditionally to wolfJSSE when supported. */
         /*ret.setAlgorithmConstraints(in.getAlgorithmConstraints());
-        ret.setApplicationProtocols(in.getApplicationProtocols());
         ret.setEnableRetransmissions(in.getEnableRetransmissions());
         ret.setEndpointIdentificationAlgorithm(
             in.getEndpointIdentificationAlgorithm());
@@ -170,7 +184,7 @@ public class WolfSSLParametersHelper
         /* Methods added as of JDK 1.8, older JDKs will not have them. Using
          * Java reflection to detect availability. */
 
-        if (getServerNames != null) {
+        if (getServerNames != null || getApplicationProtocols != null) {
             try {
                 /* load WolfSSLJDK8Helper at runtime, not compiled on older JDKs */
                 Class<?> cls = Class.forName("com.wolfssl.provider.jsse.WolfSSLJDK8Helper");
@@ -178,9 +192,16 @@ public class WolfSSLParametersHelper
                 Class[] paramList = new Class[2];
                 paramList[0] = javax.net.ssl.SSLParameters.class;
                 paramList[1] = com.wolfssl.provider.jsse.WolfSSLParameters.class;
+                Method mth = null;
 
-                Method mth = cls.getDeclaredMethod("getServerNames", paramList);
-                mth.invoke(obj, in, out);
+                if (getServerNames != null) {
+                    mth = cls.getDeclaredMethod("getServerNames", paramList);
+                    mth.invoke(obj, in, out);
+                }
+                if (getApplicationProtocols != null) {
+                    mth = cls.getDeclaredMethod("getApplicationProtocols", paramList);
+                    mth.invoke(obj, in, out);
+                }
 
             } catch (Exception e) {
                 /* ignore, class not found */
@@ -192,7 +213,6 @@ public class WolfSSLParametersHelper
          * with newer versions of SSLParameters, but will need to be added
          * conditionally to wolfJSSE when supported. */
         /*out.setAlgorithmConstraints(in.getAlgorithmConstraints());
-        out.setApplicationProtocols(in.getApplicationProtocols());
         out.setEnableRetransmissions(in.getEnableRetransmissions());
         out.setEndpointIdentificationAlgorithm(
             in.getEndpointIdentificationAlgorithm());

--- a/src/java/com/wolfssl/provider/jsse/adapter/WolfSSLJDK8Helper.java
+++ b/src/java/com/wolfssl/provider/jsse/adapter/WolfSSLJDK8Helper.java
@@ -110,8 +110,14 @@ public class WolfSSLJDK8Helper
         }
     }
 
-    /* Call SSLParameters.setApplicationProtocols() to set ALPN protocols from
-     * WolfSSLParameters into SSLParameters */
+    /**
+     * Call SSLParameters.setApplicationProtocols() to set ALPN protocols from
+     * WolfSSLParameters into SSLParameters.
+     *
+     * @param out output SSLParameters to store ALPN protocols into
+     * @param m method to invoke to set protocols
+     * @param in input WolfSSLParameters to read ALPN protocols from
+     */
     protected static void setApplicationProtocols(final SSLParameters out,
                                          final Method m, WolfSSLParameters in) {
 
@@ -137,8 +143,13 @@ public class WolfSSLJDK8Helper
         }
     }
 
-    /* Call SSLParameters.getApplicationProtocols() to get ALPN protocols from
-     * SSLParameters into WolfSSLParameters */
+    /**
+     * Call SSLParameters.getApplicationProtocols() to get ALPN protocols from
+     * SSLParameters into WolfSSLParameters.
+     *
+     * @param in input SSLParameters to read ALPN protocols from
+     * @param out output WolfSSLParameters to store ALPN protocols into
+     */
     protected static void getApplicationProtocols(final SSLParameters in,
                                          WolfSSLParameters out) {
 

--- a/src/java/com/wolfssl/provider/jsse/adapter/WolfSSLJDK8Helper.java
+++ b/src/java/com/wolfssl/provider/jsse/adapter/WolfSSLJDK8Helper.java
@@ -109,5 +109,49 @@ public class WolfSSLJDK8Helper
             out.setServerNames(wsni);
         }
     }
+
+    /* Call SSLParameters.setApplicationProtocols() to set ALPN protocols from
+     * WolfSSLParameters into SSLParameters */
+    protected static void setApplicationProtocols(final SSLParameters out,
+                                         final Method m, WolfSSLParameters in) {
+
+        if (out == null || m == null || in == null) {
+            throw new NullPointerException("input arguments to " +
+                "WolfSSLJDK8Helper.setApplicationProtocols() cannot be null");
+        }
+
+        final String[] appProtos = in.getApplicationProtocols();
+        if (appProtos != null) {
+            /* call SSLParameters.setApplicationProtocols() */
+            AccessController.doPrivileged(new PrivilegedAction<Object>() {
+                public Object run() {
+                    try {
+                        m.invoke(out, appProtos);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+
+                    return null;
+                }
+            });
+        }
+    }
+
+    /* Call SSLParameters.getApplicationProtocols() to get ALPN protocols from
+     * SSLParameters into WolfSSLParameters */
+    protected static void getApplicationProtocols(final SSLParameters in,
+                                         WolfSSLParameters out) {
+
+        if (out == null || in == null) {
+            throw new NullPointerException("input arguments to " +
+                "WolfSSLJDK8Helper.getApplicationProtocols() cannot be null");
+        }
+
+        String[] appProtos = in.getApplicationProtocols();
+        if (appProtos != null) {
+            /* call WolfSSLParameters.setApplicationProtocols() */
+            out.setApplicationProtocols(appProtos);
+        }
+    }
 }
 

--- a/src/test/com/wolfssl/test/WolfSSLSessionTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLSessionTest.java
@@ -79,6 +79,7 @@ public class WolfSSLSessionTest {
         test_WolfSSLSession_timeout();
         test_WolfSSLSession_status();
         test_WolfSSLSession_useSNI();
+        test_WolfSSLSession_useALPN();
         test_WolfSSLSession_freeSSL();
         test_WolfSSLSession_UseAfterFree();
         test_WolfSSLSession_getSessionID();
@@ -378,6 +379,71 @@ public class WolfSSLSessionTest {
 
         System.out.print("\tuseSNI()");
         ret = ssl.useSNI((byte)0, sniHostName.getBytes());
+        if (ret == WolfSSL.NOT_COMPILED_IN) {
+            System.out.println("\t\t\t... skipped");
+        } else if (ret != WolfSSL.SSL_SUCCESS) {
+            System.out.println("\t\t\t... failed");
+        } else {
+            System.out.println("\t\t\t... passed");
+        }
+    }
+
+    public void test_WolfSSLSession_useALPN() {
+
+        int ret;
+        String[] alpnProtos = new String[] {
+            "h2", "http/1.1"
+        };
+        byte[] alpnProtoBytes = "http/1.1".getBytes();
+
+        System.out.print("\tuseALPN()");
+
+        /* Testing useALPN(String[], int) */
+        ret = ssl.useALPN(alpnProtos,
+                          WolfSSL.WOLFSSL_ALPN_CONTINUE_ON_MISMATCH);
+
+        if (ret == WolfSSL.SSL_SUCCESS) {
+            ret = ssl.useALPN(alpnProtos,
+                              WolfSSL.WOLFSSL_ALPN_FAILED_ON_MISMATCH);
+        }
+
+        if (ret == WolfSSL.SSL_SUCCESS) {
+            ret = ssl.useALPN(null, WolfSSL.WOLFSSL_ALPN_CONTINUE_ON_MISMATCH);
+            if (ret < 0) {
+                /* error expected, null input */
+                ret = WolfSSL.SSL_SUCCESS;
+            }
+        }
+
+        if (ret == WolfSSL.SSL_SUCCESS) {
+            ret = ssl.useALPN(alpnProtos, 0);
+            if (ret < 0) {
+                /* error expected, no options */
+                ret = WolfSSL.SSL_SUCCESS;
+            }
+        }
+
+        if (ret == WolfSSL.SSL_SUCCESS) {
+            ret = ssl.useALPN(alpnProtos, -123);
+            if (ret < 0) {
+                /* error expected, invalid options */
+                ret = WolfSSL.SSL_SUCCESS;
+            }
+        }
+
+        /* Testing useALPN(byte[]) */
+        if (ret == WolfSSL.SSL_SUCCESS) {
+            ret = ssl.useALPN(alpnProtoBytes);
+        }
+
+        if (ret == WolfSSL.SSL_SUCCESS) {
+            ret = ssl.useALPN(null);
+            if (ret < 0) {
+                /* error expected, null input */
+                ret = WolfSSL.SSL_SUCCESS;
+            }
+        }
+
         if (ret == WolfSSL.NOT_COMPILED_IN) {
             System.out.println("\t\t\t... skipped");
         } else if (ret != WolfSSL.SSL_SUCCESS) {


### PR DESCRIPTION
This PR adds support to WolfSSLEngine for the `getApplicationProtocol()` method.  Fixes test case with Undertow server.

Other items added/changed as part of this PR:
- Wrap native `wolfSSL_UseALPN()` function at JNI level
- Fix compile error with wolfSSL versions less than 4.2.0 where `wolfSSL_set_alpn_protos()` was not available.
- Add support to WolfSSLParameters for `getApplicationProtocols()` and `setApplicationProtocols()` if using Java 8 or later.   These APIs are not available in SSLParameters for JDK versions less than 1.8.  As such, test cases have been omitted for now until we can add support to test harness for conditional JDK version builds.  Same situation as SNI related get/set methods in SSLParameters.