### PR TITLE
WolfSSLSocket: test if close() called before WolfSSLSocket init

### DIFF
--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
@@ -43,6 +43,8 @@ import java.io.ByteArrayInputStream;
 import java.net.Socket;
 import java.net.ServerSocket;
 import java.net.UnknownHostException;
+import java.net.ConnectException;
+import javax.net.SocketFactory;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLContext;
@@ -99,6 +101,8 @@ import com.wolfssl.WolfSSLException;
     public void testProtocolTLSv13();
     public void testSessionResumption();
     public void testSessionResumptionWithTicketEnabled();
+    public void testDoubleSocketClose();
+    public void testSocketConnectException();
  */
 public class WolfSSLSocketTest {
 
@@ -1512,6 +1516,30 @@ public class WolfSSLSocketTest {
         cs.close();
 
         System.out.println("\t\t... passed");
+    }
+
+    @Test
+    public void testSocketConnectException() throws Exception {
+
+        System.out.print("\tTesting for ConnectException");
+
+        this.ctx = tf.createSSLContext("TLS", ctxProvider);
+        SocketFactory sf = this.ctx.getSocketFactory();
+
+        try {
+            /* connect to invalid host/port, expect java.net.ConnectException.
+             * we do not expecdt anything to be running at localhost:12345 */
+            SSLSocket cs = (SSLSocket)sf.createSocket("localhost", 12345);
+        } catch (ConnectException ce) {
+            /* expected */
+        } catch (Exception e) {
+            /* other Exceptions (ie NullPointerException) are unexpected */
+            System.out.println("\t... failed");
+            e.printStackTrace();
+            fail();
+        }
+
+        System.out.println("\t... passed");
     }
 
     protected class TestServer extends Thread


### PR DESCRIPTION
This PR makes a small fix to `com.wolfssl.provider.jsse.WolfSSLSocket`.  Inside WolfSSLSocket.close() try to synchronize on `handshakeLock` first to determine if WolfSSLObject has been initialized. There is a case during WolfSSLSocket creation that WolfSSLSocket.super() can call close() before WolfSSLSocket object itself has been initialized.  In this scenario, `handshakeLock` is NULL and `synchronized(handshakeLock)` throws a NullPointerException.

Before this PR, this exception case could be reproduced using the example ClientJSSE.java and trying to connect to a server that is not here / ie underlying Socket connect() fails:

```
$ ./examples/provider/ClientJSSE.sh (without having a server running)

Unable to set FIPS callback without wolfCrypt FIPS code
Unable to set FIPS callback without wolfCrypt FIPS code
java.lang.NullPointerException
	at com.wolfssl.provider.jsse.WolfSSLSocket.close(WolfSSLSocket.java:1349)
	at java.net.Socket.<init>(Socket.java:455)
	at java.net.Socket.<init>(Socket.java:229)
	at javax.net.ssl.SSLSocket.<init>(SSLSocket.java:173)
	at com.wolfssl.provider.jsse.WolfSSLSocket.<init>(WolfSSLSocket.java:185)
	at com.wolfssl.provider.jsse.WolfSSLSocketFactory.createSocket(WolfSSLSocketFactory.java:237)
	at ClientJSSE.run(ClientJSSE.java:236)
	at ClientJSSE.main(ClientJSSE.java:334)
```

The corrected behavior (matches SunJSSE) should throw a ConnectException instead:

```
$ ./examples/provider/ClientJSSE.sh (without having a server running)

Unable to set FIPS callback without wolfCrypt FIPS code
Unable to set FIPS callback without wolfCrypt FIPS code
java.net.ConnectException: Connection refused (Connection refused)
	at java.net.PlainSocketImpl.socketConnect(Native Method)
	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350)
	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206)
	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188)
	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
	at java.net.Socket.connect(Socket.java:607)
	at com.wolfssl.provider.jsse.WolfSSLSocket.connect(WolfSSLSocket.java:1515)
	at java.net.Socket.connect(Socket.java:556)
	at com.wolfssl.provider.jsse.WolfSSLSocket.connect(WolfSSLSocket.java:1467)
	at java.net.Socket.<init>(Socket.java:452)
	at java.net.Socket.<init>(Socket.java:229)
	at javax.net.ssl.SSLSocket.<init>(SSLSocket.java:173)
	at com.wolfssl.provider.jsse.WolfSSLSocket.<init>(WolfSSLSocket.java:185)
	at com.wolfssl.provider.jsse.WolfSSLSocketFactory.createSocket(WolfSSLSocketFactory.java:237)
	at ClientJSSE.run(ClientJSSE.java:236)
	at ClientJSSE.main(ClientJSSE.java:334)
```