### PR TITLE
Remove IDEA support

### DIFF
--- a/IDE/Android/app/src/main/cpp/CMakeLists.txt
+++ b/IDE/Android/app/src/main/cpp/CMakeLists.txt
@@ -65,7 +65,6 @@ add_library(wolfssl SHARED
         ${wolfssl_DIR}/wolfcrypt/src/ge_operations.c
         ${wolfssl_DIR}/wolfcrypt/src/hash.c
         ${wolfssl_DIR}/wolfcrypt/src/hmac.c
-        ${wolfssl_DIR}/wolfcrypt/src/idea.c
         ${wolfssl_DIR}/wolfcrypt/src/integer.c
         ${wolfssl_DIR}/wolfcrypt/src/kdf.c
         ${wolfssl_DIR}/wolfcrypt/src/logging.c

--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -238,19 +238,6 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumDES40
     return wolfssl_des40;
 }
 
-JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumIDEA
-  (JNIEnv* jenv, jclass jcl)
-{
-    (void)jenv;
-    (void)jcl;
-
-#ifdef HAVE_IDEA
-    return wolfssl_idea;
-#else
-    return NOT_COMPILED_IN;
-#endif
-}
-
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumAES
   (JNIEnv* jenv, jclass jcl)
 {

--- a/native/com_wolfssl_WolfSSL.h
+++ b/native/com_wolfssl_WolfSSL.h
@@ -255,14 +255,6 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumDES40
 
 /*
  * Class:     com_wolfssl_WolfSSL
- * Method:    getBulkCipherAlgorithmEnumIDEA
- * Signature: ()I
- */
-JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumIDEA
-  (JNIEnv *, jclass);
-
-/*
- * Class:     com_wolfssl_WolfSSL
  * Method:    getBulkCipherAlgorithmEnumAES
  * Signature: ()I
  */

--- a/platform/android_aosp/wolfssl/Android.mk
+++ b/platform/android_aosp/wolfssl/Android.mk
@@ -49,7 +49,6 @@ LOCAL_SRC_FILES+= \
 	./wolfcrypt/src/ge_operations.c \
 	./wolfcrypt/src/hash.c \
 	./wolfcrypt/src/hmac.c \
-	./wolfcrypt/src/idea.c \
 	./wolfcrypt/src/integer.c \
 	./wolfcrypt/src/kdf.c \
 	./wolfcrypt/src/logging.c \

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -224,8 +224,6 @@ public class WolfSSL {
     public static int wolfssl_triple_des;
     /** Bulk cipher algorithm enum: DES40 */
     public static int wolfssl_des40;
-    /** Bulk cipher algorithm enum: IDEA */
-    public static int wolfssl_idea;
     /** Bulk cipher algorithm enum: AES */
     public static int wolfssl_aes;
     /** Bulk cipher algorithm enum: AES-GCM */
@@ -369,7 +367,6 @@ public class WolfSSL {
         wolfssl_des         = getBulkCipherAlgorithmEnumDES();
         wolfssl_triple_des  = getBulkCipherAlgorithmEnumDES();
         wolfssl_des40       = getBulkCipherAlgorithmEnumDES40();
-        wolfssl_idea        = getBulkCipherAlgorithmEnumIDEA();
         wolfssl_aes_gcm     = getBulkCipherAlgorithmEnumAESGCM();
         wolfssl_aes_ccm     = getBulkCipherAlgorithmEnumAESCCM();
         wolfssl_rabbit      = getBulkCipherAlgorithmEnumRABBIT();
@@ -393,7 +390,6 @@ public class WolfSSL {
     static native int getBulkCipherAlgorithmEnumDES();
     static native int getBulkCipherAlgorithmEnum3DES();
     static native int getBulkCipherAlgorithmEnumDES40();
-    static native int getBulkCipherAlgorithmEnumIDEA();
     static native int getBulkCipherAlgorithmEnumAES();
     static native int getBulkCipherAlgorithmEnumAESGCM();
     static native int getBulkCipherAlgorithmEnumAESCCM();


### PR DESCRIPTION
This PR removes IDEA wrapper support. Native wolfSSL removed support for IDEA with Pull Request https://github.com/wolfSSL/wolfssl/pull/4806.

If this is a feature that you are/were using, please contact wolfSSL at [facts@wolfssl.com](mailto:facts@wolfssl.com).