### PR TITLE
Support Socket timeout for SSL_connect() and SSL_write() in wolfJSSE

### DIFF
--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -608,7 +608,7 @@ static int socketSelect(int sockfd, int timeout_ms, int rx)
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_connect
-  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jint timeout)
 {
     int ret = 0, err = 0, sockfd = 0;
     WOLFSSL* ssl = NULL;
@@ -666,7 +666,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_connect
                 break;
             }
 
-            ret = socketSelect(sockfd, 0, 1);
+            ret = socketSelect(sockfd, (int)timeout, 1);
             if (ret == WOLFJNI_RECV_READY || ret == WOLFJNI_SEND_READY) {
                 /* I/O ready, continue handshake and try again */
                 continue;
@@ -688,8 +688,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_connect
     return ret;
 }
 
-JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_write(JNIEnv* jenv,
-    jobject jcl, jlong sslPtr, jbyteArray raw, jint length)
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_write
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jbyteArray raw, jint length,
+   jint timeout)
 {
     byte* data;
     int ret = SSL_FAILURE, err, sockfd;
@@ -751,7 +752,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_write(JNIEnv* jenv,
                     break;
                 }
 
-                ret = socketSelect(sockfd, 0, 0);
+                ret = socketSelect(sockfd, (int)timeout, 0);
                 if (ret == WOLFJNI_RECV_READY || ret == WOLFJNI_SEND_READY) {
                     /* loop around and try wolfSSL_write() again */
                     continue;

--- a/native/com_wolfssl_WolfSSLSession.h
+++ b/native/com_wolfssl_WolfSSLSession.h
@@ -82,18 +82,18 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getFd
 /*
  * Class:     com_wolfssl_WolfSSLSession
  * Method:    connect
- * Signature: (J)I
+ * Signature: (JI)I
  */
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_connect
-  (JNIEnv *, jobject, jlong);
+  (JNIEnv *, jobject, jlong, jint);
 
 /*
  * Class:     com_wolfssl_WolfSSLSession
  * Method:    write
- * Signature: (J[BI)I
+ * Signature: (J[BII)I
  */
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_write
-  (JNIEnv *, jobject, jlong, jbyteArray, jint);
+  (JNIEnv *, jobject, jlong, jbyteArray, jint, jint);
 
 /*
  * Class:     com_wolfssl_WolfSSLSession

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
@@ -37,6 +37,7 @@ import javax.net.ssl.SSLEngineResult.Status;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLParameters;
+import java.net.SocketTimeoutException;
 
 /**
  * wolfSSL implementation of SSLEngine
@@ -488,7 +489,11 @@ public class WolfSSLEngine extends SSLEngine {
     @Override
     public synchronized void beginHandshake() throws SSLException {
         EngineHelper.initHandshake();
-        EngineHelper.doHandshake(1);
+        try {
+            EngineHelper.doHandshake(1, 0);
+        } catch (SocketTimeoutException e) {
+            throw new SSLException(e);
+        }
     }
 
     @Override

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.security.cert.X509Certificate;
 import java.security.cert.CertificateException;
+import java.net.SocketTimeoutException;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.X509TrustManager;
@@ -646,13 +647,18 @@ public class WolfSSLEngineHelper {
      *
      * @param isSSLEngine specifies if this is being called by an SSLEngine
      *                    or not.
+     * @param timeout socket timeout (milliseconds) for connect(), or 0 for
+     *                infinite/no timeout.
      *
      * @return WolfSSL.SSL_SUCCESS on success or either WolfSSL.SSL_FAILURE
      *         or WolfSSL.SSL_HANDSHAKE_FAILURE on error
      *
      * @throws SSLException if setUseClientMode() has not been called.
+     * @throws SocketTimeoutException if socket timed out
      */
-    protected int doHandshake(int isSSLEngine) throws SSLException {
+    protected int doHandshake(int isSSLEngine, int timeout)
+        throws SSLException, SocketTimeoutException {
+
         int ret, err;
 
         if (!modeSet) {
@@ -691,7 +697,7 @@ public class WolfSSLEngineHelper {
             if (this.clientMode) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                         "calling native wolfSSL_connect()");
-                ret = this.ssl.connect();
+                ret = this.ssl.connect(timeout);
 
             } else {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,


### PR DESCRIPTION
This PR adds support for handling Socket timeout values for native SSL_connect() and SSL_write() with socketSelect().