### PR TITLE
update missing Javadocs

### DIFF
--- a/native/com_wolfssl_WolfSSL.h
+++ b/native/com_wolfssl_WolfSSL.h
@@ -155,6 +155,8 @@ extern "C" {
 #define com_wolfssl_WolfSSL_THREAD_CREATE_E -264L
 #undef com_wolfssl_WolfSSL_CACHE_MATCH_ERROR
 #define com_wolfssl_WolfSSL_CACHE_MATCH_ERROR -280L
+#undef com_wolfssl_WolfSSL_WOLFSSL_SNI_HOST_NAME
+#define com_wolfssl_WolfSSL_WOLFSSL_SNI_HOST_NAME 0L
 #undef com_wolfssl_WolfSSL_MEMORY_E
 #define com_wolfssl_WolfSSL_MEMORY_E -125L
 #undef com_wolfssl_WolfSSL_BUFFER_E

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -37,35 +37,57 @@ public class WolfSSL {
     /* If this enum is changed, also change switch statement cases in
      * ./native/com_wolfssl_WolfSSL.c,
      * Java_com_wolfssl_WolfSSL_getAvailableCipherSuitesIana() */
+    /** TLS protocol versions */
     public static enum TLS_VERSION {
+        /** invalid TLS version */
         INVALID,
+        /** TLS 1.0 */
         TLSv1,
+        /** TLS 1.1 */
         TLSv1_1,
+        /** TLS 1.2 */
         TLSv1_2,
+        /** TLS 1.3 */
         TLSv1_3,
+        /** Downgrade starting from highest supported SSL/TLS version */
         SSLv23
     }
 
     /* ------------------ wolfSSL JNI error codes ----------------------- */
+    /** Session unavailable */
     public final static int JNI_SESSION_UNAVAILABLE = -10001;
 
     /* ----------------------- wolfSSL codes ---------------------------- */
 
+    /** Error code: no error */
     public final static int SSL_ERROR_NONE      =  0;
+    /** Error code: failure */
     public final static int SSL_FAILURE         =  0;
+    /** Error code: success */
     public final static int SSL_SUCCESS         =  1;
+    /** Error code: TLS shutdown not done */
     public final static int SSL_SHUTDOWN_NOT_DONE = 2;
 
+    /** Error code: bad certificate */
     public final static int SSL_BAD_CERTTYPE    = -8;
+    /** Error code: bad file stat */
     public final static int SSL_BAD_STAT        = -7;
+    /** Error code: bad path */
     public final static int SSL_BAD_PATH        = -6;
+    /** Error code: bad file type */
     public final static int SSL_BAD_FILETYPE    = -5;
+    /** Error code: bad file */
     public final static int SSL_BAD_FILE        = -4;
+    /** Error code: not implemented */
     public final static int SSL_NOT_IMPLEMENTED = -3;
+    /** Error code: unknown */
     public final static int SSL_UNKNOWN         = -2;
+    /** Error code: fatal error */
     public final static int SSL_FATAL_ERROR     = -1;
 
+    /** wolfSSL file type: ASN.1/DER */
     public final static int SSL_FILETYPE_ASN1    = 2;
+    /** wolfSSL file type: PEM */
     public final static int SSL_FILETYPE_PEM     = 1;
     /** ASN1 */
     public final static int SSL_FILETYPE_DEFAULT = 2;
@@ -111,78 +133,143 @@ public class WolfSSL {
      * @see WolfSSLContext#setVerify(long, int, WolfSSLVerifyCallback)
      */
     public final static int SSL_VERIFY_FAIL_IF_NO_PEER_CERT = 2;
+
+    /**
+     * Verification mode for peer certificates.
+     * Currently not supported by native wolfSSL.
+     *
+     * @see WolfSSLContext#setVerify(long, int, WolfSSLVerifyCallback)
+     */
     public final static int SSL_VERIFY_CLIENT_ONCE          = 4;
 
+    /** Disable session cache */
     public final static int SSL_SESS_CACHE_OFF                = 30;
+    /** currently unused */
     public final static int SSL_SESS_CACHE_CLIENT             = 31;
+    /** Native session cache mode: server */
     public final static int SSL_SESS_CACHE_SERVER             = 32;
+    /** currently unused */
     public final static int SSL_SESS_CACHE_BOTH               = 33;
+    /** Native session cache mode: auto flush */
     public final static int SSL_SESS_CACHE_NO_AUTO_CLEAR      = 34;
+    /** currently unused */
     public final static int SSL_SESS_CACHE_NO_INTERNAL_LOOKUP = 35;
 
+    /** I/O read would block, wolfSSL needs more data */
     public final static int SSL_ERROR_WANT_READ        =  2;
+    /** I/O send would block, wolfSSL needs to write data */
     public final static int SSL_ERROR_WANT_WRITE       =  3;
+    /** currently unused */
     public final static int SSL_ERROR_WANT_CONNECT     =  7;
+    /** currently unused */
     public final static int SSL_ERROR_WANT_ACCEPT      =  8;
+    /** Error with underlying I/O */
     public final static int SSL_ERROR_SYSCALL          =  5;
+    /** I/O operation should be called again when client cert is available */
     public final static int SSL_ERROR_WANT_X509_LOOKUP = 83;
+    /** I/O error, zero return, no more data */
     public final static int SSL_ERROR_ZERO_RETURN      =  6;
+    /** Generatl SSL error */
     public final static int SSL_ERROR_SSL              = 85;
+    /** Peer closed socket */
     public final static int SSL_ERROR_SOCKET_PEER_CLOSED = -397;
 
     /* extra definitions from ssl.h */
+    /** CertManager: check all cert CRLs */
     public final static int WOLFSSL_CRL_CHECKALL      = 1;
+    /** CertManager: use override URL instead of URL in certificates */
     public final static int WOLFSSL_OCSP_URL_OVERRIDE = 1;
+    /** CertManager: disable sending OCSP nonce */
     public final static int WOLFSSL_OCSP_NO_NONCE     = 2;
 
     /* I/O callback default errors, pulled from wolfssl/ssl.h IOerrors */
+    /** I/O callback error: general error */
     public final static int WOLFSSL_CBIO_ERR_GENERAL    = -1;
+    /** I/O callback error: want read */
     public final static int WOLFSSL_CBIO_ERR_WANT_READ  = -2;
+    /** I/O callback error: want write */
     public final static int WOLFSSL_CBIO_ERR_WANT_WRITE = -2;
+    /** I/O callback error: connection reset */
     public final static int WOLFSSL_CBIO_ERR_CONN_RST   = -3;
+    /** I/O callback error: socket interrupted */
     public final static int WOLFSSL_CBIO_ERR_ISR        = -4;
+    /** I/O callback error: connection closed */
     public final static int WOLFSSL_CBIO_ERR_CONN_CLOSE = -5;
+    /** I/O callback error: timeout */
     public final static int WOLFSSL_CBIO_ERR_TIMEOUT    = -6;
 
     /* Atomic User Needs, from ssl.h */
+    /** Represents server side */
     public final static int WOLFSSL_SERVER_END  = 0;
+    /** Represents Client side */
     public final static int WOLFSSL_CLIENT_END  = 1;
+    /** wolfSSL block algorithm type */
     public final static int WOLFSSL_BLOCK_TYPE  = 2;
+    /** wolfSSL stream algorithm type */
     public final static int WOLFSSL_STREAM_TYPE = 3;
+    /** wolfSSL AEAD algorithm type */
     public final static int WOLFSSL_AEAD_TYPE   = 4;
+    /** wolfSSL TLS HMAC inner size */
     public final static int WOLFSSL_TLS_HMAC_INNER_SZ = 13;
 
     /* GetBulkCipher enum, pulled in from ssl.h for Atomic Record layer */
+    /** Bulk cipher algorithm enum: NULL */
     public static int wolfssl_cipher_null;
+    /** Bulk cipher algorithm enum: RC4 */
     public static int wolfssl_rc4;
+    /** Bulk cipher algorithm enum: RC2 */
     public static int wolfssl_rc2;
+    /** Bulk cipher algorithm enum: DES */
     public static int wolfssl_des;
+    /** Bulk cipher algorithm enum: 3DES */
     public static int wolfssl_triple_des;
+    /** Bulk cipher algorithm enum: DES40 */
     public static int wolfssl_des40;
+    /** Bulk cipher algorithm enum: IDEA */
     public static int wolfssl_idea;
+    /** Bulk cipher algorithm enum: AES */
     public static int wolfssl_aes;
+    /** Bulk cipher algorithm enum: AES-GCM */
     public static int wolfssl_aes_gcm;
+    /** Bulk cipher algorithm enum: AES-CCM */
     public static int wolfssl_aes_ccm;
+    /** Bulk cipher algorithm enum: HC-128 */
     public static int wolfssl_hc128;
+    /** Bulk cipher algorithm enum: RABBIT */
     public static int wolfssl_rabbit;
 
     /* wolfSSL error codes, pulled in from wolfssl/error.h wolfSSL_ErrorCodes */
+    /** Generate Cookie Error */
     public final static int GEN_COOKIE_E    =   -277;
 
+    /** Close notify alert sent */
     public final static int SSL_SENT_SHUTDOWN                   = 1;
+    /** Close notify alert received */
     public final static int SSL_RECEIVED_SHUTDOWN               = 2;
+    /** Make it possible to return SSL write with changed buffer location */
     public final static int SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER = 4;
+    /** Disable SSL 2.0. wolfSSL does not support SSL 2.0. */
     public final static int SSL_OP_NO_SSLv2                     = 8;
+    /** Disable SSL 3.0 */
     public final static int SSL_OP_NO_SSLv3                     = 0x00001000;
+    /** Disable TLS 1.0 */
     public final static int SSL_OP_NO_TLSv1                     = 0x00002000;
+    /** Disable TLS 1.1 */
     public final static int SSL_OP_NO_TLSv1_1                   = 0x04000000;
+    /** Disable TLS 1.2 */
     public final static int SSL_OP_NO_TLSv1_2                   = 0x08000000;
+    /** Disable TLS compression. Off by default */
     public final static int SSL_OP_NO_COMPRESSION               = 0x10000000;
+    /** Disable TLS 1.3 */
     public final static int SSL_OP_NO_TLSv1_3                   = 0x20000000;
 
+    /** SSL/TLS handshake failure */
     public final static int SSL_HANDSHAKE_FAILURE                 = 101;
+    /** Alert: Unknown CA */
     public final static int SSL_R_TLSV1_ALERT_UNKNOWN_CA          = 102;
+    /** Alert: Certificate Unknown */
     public final static int SSL_R_SSLV3_ALERT_CERTIFICATE_UNKNOWN = 103;
+    /** Alert: Bad certificate */
     public final static int SSL_R_SSLV3_ALERT_BAD_CERTIFICATE     = 104;
 
     /** Monitor this CRL directory flag */
@@ -206,6 +293,10 @@ public class WolfSSL {
     /** Cache header match error */
     public final static int CACHE_MATCH_ERROR    = -280;
 
+    /* ------------------ TLS extension specific  ------------------------ */
+    /** SNI Host name type, for UseSNI() */
+    public final static int WOLFSSL_SNI_HOST_NAME = 0;
+
     /* ---------------------- wolfCrypt codes ---------------------------- */
 
     /** Out of memory error */
@@ -227,17 +318,27 @@ public class WolfSSL {
     public final static int NO_PASSWORD     = -176;
 
     /* hmac codes, from wolfssl/wolfcrypt/hmac.h */
+    /** Md5 HMAC type */
     public final static int MD5   = 0;
+    /** SHA-1 HMAC type */
     public final static int SHA   = 1;
+    /** SHA2-256 HMAC type */
     public final static int SHA256 = 2;
+    /** SHA2-512 HMAC type */
     public final static int SHA512 = 4;
+    /** SHA2-384 HMAC type */
     public final static int SHA384 = 5;
 
     /* key types */
+    /** DSA key type */
     public final static int DSAk     = 515;
+    /** RSA key type */
     public final static int RSAk     = 645;
+    /** NTRU key type */
     public final static int NTRUk    = 274;
+    /** ECDSA key type */
     public final static int ECDSAk   = 518;
+    /** Ed25519 key type */
     public final static int ED25519k = 256;
 
     /* is this object active, or has it been cleaned up? */
@@ -284,6 +385,10 @@ public class WolfSSL {
 
     private native int init();
 
+    /**
+     * Free native memory allocated at pointer provided.
+     * @param ptr native pointer
+     */
     public static native void nativeFree(long ptr);
 
     static native int getBulkCipherAlgorithmEnumNULL();
@@ -873,6 +978,11 @@ public class WolfSSL {
      */
     public static native int getHmacMaxSize();
 
+    /**
+     * Returns the enabled cipher suites for native wolfSSL.
+     *
+     * @return array of cipher suite Strings
+     */
     public static String[] getCiphers() {
 
         String cipherSuites = getEnabledCipherSuites();

--- a/src/java/com/wolfssl/WolfSSLCertManager.java
+++ b/src/java/com/wolfssl/WolfSSLCertManager.java
@@ -49,6 +49,11 @@ public class WolfSSLCertManager {
     static native int CertManagerVerifyBuffer(long cm, byte[] in, long sz,
                                               int format);
 
+    /**
+     * Create new WolfSSLCertManager object
+     *
+     * @throws WolfSSLException if unable to create new manager
+     */
     public WolfSSLCertManager() throws WolfSSLException {
         cmPtr = CertManagerNew();
         if (cmPtr == 0) {
@@ -57,6 +62,14 @@ public class WolfSSLCertManager {
         this.active = true;
     }
 
+    /**
+     * Load CA into CertManager
+     *
+     * @param f X.509 certificate file to load
+     * @param d directory of X.509 certs to load, or null
+     *
+     * @return WolfSSL.SSL_SUCESS on success, negative on error
+     */
     public int CertManagerLoadCA(String f, String d) {
         if (this.active == false)
             throw new IllegalStateException("Object has been freed");
@@ -64,6 +77,17 @@ public class WolfSSLCertManager {
         return CertManagerLoadCA(this.cmPtr, f, d);
     }
 
+    /**
+     * Load CA into CertManager from byte array
+     *
+     * @param in byte array holding X.509 certificate to load
+     * @param sz size of input byte array, bytes
+     * @param format format of input certificate, either
+     *               WolfSSL.SSL_FILETYPE_PEM (PEM formatted) or
+     *               WolfSSL.SSL_FILETYPE_ASN1 (ASN.1/DER).
+     *
+     * @return WolfSSL.SSL_SUCCESS on success, negative on error
+     */
     public int CertManagerLoadCABuffer(byte[] in, long sz, int format) {
         if (this.active == false)
             throw new IllegalStateException("Object has been freed");
@@ -127,6 +151,18 @@ public class WolfSSLCertManager {
         }
     }
 
+    /**
+     * Verify X.509 certificate held in byte array
+     *
+     * @param in input X.509 certificate as byte array
+     * @param sz size of input certificate array, bytes
+     * @param format format of input certificate, either
+     *               WolfSSL.SSL_FILETYPE_PEM (PEM formatted) or
+     *               WolfSSL.SSL_FILETYPE_ASN1 (ASN.1/DER).
+     *
+     * @return WolfSSL.SSL_SUCCESS on successful verification, otherwise
+     *         negative on error.
+     */
     public int CertManagerVerifyBuffer(byte[] in, long sz, int format) {
         if (this.active == false)
             throw new IllegalStateException("Object has been freed");

--- a/src/java/com/wolfssl/WolfSSLCertificate.java
+++ b/src/java/com/wolfssl/WolfSSLCertificate.java
@@ -41,6 +41,9 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.security.cert.CertificateException;
 
+/**
+ * WolfSSLCertificate class, wraps native wolfSSL WOLFSSL_X509 functionality.
+ */
 public class WolfSSLCertificate {
 
     private boolean active = false;
@@ -74,6 +77,14 @@ public class WolfSSLCertificate {
     static native long X509_load_certificate_buffer(byte[] buf, int format);
     static native long X509_load_certificate_file(String path, int format);
 
+    /**
+     * Create new WolfSSLCertificate from DER-encoded byte array.
+     *
+     * @param der ASN.1/DER encoded X.509 certificate
+     *
+     * @throws WolfSSLException if input is null, input array length is 0,
+     *                          or native API call fails.
+     */
     public WolfSSLCertificate(byte[] der) throws WolfSSLException {
 
         if (der == null || der.length == 0) {
@@ -89,6 +100,17 @@ public class WolfSSLCertificate {
         this.active = true;
     }
 
+    /**
+     * Create WolfSSLCertificate from byte array in specified format.
+     *
+     * @param in X.509 certificate byte array in format specified
+     * @param format format of certificate, either WolfSSL.SSL_FILETYPE_ASN1
+     *               or WolfSSL.SSL_FILETYPE_PEM
+     *
+     * @throws WolfSSLException if in array is null, input array length is 0,
+     *                          format does not match valid options, or
+     *                          native API call fails.
+     */
     public WolfSSLCertificate(byte[] in, int format) throws WolfSSLException {
 
         if (in == null || in.length == 0) {
@@ -111,6 +133,14 @@ public class WolfSSLCertificate {
         this.active = true;
     }
 
+    /**
+     * Create WolfSSLCertificate from specified ASN.1/DER X.509 file.
+     *
+     * @param fileName path to X.509 certificate file in ASN.1/DER format
+     *
+     * @throws WolfSSLException if fileName is null or native API
+     *                          call fails with error.
+     */
     public WolfSSLCertificate(String fileName) throws WolfSSLException {
 
         if (fileName == null) {
@@ -126,6 +156,18 @@ public class WolfSSLCertificate {
         this.active = true;
     }
 
+    /**
+     * Create WolfSSLCertificate from specified X.509 file in specified
+     * format.
+     *
+     * @param fileName path to X.509 certificate file
+     * @param format format of certificate file, either
+     *               WolfSSL.SSL_FILETYPE_ASN1 or
+     *               WolfSSL.SSL_FILETYPE_PEM
+     *
+     * @throws WolfSSLException if input fileName is null, format is not
+     *                          valid, or native API call fails.
+     */
     public WolfSSLCertificate(String fileName, int format)
             throws WolfSSLException {
 
@@ -148,6 +190,13 @@ public class WolfSSLCertificate {
         this.active = true;
     }
 
+    /**
+     * Create WolfSSLCertificate from pre existing native pointer.
+     *
+     * @param x509 pre existing native pointer to WOLFSSL_X509 structure.
+     *
+     * @throws WolfSSLException if input pointer is invalid
+     */
     public WolfSSLCertificate(long x509) throws WolfSSLException {
 
         if (x509 <= 0) {
@@ -157,7 +206,11 @@ public class WolfSSLCertificate {
         this.active = true;
     }
 
-    /* return DER encoding of certificate */
+    /**
+     * Get ASN.1/DER encoding of this X.509 certificate
+     *
+     * @return DER encoded array of certificate or null if not available.
+     */
     public byte[] getDer() {
 
         if (this.active == true) {
@@ -167,7 +220,11 @@ public class WolfSSLCertificate {
         return null;
     }
 
-    /* return the buffer that is To Be Signed */
+    /**
+     * Get buffer that is To Be Signed (Tbs)
+     *
+     * @return byte array to be signed
+     */
     public byte[] getTbs() {
 
         if (this.active == true) {
@@ -177,6 +234,11 @@ public class WolfSSLCertificate {
         return null;
     }
 
+    /**
+     * Get X.509 serial number as BigInteger
+     *
+     * @return serial number as BigInteger, or null if not available
+     */
     public BigInteger getSerial() {
         byte[] out = new byte[32];
         int sz;
@@ -195,6 +257,11 @@ public class WolfSSLCertificate {
         }
     }
 
+    /**
+     * Get X.509 validity notBefore date
+     *
+     * @return notBefore date as Date object, or null if not available
+     */
     public Date notBefore() {
         String nb;
 
@@ -215,6 +282,11 @@ public class WolfSSLCertificate {
         return null;
     }
 
+    /**
+     * Get X.509 validity notAfter date
+     *
+     * @return notAfter date as Date object, or null if not available
+     */
     public Date notAfter() {
         String nb;
 
@@ -235,6 +307,11 @@ public class WolfSSLCertificate {
         return null;
     }
 
+    /**
+     * Get X.509 version
+     *
+     * @return version of X.509 certificate
+     */
     public int getVersion() {
 
         if (this.active == true) {
@@ -244,6 +321,11 @@ public class WolfSSLCertificate {
         return 0;
     }
 
+    /**
+     * Get signature from X.509 certificate
+     *
+     * @return byte array with signature from X.509 certificate, or null
+     */
     public byte[] getSignature() {
 
         if (this.active == true) {
@@ -253,6 +335,11 @@ public class WolfSSLCertificate {
         return null;
     }
 
+    /**
+     * Get signature type from X.509 certificate
+     *
+     * @return signature type String, or null
+     */
     public String getSignatureType() {
 
         if (this.active == true) {
@@ -262,6 +349,11 @@ public class WolfSSLCertificate {
         return null;
     }
 
+    /**
+     * Get X.509 signature algorithm OID
+     *
+     * @return algorithm OID of signature, or null
+     */
     public String getSignatureOID() {
 
         if (this.active == true) {
@@ -271,6 +363,11 @@ public class WolfSSLCertificate {
         return null;
     }
 
+    /**
+     * Get public key from X.509 certificate
+     *
+     * @return certificate public key, byte array. Or null.
+     */
     public byte[] getPubkey() {
 
         if (this.active == true) {
@@ -280,6 +377,11 @@ public class WolfSSLCertificate {
         return null;
     }
 
+    /**
+     * Get public key type of certificate
+     *
+     * @return public key type String, or null
+     */
     public String getPubkeyType() {
 
         if (this.active == true) {
@@ -289,6 +391,11 @@ public class WolfSSLCertificate {
         return null;
     }
 
+    /**
+     * Get certificate isCA value
+     *
+     * @return X.509 isCA value
+     */
     public int isCA() {
 
         if (this.active == true) {
@@ -298,7 +405,11 @@ public class WolfSSLCertificate {
         return 0;
     }
 
-    /* if not set -1 is returned */
+    /**
+     * Get certificate path length
+     *
+     * @return path length, or -1 if not set
+     */
     public int getPathLen() {
 
         if (this.active == true) {
@@ -308,6 +419,11 @@ public class WolfSSLCertificate {
         return 0;
     }
 
+    /**
+     * Get certificate Subject
+     *
+     * @return X.509 Subject String, or null
+     */
     public String getSubject() {
 
         if (this.active == true) {
@@ -317,6 +433,11 @@ public class WolfSSLCertificate {
         return null;
     }
 
+    /**
+     * Get certificate Issuer
+     *
+     * @return X.509 Issuer String, or null
+     */
     public String getIssuer() {
 
         if (this.active == true) {
@@ -326,7 +447,14 @@ public class WolfSSLCertificate {
         return null;
     }
 
-    /* returns WOLFSSL_SUCCESS on successful verification */
+    /**
+     * Verify signature in certificate with provided public key
+     *
+     * @param pubKey public key, ASN.1/DER formatted
+     * @param pubKeySz size of public key array, bytes
+     *
+     * @return true if verified, otherwise false
+     */
     public boolean verify(byte[] pubKey, int pubKeySz) {
         int ret;
 
@@ -341,6 +469,22 @@ public class WolfSSLCertificate {
         return false;
     }
 
+    /**
+     * Get array of key usage values set in certificate
+     *
+     * Array returned will represent the following key usages (true/false):
+     *    [0] = KEYUSE_DIGITAL_SIG
+     *    [1] = KEYUSE_CONTENT_COMMIT
+     *    [2] = KEYUSE_KEY_ENCIPHER
+     *    [3] = KEYUSE_DATA_ENCIPHER
+     *    [4] = KEYUSE_KEY_AGREE
+     *    [5] = KEYUSE_KEY_CERT_SIGN
+     *    [6] = KEYUSE_CRL_SIGN
+     *    [7] = KEYUSE_ENCIPHER_ONLY
+     *    [8] = KEYUSE_DECIPHER_ONLY
+     *
+     * @return arrray of key usages set for certificate, or null
+     */
     public boolean[] getKeyUsage() {
 
         if (this.active == true) {
@@ -350,7 +494,13 @@ public class WolfSSLCertificate {
         return null;
     }
 
-    /* gets the DER encoded extension value from an OID passed in */
+    /**
+     * Get DER encoded extension value from a specified OID
+     *
+     * @param oid OID value of extension to retreive value for
+     *
+     * @return DER encoded extension value, or null
+     */
     public byte[] getExtension(String oid) {
         if (oid == null || this.active == false) {
             return null;
@@ -358,10 +508,15 @@ public class WolfSSLCertificate {
         return X509_get_extension(this.x509Ptr, oid);
     }
 
-    /* returns 1 if extension OID is set but not critical
-     * returns 2 if extension OID is set and is critical
-     * return  0 if not set
-     * return negative value on error
+    /**
+     * Poll if certificate extension is set for this certificate
+     *
+     * @param oid OID value of extension to poll for
+     *
+     * @return 1 if extension OID is set but not critical,
+     *         2 if extension OID is set and is critical,
+     *         0 if not set,
+     *         otherwise negative value on error
      */
     public int getExtensionSet(String oid) {
         if (this.active == false) {

--- a/src/java/com/wolfssl/WolfSSLCustomUser.java
+++ b/src/java/com/wolfssl/WolfSSLCustomUser.java
@@ -31,8 +31,11 @@ import  com.wolfssl.WolfSSL.TLS_VERSION;
  * @version 1.0, August 2013
  */
 public class WolfSSLCustomUser {
+    /** SSL/TLS version */
     public TLS_VERSION version;
+    /** String array of allowed cipher suites */
     public String[] list;
+    /** Mask of options to set for the associated WOLFSSL_CTX */
     public long noOptions;
 
     /**

--- a/src/java/com/wolfssl/WolfSSLException.java
+++ b/src/java/com/wolfssl/WolfSSLException.java
@@ -21,16 +21,35 @@
 
 package com.wolfssl;
 
+/**
+ * WolfSSL Exception class
+ */
 public class WolfSSLException extends Exception {
 
+    /**
+     * Create WolfSSLException with reason String
+     *
+     * @param reason reason String
+     */
     public WolfSSLException(String reason) {
         super(reason);
     }
 
+    /**
+     * Create WolfSSLException with reason and cause
+     *
+     * @param reason reason String
+     * @param cause cause of Exception
+     */
     public WolfSSLException(String reason, Throwable cause) {
         super(reason, cause);
     }
 
+    /**
+     * Create WolfSSLException with cause
+     *
+     * @param cause of Exception
+     */
     public WolfSSLException(Throwable cause) {
         super(cause);
     }

--- a/src/java/com/wolfssl/WolfSSLJNIException.java
+++ b/src/java/com/wolfssl/WolfSSLJNIException.java
@@ -21,16 +21,35 @@
 
 package com.wolfssl;
 
+/**
+ * WolfSSL JNI Exception class
+ */
 public class WolfSSLJNIException extends Exception {
 
+    /**
+     * Create WolfSSLJNIException with reason String
+     *
+     * @param reason reason String
+     */
     public WolfSSLJNIException(String reason) {
         super(reason);
     }
 
+    /**
+     * Create WolfSSLJNIException with reason and cause
+     *
+     * @param reason reason String
+     * @param cause cause of Exception
+     */
     public WolfSSLJNIException(String reason, Throwable cause) {
         super(reason, cause);
     }
 
+    /**
+     * Create WolfSSLJNIException with cause
+     *
+     * @param cause of Exception
+     */
     public WolfSSLJNIException(Throwable cause) {
         super(cause);
     }

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -2575,6 +2575,18 @@ public class WolfSSLSession {
         setSSLIOSend(getSessionPtr());
     }
 
+    /**
+     * Use SNI name with this session.
+     *
+     * @param type SNI type. Currently supported type is
+     *        WolfSSL.WOLFSSL_SNI_HOST_NAME.
+     * @param data encoded data for SNI extension value
+     *
+     * @return WolfSSL.SSL_SUCCESS on success, negative on error
+     *
+     * @throws IllegalStateException if called when WolfSSLSession is not
+     *         active
+     */
     public int useSNI(byte type, byte[] data) throws IllegalStateException {
 
         int ret;

--- a/src/java/com/wolfssl/WolfSSLX509StoreCtx.java
+++ b/src/java/com/wolfssl/WolfSSLX509StoreCtx.java
@@ -22,6 +22,11 @@ package com.wolfssl;
 
 import com.wolfssl.WolfSSLCertificate;
 
+/**
+ * WolfSSLX509StoreCtx class
+ *
+ * @author wolfSSL Inc.
+ */
 public class WolfSSLX509StoreCtx {
 
     private boolean active = false;
@@ -29,6 +34,13 @@ public class WolfSSLX509StoreCtx {
 
     static native byte[][] X509_STORE_CTX_getDerCerts(long ctxPtr);
 
+    /**
+     * Create new WolfSSLX509StoreCtx object
+     *
+     * @param ctxPtr native pointer to WOLFSSL_X509_STORE structure
+     *
+     * @throws WolfSSLException if ctxPtr is 0
+     */
     public WolfSSLX509StoreCtx(long ctxPtr) throws WolfSSLException {
         if (ctxPtr == 0) {
             throw new WolfSSLException("Failed to create " +

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLContext.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLContext.java
@@ -485,17 +485,32 @@ public class WolfSSLContext extends SSLContextSpi {
         return WolfSSLParametersHelper.decoupleParams(this.params);
     }
 
-    /* used internally by SSLSocketFactory() */
+    /**
+     * Get WolfSSLAuthStore for this WolfSSLContext.
+     * Used internally by SSLSocketFactory()
+     *
+     * @return WolfSSLAuthStore for this WolfSSLContext object
+     */
     protected WolfSSLAuthStore getInternalAuthStore() {
         return this.authStore;
     }
 
-    /* used internally by SSLSocketFactory() */
+    /**
+     * Get internal SSLParameters.
+     * Used internally by SSLSocketFactory()
+     *
+     * @return WolfSSLParameters for this WolfSSLContext object
+     */
     protected WolfSSLParameters getInternalSSLParams() {
         return this.params;
     }
 
-    /* used internally by SSLSocketFactory() */
+    /**
+     * Get internal com.wolfssl.WolfSSLContext for this object.
+     * Used internally by SSLSocketFactory()
+     *
+     * @return com.wolfssl.WolfSSLContext for this object
+     */
     protected com.wolfssl.WolfSSLContext getInternalWolfSSLContext() {
         return this.ctx;
     }
@@ -509,6 +524,16 @@ public class WolfSSLContext extends SSLContextSpi {
         super.finalize();
     }
 
+    /**
+     * Sets the WolfSSLContext options using specified protocol mask.
+     * Also translates the protocol mask provided to an array of Strings
+     * for the enabled SSL/TLS protocols.
+     *
+     * @param noOpt protocol mask set into native WOLFSSL_CTX
+     *
+     * @return String array of enabled SSL/TLS protocols for this
+     *         WolfSSLContext object
+     */
     public String[] getProtocolsMask(long noOpt) {
         if (ctx != null) {
             ctx.setOptions(noOpt);
@@ -516,7 +541,13 @@ public class WolfSSLContext extends SSLContextSpi {
         return WolfSSL.getProtocolsMask(noOpt);
     }
 
+    /**
+     * SSLContext implementation supporting TLS 1.0
+     */
     public static final class TLSV1_Context extends WolfSSLContext {
+        /**
+         * Create new TLSv1_Context, calls parent WolfSSLContext constructor
+         */
         public TLSV1_Context() {
             super(TLS_VERSION.TLSv1);
 
@@ -525,7 +556,13 @@ public class WolfSSLContext extends SSLContextSpi {
         }
     }
 
+    /**
+     * SSLContext implementation supporting TLS 1.1
+     */
     public static final class TLSV11_Context extends WolfSSLContext {
+        /**
+         * Create new TLSv11_Context, calls parent WolfSSLContext constructor
+         */
         public TLSV11_Context() {
             super(TLS_VERSION.TLSv1_1);
 
@@ -534,7 +571,13 @@ public class WolfSSLContext extends SSLContextSpi {
         }
     }
 
+    /**
+     * SSLContext implementation supporting TLS 1.2
+     */
     public static final class TLSV12_Context extends WolfSSLContext {
+        /**
+         * Create new TLSv12_Context, calls parent WolfSSLContext constructor
+         */
         public TLSV12_Context() {
             super(TLS_VERSION.TLSv1_2);
 
@@ -543,7 +586,13 @@ public class WolfSSLContext extends SSLContextSpi {
         }
     }
 
+    /**
+     * SSLContext implementation supporting TLS 1.3
+     */
     public static final class TLSV13_Context extends WolfSSLContext {
+        /**
+         * Create new TLSv13_Context, calls parent WolfSSLContext constructor
+         */
         public TLSV13_Context() {
             super(TLS_VERSION.TLSv1_3);
 
@@ -552,7 +601,15 @@ public class WolfSSLContext extends SSLContextSpi {
         }
     }
 
+    /**
+     * TLSv23 SSLContext class.
+     * Created using SSLv23 method, supporting highest protocol enabled
+     * in native wolfSSL. Downgrades to native minimum downgrade level.
+     */
     public static final class TLSV23_Context extends WolfSSLContext {
+        /**
+         * Create new TLSv23_Context, calls parent WolfSSLContext constructor
+         */
         public TLSV23_Context() {
             super(TLS_VERSION.SSLv23);
 
@@ -562,8 +619,16 @@ public class WolfSSLContext extends SSLContextSpi {
     }
 
 
+    /**
+     * DEFAULT SSLContext class.
+     * Created using SSLv23 method, supporting highest protocol enabled
+     * in native wolfSSL. Downgrades to native minimum downgrade level.
+     */
     public static final class DEFAULT_Context extends WolfSSLContext {
         /**
+         * Create new DEFAULT_Context, calls parent WolfSSLContext constructor
+         * with TLS_VERSION.SSLv23
+         *
          * @throws IllegalStateException when engine init fails
          */
         public DEFAULT_Context() {

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
@@ -547,8 +547,15 @@ public class WolfSSLEngine extends SSLEngine {
         }
     }
 
-    /* encrypted packet ready to be sent out. Copies buffer to end of to send
-     * queue */
+    /**
+     * Copies buffer to end of to send queue. Encrypted packet is ready to be
+     * sent out.
+     *
+     * @param in byte array with encrypted data to be sent
+     * @param sz size of data in input array to be sent
+     *
+     * @return number of bytes placed into send queue
+     */
     protected synchronized int setOut(byte[] in, int sz) {
         int totalSz = sz, idx = 0;
         byte[] tmp;
@@ -567,7 +574,15 @@ public class WolfSSLEngine extends SSLEngine {
     }
 
 
-    /* reads from buffer toRead */
+    /**
+     * Reads from buffer toRead
+     *
+     * @param toRead byte array to read data from
+     * @param sz size of toRead array, bytes
+     *
+     * @return number of bytes read into toRead array or negative
+     *         value on error
+     */
     protected synchronized int setIn(byte[] toRead, int sz) {
         int max = (sz < toReadSz)? sz : toReadSz;
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
@@ -116,30 +116,65 @@ public class WolfSSLEngineHelper {
             ", hostname: " + hostname + ")");
     }
 
-    /* used internally by SSLSocket.connect(SocketAddress) */
+    /**
+     * Set hostname and port
+     * Used internally by SSLSocket.connect(SocketAddress)
+     *
+     * @param hostname peer hostname String
+     * @param port peer port number
+     */
     protected void setHostAndPort(String hostname, int port) {
         this.hostname = hostname;
         this.port = port;
     }
 
+    /**
+     * Get the com.wolfssl.WolfSSLSession for this object
+     *
+     * @return com.wolfssl.WolfSSLSession for this object
+     */
     protected WolfSSLSession getWolfSSLSession() {
         return ssl;
     }
 
+    /**
+     * Get WolfSSLImplementSession for this object
+     *
+     * @return WolfSSLImplementSession for this object
+     */
     protected WolfSSLImplementSSLSession getSession() {
         return session;
     }
 
-    /* gets all supported cipher suites */
+    /**
+     * Get all supported cipher suites in native wolfSSL library
+     *
+     * @return String array of all supported cipher suites
+     */
     protected String[] getAllCiphers() {
         return WolfSSL.getCiphersIana();
     }
 
-    /* gets all enabled cipher suites */
+    /**
+     * Get all enabled cipher suites
+     *
+     * @return String array of all enabled cipher suites
+     */
     protected String[] getCiphers() {
         return this.params.getCipherSuites();
     }
 
+    /**
+     * Set cipher suites enabled in WolfSSLParameters
+     *
+     * Sanitizes input array for invalid suites
+     *
+     * @param suites String array of cipher suites to be enabled
+     *
+     * @throws IllegalArgumentException if input array contains invalid
+     *         cipher suites, input array is null, or input array has length
+     *         zero
+     */
     protected void setCiphers(String[] suites) throws IllegalArgumentException {
 
         if (suites == null) {
@@ -162,6 +197,16 @@ public class WolfSSLEngineHelper {
         this.params.setCipherSuites(suites);
     }
 
+    /**
+     * Set protocols enabled in WolfSSLParameters
+     *
+     * Sanitizes protocol array for invalid protocols
+     *
+     * @param p String array of SSL/TLS protocols to be enabled
+     *
+     * @throws IllegalArgumentException if input array is null,
+     *         has length zero, or contains invalid/unsupported protocols
+     */
     protected void setProtocols(String[] p) throws IllegalArgumentException {
 
         if (p == null) {
@@ -184,16 +229,32 @@ public class WolfSSLEngineHelper {
         this.params.setProtocols(p);
     }
 
-    /* gets enabled protocols */
+    /**
+     * Get enabled SSL/TLS protocols from WolfSSLParameters
+     *
+     * @return String array of enabled SSL/TLS protocols
+     */
     protected String[] getProtocols() {
         return this.params.getProtocols();
     }
 
-    /* gets all supported protocols */
+    /**
+     * Get all supported SSL/TLS protocols in native wolfSSL library
+     *
+     * @return String array of supported protocols
+     */
     protected String[] getAllProtocols() {
         return WolfSSL.getProtocols();
     }
 
+    /**
+     * Set client mode for associated WOLFSSL session
+     *
+     * @param mode client mode (true/false)
+     *
+     * @throws IllegalArgumentException if called after SSL/TLS handshake
+     *         has been completed. Only allowed before.
+     */
     protected void setUseClientMode(boolean mode)
         throws IllegalArgumentException {
 
@@ -212,42 +273,93 @@ public class WolfSSLEngineHelper {
         this.modeSet = true;
     }
 
+    /**
+     * Get clientMode for associated session
+     *
+     * @return boolean value of clientMode set for this session
+     */
     protected boolean getUseClientMode() {
         return this.clientMode;
     }
 
+    /**
+     * Set if session needs client authentication
+     *
+     * @param need boolean if session needs client authentication
+     */
     protected void setNeedClientAuth(boolean need) {
         this.params.setNeedClientAuth(need);
     }
 
+    /**
+     * Get value of needClientAuth for this session
+     *
+     * @return boolean value for needClientAuth
+     */
     protected boolean getNeedClientAuth() {
         return this.params.getNeedClientAuth();
     }
 
+    /**
+     * Set value of wantClientAuth for this session
+     *
+     * @param want boolean value of wantClientAuth for this session
+     */
     protected void setWantClientAuth(boolean want) {
         this.params.setWantClientAuth(want);
     }
 
+    /**
+     * Get value of wantClientAuth for this session
+     *
+     * @return boolean value for wantClientAuth
+     */
     protected boolean getWantClientAuth() {
         return this.params.getWantClientAuth();
     }
 
+    /**
+     * Set ability to create sessions
+     *
+     * @param flag boolean to set enable session creation
+     */
     protected void setEnableSessionCreation(boolean flag) {
         this.sessionCreation = flag;
     }
 
+    /**
+     * Get boolean if session creation is allowed
+     *
+     * @return boolean value for enableSessionCreation
+     */
     protected boolean getEnableSessionCreation() {
         return this.sessionCreation;
     }
 
+    /**
+     * Enable use of session tickets
+     *
+     * @param flag boolean to enable/disable session tickets
+     */
     protected void setUseSessionTickets(boolean flag) {
         this.params.setUseSessionTickets(flag);
     }
 
+    /**
+     * Set ALPN protocols
+     *
+     * @param alpnProtos encoded byte array of ALPN protocols
+     */
     protected void setAlpnProtocols(byte[] alpnProtos) {
         this.params.setAlpnProtocols(alpnProtos);
     }
 
+    /**
+     * Get selected ALPN protocol
+     *
+     * @return encoded byte array for selected ALPN protocol or null if
+     *         handshake has not finished
+     */
     protected byte[] getAlpnSelectedProtocol() {
         if (ssl.handshakeDone()) {
             return ssl.getAlpnSelected();
@@ -477,9 +589,16 @@ public class WolfSSLEngineHelper {
         this.setLocalAlpnProtocols();
     }
 
-    /* sets all parameters from WolfSSLParameters into WOLFSSL object and
-     * creates session.
-     * Should be called before doHandshake */
+    /**
+     * Sets all parameters from WolfSSLParameters into native WOLFSSL object
+     * and creates session.
+     *
+     * This should be called before doHandshake()
+     *
+     * @throws SSLException if setUseClientMode() has not been called
+     * @throws SSLHandshakeException session creation is not allowed
+     *
+     */
     protected void initHandshake() throws SSLException {
         if (!modeSet) {
             throw new SSLException("setUseClientMode has not been called");
@@ -520,10 +639,19 @@ public class WolfSSLEngineHelper {
         this.setLocalParams();
     }
 
-    /* start or continue handshake, return WolfSSL.SSL_SUCCESS or
-     * WolfSSL.SSL_FAILURE.
-     * isSSLEngine param specifies if this is being called by an SSLEngine
-     * or not. Should not loop on WANT_READ/WRITE for SSLEngine */
+    /**
+     * Start or continue handshake
+     *
+     * Callers should not loop on WANT_READ/WRITE when used with SSLEngine.
+     *
+     * @param isSSLEngine specifies if this is being called by an SSLEngine
+     *                    or not.
+     *
+     * @return WolfSSL.SSL_SUCCESS on success or either WolfSSL.SSL_FAILURE
+     *         or WolfSSL.SSL_HANDSHAKE_FAILURE on error
+     *
+     * @throws SSLException if setUseClientMode() has not been called.
+     */
     protected int doHandshake(int isSSLEngine) throws SSLException {
         int ret, err;
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
@@ -62,15 +62,21 @@ public class WolfSSLImplementSSLSession implements SSLSession {
     byte pseudoSessionID[] = null; /* used with TLS 1.3*/
     private int side = 0;
 
-    /**
-     * has this session been registered
-     */
+    /** Has this session been registered */
     protected boolean fromTable = false;
+
     private long sesPtr = 0;
     private String nullCipher = "SSL_NULL_WITH_NULL_NULL";
     private String nullProtocol = "NONE";
 
-
+    /**
+     * Create new WolfSSLImplementSSLSession
+     *
+     * @param in WolfSSLSession to be used with this object
+     * @param port peer port for this session
+     * @param host peer hostname String for this session
+     * @param params WolfSSLAuthStore for this session
+     */
     public WolfSSLImplementSSLSession (WolfSSLSession in, int port, String host,
             WolfSSLAuthStore params) {
         this.ssl = in;
@@ -84,6 +90,12 @@ public class WolfSSLImplementSSLSession implements SSLSession {
         accessed = new Date();
     }
 
+    /**
+     * Create new WolfSSLImplementSSLSession
+     *
+     * @param in WolfSSLSession to be used with this object
+     * @param params WolfSSLAuthStore for this session
+     */
     public WolfSSLImplementSSLSession (WolfSSLSession in,
                                        WolfSSLAuthStore params) {
         this.ssl = in;
@@ -97,6 +109,11 @@ public class WolfSSLImplementSSLSession implements SSLSession {
         accessed = new Date();
     }
 
+    /**
+     * Create new WolfSSLImplementSSLSession
+     *
+     * @param params WolfSSLAuthStore for this session
+     */
     public WolfSSLImplementSSLSession (WolfSSLAuthStore params) {
         this.port = -1;
         this.host = null;
@@ -108,6 +125,13 @@ public class WolfSSLImplementSSLSession implements SSLSession {
         accessed = new Date();
     }
 
+    /**
+     * Get session ID for this session
+     *
+     * @return session ID as byte array, empty byte array if wrapped
+     *         com.wolfssl.WolfSSLSession is null, or null if inner
+     *         IllegalStateException or WolfSSLJNIException are thrown
+     */
     public synchronized byte[] getId() {
         if (ssl == null) {
             return new byte[0];
@@ -125,30 +149,54 @@ public class WolfSSLImplementSSLSession implements SSLSession {
         }
     }
 
+    /**
+     * Get SSLSessionContext for this session
+     *
+     * @return SSLSessionContext
+     */
     public synchronized SSLSessionContext getSessionContext() {
         return ctx;
     }
 
     /**
      * Setter function for the SSLSessionContext used with session creation
+     *
      * @param ctx value to set the session context as
      */
     protected void setSessionContext(WolfSSLSessionContext ctx) {
         this.ctx = ctx;
     }
 
+    /**
+     * Get session creation time
+     *
+     * @return session creation time
+     */
     public long getCreationTime() {
         return creation.getTime();
     }
 
+    /**
+     * Get session last accessed time
+     *
+     * @return session last accessed time
+     */
     public long getLastAccessedTime() {
         return accessed.getTime();
     }
 
+    /**
+     * Invalidate this session
+     */
     public void invalidate() {
         this.valid = false;
     }
 
+    /**
+     * Check if this session is valid
+     *
+     * @return boolean if this session is valid
+     */
     public boolean isValid() {
         return this.valid;
     }
@@ -162,6 +210,14 @@ public class WolfSSLImplementSSLSession implements SSLSession {
         this.valid = in;
     }
 
+    /**
+     * Put value into this session
+     *
+     * @param name String name of value
+     * @param obj Object to store associated with name
+     *
+     * @throws IllegalArgumentException if input name is null
+     */
     public void putValue(String name, Object obj) {
         Object old;
 
@@ -184,10 +240,24 @@ public class WolfSSLImplementSSLSession implements SSLSession {
         }
     }
 
+    /**
+     * Get stored value associated with name
+     *
+     * @param name String name to retrieve associated Object value
+     *
+     * @return Object value associated with name
+     */
     public Object getValue(String name) {
         return binding.get(name);
     }
 
+    /**
+     * Remove stored String:Object from session
+     *
+     * @param name String name to remove from session
+     *
+     * @throws IllegalArgumentException if input name is null
+     */
     public void removeValue(String name) {
         Object obj;
 
@@ -206,10 +276,23 @@ public class WolfSSLImplementSSLSession implements SSLSession {
         }
     }
 
+    /**
+     * Get stored value names in this session
+     *
+     * @return String array of value names stored in session
+     */
     public String[] getValueNames() {
         return binding.keySet().toArray(new String[binding.keySet().size()]);
     }
 
+    /**
+     * Get peer certificates for this session
+     *
+     * @return Certificate array of peer certs for session
+     *
+     * @throws SSLPeerUnverifiedException if handshake is not complete,
+     *         or error getting certificates
+     */
     public synchronized Certificate[] getPeerCertificates()
             throws SSLPeerUnverifiedException {
         long x509;

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLInternalVerifyCb.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLInternalVerifyCb.java
@@ -37,21 +37,41 @@ import javax.net.ssl.X509TrustManager;
 import javax.net.ssl.SSLHandshakeException;
 import java.io.IOException;
 
-/* Internal verify callback. This is used when a user registers a
- * TrustManager which is NOT com.wolfssl.provider.jsse.WolfSSLTrustManager
- * and is used to call TrustManager checkClientTrusted() or
- * checkServerTrusted(). If wolfJSSE TrustManager is used, native wolfSSL
- * does certificate verification internally. Used by WolfSSLEngineHelper. */
+/**
+ * Internal verify callback.
+ * This is used when a user registers a TrustManager which is NOT
+ * com.wolfssl.provider.jsse.WolfSSLTrustManager. It is used to call
+ * TrustManager checkClientTrusted() or checkServerTrusted().
+ * If wolfJSSE TrustManager is used, native wolfSSL does certificate
+ * verification internally. Used by WolfSSLEngineHelper.
+ */
 public class WolfSSLInternalVerifyCb implements WolfSSLVerifyCallback {
 
     private X509TrustManager tm = null;
     private boolean clientMode;
 
+    /**
+     * Create new WolfSSLInternalVerifyCb
+     *
+     * @param xtm X509TrustManager to use with this object
+     * @param client boolean representing if this is client side
+     */
     public WolfSSLInternalVerifyCb(X509TrustManager xtm, boolean client) {
         this.tm = xtm;
         this.clientMode = client;
     }
 
+    /**
+     * Native wolfSSL verify callback.
+     *
+     * @param preverify_ok Will be 1 if native wolfSSL verification
+     *        procedured have passed, otherwise 0.
+     * @param x509StorePtr Native pointer to WOLFSSL_X509_STORE structure
+     *
+     * @return 1 if verification should be considered successful and
+     *         SSL/TLS handshake should continue. Otherwise return 0
+     *         to mark verification failure and stop/abort handshake.
+     */
     public int verifyCallback(int preverify_ok, long x509StorePtr) {
 
         WolfSSLCertificate[] certs = null;
@@ -63,7 +83,7 @@ public class WolfSSLInternalVerifyCb implements WolfSSLVerifyCallback {
                     "Native wolfSSL peer verification passed");
         } else {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "WARNING: Native wolfSSL peer verification failed!");
+                    "NOTE: Native wolfSSL peer verification failed");
         }
 
         try {

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLKeyManager.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLKeyManager.java
@@ -31,7 +31,9 @@ import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactorySpi;
 import javax.net.ssl.ManagerFactoryParameters;
 
-
+/**
+ * WolfSSL KeyManagerFactory implementation
+ */
 public class WolfSSLKeyManager extends KeyManagerFactorySpi {
     private char[] pswd;
     private KeyStore store;

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLKeyX509.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLKeyX509.java
@@ -36,7 +36,6 @@ import javax.net.ssl.X509KeyManager;
 
 import com.wolfssl.WolfSSLException;
 
-
 /**
  * wolfSSL implementation of X509KeyManager
  *
@@ -46,6 +45,12 @@ public class WolfSSLKeyX509 implements X509KeyManager{
     private KeyStore store;
     private char[] password;
 
+    /**
+     * Create new WolfSSLKeyX509 object
+     *
+     * @param in input KeyStore to use with this object
+     * @param password input KeyStore password
+     */
     public WolfSSLKeyX509(KeyStore in, char[] password) {
         this.store = in;
         this.password = password;

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLParametersHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLParametersHelper.java
@@ -25,6 +25,10 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import javax.net.ssl.SSLParameters;
 
+/**
+ * WolfSSLParametersHelper class
+ * @author wolfSSL Inc.
+ */
 public class WolfSSLParametersHelper
 {
     private static Method getServerNames = null;

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java
@@ -30,7 +30,7 @@ import com.wolfssl.WolfSSLFIPSErrorCallback;
  * wolfSSL JSSE Provider implementation
  *
  * @author wolfSSL
- * @version 1.0
+ * @version 1.8
  */
 public final class WolfSSLProvider extends Provider {
 
@@ -38,7 +38,18 @@ public final class WolfSSLProvider extends Provider {
      * all WolfSSLProvider objects. */
     private static WolfSSL sslLib = null;
 
+    /**
+     * Inner callback class for wolfCrypt FIPS 140-2/3 errors
+     */
     public class JSSEFIPSErrorCallback implements WolfSSLFIPSErrorCallback {
+        /**
+         * wolfCrypt FIPS 140-2/3 error callback.
+         * Called when FIPS integrity test fails
+         *
+         * @param ok 0 if FIPS error not OK, otherwise 1
+         * @param err wolfCrypt FIPS error code
+         * @param hash expected wolfCrypt FIPS verifyCore hash value
+         */
         public void errorCallback(int ok, int err, String hash) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                     "In FIPS error callback, ok = " + ok + " err = " + err);
@@ -54,9 +65,12 @@ public final class WolfSSLProvider extends Provider {
         }
     }
 
+    /**
+     * wolfSSL JSSE Provider class
+     */
     public WolfSSLProvider() {
-        super("wolfJSSE", 1, "wolfSSL JSSE Provider");
-        //super("wolfJSSE", "1.0", "wolfSSL JSSE Provider");
+        super("wolfJSSE", 1.8, "wolfSSL JSSE Provider");
+        //super("wolfJSSE", "1.8", "wolfSSL JSSE Provider");
 
         /* load native wolfSSLJNI library */
         WolfSSL.loadLibrary();

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSNIServerName.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSNIServerName.java
@@ -34,6 +34,12 @@ public abstract class WolfSSLSNIServerName
     private int type;
     private byte[] encoded = null;
 
+    /**
+     * Create new WolfSSLSNIServerName object
+     *
+     * @param type type of the server name
+     * @param encoded encoded byte array value of server name
+     */
     protected WolfSSLSNIServerName(int type, byte[] encoded) {
 
         if (type < 0 || type > 255) {
@@ -50,10 +56,20 @@ public abstract class WolfSSLSNIServerName
         this.encoded = encoded.clone();
     }
 
+    /**
+     * Get server name type
+     *
+     * @return the name type of this server name
+     */
     public final int getType() {
         return this.type;
     }
 
+    /**
+     * Get encoded byte array of server name
+     *
+     * @return a copy of this encoded server name value, or null
+     */
     public final byte[] getEncoded() {
         if (this.encoded == null) {
             return null;
@@ -61,6 +77,13 @@ public abstract class WolfSSLSNIServerName
         return encoded.clone();
     }
 
+    /**
+     * Test if equal to provided Object
+     *
+     * @param other Object to test for equality to this WolfSSLSNIServerName
+     *
+     * @return true if equal, otherwise false
+     */
     public boolean equals(Object other) {
         if (other == null) {
             return false;
@@ -82,10 +105,20 @@ public abstract class WolfSSLSNIServerName
         return true;
     }
 
+    /**
+     * Get hashCode of this object
+     *
+     * @return hash code value specific to this type and encoded name
+     */
     public int hashCode() {
         return Objects.hash(this.type, this.encoded);
     }
 
+    /**
+     * Return String representation of this object
+     *
+     * @return String representing this object
+     */
     public String toString() {
         StringBuilder s = new StringBuilder();
         s.append("type=(" + this.type + "), ");

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLServerSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLServerSocket.java
@@ -49,6 +49,15 @@ public class WolfSSLServerSocket extends SSLServerSocket {
     private WolfSSLSocket socket = null;
     private WolfSSLDebug debug;
 
+    /**
+     * Create new WolfSSLServerSocket
+     *
+     * @param context WolfSSLContext object to use with this socket
+     * @param authStore WolfSSLAuthStore object to use with this socket
+     * @param params WolfSSLParameters object to use with this socket
+     *
+     * @throws IOException if parent SSLServerSocket constructor call fails
+     */
     public WolfSSLServerSocket(com.wolfssl.WolfSSLContext context,
             WolfSSLAuthStore authStore,
             WolfSSLParameters params) throws IOException {
@@ -64,6 +73,16 @@ public class WolfSSLServerSocket extends SSLServerSocket {
         this.params = params.copy();
     }
 
+    /**
+     * Create new WolfSSLServerSocket
+     *
+     * @param context WolfSSLContext object to use with this socket
+     * @param authStore WolfSSLAuthStore object to use with this socket
+     * @param params WolfSSLParameters object to use with this socket
+     * @param port port for this SSLServerSocket
+     *
+     * @throws IOException if parent SSLServerSocket constructor call fails
+     */
     public WolfSSLServerSocket(com.wolfssl.WolfSSLContext context,
             WolfSSLAuthStore authStore, WolfSSLParameters params, int port)
         throws IOException {
@@ -79,6 +98,17 @@ public class WolfSSLServerSocket extends SSLServerSocket {
         this.params = params.copy();
     }
 
+    /**
+     * Create new WolfSSLServerSocket
+     *
+     * @param context WolfSSLContext object to use with this socket
+     * @param authStore WolfSSLAuthStore object to use with this socket
+     * @param params WolfSSLParameters object to use with this socket
+     * @param port port for this SSLServerSocket
+     * @param backlog requested max length of queue for incoming connections
+     *
+     * @throws IOException if parent SSLServerSocket constructor call fails
+     */
     public WolfSSLServerSocket(com.wolfssl.WolfSSLContext context,
             WolfSSLAuthStore authStore,
             WolfSSLParameters params, int port, int backlog)
@@ -96,6 +126,19 @@ public class WolfSSLServerSocket extends SSLServerSocket {
         this.params = params.copy();
     }
 
+    /**
+     * Create new WolfSSLServerSocket
+     *
+     * @param context WolfSSLContext object to use with this socket
+     * @param authStore WolfSSLAuthStore object to use with this socket
+     * @param params WolfSSLParameters object to use with this socket
+     * @param port port for this SSLServerSocket
+     * @param backlog requested max length of queue for incoming connections
+     * @param address address of network interface from where to accept
+     *        connections
+     *
+     * @throws IOException if parent SSLServerSocket constructor call fails
+     */
     public WolfSSLServerSocket(com.wolfssl.WolfSSLContext context,
             WolfSSLAuthStore authStore,
             WolfSSLParameters params, int port, int backlog,

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLServerSocketFactory.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLServerSocketFactory.java
@@ -32,7 +32,7 @@ import com.wolfssl.WolfSSLContext;
 /**
  * wolfSSL implementation of SSLServerSocketFactory
  *
- * @author wolfSSL
+ * @author wolfSSL Inc.
  */
 public class WolfSSLServerSocketFactory extends SSLServerSocketFactory {
 
@@ -40,6 +40,13 @@ public class WolfSSLServerSocketFactory extends SSLServerSocketFactory {
     private WolfSSLContext ctx = null;
     private WolfSSLParameters params;
 
+    /**
+     * Create new WolfSSLServerSocketFactory
+     *
+     * @param ctx WolfSSLContext object to use with this factory
+     * @param authStore WolfSSLAuthStore object to use for this factory
+     * @param params WolfSSLParameters object to use with this factory
+     */
     public WolfSSLServerSocketFactory(com.wolfssl.WolfSSLContext ctx,
             WolfSSLAuthStore authStore, WolfSSLParameters params) {
         super();

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSessionContext.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSessionContext.java
@@ -25,12 +25,25 @@ import java.util.Enumeration;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSessionContext;
 
+/**
+ * WolfSSLSessionContext class
+ *
+ * @author wolfSSL Inc.
+ */
 public class WolfSSLSessionContext implements SSLSessionContext {
     private WolfSSLAuthStore store;
     private int sesTimout;
     private int sesCache;
     private int side;
 
+    /**
+     * Create new WolfSSLSessionContext
+     *
+     * @param in WolfSSLAuthStore object to use with this context
+     * @param defaultCacheSize default session cache size
+     * @param side client or server side. Either WolfSSL.WOLFSSL_CLIENT_END or
+     *        WolfSSL.WOLFSSL_SERVER_END
+     */
     public WolfSSLSessionContext(WolfSSLAuthStore in, int defaultCacheSize,
             int side) {
         this.store     = in;

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -76,8 +76,11 @@ public class WolfSSLSocket extends SSLSocket {
     private ArrayList<HandshakeCompletedListener> hsListeners = null;
     private WolfSSLDebug debug;
 
+    /** TLS handshake initialization called */
     protected volatile boolean handshakeInitCalled = false;
+    /** TLS handshake has completed */
     protected volatile boolean handshakeComplete = false;
+    /** Connection to peer has closed */
     protected volatile boolean connectionClosed = false;
 
     /* lock for handshakInitCalled and handshakeComplete */
@@ -87,6 +90,16 @@ public class WolfSSLSocket extends SSLSocket {
      * entering library */
     final private Object ioLock = new Object();
 
+    /**
+     * Create new WolfSSLSocket object
+     *
+     * @param context WolfSSLContext to use with this SSLSocket
+     * @param authStore WolfSSLAuthStore to use with this SSLSocket
+     * @param params WolfSSLParameters to use with this SSLSocket
+     * @param clientMode true if this is a client socket, otherwise false
+     *
+     * @throws IOException if initialization fails
+     */
     public WolfSSLSocket(com.wolfssl.WolfSSLContext context,
            WolfSSLAuthStore authStore, WolfSSLParameters params,
            boolean clientMode)
@@ -116,6 +129,18 @@ public class WolfSSLSocket extends SSLSocket {
         }
     }
 
+    /**
+     * Create new WolfSSLSocket object
+     *
+     * @param context WolfSSLContext to use with this SSLSocket
+     * @param authStore WolfSSLAuthStore to use with this SSLSocket
+     * @param params WolfSSLParameters to use with this SSLSocket
+     * @param clientMode true if this is a client socket, otherwise false
+     * @param host InetAddress of peer hostname
+     * @param port port of peer
+     *
+     * @throws IOException if initialization fails
+     */
     public WolfSSLSocket(com.wolfssl.WolfSSLContext context,
             WolfSSLAuthStore authStore, WolfSSLParameters params,
             boolean clientMode, InetAddress host, int port)
@@ -146,6 +171,20 @@ public class WolfSSLSocket extends SSLSocket {
         }
    }
 
+    /**
+     * Create new WolfSSLSocket object
+     *
+     * @param context WolfSSLContext to use with this SSLSocket
+     * @param authStore WolfSSLAuthStore to use with this SSLSocket
+     * @param params WolfSSLParameters to use with this SSLSocket
+     * @param clientMode true if this is a client socket, otherwise false
+     * @param address InetAddress of peer hostname
+     * @param port port of peer
+     * @param localAddress local InetAddress to use for SSLSocket
+     * @param localPort local port to use for SSLSocket
+     *
+     * @throws IOException if initialization fails
+     */
     public WolfSSLSocket(com.wolfssl.WolfSSLContext context,
             WolfSSLAuthStore authStore, WolfSSLParameters params,
             boolean clientMode, InetAddress address, int port,
@@ -177,6 +216,18 @@ public class WolfSSLSocket extends SSLSocket {
         }
     }
 
+    /**
+     * Create new WolfSSLSocket object
+     *
+     * @param context WolfSSLContext to use with this SSLSocket
+     * @param authStore WolfSSLAuthStore to use with this SSLSocket
+     * @param params WolfSSLParameters to use with this SSLSocket
+     * @param clientMode true if this is a client socket, otherwise false
+     * @param host String of peer hostname
+     * @param port port of peer
+     *
+     * @throws IOException if initialization fails
+     */
     public WolfSSLSocket(com.wolfssl.WolfSSLContext context,
             WolfSSLAuthStore authStore, WolfSSLParameters params,
             boolean clientMode, String host, int port)
@@ -207,6 +258,20 @@ public class WolfSSLSocket extends SSLSocket {
         }
     }
 
+    /**
+     * Create new WolfSSLSocket object
+     *
+     * @param context WolfSSLContext to use with this SSLSocket
+     * @param authStore WolfSSLAuthStore to use with this SSLSocket
+     * @param params WolfSSLParameters to use with this SSLSocket
+     * @param clientMode true if this is a client socket, otherwise false
+     * @param host InetAddress of peer hostname
+     * @param port port of peer
+     * @param localHost local InetAddress to use for SSLSocket
+     * @param localPort local port to use for SSLSocket
+     *
+     * @throws IOException if initialization fails
+     */
     public WolfSSLSocket(com.wolfssl.WolfSSLContext context,
             WolfSSLAuthStore authStore, WolfSSLParameters params,
             boolean clientMode, String host, int port, InetAddress localHost,
@@ -238,9 +303,24 @@ public class WolfSSLSocket extends SSLSocket {
         }
     }
 
-    /* creates an SSLSocket layered over an existing socket connected to the
-       named host, at the given port. host/port refer to logical peer, but
-       Socket could be connected to a proxy */
+    /**
+     * Create new WolfSSLSocket object layered over an existing Socket
+     * connected to the named host, at the given port.
+     *
+     * host/port refer to logical peer, but Socket could be connected to
+     * a proxy.
+     *
+     * @param context WolfSSLContext to use with this SSLSocket
+     * @param authStore WolfSSLAuthStore to use with this SSLSocket
+     * @param params WolfSSLParameters to use with this SSLSocket
+     * @param clientMode true if this is a client socket, otherwise false
+     * @param s existing connected Socket
+     * @param host String with peer hostname
+     * @param port port of peer
+     * @param autoClose automatically close wrapped Socket when finished
+     *
+     * @throws IOException if initialization fails
+     */
     public WolfSSLSocket(com.wolfssl.WolfSSLContext context,
             WolfSSLAuthStore authStore, WolfSSLParameters params,
             boolean clientMode, Socket s, String host, int port,
@@ -667,6 +747,18 @@ public class WolfSSLSocket extends SSLSocket {
                 "supported by wolfSSLSocket");
     }
 
+    /**
+     * Create new WolfSSLSocket object layered over an existing Socket.
+     *
+     * @param context WolfSSLContext to use with this SSLSocket
+     * @param authStore WolfSSLAuthStore to use with this SSLSocket
+     * @param params WolfSSLParameters to use with this SSLSocket
+     * @param clientMode true if this is a client socket, otherwise false
+     * @param s existing connected Socket
+     * @param autoClose automatically close wrapped Socket when finished
+     *
+     * @throws IOException if initialization fails
+     */
     public WolfSSLSocket(com.wolfssl.WolfSSLContext context,
             WolfSSLAuthStore authStore, WolfSSLParameters params,
             boolean clientMode, Socket s, boolean autoClose)
@@ -703,7 +795,20 @@ public class WolfSSLSocket extends SSLSocket {
         }
     }
 
-    /* only creates a server mode Socket */
+    /**
+     * Create new WolfSSLSocket object layered over an existing Socket,
+     * only a server mode Socket. Use pre-consumed InputStream data
+     * if provided.
+     *
+     * @param context WolfSSLContext to use with this SSLSocket
+     * @param authStore WolfSSLAuthStore to use with this SSLSocket
+     * @param params WolfSSLParameters to use with this SSLSocket
+     * @param s existing connected Socket
+     * @param consumed pre-consumed Socket data to use for this SSLSocket
+     * @param autoClose automatically close wrapped Socket when finished
+     *
+     * @throws IOException if initialization fails
+     */
     public WolfSSLSocket(com.wolfssl.WolfSSLContext context,
             WolfSSLAuthStore authStore, WolfSSLParameters params, Socket s,
             InputStream consumed, boolean autoClose) throws IOException {

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocketFactory.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocketFactory.java
@@ -51,8 +51,12 @@ public class WolfSSLSocketFactory extends SSLSocketFactory {
     private int isDefault = 0;
     private int isDefaultInitialized = 0;
 
-    /* This constructor is used when the JSSE call
-     * SSLSocketFactory.getDefault() */
+    /**
+     * Create new WolfSSLSocketFactory object with default settings
+     *
+     * This constructor is used when the JSSE calls
+     * SSLSocketFactory.getDefault()
+     */
     public WolfSSLSocketFactory() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
@@ -68,6 +72,13 @@ public class WolfSSLSocketFactory extends SSLSocketFactory {
         this.params = null;
     }
 
+    /**
+     * Create new WolfSSLSocketFactory object
+     *
+     * @param ctx WolfSSLContext object to use with this factory
+     * @param authStore WolfSSLAuthStore object to use with this factory
+     * @param params WolfSSLParameters to use with this factory
+     */
     public WolfSSLSocketFactory(com.wolfssl.WolfSSLContext ctx,
             WolfSSLAuthStore authStore, WolfSSLParameters params) {
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLTrustX509.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLTrustX509.java
@@ -49,6 +49,11 @@ import java.util.Set;
 public class WolfSSLTrustX509 implements X509TrustManager {
     private KeyStore store = null;
 
+    /**
+     * Create new WolfSSLTrustX509 object
+     *
+     * @param in KeyStore to use with this X509TrustManager
+     */
     public WolfSSLTrustX509(KeyStore in) {
         this.store = in;
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLX509.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLX509.java
@@ -52,7 +52,10 @@ import com.wolfssl.WolfSSLException;
  * @author wolfSSL
  */
 public class WolfSSLX509 extends X509Certificate {
+
+    /** Inner WolfSSLCertificate object */
     private WolfSSLCertificate cert = null;
+    /** Certificate extension OID values */
     private String[] extensionOid = {
         "2.5.29.15", /* key usage */
         "2.5.29.19", /* basic constraint */
@@ -62,6 +65,13 @@ public class WolfSSLX509 extends X509Certificate {
         "2.5.29.31"  /* CRL dist */
     };
 
+    /**
+     * Create new WolfSSLX509 object
+     *
+     * @param der ASN.1/DER encoded X.509 certificate
+     *
+     * @throws WolfSSLException if certificate parsing fails
+     */
     public WolfSSLX509(byte[] der) throws WolfSSLException{
         super();
         this.cert = new WolfSSLCertificate(der);
@@ -70,6 +80,13 @@ public class WolfSSLX509 extends X509Certificate {
             "created new WolfSSLX509(byte[] der)");
     }
 
+    /**
+     * Create new WolfSSLX509 object
+     *
+     * @param derName ASN.1/DER X.509 certificate file name to load
+     *
+     * @throws WolfSSLException if certificate parsing fails
+     */
     public WolfSSLX509(String derName) throws WolfSSLException {
         super();
         this.cert = new WolfSSLCertificate(derName);
@@ -78,6 +95,13 @@ public class WolfSSLX509 extends X509Certificate {
             "created new WolfSSLX509(String derName)");
     }
 
+    /**
+     * Create new WolfSSLX509 object
+     *
+     * @param x509 initialized pointer to native WOLFSSL_X509 struct
+     *
+     * @throws WolfSSLException if certificate parsing fails
+     */
     public WolfSSLX509(long x509) throws WolfSSLException {
         super();
         this.cert = new WolfSSLCertificate(x509);
@@ -438,6 +462,9 @@ public class WolfSSLX509 extends X509Certificate {
         return this.cert.toString();
     }
 
+    /**
+     * Free native resources used by this object.
+     */
     public void free() {
         try {
             if (this.cert != null) {

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLX509X.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLX509X.java
@@ -43,6 +43,13 @@ import com.wolfssl.WolfSSLException;
 public class WolfSSLX509X extends X509Certificate {
     WolfSSLX509 cert;
 
+    /**
+     * Create new WolfSSLX509X object
+     *
+     * @param der ASN.1/DER encoded X.509 certificate
+     *
+     * @throws WolfSSLException if certificate parsing fails
+     */
     public WolfSSLX509X(byte[] der) throws WolfSSLException{
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
@@ -51,6 +58,13 @@ public class WolfSSLX509X extends X509Certificate {
         this.cert = new WolfSSLX509(der);
     }
 
+    /**
+     * Create new WolfSSLX509X object
+     *
+     * @param derName ASN.1/DER X.509 certificate file name to load
+     *
+     * @throws WolfSSLException if certificate parsing fails
+     */
     public WolfSSLX509X(String derName) throws WolfSSLException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
@@ -59,6 +73,13 @@ public class WolfSSLX509X extends X509Certificate {
         this.cert = new WolfSSLX509(derName);
     }
 
+    /**
+     * Create new WolfSSLX509X object
+     *
+     * @param x509 initialized pointer to native WOLFSSL_X509 struct
+     *
+     * @throws WolfSSLException if certificate parsing fails
+     */
     public WolfSSLX509X(long x509) throws WolfSSLException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,

--- a/src/java/com/wolfssl/provider/jsse/adapter/WolfSSLJDK8Helper.java
+++ b/src/java/com/wolfssl/provider/jsse/adapter/WolfSSLJDK8Helper.java
@@ -40,8 +40,14 @@ import javax.net.ssl.SNIHostName;
  */
 public class WolfSSLJDK8Helper
 {
-    /* Call SSLParameters.setServerNames() to set SNI server names from
-     * WolfSSLParameters into SSLParameters */
+    /**
+     * Call SSLParameters.setServerNames() to set SNI server names from
+     * WolfSSLParameters into SSLParameters.
+     *
+     * @param out SSLParameters object to set SNI names into
+     * @param m Java method to call to set SNI server names
+     * @param in WolfSSLParameters to set SNI names from
+     */
     protected static void setServerNames(final SSLParameters out,
                                          final Method m, WolfSSLParameters in) {
 
@@ -73,8 +79,13 @@ public class WolfSSLJDK8Helper
         }
     }
 
-    /* Call SSLParameters.getServerNames() to set SNI server names from
-     * SSLParameters into WolfSSLParameters */
+    /**
+     * Call SSLParameters.getServerNames() to set SNI server names from
+     * SSLParameters into WolfSSLParameters.
+     *
+     * @param in input SSLParameters to read SNI names from
+     * @param out WolfSSLParameters to store SNI names into
+     */
     protected static void getServerNames(final SSLParameters in,
                                          WolfSSLParameters out) {
 

--- a/src/java/com/wolfssl/wolfcrypt/ECC.java
+++ b/src/java/com/wolfssl/wolfcrypt/ECC.java
@@ -34,9 +34,39 @@ import java.nio.ByteBuffer;
  */
 public class ECC {
 
+    /**
+     * ECC verify. Wraps native wc_ecc_verify_hash() to verify ECDSA
+     * signature against known hash value.
+     *
+     * @param sig input ByteBuffer to be verified
+     * @param sigSz size of input buffer, bytes
+     * @param hash input hash to compare signature against
+     * @param hashLen size of input hash, bytes
+     * @param keyDer public key to use for verify, DER format
+     * @param keySz size of keyDer, bytes
+     * @param result first array element set to 0 on successful verify
+     *
+     * @return 0 on success, negative on error.
+     */
     public native int doVerify(ByteBuffer sig, long sigSz, ByteBuffer hash,
             long hashLen, ByteBuffer keyDer, long keySz, int[] result);
 
+    /**
+     * ECC sign. Wraps native wolfCrypt wc_ecc_sign_hash() to
+     * sign input hash with ECDSA.
+     *
+     * Currently only used with public key callbacks.
+     *
+     * @param in input ByteBuffer to be signed
+     * @param inSz size of input, bytes
+     * @param out ByteBuffer to place output signature
+     * @param outSz [IN/OUT] size of output buffer on input, size of
+     *              generated signature on return.
+     * @param key ByteBuffer holding DER encoded ECC key
+     * @param keySz size of input key, bytes
+     *
+     * @return 0 on success, negative on error.
+     */
     public native int doSign(ByteBuffer in, long inSz, ByteBuffer out,
             long[] outSz, ByteBuffer key, long keySz);
 

--- a/src/java/com/wolfssl/wolfcrypt/RSA.java
+++ b/src/java/com/wolfssl/wolfcrypt/RSA.java
@@ -34,17 +34,66 @@ import java.nio.ByteBuffer;
  */
 public class RSA {
 
+    /**
+     * RSA sign, wraps native wolfCrypt operation.
+     *
+     * @param in input buffer to be signed
+     * @param inSz size of input buffer, bytes
+     * @param out output for generated signature
+     * @param outSz [IN/OUT] size of output buffer on input, size of
+     *              generated signature on output
+     * @param key DER formatted RSA key to be used for signing
+     * @param keySz size of key, bytes
+     *
+     * @return 0 on success, negative on error.
+     */
     public native int doSign(ByteBuffer in, long inSz, ByteBuffer out,
             int[] outSz, ByteBuffer key, long keySz);
 
+    /**
+     * RSA verify, wraps native wolfCrypt operation.
+     *
+     * @param sig input signature to verify
+     * @param sigSz size of input signature, bytes
+     * @param out output buffer to place signed data
+     * @param outSz size of output buffer, bytes
+     * @param keyDer public key used for verify, DER formatted
+     * @param keySz size of public key, bytes
+     *
+     * @return size of returned data on success, negative on error.
+     */
     public native int doVerify(ByteBuffer sig, long sigSz, ByteBuffer out,
            long outSz, ByteBuffer keyDer, long keySz);
 
+    /**
+     * RSA encrypt, wraps native wolfCrypt operation.
+     *
+     * @param in input data to be encrypted
+     * @param inSz size of input data, bytes
+     * @param out output buffer to place encrypted result
+     * @param outSz [IN/OUT] size of output buffer on input, size of
+     *              encrypted data on return
+     * @param keyDer RSA key used for encrypt, DER formatted
+     * @param keySz size of RSA key, bytes
+     *
+     * @return 0 on success, negative on error
+     */
     public native int doEnc(ByteBuffer in, long inSz, ByteBuffer out,
             int[] outSz, ByteBuffer keyDer, long keySz);
 
+    /**
+     * RSA decrypt, wraps native wolfCrypt operation.
+     *
+     * @param in input buffer to decrypt
+     * @param inSz size of input buffer, bytes
+     * @param out output buffer for decrypted data
+     * @param outSz size of output buffer, bytes
+     * @param keyDer RSA key used for decryption, DER formatted
+     * @param keySz size of RSA key, bytes
+     *
+     * @return size of decrypted data on success, negative on error.
+     */
     public native int doDec(ByteBuffer in, long inSz, ByteBuffer out,
             long outSz, ByteBuffer keyDer, long keySz);
-
 }
 


### PR DESCRIPTION
This PR updates missing Javadocs.  This fixes build warnings when building the Javadocs on newer JDK distributions (ex: JDK 17).