### PR TITLE
Fix possible typecasting issues, typecast cleanup in native functions

### DIFF
--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -173,13 +173,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_init
 
 /* used in unit tests */
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSL_nativeFree
-  (JNIEnv* jenv, jobject jcl, jlong ptr)
+  (JNIEnv* jenv, jobject jcl, jlong jptr)
 {
+    void* ptr = (void*)(uintptr_t)jptr;
     (void)jenv;
     (void)jcl;
 
-    if((void*)(uintptr_t)ptr) {
-        XFREE((void*)(uintptr_t)ptr, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if(ptr != NULL) {
+        XFREE(ptr, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     }
 }
 
@@ -1063,19 +1064,21 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getPkcs8TraditionalOffset
 }
 
 JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSL_x509_1getDer
-  (JNIEnv* jenv, jclass jcl, jlong x509)
+  (JNIEnv* jenv, jclass jcl, jlong x509Ptr)
 {
 #if defined(KEEP_PEER_CERT) || defined(SESSION_CERTS)
     int* outSz = NULL;
     const unsigned char* derCert;
     jbyteArray out = NULL;
+    WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
 
     (void)jcl;
 
-    if (!jenv || !x509)
+    if (jenv == NULL || x509 == NULL) {
         return NULL;
+    }
 
-    derCert = wolfSSL_X509_get_der((WOLFSSL_X509*)(uintptr_t)x509, outSz);
+    derCert = wolfSSL_X509_get_der(x509, outSz);
 
     if (*outSz >= 0) {
 
@@ -1093,7 +1096,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSL_x509_1getDer
 #else
     (void)jenv;
     (void)jcl;
-    (void)x509;
+    (void)x509Ptr;
     return NULL;
 #endif
 }

--- a/native/com_wolfssl_WolfSSLCertManager.c
+++ b/native/com_wolfssl_WolfSSLCertManager.c
@@ -48,22 +48,22 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLCertManager_CertManagerFree
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertManager_CertManagerLoadCA
-  (JNIEnv* jenv, jclass jcl, jlong cm, jstring f, jstring d)
+  (JNIEnv* jenv, jclass jcl, jlong cmPtr, jstring f, jstring d)
 {
     int ret;
     const char* certFile = NULL;
     const char* certPath = NULL;
+    WOLFSSL_CERT_MANAGER* cm = (WOLFSSL_CERT_MANAGER*)(uintptr_t)cmPtr;
     (void)jcl;
 
-    if (jenv == NULL || cm == 0) {
+    if (jenv == NULL || cm == NULL) {
         return (jint)BAD_FUNC_ARG;
     }
 
     certFile = (*jenv)->GetStringUTFChars(jenv, f, 0);
     certPath = (*jenv)->GetStringUTFChars(jenv, d, 0);
 
-    ret = wolfSSL_CertManagerLoadCA((WOLFSSL_CERT_MANAGER*)(uintptr_t)cm,
-                                    certFile, certPath);
+    ret = wolfSSL_CertManagerLoadCA(cm, certFile, certPath);
 
     (*jenv)->ReleaseStringUTFChars(jenv, f, certFile);
     (*jenv)->ReleaseStringUTFChars(jenv, d, certPath);
@@ -72,11 +72,12 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertManager_CertManagerLoadCA
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertManager_CertManagerLoadCABuffer
-  (JNIEnv* jenv, jclass jcl, jlong cm, jbyteArray in, jlong sz, jint format)
+  (JNIEnv* jenv, jclass jcl, jlong cmPtr, jbyteArray in, jlong sz, jint format)
 {
     int ret = 0;
     word32 buffSz = 0;
     byte* buff = NULL;
+    WOLFSSL_CERT_MANAGER* cm = (WOLFSSL_CERT_MANAGER*)(uintptr_t)cmPtr;
     (void)jcl;
 
     if (jenv == NULL || in == NULL || (sz < 0)) {
@@ -86,8 +87,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertManager_CertManagerLoadCABuff
     buff = (byte*)(*jenv)->GetByteArrayElements(jenv, in, NULL);
     buffSz = (*jenv)->GetArrayLength(jenv, in);
 
-    ret = wolfSSL_CertManagerLoadCABuffer((WOLFSSL_CERT_MANAGER*)(uintptr_t)cm,
-                                          buff, buffSz, format);
+    ret = wolfSSL_CertManagerLoadCABuffer(cm, buff, buffSz, format);
 
     (*jenv)->ReleaseByteArrayElements(jenv, in, (jbyte*)buff, JNI_ABORT);
 
@@ -95,11 +95,12 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertManager_CertManagerLoadCABuff
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertManager_CertManagerVerifyBuffer
-  (JNIEnv* jenv, jclass jcl, jlong cm, jbyteArray in, jlong sz, jint format)
+  (JNIEnv* jenv, jclass jcl, jlong cmPtr, jbyteArray in, jlong sz, jint format)
 {
     int ret = 0;
     word32 buffSz = 0;
     byte* buff = NULL;
+    WOLFSSL_CERT_MANAGER* cm = (WOLFSSL_CERT_MANAGER*)(uintptr_t)cmPtr;
     (void)jcl;
 
     if (jenv == NULL || in == NULL || (sz < 0))
@@ -108,8 +109,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertManager_CertManagerVerifyBuff
     buff = (byte*)(*jenv)->GetByteArrayElements(jenv, in, NULL);
     buffSz = (*jenv)->GetArrayLength(jenv, in);
 
-    ret = wolfSSL_CertManagerVerifyBuffer((WOLFSSL_CERT_MANAGER*)(uintptr_t)cm,
-                                          buff, buffSz, format);
+    ret = wolfSSL_CertManagerVerifyBuffer(cm, buff, buffSz, format);
 
     (*jenv)->ReleaseByteArrayElements(jenv, in, (jbyte*)buff, JNI_ABORT);
 

--- a/native/com_wolfssl_WolfSSLCertificate.c
+++ b/native/com_wolfssl_WolfSSLCertificate.c
@@ -83,17 +83,18 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1load_1certific
 }
 
 JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1der
-  (JNIEnv* jenv, jclass jcl, jlong x509)
+  (JNIEnv* jenv, jclass jcl, jlong x509Ptr)
 {
     int sz = 0;
     const byte* der = NULL;
     jbyteArray  derArr = NULL;
+    WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
 
-    if (jenv == NULL || x509 <= 0) {
+    if (jenv == NULL || x509 == NULL) {
         return NULL;
     }
 
-    der = wolfSSL_X509_get_der((WOLFSSL_X509*)(uintptr_t)x509, &sz);
+    der = wolfSSL_X509_get_der(x509, &sz);
     if (der == NULL || sz == 0) {
         return NULL;
     }
@@ -127,17 +128,18 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1der
 }
 
 JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1tbs
-  (JNIEnv* jenv, jclass jcl, jlong x509)
+  (JNIEnv* jenv, jclass jcl, jlong x509Ptr)
 {
     jbyteArray tbsArr;
     int sz;
     const unsigned char* tbs;
+    WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
 
-    if (jenv == NULL || x509 <= 0) {
+    if (jenv == NULL || x509 == NULL) {
         return NULL;
     }
 
-    tbs = wolfSSL_X509_get_tbs((WOLFSSL_X509*)(uintptr_t)x509, &sz);
+    tbs = wolfSSL_X509_get_tbs(x509, &sz);
     if (tbs == NULL) {
         return NULL;
     }
@@ -171,32 +173,32 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1tbs
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1free
-  (JNIEnv* jenv, jclass jcl, jlong x509)
+  (JNIEnv* jenv, jclass jcl, jlong x509Ptr)
 {
+    WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
     (void)jcl;
 
-    if (jenv == NULL || x509 <= 0) {
+    if (jenv == NULL || x509 == NULL) {
         return;
     }
 
-    wolfSSL_X509_free((WOLFSSL_X509*)(uintptr_t)x509);
+    wolfSSL_X509_free(x509);
 }
 
 #define MAX_SERIAL_SIZE 32
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1serial_1number
-  (JNIEnv* jenv, jclass jcl, jlong x509, jbyteArray out)
+  (JNIEnv* jenv, jclass jcl, jlong x509Ptr, jbyteArray out)
 {
     unsigned char s[MAX_SERIAL_SIZE];
     int sz = MAX_SERIAL_SIZE;
+    WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
     (void)jcl;
 
-    if (jenv == NULL || x509 <= 0 || out == NULL) {
+    if (jenv == NULL || x509 == NULL || out == NULL) {
         return BAD_FUNC_ARG;
     }
 
-    if (wolfSSL_X509_get_serial_number((WOLFSSL_X509*)(uintptr_t)x509,
-                                       s, &sz) == WOLFSSL_SUCCESS) {
-
+    if (wolfSSL_X509_get_serial_number(x509, s, &sz) == WOLFSSL_SUCCESS) {
         /* find exception class */
         jclass excClass = (*jenv)->FindClass(jenv,
                 "com/wolfssl/WolfSSLJNIException");
@@ -221,24 +223,25 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1serial_1nu
 }
 
 JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1notBefore
-  (JNIEnv* jenv, jclass jcl, jlong x509)
+  (JNIEnv* jenv, jclass jcl, jlong x509Ptr)
 {
 #if LIBWOLFSSL_VERSION_HEX >= 0x04002000
     WOLFSSL_ASN1_TIME* date = NULL;
 #else
     const unsigned char* date = NULL;
 #endif
+    WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
     char ret[32];
     (void)jcl;
 
-    if (jenv == NULL || x509 <= 0) {
+    if (jenv == NULL || x509 == NULL) {
         return NULL;
     }
 
 #if LIBWOLFSSL_VERSION_HEX >= 0x04002000
-    date = wolfSSL_X509_get_notBefore((WOLFSSL_X509*)(uintptr_t)x509);
+    date = wolfSSL_X509_get_notBefore(x509);
 #else
-    date = wolfSSL_X509_notBefore((WOLFSSL_X509*)(uintptr_t)x509);
+    date = wolfSSL_X509_notBefore(x509);
 #endif
     /* returns string holding date i.e. "Thu Jan 07 08:23:09 MST 2021" */
     if (date != NULL) {
@@ -250,24 +253,25 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1notBefore
 }
 
 JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1notAfter
-  (JNIEnv* jenv, jclass jcl, jlong x509)
+  (JNIEnv* jenv, jclass jcl, jlong x509Ptr)
 {
 #if LIBWOLFSSL_VERSION_HEX >= 0x04002000
     WOLFSSL_ASN1_TIME* date = NULL;
 #else
     const unsigned char* date = NULL;
 #endif
+    WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
     char ret[32];
     (void)jcl;
 
-    if (jenv == NULL || x509 <= 0) {
+    if (jenv == NULL || x509 == NULL) {
         return NULL;
     }
 
 #if LIBWOLFSSL_VERSION_HEX >= 0x04002000
-    date = wolfSSL_X509_get_notAfter((WOLFSSL_X509*)(uintptr_t)x509);
+    date = wolfSSL_X509_get_notAfter(x509);
 #else
-    date = wolfSSL_X509_notAfter((WOLFSSL_X509*)(uintptr_t)x509);
+    date = wolfSSL_X509_notAfter(x509);
 #endif
     /* returns string holding date i.e. "Thu Jan 07 08:23:09 MST 2021" */
     if (date != NULL) {
@@ -279,30 +283,31 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1notAfter
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1version
-  (JNIEnv* jenv, jclass jcl, jlong x509)
+  (JNIEnv* jenv, jclass jcl, jlong x509Ptr)
 {
+    WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
     (void)jcl;
 
-    if (jenv == NULL || x509 <= 0) {
+    if (jenv == NULL || x509 == NULL) {
         return 0;
     }
 
-    return (jint)wolfSSL_X509_version((WOLFSSL_X509*)(uintptr_t)x509);
+    return (jint)wolfSSL_X509_version(x509);
 }
 
 JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1signature
-  (JNIEnv* jenv, jclass jcl, jlong x509)
+  (JNIEnv* jenv, jclass jcl, jlong x509Ptr)
 {
     int sz = 0;
     unsigned char* buf = NULL;
     jbyteArray ret = NULL;
+    WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
 
-    if (jenv == NULL || x509 <= 0) {
+    if (jenv == NULL || x509 == NULL) {
         return NULL;
     }
 
-    if (wolfSSL_X509_get_signature((WOLFSSL_X509*)(uintptr_t)x509, NULL, &sz) !=
-            WOLFSSL_SUCCESS) {
+    if (wolfSSL_X509_get_signature(x509, NULL, &sz) != WOLFSSL_SUCCESS) {
         return NULL;
     }
 
@@ -319,8 +324,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1sign
         return NULL;
     }
 
-    if (wolfSSL_X509_get_signature((WOLFSSL_X509*)(uintptr_t)x509, buf, &sz) !=
-            WOLFSSL_SUCCESS) {
+    if (wolfSSL_X509_get_signature(x509, buf, &sz) != WOLFSSL_SUCCESS) {
         (*jenv)->DeleteLocalRef(jenv, ret);
         XFREE(buf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         return NULL;
@@ -339,15 +343,16 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1sign
 }
 
 JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1signature_1type
-  (JNIEnv* jenv, jclass jcl, jlong x509)
+  (JNIEnv* jenv, jclass jcl, jlong x509Ptr)
 {
     int type;
+    WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
 
-    if (jenv == NULL || x509 <= 0) {
+    if (jenv == NULL || x509 == NULL) {
         return NULL;
     }
 
-    type = wolfSSL_X509_get_signature_type((WOLFSSL_X509*)(uintptr_t)x509);
+    type = wolfSSL_X509_get_signature_type(x509);
 
     switch (type) {
         case CTC_SHAwDSA:
@@ -386,19 +391,20 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1signatu
 }
 
 JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1signature_1OID
-  (JNIEnv* jenv, jclass jcl, jlong x509)
+  (JNIEnv* jenv, jclass jcl, jlong x509Ptr)
 {
     WOLFSSL_ASN1_OBJECT* obj;
     char oid[40];
     int  oidSz = sizeof(oid);
     int  nid;
+    WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
     (void)jcl;
 
-    if (jenv == NULL || x509 <= 0) {
+    if (jenv == NULL || x509 == NULL) {
         return NULL;
     }
 
-    nid = wolfSSL_X509_get_signature_nid((WOLFSSL_X509*)(uintptr_t)x509);
+    nid = wolfSSL_X509_get_signature_nid(x509);
     obj = wolfSSL_OBJ_nid2obj(nid);
     if (obj == NULL) {
         return NULL;
@@ -413,14 +419,15 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1signatu
 }
 
 JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1print
-  (JNIEnv* jenv, jclass jcl, jlong x509)
+  (JNIEnv* jenv, jclass jcl, jlong x509Ptr)
 {
     WOLFSSL_BIO* bio;
     jstring ret = NULL;
     const char* mem = NULL;
+    WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
     (void)jcl;
 
-    if (jenv == NULL || x509 <= 0) {
+    if (jenv == NULL || x509 == NULL) {
         return NULL;
     }
 
@@ -429,8 +436,7 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1print
         return NULL;
     }
 
-    if (wolfSSL_X509_print(bio, (WOLFSSL_X509*)(uintptr_t)x509) !=
-        WOLFSSL_SUCCESS) {
+    if (wolfSSL_X509_print(bio, x509) != WOLFSSL_SUCCESS) {
         wolfSSL_BIO_free(bio);
         return NULL;
     }
@@ -444,29 +450,31 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1print
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1isCA
-  (JNIEnv* jenv, jclass jcl, jlong x509)
+  (JNIEnv* jenv, jclass jcl, jlong x509Ptr)
 {
+    WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
     (void)jcl;
 
-    if (jenv == NULL || x509 <= 0) {
+    if (jenv == NULL || x509 == NULL) {
         return 0;
     }
 
-    return (jint)wolfSSL_X509_get_isCA((WOLFSSL_X509*)(uintptr_t)x509);
+    return (jint)wolfSSL_X509_get_isCA(x509);
 }
 
 
 JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1subject_1name
-  (JNIEnv* jenv, jclass jcl, jlong x509)
+  (JNIEnv* jenv, jclass jcl, jlong x509Ptr)
 {
     WOLFSSL_X509_NAME* name = NULL;
+    WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
     (void)jcl;
 
-    if (jenv == NULL || x509 <= 0) {
+    if (jenv == NULL || x509 == NULL) {
         return NULL;
     }
 
-    name = wolfSSL_X509_get_subject_name((WOLFSSL_X509*)(uintptr_t)x509);
+    name = wolfSSL_X509_get_subject_name(x509);
     if (name != NULL) {
         jstring ret = NULL;
         char* subj = wolfSSL_X509_NAME_oneline(name, NULL, 0);
@@ -481,16 +489,17 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1subject
 }
 
 JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1issuer_1name
-  (JNIEnv* jenv, jclass jcl, jlong x509)
+  (JNIEnv* jenv, jclass jcl, jlong x509Ptr)
 {
     WOLFSSL_X509_NAME* name = NULL;
+    WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
     (void)jcl;
 
-    if (jenv == NULL || x509 <= 0) {
+    if (jenv == NULL || x509 == NULL) {
         return NULL;
     }
 
-    name = wolfSSL_X509_get_issuer_name((WOLFSSL_X509*)(uintptr_t)x509);
+    name = wolfSSL_X509_get_issuer_name(x509);
     if (name != NULL) {
         jstring ret = NULL;
         char* isur = wolfSSL_X509_NAME_oneline(name, NULL, 0);
@@ -505,18 +514,18 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1issuer_
 }
 
 JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1pubkey
-  (JNIEnv* jenv, jclass jcl, jlong x509)
+  (JNIEnv* jenv, jclass jcl, jlong x509Ptr)
 {
     int sz = 0;
     unsigned char* buf;
     jbyteArray ret;
+    WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
 
-    if (jenv == NULL || x509 <= 0) {
+    if (jenv == NULL || x509 == NULL) {
         return NULL;
     }
 
-    if (wolfSSL_X509_get_pubkey_buffer((WOLFSSL_X509*)(uintptr_t)x509, NULL,
-                                       &sz) != WOLFSSL_SUCCESS) {
+    if (wolfSSL_X509_get_pubkey_buffer(x509, NULL, &sz) != WOLFSSL_SUCCESS) {
         return NULL;
     }
 
@@ -533,8 +542,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1pubk
         return NULL;
     }
 
-    if (wolfSSL_X509_get_pubkey_buffer((WOLFSSL_X509*)(uintptr_t)x509, buf,
-                                       &sz) != WOLFSSL_SUCCESS) {
+    if (wolfSSL_X509_get_pubkey_buffer(x509, buf, &sz) != WOLFSSL_SUCCESS) {
         (*jenv)->DeleteLocalRef(jenv, ret);
         XFREE(buf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         return NULL;
@@ -553,15 +561,16 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1pubk
 }
 
 JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1pubkey_1type
-  (JNIEnv* jenv, jclass jcl, jlong x509)
+  (JNIEnv* jenv, jclass jcl, jlong x509Ptr)
 {
     int type;
+    WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
 
-    if (jenv == NULL || x509 <= 0) {
+    if (jenv == NULL || x509 == NULL) {
         return NULL;
     }
 
-    type = wolfSSL_X509_get_pubkey_type((WOLFSSL_X509*)(uintptr_t)x509);
+    type = wolfSSL_X509_get_pubkey_type(x509);
     switch (type) {
         case RSAk:
             return (*jenv)->NewStringUTF(jenv, "RSA");
@@ -578,17 +587,17 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1pubkey_
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1pathLength
-  (JNIEnv* jenv, jclass jcl, jlong x509)
+  (JNIEnv* jenv, jclass jcl, jlong x509Ptr)
 {
+    WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
     (void)jcl;
 
-    if (jenv == NULL || x509 <= 0) {
+    if (jenv == NULL || x509 == NULL) {
         return 0;
     }
 
-    if (wolfSSL_X509_get_isSet_pathLength((WOLFSSL_X509*)(uintptr_t)x509)) {
-        return (jint)wolfSSL_X509_get_pathLength(
-                        (WOLFSSL_X509*)(uintptr_t)x509);
+    if (wolfSSL_X509_get_isSet_pathLength(x509)) {
+        return (jint)wolfSSL_X509_get_pathLength(x509);
     }
     else {
         return (jint)-1;
@@ -596,7 +605,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1pathLength
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1verify
-  (JNIEnv* jenv, jclass jcl, jlong x509, jbyteArray pubKey, jint pubKeySz)
+  (JNIEnv* jenv, jclass jcl, jlong x509Ptr, jbyteArray pubKey, jint pubKeySz)
 {
     WOLFSSL_EVP_PKEY* pkey;
     int sz = (int)pubKeySz;
@@ -607,6 +616,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1verify
 #else
     unsigned char* ptr = buff;
 #endif
+    WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
 
     (void)jcl;
 
@@ -637,7 +647,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1verify
         return WOLFSSL_FAILURE;
     }
 
-    ret = wolfSSL_X509_verify((WOLFSSL_X509*)(uintptr_t)x509, pkey);
+    ret = wolfSSL_X509_verify(x509, pkey);
     wolfSSL_EVP_PKEY_free(pkey);
     return ret;
 
@@ -658,18 +668,18 @@ static unsigned int getOBJSize(WOLFSSL_ASN1_OBJECT* obj)
 }
 
 JNIEXPORT jbooleanArray JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1key_1usage
-  (JNIEnv* jenv, jclass jcl, jlong x509)
+  (JNIEnv* jenv, jclass jcl, jlong x509Ptr)
 {
     jbooleanArray ret = NULL;
     jboolean values[9];
     unsigned short kuse;
+    WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
 
-    if (jenv == NULL || x509 <= 0) {
+    if (jenv == NULL || x509 == NULL) {
         return NULL;
     }
 
-    kuse = wolfSSL_X509_get_keyUsage((WOLFSSL_X509*)(uintptr_t)x509);
-
+    kuse = wolfSSL_X509_get_keyUsage(x509);
     if (kuse != 0) {
         ret = (*jenv)->NewBooleanArray(jenv, 9);
         if (!ret) {
@@ -703,7 +713,7 @@ JNIEXPORT jbooleanArray JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1k
 }
 
 JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1extension
-  (JNIEnv* jenv, jclass jcl, jlong x509, jstring oidIn)
+  (JNIEnv* jenv, jclass jcl, jlong x509Ptr, jstring oidIn)
 {
     int nid = 0;
     jbyteArray ret = NULL;
@@ -716,8 +726,9 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1exte
 #if LIBWOLFSSL_VERSION_HEX < 0x04002000
     void* sk = NULL;
 #endif
+    WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
 
-    if (jenv == NULL || oidIn == NULL || x509 <= 0) {
+    if (jenv == NULL || oidIn == NULL || x509 == NULL) {
         return NULL;
     }
 
@@ -730,19 +741,18 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1exte
 
 #if LIBWOLFSSL_VERSION_HEX >= 0x04002000
     /* get extension index, or -1 if not found */
-    idx = wolfSSL_X509_get_ext_by_NID((WOLFSSL_X509*)(uintptr_t)x509, nid, -1);
+    idx = wolfSSL_X509_get_ext_by_NID(x509, nid, -1);
 
     if (idx >= 0) {
         /* extension found at idx, get WOLFSSL_ASN1_OBJECT */
-        ext = wolfSSL_X509_get_ext((WOLFSSL_X509*)(uintptr_t)x509, idx);
+        ext = wolfSSL_X509_get_ext(x509, idx);
         if (ext != NULL) {
             obj = ext->obj;
         }
     }
 #else
     /* wolfSSL prior to 4.2.0 did not have wolfSSL_X509_get_ext_by_NID */
-    sk = wolfSSL_X509_get_ext_d2i((WOLFSSL_X509*)(uintptr_t)x509, nid,
-                                  NULL, NULL);
+    sk = wolfSSL_X509_get_ext_d2i(x509, nid, NULL, NULL);
     if (sk == NULL) {
         /* extension was not found or error was encountered */
         return NULL;
@@ -780,13 +790,14 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1exte
  * return negative value on error
  */
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1is_1extension_1set
-  (JNIEnv* jenv, jclass jcl, jlong x509, jstring oidIn)
+  (JNIEnv* jenv, jclass jcl, jlong x509Ptr, jstring oidIn)
 {
     int nid;
     const char* oid;
+    WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
     (void)jcl;
 
-    if (jenv == NULL || x509 <= 0) {
+    if (jenv == NULL || x509 == NULL) {
         return 0;
     }
 
@@ -798,9 +809,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1is_1extension_1
     }
     (*jenv)->ReleaseStringUTFChars(jenv, oidIn, oid);
 
-    if (wolfSSL_X509_ext_isSet_by_NID((WOLFSSL_X509*)(uintptr_t)x509, nid)) {
-        if (wolfSSL_X509_ext_get_critical_by_NID((WOLFSSL_X509*)(uintptr_t)x509,
-            nid)) {
+    if (wolfSSL_X509_ext_isSet_by_NID(x509, nid)) {
+        if (wolfSSL_X509_ext_get_critical_by_NID(x509, nid)) {
             return 2;
         }
         return 1;
@@ -810,17 +820,19 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1is_1extension_1
 }
 
 JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1next_1altname
-  (JNIEnv* jenv, jclass jcl, jlong x509)
+  (JNIEnv* jenv, jclass jcl, jlong x509Ptr)
 {
 #if defined(KEEP_PEER_CERT) || defined(SESSION_CERTS)
     char* altname;
     jstring retString;
+    WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
     (void)jcl;
 
-    if (!jenv || !x509)
+    if (jenv == NULL || x509 == NULL) {
         return NULL;
+    }
 
-    altname = wolfSSL_X509_get_next_altname((WOLFSSL_X509*)(uintptr_t)x509);
+    altname = wolfSSL_X509_get_next_altname(x509);
     if (altname == NULL) {
         return NULL;
     }
@@ -830,7 +842,7 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1next_1a
 #else
     (void)jenv;
     (void)jcl;
-    (void)x509;
+    (void)x509Ptr;
     return NULL;
 #endif
 }

--- a/native/com_wolfssl_WolfSSLContext.c
+++ b/native/com_wolfssl_WolfSSLContext.c
@@ -160,19 +160,19 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLContext_newContext(JNIEnv* jenv,
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useCertificateFile
-  (JNIEnv* jenv, jobject jcl, jlong ctx, jstring file, jint format)
+  (JNIEnv* jenv, jobject jcl, jlong ctxPtr, jstring file, jint format)
 {
     jint ret = 0;
     jclass excClass;
     const char* certFile;
-
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
 
-    if (!jenv)
+    if (jenv == NULL) {
         return SSL_FAILURE;
+    }
 
-    if (!file)
-    {
+    if (file == NULL) {
         excClass = (*jenv)->FindClass(jenv, "java/lang/NullPointerException");
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
@@ -187,8 +187,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useCertificateFile
 
     certFile = (*jenv)->GetStringUTFChars(jenv, file, 0);
 
-    ret = (jint) wolfSSL_CTX_use_certificate_file((WOLFSSL_CTX*)(uintptr_t)ctx,
-                                                  certFile, (int)format);
+    ret = (jint) wolfSSL_CTX_use_certificate_file(ctx, certFile, (int)format);
 
     (*jenv)->ReleaseStringUTFChars(jenv, file, certFile);
 
@@ -196,19 +195,19 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useCertificateFile
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_usePrivateKeyFile
-  (JNIEnv* jenv, jobject jcl, jlong ctx, jstring file, jint format)
+  (JNIEnv* jenv, jobject jcl, jlong ctxPtr, jstring file, jint format)
 {
     jint ret = 0;
     jclass excClass;
     const char* keyFile;
-
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
 
-    if (!jenv)
+    if (jenv == NULL) {
         return SSL_FAILURE;
+    }
 
-    if (!file)
-    {
+    if (file == NULL) {
         excClass = (*jenv)->FindClass(jenv, "java/lang/NullPointerException");
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
@@ -223,8 +222,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_usePrivateKeyFile
 
     keyFile = (*jenv)->GetStringUTFChars(jenv, file, 0);
 
-    ret = (jint) wolfSSL_CTX_use_PrivateKey_file((WOLFSSL_CTX*)(uintptr_t)ctx,
-                                                 keyFile, (int)format);
+    ret = (jint) wolfSSL_CTX_use_PrivateKey_file(ctx, keyFile, (int)format);
 
     (*jenv)->ReleaseStringUTFChars(jenv, file, keyFile);
 
@@ -232,20 +230,20 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_usePrivateKeyFile
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_loadVerifyLocations
-  (JNIEnv* jenv, jobject jcl, jlong ctx, jstring file, jstring path)
+  (JNIEnv* jenv, jobject jcl, jlong ctxPtr, jstring file, jstring path)
 {
     jint ret = 0;
     jclass excClass;
     const char* caFile;
     const char* caPath;
-
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
 
-    if (!jenv)
+    if (jenv == NULL) {
         return SSL_FAILURE;
+    }
 
-    if (!file && !path)
-    {
+    if (file == NULL && path == NULL) {
         excClass = (*jenv)->FindClass(jenv, "java/lang/NullPointerException");
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
@@ -270,8 +268,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_loadVerifyLocations
         caPath = NULL;
     }
 
-    ret = (jint) wolfSSL_CTX_load_verify_locations((WOLFSSL_CTX*)(uintptr_t)ctx,
-                                                   caFile, caPath);
+    ret = (jint) wolfSSL_CTX_load_verify_locations(ctx, caFile, caPath);
 
     if (caFile)
         (*jenv)->ReleaseStringUTFChars(jenv, file, caFile);
@@ -282,20 +279,20 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_loadVerifyLocations
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useCertificateChainFile
-  (JNIEnv* jenv, jobject jcl, jlong ctx, jstring file)
+  (JNIEnv* jenv, jobject jcl, jlong ctxPtr, jstring file)
 {
     jint ret = 0;
     jclass excClass;
     const char* chainFile;
-
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
 
-    if (!jenv)
+    if (jenv == NULL) {
         return SSL_FAILURE;
+    }
 
     /* throw exception if no input file */
-    if (!file)
-    {
+    if (file == NULL) {
         excClass = (*jenv)->FindClass(jenv, "java/lang/NullPointerException");
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
@@ -310,8 +307,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useCertificateChainFile
 
     chainFile = (*jenv)->GetStringUTFChars(jenv, file, 0);
 
-    ret = (jint) wolfSSL_CTX_use_certificate_chain_file(
-                    (WOLFSSL_CTX*)(uintptr_t)ctx, chainFile);
+    ret = (jint) wolfSSL_CTX_use_certificate_chain_file(ctx, chainFile);
 
     (*jenv)->ReleaseStringUTFChars(jenv, file, chainFile);
 
@@ -319,8 +315,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useCertificateChainFile
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_freeContext
-  (JNIEnv* jenv, jobject jcl, jlong ctx)
+  (JNIEnv* jenv, jobject jcl, jlong ctxPtr)
 {
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jenv;
     (void)jcl;
 
@@ -337,12 +334,13 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_freeContext
     }
 
     /* wolfSSL checks for null pointer */
-    wolfSSL_CTX_free((WOLFSSL_CTX*)(uintptr_t)ctx);
+    wolfSSL_CTX_free(ctx);
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setVerify(JNIEnv* jenv,
-    jobject jcl, jlong ctx, jint mode, jobject callbackIface)
+    jobject jcl, jlong ctxPtr, jint mode, jobject callbackIface)
 {
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
 
     if (jenv == NULL) {
@@ -356,7 +354,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setVerify(JNIEnv* jenv,
     }
 
     if (!callbackIface) {
-        wolfSSL_CTX_set_verify((WOLFSSL_CTX*)(uintptr_t)ctx, mode, NULL);
+        wolfSSL_CTX_set_verify(ctx, mode, NULL);
     }
     else {
         /* store Java verify Interface object */
@@ -366,8 +364,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setVerify(JNIEnv* jenv,
         }
 
         /* set verify mode, register Java callback with wolfSSL */
-        wolfSSL_CTX_set_verify((WOLFSSL_CTX*)(uintptr_t)ctx, mode,
-                               NativeVerifyCallback);
+        wolfSSL_CTX_set_verify(ctx, mode, NativeVerifyCallback);
     }
 }
 
@@ -463,40 +460,45 @@ int NativeVerifyCallback(int preverify_ok, WOLFSSL_X509_STORE_CTX* store)
 }
 
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLContext_setOptions
-  (JNIEnv* jenv, jobject jcl, jlong ctx, jlong op)
+  (JNIEnv* jenv, jobject jcl, jlong ctxPtr, jlong op)
 {
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
 
-    if (!jenv || !ctx)
+    if (jenv == NULL || ctx == NULL) {
         return 0;
+    }
 
-    return wolfSSL_CTX_set_options((WOLFSSL_CTX*)(uintptr_t)ctx, op);
+    return wolfSSL_CTX_set_options(ctx, op);
 }
 
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLContext_getOptions
-  (JNIEnv* jenv, jobject jcl, jlong ctx)
+  (JNIEnv* jenv, jobject jcl, jlong ctxPtr)
 {
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
 
-    if (!jenv || !ctx)
+    if (jenv == NULL || ctx == NULL) {
         return 0;
+    }
 
-    return wolfSSL_CTX_get_options((WOLFSSL_CTX*)(uintptr_t)ctx);
+    return wolfSSL_CTX_get_options(ctx);
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_memsaveCertCache
-  (JNIEnv* jenv, jobject jcl, jlong ctx, jbyteArray mem, jint sz,
+  (JNIEnv* jenv, jobject jcl, jlong ctxPtr, jbyteArray mem, jint sz,
     jintArray used)
 {
 #ifdef PERSIST_CERT_CACHE
     int ret;
     int usedTmp;
     char memBuf[sz];
-
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
 
-    if (!jenv || !ctx || !mem || (sz <= 0))
+    if (jenv == NULL || ctx == NULL || mem == NULL || sz <= 0) {
         return BAD_FUNC_ARG;
+    }
 
     /* find exception class */
     jclass excClass = (*jenv)->FindClass(jenv,
@@ -507,8 +509,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_memsaveCertCache
         return SSL_FAILURE;
     }
 
-    ret = wolfSSL_CTX_memsave_cert_cache((WOLFSSL_CTX*)(uintptr_t)ctx, memBuf,
-            sz, &usedTmp);
+    ret = wolfSSL_CTX_memsave_cert_cache(ctx, memBuf, sz, &usedTmp);
 
     /* set used value for return */
     (*jenv)->SetIntArrayRegion(jenv, used, 0, 1, &usedTmp);
@@ -537,7 +538,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_memsaveCertCache
 #else
     (void)jenv;
     (void)jcl;
-    (void)ctx;
+    (void)ctxPtr;
     (void)mem;
     (void)sz;
     (void)used;
@@ -546,16 +547,17 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_memsaveCertCache
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_memrestoreCertCache
-  (JNIEnv* jenv, jobject jcl, jlong ctx, jbyteArray mem, jint sz)
+  (JNIEnv* jenv, jobject jcl, jlong ctxPtr, jbyteArray mem, jint sz)
 {
 #ifdef PERSIST_CERT_CACHE
     int ret = WOLFSSL_FAILURE;
     byte* buff = NULL;
     word32 buffSz = 0;
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
     (void)sz;
 
-    if (jenv == NULL || ctx == 0 || mem == NULL) {
+    if (jenv == NULL || ctx == NULL || mem == NULL) {
         return (jint)BAD_FUNC_ARG;
     }
 
@@ -563,8 +565,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_memrestoreCertCache
     buffSz = (*jenv)->GetArrayLength(jenv, mem);
 
     if (buff != NULL && buffSz > 0) {
-        ret = wolfSSL_CTX_memrestore_cert_cache((WOLFSSL_CTX*)(uintptr_t)ctx,
-                buff, buffSz);
+        ret = wolfSSL_CTX_memrestore_cert_cache(ctx, buff, buffSz);
     }
 
     (*jenv)->ReleaseByteArrayElements(jenv, mem, (jbyte*)buff, JNI_ABORT);
@@ -573,7 +574,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_memrestoreCertCache
 #else
     (void)jenv;
     (void)jcl;
-    (void)ctx;
+    (void)ctxPtr;
     (void)mem;
     (void)sz;
     return NOT_COMPILED_IN;
@@ -613,19 +614,19 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLContext_getCacheSize
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setCipherList
-  (JNIEnv* jenv, jobject jcl, jlong ctx, jstring list)
+  (JNIEnv* jenv, jobject jcl, jlong ctxPtr, jstring list)
 {
     jint ret = 0;
     jclass excClass;
     const char* cipherList;
-
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
 
-    if (!jenv)
+    if (jenv == NULL) {
         return SSL_FAILURE;
+    }
 
-    if (!list)
-    {
+    if (list == NULL) {
         excClass = (*jenv)->FindClass(jenv, "java/lang/NullPointerException");
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
@@ -641,8 +642,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setCipherList
 
     cipherList = (*jenv)->GetStringUTFChars(jenv, list, 0);
 
-    ret = (jint) wolfSSL_CTX_set_cipher_list((WOLFSSL_CTX*)(uintptr_t)ctx,
-            cipherList);
+    ret = (jint) wolfSSL_CTX_set_cipher_list(ctx, cipherList);
 
     (*jenv)->ReleaseStringUTFChars(jenv, list, cipherList);
 
@@ -650,15 +650,16 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setCipherList
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_loadVerifyBuffer
-  (JNIEnv* jenv, jobject jcl, jlong ctx, jbyteArray in, jlong sz, jint format)
+  (JNIEnv* jenv, jobject jcl, jlong ctxPtr, jbyteArray in, jlong sz, jint format)
 {
     int ret = WOLFSSL_FAILURE;
     byte* buff = NULL;
     word32 buffSz = 0;
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
     (void)sz;
 
-    if (jenv == NULL || ctx == 0 || in == NULL) {
+    if (jenv == NULL || ctx == NULL || in == NULL) {
         return (jint)BAD_FUNC_ARG;
     }
 
@@ -666,8 +667,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_loadVerifyBuffer
     buffSz = (*jenv)->GetArrayLength(jenv, in);
 
     if (buff != NULL && buffSz > 0) {
-        ret = wolfSSL_CTX_load_verify_buffer((WOLFSSL_CTX*)(uintptr_t)ctx,
-                                             buff, buffSz, format);
+        ret = wolfSSL_CTX_load_verify_buffer(ctx, buff, buffSz, format);
     }
 
     (*jenv)->ReleaseByteArrayElements(jenv, in, (jbyte*)buff, JNI_ABORT);
@@ -676,15 +676,17 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_loadVerifyBuffer
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useCertificateBuffer
-  (JNIEnv* jenv, jobject jcl, jlong ctx, jbyteArray in, jlong sz, jint format)
+  (JNIEnv* jenv, jobject jcl, jlong ctxPtr, jbyteArray in, jlong sz,
+   jint format)
 {
     int ret = WOLFSSL_FAILURE;
     byte* buff = NULL;
     word32 buffSz = 0;
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
     (void)sz;
 
-    if (jenv == NULL || ctx == 0 || in == NULL) {
+    if (jenv == NULL || ctx == NULL || in == NULL) {
         return (jint)BAD_FUNC_ARG;
     }
 
@@ -692,8 +694,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useCertificateBuffer
     buffSz = (*jenv)->GetArrayLength(jenv, in);
 
     if (buff != NULL && buffSz > 0) {
-        ret = wolfSSL_CTX_use_certificate_buffer((WOLFSSL_CTX*)(uintptr_t)ctx,
-                                                 buff, buffSz, format);
+        ret = wolfSSL_CTX_use_certificate_buffer(ctx, buff, buffSz, format);
     }
 
     (*jenv)->ReleaseByteArrayElements(jenv, in, (jbyte*)buff, JNI_ABORT);
@@ -702,15 +703,17 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useCertificateBuffer
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_usePrivateKeyBuffer
-  (JNIEnv* jenv, jobject jcl, jlong ctx, jbyteArray in, jlong sz, jint format)
+  (JNIEnv* jenv, jobject jcl, jlong ctxPtr, jbyteArray in, jlong sz,
+   jint format)
 {
     int ret = WOLFSSL_FAILURE;
     byte* buff = NULL;
     word32 buffSz = 0;
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
     (void)sz;
 
-    if (jenv == NULL || ctx == 0 || in == NULL) {
+    if (jenv == NULL || ctx == NULL || in == NULL) {
         return (jint)BAD_FUNC_ARG;
     }
 
@@ -718,8 +721,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_usePrivateKeyBuffer
     buffSz = (*jenv)->GetArrayLength(jenv, in);
 
     if (buff != NULL && buffSz > 0) {
-        ret = wolfSSL_CTX_use_PrivateKey_buffer((WOLFSSL_CTX*)(uintptr_t)ctx,
-                                                buff, buffSz, format);
+        ret = wolfSSL_CTX_use_PrivateKey_buffer(ctx, buff, buffSz, format);
     }
 
     (*jenv)->ReleaseByteArrayElements(jenv, in, (jbyte*)buff, JNI_ABORT);
@@ -728,15 +730,16 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_usePrivateKeyBuffer
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useCertificateChainBuffer
-  (JNIEnv* jenv, jobject jcl, jlong ctx, jbyteArray in, jlong sz)
+  (JNIEnv* jenv, jobject jcl, jlong ctxPtr, jbyteArray in, jlong sz)
 {
     int ret = WOLFSSL_FAILURE;
     byte* buff = NULL;
     word32 buffSz = 0;
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
     (void)sz;
 
-    if (jenv == NULL || ctx == 0 || in == NULL) {
+    if (jenv == NULL || ctx == NULL || in == NULL) {
         return (jint)BAD_FUNC_ARG;
     }
 
@@ -744,8 +747,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useCertificateChainBuffer
     buffSz = (*jenv)->GetArrayLength(jenv, in);
 
     if (buff != NULL && buffSz > 0) {
-        ret = wolfSSL_CTX_use_certificate_chain_buffer(
-                (WOLFSSL_CTX*)(uintptr_t)ctx, buff, buffSz);
+        ret = wolfSSL_CTX_use_certificate_chain_buffer(ctx, buff, buffSz);
     }
 
     (*jenv)->ReleaseByteArrayElements(jenv, in, (jbyte*)buff, JNI_ABORT);
@@ -754,15 +756,16 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useCertificateChainBuffer
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useCertificateChainBufferFormat
-  (JNIEnv* jenv, jobject jcl, jlong ctx, jbyteArray in, jlong sz, jint format)
+  (JNIEnv* jenv, jobject jcl, jlong ctxPtr, jbyteArray in, jlong sz, jint format)
 {
     int ret = WOLFSSL_FAILURE;
     byte* buff = NULL;
     word32 buffSz = 0;
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
     (void)sz;
 
-    if (jenv == NULL || ctx == 0 || in == NULL) {
+    if (jenv == NULL || ctx == NULL || in == NULL) {
         return (jint)BAD_FUNC_ARG;
     }
 
@@ -771,7 +774,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useCertificateChainBuffer
 
     if (buff != NULL && buffSz > 0) {
         ret = wolfSSL_CTX_use_certificate_chain_buffer_format(
-                (WOLFSSL_CTX*)(uintptr_t)ctx, buff, buffSz, format);
+                ctx, buff, buffSz, format);
     }
 
     (*jenv)->ReleaseByteArrayElements(jenv, in, (jbyte*)buff, JNI_ABORT);
@@ -793,8 +796,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setGroupMessages
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setIORecv(JNIEnv* jenv,
-        jobject jcl, jlong ctx)
+        jobject jcl, jlong ctxPtr)
 {
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
 
     /* find exception class */
@@ -806,9 +810,9 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setIORecv(JNIEnv* jenv,
         return;
     }
 
-    if(ctx) {
+    if(ctx != NULL) {
         /* set I/O recv callback */
-        wolfSSL_SetIORecv((WOLFSSL_CTX*)(uintptr_t)ctx, NativeIORecvCb);
+        wolfSSL_SetIORecv(ctx, NativeIORecvCb);
 
     } else {
         (*jenv)->ThrowNew(jenv, excClass,
@@ -1013,8 +1017,9 @@ int NativeIORecvCb(WOLFSSL *ssl, char *buf, int sz, void *ctx)
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setIOSend
-  (JNIEnv* jenv, jobject jcl, jlong ctx)
+  (JNIEnv* jenv, jobject jcl, jlong ctxPtr)
 {
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
 
     /* find exception class in case we need it */
@@ -1025,9 +1030,9 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setIOSend
         (*jenv)->ExceptionClear(jenv);
     }
 
-    if (ctx) {
+    if (ctx != NULL) {
         /* set I/O send callback */
-        wolfSSL_SetIOSend((WOLFSSL_CTX*)(uintptr_t)ctx, NativeIOSendCb);
+        wolfSSL_SetIOSend(ctx, NativeIOSendCb);
 
     } else {
         (*jenv)->ThrowNew(jenv, excClass,
@@ -1231,8 +1236,9 @@ int NativeIOSendCb(WOLFSSL *ssl, char *buf, int sz, void *ctx)
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setGenCookie
-  (JNIEnv* jenv, jobject jcl, jlong ctx)
+  (JNIEnv* jenv, jobject jcl, jlong ctxPtr)
 {
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
 
     /* find exception class in case we need it */
@@ -1244,10 +1250,9 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setGenCookie
     }
 
 #ifdef WOLFSSL_DTLS
-    if (ctx) {
+    if (ctx != NULL) {
         /* set gen cookie callback */
-        wolfSSL_CTX_SetGenCookie((WOLFSSL_CTX*)(uintptr_t)ctx,
-                                 NativeGenCookieCb);
+        wolfSSL_CTX_SetGenCookie(ctx, NativeGenCookieCb);
 
     } else {
         (*jenv)->ThrowNew(jenv, excClass,
@@ -1495,21 +1500,22 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_disableCRL
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_loadCRL
-  (JNIEnv* jenv, jobject jcl, jlong ctx, jstring path, jint type, jint monitor)
+  (JNIEnv* jenv, jobject jcl, jlong ctxPtr, jstring path, jint type,
+   jint monitor)
 {
 #ifdef HAVE_CRL
     int ret;
     const char* crlPath;
-
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
 
-    if (!jenv || !ctx || !path)
+    if (jenv == NULL || ctx == NULL || path == NULL) {
         return BAD_FUNC_ARG;
+    }
 
     crlPath = (*jenv)->GetStringUTFChars(jenv, path, 0);
 
-    ret = wolfSSL_CTX_LoadCRL((WOLFSSL_CTX*)(uintptr_t)ctx, crlPath, type,
-                              monitor);
+    ret = wolfSSL_CTX_LoadCRL(ctx, crlPath, type, monitor);
 
     (*jenv)->ReleaseStringUTFChars(jenv, path, crlPath);
 
@@ -1517,7 +1523,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_loadCRL
 #else
     (void)jenv;
     (void)jcl;
-    (void)ctx;
+    (void)ctxPtr;
     (void)path;
     (void)type;
     (void)monitor;
@@ -1526,15 +1532,15 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_loadCRL
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setCRLCb
-  (JNIEnv* jenv, jobject jcl, jlong ctx, jobject cb)
+  (JNIEnv* jenv, jobject jcl, jlong ctxPtr, jobject cb)
 {
 #ifdef HAVE_CRL
     int ret = 0;
     jclass excClass;
-
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
 
-    if (jenv == NULL || ctx == 0) {
+    if (jenv == NULL || ctx == NULL) {
         return BAD_FUNC_ARG;
     }
 
@@ -1559,15 +1565,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setCRLCb
                     "error storing global missing CTX CRL callback interface");
         }
 
-        ret = wolfSSL_CTX_SetCRL_Cb((WOLFSSL_CTX*)(uintptr_t)ctx,
-                                    NativeCtxMissingCRLCallback);
+        ret = wolfSSL_CTX_SetCRL_Cb(ctx, NativeCtxMissingCRLCallback);
     }
 
     return ret;
 #else
     (void)jenv;
     (void)jcl;
-    (void)ctx;
+    (void)ctxPtr;
     (void)cb;
     return NOT_COMPILED_IN;
 #endif
@@ -1684,17 +1689,17 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_disableOCSP
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setOCSPOverrideUrl
-  (JNIEnv* jenv, jobject jcl, jlong ctx, jstring urlString)
+  (JNIEnv* jenv, jobject jcl, jlong ctxPtr, jstring urlString)
 {
 #ifdef HAVE_OCSP
     jint ret = 0;
     jclass excClass;
     const char* url;
-
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
 
     /* wolfSSL checks ctx for NULL */
-    if (!jenv)
+    if (jenv == NULL)
         return BAD_FUNC_ARG;
 
     if (urlString == NULL)
@@ -1714,8 +1719,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setOCSPOverrideUrl
 
     url = (*jenv)->GetStringUTFChars(jenv, urlString, 0);
 
-    ret = (jint) wolfSSL_CTX_SetOCSP_OverrideURL((WOLFSSL_CTX*)(uintptr_t)ctx,
-                                                 url);
+    ret = (jint) wolfSSL_CTX_SetOCSP_OverrideURL(ctx, url);
 
     (*jenv)->ReleaseStringUTFChars(jenv, urlString, url);
 
@@ -1723,7 +1727,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setOCSPOverrideUrl
 #else
     (void)jenv;
     (void)jcl;
-    (void)ctx;
+    (void)ctxPtr;
     (void)urlString;
     return NOT_COMPILED_IN;
 #endif
@@ -2903,14 +2907,15 @@ int  NativeEccVerifyCb(WOLFSSL* ssl, const unsigned char* sig,
 #endif /* HAVE_PK_CALLBACKS */
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setEccSharedSecretCb
-  (JNIEnv* jenv, jobject jcl, jlong ctx)
+  (JNIEnv* jenv, jobject jcl, jlong ctxPtr)
 {
-    (void)jcl;
 #if defined(HAVE_PK_CALLBACKS) && defined(HAVE_ECC)
-    if(ctx) {
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
+    (void)jcl;
+
+    if(ctx != NULL) {
         /* set ECC shared secret callback */
-        wolfSSL_CTX_SetEccSharedSecretCb((WOLFSSL_CTX*)(uintptr_t)ctx,
-                NativeEccSharedSecretCb);
+        wolfSSL_CTX_SetEccSharedSecretCb(ctx, NativeEccSharedSecretCb);
 
     } else {
         throwWolfSSLJNIExceptionWithMsg(jenv,
@@ -2918,7 +2923,8 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setEccSharedSecretCb
                 "EccSharedSecretCb", 0);
     }
 #else
-    (void)ctx;
+    (void)ctxPtr;
+    (void)jcl;
     throwWolfSSLJNIExceptionWithMsg(jenv,
              "wolfSSL not compiled with PK Callback support "
              "(HAVE_PK_CALLBACKS)", 0);
@@ -3348,8 +3354,9 @@ int  NativeEccSharedSecretCb(WOLFSSL* ssl, ecc_key* otherKey,
 #endif /* HAVE_PK_CALLBACKS */
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setRsaSignCb
-  (JNIEnv* jenv, jobject jcl, jlong ctx)
+  (JNIEnv* jenv, jobject jcl, jlong ctxPtr)
 {
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
 
     /* find exception class */
@@ -3362,9 +3369,9 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setRsaSignCb
     }
 
 #if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
-    if(ctx) {
+    if(ctx != NULL) {
         /* set RSA sign callback */
-        wolfSSL_CTX_SetRsaSignCb((WOLFSSL_CTX*)(uintptr_t)ctx, NativeRsaSignCb);
+        wolfSSL_CTX_SetRsaSignCb(ctx, NativeRsaSignCb);
 
     } else {
         (*jenv)->ThrowNew(jenv, excClass,
@@ -3372,6 +3379,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setRsaSignCb
                 "RsaSignCb");
     }
 #else
+    (void)ctx;
     (*jenv)->ThrowNew(jenv, excClass,
             "wolfSSL not compiled with PK Callback support and/or RSA support");
 #endif
@@ -3652,8 +3660,9 @@ int  NativeRsaSignCb(WOLFSSL* ssl, const unsigned char* in, unsigned int inSz,
 #endif /* HAVE_PK_CALLBACKS */
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setRsaVerifyCb
-  (JNIEnv* jenv, jobject jcl, jlong ctx)
+  (JNIEnv* jenv, jobject jcl, jlong ctxPtr)
 {
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
 
     /* find exception class */
@@ -3666,10 +3675,9 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setRsaVerifyCb
     }
 
 #if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
-    if(ctx) {
+    if(ctx != NULL) {
         /* set RSA verify callback */
-        wolfSSL_CTX_SetRsaVerifyCb((WOLFSSL_CTX*)(uintptr_t)ctx,
-                                   NativeRsaVerifyCb);
+        wolfSSL_CTX_SetRsaVerifyCb(ctx, NativeRsaVerifyCb);
 
     } else {
         (*jenv)->ThrowNew(jenv, excClass,
@@ -3677,6 +3685,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setRsaVerifyCb
                 "RsaVerifyCb");
     }
 #else
+    (void)ctx;
     (*jenv)->ThrowNew(jenv, excClass,
             "wolfSSL not compiled with PK Callback and/or RSA support");
 #endif
@@ -3902,8 +3911,9 @@ int  NativeRsaVerifyCb(WOLFSSL* ssl, unsigned char* sig, unsigned int sigSz,
 #endif /* HAVE_PK_CALLBACKS */
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setRsaEncCb
-  (JNIEnv* jenv, jobject jcl, jlong ctx)
+  (JNIEnv* jenv, jobject jcl, jlong ctxPtr)
 {
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
 
     /* find exception class */
@@ -3916,9 +3926,9 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setRsaEncCb
     }
 
 #if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
-    if(ctx) {
+    if(ctx != NULL) {
         /* set RSA encrypt callback */
-        wolfSSL_CTX_SetRsaEncCb((WOLFSSL_CTX*)(uintptr_t)ctx, NativeRsaEncCb);
+        wolfSSL_CTX_SetRsaEncCb(ctx, NativeRsaEncCb);
 
     } else {
         (*jenv)->ThrowNew(jenv, excClass,
@@ -3926,6 +3936,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setRsaEncCb
                 "RsaEncCb");
     }
 #else
+    (void)ctx;
     (*jenv)->ThrowNew(jenv, excClass,
             "wolfSSL not compiled with PK Callback and/or RSA support");
 #endif
@@ -4199,8 +4210,9 @@ int  NativeRsaEncCb(WOLFSSL* ssl, const unsigned char* in, unsigned int inSz,
 #endif /* HAVE_PK_CALLBACKS */
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setRsaDecCb
-  (JNIEnv* jenv, jobject jcl, jlong ctx)
+  (JNIEnv* jenv, jobject jcl, jlong ctxPtr)
 {
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
 
     /* find exception class */
@@ -4213,9 +4225,9 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setRsaDecCb
     }
 
 #if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
-    if(ctx) {
+    if(ctx != NULL) {
         /* set RSA encrypt callback */
-        wolfSSL_CTX_SetRsaDecCb((WOLFSSL_CTX*)(uintptr_t)ctx, NativeRsaDecCb);
+        wolfSSL_CTX_SetRsaDecCb(ctx, NativeRsaDecCb);
 
     } else {
         (*jenv)->ThrowNew(jenv, excClass,
@@ -4223,6 +4235,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setRsaDecCb
                 "RsaDecCb");
     }
 #else
+    (void)ctx;
     (*jenv)->ThrowNew(jenv, excClass,
             "wolfSSL not compiled with PK Callback and/or RSA support");
 #endif
@@ -4454,8 +4467,9 @@ int  NativeRsaDecCb(WOLFSSL* ssl, unsigned char* in, unsigned int inSz,
 #endif /* HAVE_PK_CALLBAKCS */
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setPskClientCb
-  (JNIEnv* jenv, jobject jcl, jlong ctx)
+  (JNIEnv* jenv, jobject jcl, jlong ctxPtr)
 {
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
 
     /* find exception class */
@@ -4468,16 +4482,16 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setPskClientCb
     }
 
 #ifndef NO_PSK
-    if (ctx) {
+    if (ctx != NULL) {
         /* set PSK client callback */
-        wolfSSL_CTX_set_psk_client_callback((WOLFSSL_CTX*)(uintptr_t)ctx,
-                                            NativePskClientCb);
+        wolfSSL_CTX_set_psk_client_callback(ctx, NativePskClientCb);
     } else {
         (*jenv)->ThrowNew(jenv, excClass,
                 "Input WolfSSLContext object was null when setting "
                 "NativePskClientCb");
     }
 #else
+    (void)ctx;
     (*jenv)->ThrowNew(jenv, excClass,
             "wolfSSL not compiled with PSK support");
 #endif
@@ -4882,8 +4896,9 @@ unsigned int NativePskClientCb(WOLFSSL* ssl, const char* hint, char* identity,
 #endif /* NO_PSK */
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setPskServerCb
-  (JNIEnv* jenv, jobject jcl, jlong ctx)
+  (JNIEnv* jenv, jobject jcl, jlong ctxPtr)
 {
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
 
     /* find exception class */
@@ -4896,16 +4911,16 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setPskServerCb
     }
 
 #ifndef NO_PSK
-    if (ctx) {
+    if (ctx != NULL) {
         /* set PSK server callback */
-        wolfSSL_CTX_set_psk_server_callback((WOLFSSL_CTX*)(uintptr_t)ctx,
-                                            NativePskServerCb);
+        wolfSSL_CTX_set_psk_server_callback(ctx, NativePskServerCb);
     } else {
         (*jenv)->ThrowNew(jenv, excClass,
                 "Input WolfSSLContext object was null when setting "
                 "NativePskServerCb");
     }
 #else
+    (void)ctx;
     (*jenv)->ThrowNew(jenv, excClass,
             "wolfSSL not compiled with PSK support");
 #endif
@@ -5193,21 +5208,21 @@ unsigned int NativePskServerCb(WOLFSSL* ssl, const char* identity,
 #endif /* NO_PSK */
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_usePskIdentityHint
-  (JNIEnv* jenv, jobject obj, jlong ctx, jstring hint)
+  (JNIEnv* jenv, jobject obj, jlong ctxPtr, jstring hint)
 {
 #ifndef NO_PSK
     jint ret;
     const char* nativeHint;
-
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)obj;
 
-    if (!jenv || !ctx || !hint)
+    if (jenv == NULL || ctx == NULL || hint == NULL) {
         return SSL_FAILURE;
+    }
 
     nativeHint = (*jenv)->GetStringUTFChars(jenv, hint, 0);
 
-    ret = (jint)wolfSSL_CTX_use_psk_identity_hint((WOLFSSL_CTX*)(uintptr_t)ctx,
-            nativeHint);
+    ret = (jint)wolfSSL_CTX_use_psk_identity_hint(ctx, nativeHint);
 
     (*jenv)->ReleaseStringUTFChars(jenv, hint, nativeHint);
 
@@ -5215,7 +5230,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_usePskIdentityHint
 #else
     (void)jenv;
     (void)obj;
-    (void)ctx;
+    (void)ctxPtr;
     (void)hint;
     return NOT_COMPILED_IN;
 #endif

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -254,17 +254,17 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_newSSL
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setFd(JNIEnv* jenv,
-    jobject jcl, jlong ssl, jobject jsock, jint type)
+    jobject jcl, jlong sslPtr, jobject jsock, jint type)
 {
     int fd;
     jclass jcls;
     jfieldID fid;
     jobject impl;
     jobject fdesc;
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (jenv == NULL || ssl == 0 || jsock == NULL) {
+    if (jenv == NULL || ssl == NULL || jsock == NULL) {
         printf("Error: bad function args, native setFd() wrapper\n");
         return SSL_FAILURE;
     }
@@ -371,28 +371,29 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setFd(JNIEnv* jenv,
      * WANT_READ / WANT_WRITE */
     fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) | O_NONBLOCK);
 
-    return (jint)wolfSSL_set_fd((WOLFSSL*)(uintptr_t)ssl, fd);
+    return (jint)wolfSSL_set_fd(ssl, fd);
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useCertificateFile
-  (JNIEnv* jenv, jobject jcl, jlong ssl, jstring file, jint format)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jstring file, jint format)
 {
 #ifdef OPENSSL_EXTRA
     jint ret = 0;
     const char* certFile;
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (!jenv || !ssl)
+    if (jenv == NULL || ssl == NULL) {
         return SSL_FAILURE;
+    }
 
-    if (file == NULL)
+    if (file == NULL) {
         return SSL_BAD_FILE;
+    }
 
     certFile = (*jenv)->GetStringUTFChars(jenv, file, 0);
 
-    ret = (jint) wolfSSL_use_certificate_file((WOLFSSL*)(uintptr_t)ssl, certFile,
-            (int)format);
+    ret = (jint) wolfSSL_use_certificate_file(ssl, certFile, (int)format);
 
     (*jenv)->ReleaseStringUTFChars(jenv, file, certFile);
 
@@ -400,7 +401,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useCertificateFile
 #else
     (void)jenv;
     (void)jcl;
-    (void)ssl;
+    (void)sslPtr;
     (void)file;
     (void)format;
     return NOT_COMPILED_IN;
@@ -408,24 +409,25 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useCertificateFile
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_usePrivateKeyFile
-  (JNIEnv* jenv, jobject jcl, jlong ssl, jstring file, jint format)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jstring file, jint format)
 {
 #ifdef OPENSSL_EXTRA
     jint ret = 0;
     const char* keyFile;
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (!jenv || !ssl)
+    if (jenv == NULL || ssl == NULL) {
         return SSL_FAILURE;
+    }
 
-    if (file == NULL)
+    if (file == NULL) {
         return SSL_BAD_FILE;
+    }
 
     keyFile = (*jenv)->GetStringUTFChars(jenv, file, 0);
 
-    ret = (jint) wolfSSL_use_PrivateKey_file((WOLFSSL*)(uintptr_t)ssl, keyFile,
-            (int)format);
+    ret = (jint) wolfSSL_use_PrivateKey_file(ssl, keyFile, (int)format);
 
     (*jenv)->ReleaseStringUTFChars(jenv, file, keyFile);
 
@@ -433,7 +435,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_usePrivateKeyFile
 #else
     (void)jenv;
     (void)jcl;
-    (void)ssl;
+    (void)sslPtr;
     (void)file;
     (void)format;
     return NOT_COMPILED_IN;
@@ -441,24 +443,25 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_usePrivateKeyFile
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useCertificateChainFile
-  (JNIEnv* jenv, jobject jcl, jlong ssl, jstring file)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jstring file)
 {
 #ifdef OPENSSL_EXTRA
     jint ret = 0;
     const char* chainFile;
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (!jenv || !ssl)
+    if (jenv == NULL || ssl == NULL) {
         return SSL_FAILURE;
+    }
 
-    if (file == NULL)
+    if (file == NULL) {
         return SSL_BAD_FILE;
+    }
 
     chainFile = (*jenv)->GetStringUTFChars(jenv, file, 0);
 
-    ret = (jint) wolfSSL_use_certificate_chain_file((WOLFSSL*)(uintptr_t)ssl,
-                                                    chainFile);
+    ret = (jint) wolfSSL_use_certificate_chain_file(ssl, chainFile);
 
     (*jenv)->ReleaseStringUTFChars(jenv, file, chainFile);
 
@@ -466,23 +469,24 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useCertificateChainFile
 #else
     (void)jenv;
     (void)jcl;
-    (void)ssl;
+    (void)sslPtr;
     (void)file;
     return NOT_COMPILED_IN;
 #endif
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setUsingNonblock
-  (JNIEnv* jenv, jobject jcl, jlong ssl, jint nonblock)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jint nonblock)
 {
     jclass excClass;
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (!jenv)
+    if (jenv == NULL) {
         return;
+    }
 
-    if (!ssl) {
+    if (ssl == NULL) {
         excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
@@ -493,20 +497,21 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setUsingNonblock
                 "Input WolfSSLSession object was null in setUsingNonblock");
     }
 
-    wolfSSL_set_using_nonblock((WOLFSSL*)(uintptr_t)ssl, nonblock);
+    wolfSSL_set_using_nonblock(ssl, nonblock);
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getUsingNonblock
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
     jclass excClass;
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (!jenv)
+    if (jenv == NULL) {
         return 0;
+    }
 
-    if (!ssl) {
+    if (ssl == NULL) {
         excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
@@ -517,20 +522,21 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getUsingNonblock
                 "Input WolfSSLSession object was null in getUsingNonblock");
     }
 
-    return wolfSSL_get_using_nonblock((WOLFSSL*)(uintptr_t)ssl);
+    return wolfSSL_get_using_nonblock(ssl);
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getFd
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
     jclass excClass;
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (!jenv)
+    if (jenv == NULL) {
         return 0;
+    }
 
-    if (!ssl) {
+    if (ssl == NULL) {
         excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
@@ -542,7 +548,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getFd
         return 0;
     }
 
-    return wolfSSL_get_fd((WOLFSSL*)(uintptr_t)ssl);
+    return wolfSSL_get_fd(ssl);
 }
 
 /* enum values used in socketSelect() */
@@ -611,16 +617,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_connect
   (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
     int ret = 0, err = 0, sockfd = 0;
-    WOLFSSL* ssl = NULL;
     wolfSSL_Mutex* jniSessLock = NULL;
     SSLAppData* appData = NULL;
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (jenv == NULL || sslPtr <= 0) {
+    if (jenv == NULL || ssl == NULL) {
         return SSL_FATAL_ERROR;
     }
-    ssl = (WOLFSSL*)(uintptr_t)sslPtr;
 
     /* make sure we don't have any outstanding exceptions pending */
     if ((*jenv)->ExceptionCheck(jenv)) {
@@ -693,16 +697,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_write(JNIEnv* jenv,
 {
     byte* data;
     int ret = SSL_FAILURE, err, sockfd;
-    WOLFSSL* ssl = NULL;
     wolfSSL_Mutex* jniSessLock = NULL;
     SSLAppData* appData = NULL;
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (jenv == NULL || sslPtr <= 0 || raw == NULL) {
+    if (jenv == NULL || ssl == NULL || raw == NULL) {
         return BAD_FUNC_ARG;
     }
-    ssl = (WOLFSSL*)(uintptr_t)sslPtr;
 
     if (length >= 0) {
         data = (byte*)(*jenv)->GetByteArrayElements(jenv, raw, NULL);
@@ -778,16 +780,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_read(JNIEnv* jenv,
 {
     byte* data;
     int size = 0, ret, err, sockfd;
-    WOLFSSL* ssl = NULL;
     wolfSSL_Mutex* jniSessLock = NULL;
     SSLAppData* appData = NULL;
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (jenv == NULL || sslPtr <= 0 || raw == NULL) {
+    if (jenv == NULL || ssl == NULL || raw == NULL) {
         return BAD_FUNC_ARG;
     }
-    ssl = (WOLFSSL*)(uintptr_t)sslPtr;
 
     if (length >= 0) {
         data = (byte*)(*jenv)->GetByteArrayElements(jenv, raw, NULL);
@@ -861,16 +861,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_accept
   (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
     int ret = 0, err, sockfd;
-    WOLFSSL* ssl = NULL;
     wolfSSL_Mutex* jniSessLock = NULL;
     SSLAppData* appData = NULL;
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (jenv == NULL || sslPtr <= 0) {
+    if (jenv == NULL || ssl == NULL) {
         return SSL_FATAL_ERROR;
     }
-    ssl = (WOLFSSL*)(uintptr_t)sslPtr;
 
     /* make sure we don't have any outstanding exceptions pending */
     if ((*jenv)->ExceptionCheck(jenv)) {
@@ -939,12 +937,13 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_accept
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_freeSSL
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
     jobject* g_cachedSSLObj;
     jobject* g_cachedVerifyCb;
     jclass excClass;
     SSLAppData* appData;
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 #if defined(HAVE_PK_CALLBACKS) && (defined(HAVE_ECC) || !defined(NO_RSA))
     internCtx* pkCtx = NULL;
@@ -952,7 +951,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_freeSSL
 
     excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
 
-    if (!ssl) {
+    if (ssl == NULL) {
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
             (*jenv)->ExceptionClear(jenv);
@@ -964,7 +963,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_freeSSL
     }
 
     /* free session mutex lock */
-    appData = (SSLAppData*)wolfSSL_get_app_data((WOLFSSL*)(uintptr_t)ssl);
+    appData = (SSLAppData*)wolfSSL_get_app_data(ssl);
     if (appData != NULL) {
         if (appData->jniSessLock != NULL) {
             wc_FreeMutex(appData->jniSessLock);
@@ -983,7 +982,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_freeSSL
     }
 
     /* delete global WolfSSLSession object reference */
-    g_cachedSSLObj = (jobject*) wolfSSL_get_jobject((WOLFSSL*)(uintptr_t)ssl);
+    g_cachedSSLObj = (jobject*) wolfSSL_get_jobject(ssl);
     if (g_cachedSSLObj != NULL) {
         (*jenv)->DeleteGlobalRef(jenv, (jobject)(*g_cachedSSLObj));
         XFREE(g_cachedSSLObj, NULL, DYNAMIC_TYPE_TMP_BUFFER);
@@ -991,7 +990,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_freeSSL
     }
 
     /* reset internal pointer to NULL to prevent accidental usage */
-    if (wolfSSL_set_jobject((WOLFSSL*)(uintptr_t)ssl, NULL) != SSL_SUCCESS) {
+    if (wolfSSL_set_jobject(ssl, NULL) != SSL_SUCCESS) {
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
             (*jenv)->ExceptionClear(jenv);
@@ -1013,7 +1012,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_freeSSL
 #if defined(HAVE_PK_CALLBACKS)
     #ifdef HAVE_ECC
         /* free ECC sign callback CTX global reference if set */
-        pkCtx = (internCtx*) wolfSSL_GetEccSignCtx((WOLFSSL*)(uintptr_t)ssl);
+        pkCtx = (internCtx*) wolfSSL_GetEccSignCtx(ssl);
         if (pkCtx != NULL) {
             if (pkCtx->obj != NULL) {
                 (*jenv)->DeleteGlobalRef(jenv, pkCtx->obj);
@@ -1022,7 +1021,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_freeSSL
         }
 
         /* free ECC verify callback CTX global reference if set */
-        pkCtx = (internCtx*)wolfSSL_GetEccVerifyCtx((WOLFSSL*)(uintptr_t)ssl);
+        pkCtx = (internCtx*)wolfSSL_GetEccVerifyCtx(ssl);
         if (pkCtx != NULL) {
             if (pkCtx->obj != NULL) {
                 (*jenv)->DeleteGlobalRef(jenv, pkCtx->obj);
@@ -1031,8 +1030,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_freeSSL
         }
 
         /* free ECC shared secret callback CTX global reference if set */
-        pkCtx = (internCtx*)wolfSSL_GetEccSharedSecretCtx(
-                                (WOLFSSL*)(uintptr_t)ssl);
+        pkCtx = (internCtx*)wolfSSL_GetEccSharedSecretCtx(ssl);
         if (pkCtx != NULL) {
             if (pkCtx->obj != NULL) {
                 (*jenv)->DeleteGlobalRef(jenv, pkCtx->obj);
@@ -1043,7 +1041,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_freeSSL
 
     #ifndef NO_RSA
         /* free RSA sign callback CTX global reference if set */
-        pkCtx = (internCtx*) wolfSSL_GetRsaSignCtx((WOLFSSL*)(uintptr_t)ssl);
+        pkCtx = (internCtx*) wolfSSL_GetRsaSignCtx(ssl);
         if (pkCtx != NULL) {
             if (pkCtx->obj != NULL) {
                 (*jenv)->DeleteGlobalRef(jenv, pkCtx->obj);
@@ -1052,7 +1050,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_freeSSL
         }
 
         /* free RSA verify callback CTX global reference if set */
-        pkCtx = (internCtx*)wolfSSL_GetRsaVerifyCtx((WOLFSSL*)(uintptr_t)ssl);
+        pkCtx = (internCtx*)wolfSSL_GetRsaVerifyCtx(ssl);
         if (pkCtx != NULL) {
             if (pkCtx->obj != NULL) {
                 (*jenv)->DeleteGlobalRef(jenv, pkCtx->obj);
@@ -1061,7 +1059,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_freeSSL
         }
 
         /* free RSA encrypt callback CTX global reference if set */
-        pkCtx = (internCtx*) wolfSSL_GetRsaEncCtx((WOLFSSL*)(uintptr_t)ssl);
+        pkCtx = (internCtx*) wolfSSL_GetRsaEncCtx(ssl);
         if (pkCtx != NULL) {
             if (pkCtx->obj != NULL) {
                 (*jenv)->DeleteGlobalRef(jenv, pkCtx->obj);
@@ -1070,7 +1068,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_freeSSL
         }
 
         /* free RSA decrypt callback CTX global reference if set */
-        pkCtx = (internCtx*) wolfSSL_GetRsaDecCtx((WOLFSSL*)(uintptr_t)ssl);
+        pkCtx = (internCtx*) wolfSSL_GetRsaDecCtx(ssl);
         if (pkCtx != NULL) {
             if (pkCtx->obj != NULL) {
                 (*jenv)->DeleteGlobalRef(jenv, pkCtx->obj);
@@ -1081,7 +1079,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_freeSSL
 #endif /* HAVE_PK_CALLBACKS */
 
     /* native cleanup */
-    wolfSSL_free((WOLFSSL*)(uintptr_t)ssl);
+    wolfSSL_free(ssl);
     ssl = 0;
 }
 
@@ -1089,15 +1087,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_shutdownSSL
   (JNIEnv* jenv, jobject jcl, jlong sslPtr, jint timeout)
 {
     int ret = 0, err, sockfd;
-    WOLFSSL* ssl = NULL;
     wolfSSL_Mutex* jniSessLock;
     SSLAppData* appData = NULL;
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
     if (jenv == NULL) {
         return SSL_FAILURE;
     }
-    ssl = (WOLFSSL*)(uintptr_t)sslPtr;
 
     /* make sure we don't have any outstanding exceptions pending */
     if ((*jenv)->ExceptionCheck(jenv)) {
@@ -1166,48 +1163,54 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_shutdownSSL
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getError
-  (JNIEnv* jenv, jobject jcl, jlong ssl, jint ret)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jint ret)
 {
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (!jenv)
+    if (jenv == NULL) {
         return SSL_FAILURE;
+    }
 
     /* wolfSSL checks ssl for NULL */
-    return wolfSSL_get_error((WOLFSSL*)(uintptr_t)ssl, ret);
+    return wolfSSL_get_error(ssl, ret);
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setSession
-  (JNIEnv* jenv, jobject jcl, jlong ssl, jlong session)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jlong sessionPtr)
 {
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
+    WOLFSSL_SESSION* session = (WOLFSSL_SESSION*)(uintptr_t)sessionPtr;
     (void)jcl;
 
-    if (!jenv || !ssl)
+    if (jenv == NULL || ssl == NULL) {
         return SSL_FAILURE;
+    }
 
     /* wolfSSL checks session for NULL, but not ssl */
-    return wolfSSL_set_session((WOLFSSL*)(uintptr_t)ssl,
-                               (WOLFSSL_SESSION*)(uintptr_t)session);
+    return wolfSSL_set_session(ssl, session);
 }
 
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_getSession
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jenv;
     (void)jcl;
 
     /* wolfSSL checks ssl for NULL */
-    return (jlong)(uintptr_t)wolfSSL_get_session((WOLFSSL*)(uintptr_t)ssl);
+    return (jlong)(uintptr_t)wolfSSL_get_session(ssl);
 }
 
 JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getSessionID
-  (JNIEnv* jenv, jobject jcl, jlong session)
+  (JNIEnv* jenv, jobject jcl, jlong sessionPtr)
 {
     unsigned int sz;
     const unsigned char* id;
     jbyteArray ret;
+    WOLFSSL_SESSION* session = (WOLFSSL_SESSION*)(uintptr_t)sessionPtr;
 
-    id = wolfSSL_SESSION_get_id((WOLFSSL_SESSION*)(uintptr_t)session, &sz);
+    id = wolfSSL_SESSION_get_id(session, &sz);
     if (id == NULL) {
         return NULL;
     }
@@ -1230,57 +1233,61 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getSessionID
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setTimeout
-  (JNIEnv* jenv, jobject jcl, jlong ssl, jlong t)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jlong t)
 {
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jenv;
     (void)jcl;
 
-    return wolfSSL_set_timeout((WOLFSSL*)(uintptr_t)ssl, (unsigned int)t);
+    return wolfSSL_set_timeout(ssl, (unsigned int)t);
 }
 
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_getTimeout
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jenv;
     (void)jcl;
 
-    return wolfSSL_get_timeout((WOLFSSL*)(uintptr_t)ssl);
+    return wolfSSL_get_timeout(ssl);
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setSessTimeout
-  (JNIEnv* jenv, jobject jcl, jlong session, jlong sz)
+  (JNIEnv* jenv, jobject jcl, jlong sessionPtr, jlong sz)
 {
+    WOLFSSL_SESSION* session = (WOLFSSL_SESSION*)(uintptr_t)sessionPtr;
     (void)jenv;
     (void)jcl;
 
-    return wolfSSL_SSL_SESSION_set_timeout((WOLFSSL_SESSION*)(uintptr_t)session,
-                                           sz);
+    return wolfSSL_SSL_SESSION_set_timeout(session, sz);
 }
 
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_getSessTimeout
-  (JNIEnv* jenv, jobject jcl, jlong session)
+  (JNIEnv* jenv, jobject jcl, jlong sessionPtr)
 {
+    WOLFSSL_SESSION* session = (WOLFSSL_SESSION*)(uintptr_t)sessionPtr;
     (void)jenv;
     (void)jcl;
 
-    return wolfSSL_SESSION_get_timeout((WOLFSSL_SESSION*)(uintptr_t)session);
+    return wolfSSL_SESSION_get_timeout(session);
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setCipherList
-  (JNIEnv* jenv, jobject jcl, jlong ssl, jstring list)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jstring list)
 {
 
     jint ret = 0;
     const char* cipherList;
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (!jenv || !ssl || !list)
+    if (jenv == NULL || ssl == NULL || list == NULL) {
         return SSL_FAILURE;
+    }
 
     cipherList= (*jenv)->GetStringUTFChars(jenv, list, 0);
 
-    ret = (jint) wolfSSL_set_cipher_list((WOLFSSL*)(uintptr_t)ssl, cipherList);
+    ret = (jint) wolfSSL_set_cipher_list(ssl, cipherList);
 
     (*jenv)->ReleaseStringUTFChars(jenv, list, cipherList);
 
@@ -1288,14 +1295,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setCipherList
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_dtlsGetCurrentTimeout
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
 #if !defined(WOLFSSL_LEANPSK) && defined(WOLFSSL_DTLS)
     jclass excClass;
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (!ssl) {
+    if (ssl == NULL) {
         excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
@@ -1308,24 +1315,24 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_dtlsGetCurrentTimeout
         return 0;
     }
 
-    return wolfSSL_dtls_get_current_timeout((WOLFSSL*)(uintptr_t)ssl);
+    return wolfSSL_dtls_get_current_timeout(ssl);
 #else
     (void)jenv;
     (void)jcl;
-    (void)ssl;
+    (void)sslPtr;
     return NOT_COMPILED_IN;
 #endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_dtlsGotTimeout
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
 #if !defined(WOLFSSL_LEANPSK) && defined(WOLFSSL_DTLS)
     jclass excClass;
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (!ssl) {
+    if (ssl == NULL) {
         excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
@@ -1338,23 +1345,23 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_dtlsGotTimeout
         return SSL_FATAL_ERROR;
     }
 
-    return wolfSSL_dtls_got_timeout((WOLFSSL*)(uintptr_t)ssl);
+    return wolfSSL_dtls_got_timeout(ssl);
 #else
     (void)jenv;
     (void)jcl;
-    (void)ssl;
+    (void)sslPtr;
     return NOT_COMPILED_IN;
 #endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_dtls
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
     jclass excClass;
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (!ssl) {
+    if (ssl == NULL) {
         excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
@@ -1366,21 +1373,22 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_dtls
         return 0;
     }
 
-    return wolfSSL_dtls((WOLFSSL*)(uintptr_t)ssl);
+    return wolfSSL_dtls(ssl);
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_dtlsSetPeer
-  (JNIEnv* jenv, jobject jcl, jlong ssl, jobject peer)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jobject peer)
 {
     int ret;
     jstring ipAddr = NULL;
     struct sockaddr_in sa;
     const char* ipAddress = NULL;
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (!jenv || !ssl || !peer)
+    if (jenv == NULL || ssl == NULL || peer == NULL) {
         return SSL_FAILURE;
+    }
 
     /* get class references */
     jclass excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
@@ -1478,7 +1486,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_dtlsSetPeer
     }
 
     /* call native wolfSSL function */
-    ret = wolfSSL_dtls_set_peer((WOLFSSL*)(uintptr_t)ssl, &sa, sizeof(sa));
+    ret = wolfSSL_dtls_set_peer(ssl, &sa, sizeof(sa));
 
     if (!isAny) {
         (*jenv)->ReleaseStringUTFChars(jenv, ipAddr, ipAddress);
@@ -1488,25 +1496,27 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_dtlsSetPeer
 }
 
 JNIEXPORT jobject JNICALL Java_com_wolfssl_WolfSSLSession_dtlsGetPeer
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
     int ret, port;
     unsigned int peerSz;
     struct sockaddr_in peer;
     char* ipAddrString;
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
 
     jmethodID constr;
     jstring ipAddr;
 
     (void)jcl;
 
-    if (!jenv || !ssl)
+    if (jenv == NULL || ssl == NULL) {
         return NULL;
+    }
 
     /* get native sockaddr_in peer */
     memset(&peer, 0, sizeof(peer));
     peerSz = sizeof(peer);
-    ret = wolfSSL_dtls_get_peer((WOLFSSL*)(uintptr_t)ssl, &peer, &peerSz);
+    ret = wolfSSL_dtls_get_peer(ssl, &peer, &peerSz);
     if (ret != SSL_SUCCESS) {
         return NULL;
     }
@@ -1561,13 +1571,13 @@ JNIEXPORT jobject JNICALL Java_com_wolfssl_WolfSSLSession_dtlsGetPeer
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_sessionReused
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
     jclass excClass;
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (!ssl) {
+    if (ssl == NULL) {
         excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
@@ -1579,61 +1589,50 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_sessionReused
         return SSL_FAILURE;
     }
 
-    return wolfSSL_session_reused((WOLFSSL*)(uintptr_t)ssl);
+    return wolfSSL_session_reused(ssl);
 }
 
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_getPeerCertificate
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
 #ifdef KEEP_PEER_CERT
     WOLFSSL_X509* x509 = NULL;
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jenv;
     (void)jcl;
 
-    if (ssl == 0) {
+    if (ssl == NULL) {
         return (jlong)0;
     }
 
-    x509 = wolfSSL_get_peer_certificate((WOLFSSL*)(uintptr_t)ssl);
+    x509 = wolfSSL_get_peer_certificate(ssl);
 
     return (jlong)(uintptr_t)x509;
 #else
     (void)jenv;
     (void)jcl;
-    (void)ssl;
+    (void)sslPtr;
     return (jlong)0;
 #endif
 }
 
 JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_getPeerX509Issuer
-  (JNIEnv* jenv, jobject jcl, jlong ssl, jlong x509)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jlong x509Ptr)
 {
 
 #if defined(KEEP_PEER_CERT) || defined(SESSION_CERTS)
-    jclass excClass;
     char* issuer;
     jstring retString;
-
+    WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
+    (void)sslPtr;
     (void)jcl;
 
-    if (!x509)
-        return NULL;
-
-    if (!ssl) {
-        excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-        if ((*jenv)->ExceptionOccurred(jenv)) {
-            (*jenv)->ExceptionDescribe(jenv);
-            (*jenv)->ExceptionClear(jenv);
-            return NULL;
-        }
-        (*jenv)->ThrowNew(jenv, excClass,
-                "Input WolfSSLSession object was null in "
-                "getPeerX509Issuer");
+    if (x509 == NULL) {
         return NULL;
     }
 
     issuer = wolfSSL_X509_NAME_oneline(
-            wolfSSL_X509_get_issuer_name((WOLFSSL_X509*)(uintptr_t)x509), 0, 0);
+            wolfSSL_X509_get_issuer_name(x509), 0, 0);
 
     retString = (*jenv)->NewStringUTF(jenv, issuer);
     XFREE(issuer, 0, DYNAMIC_TYPE_OPENSSL);
@@ -1643,42 +1642,29 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_getPeerX509Issuer
 #else
     (void)jenv;
     (void)jcl;
-    (void)ssl;
-    (void)x509;
+    (void)sslPtr;
+    (void)x509Ptr;
     return NULL;
 #endif
 }
 
 JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_getPeerX509Subject
-  (JNIEnv* jenv, jobject jcl, jlong ssl, jlong x509)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jlong x509Ptr)
 {
 
 #if defined(KEEP_PEER_CERT) || defined(SESSION_CERTS)
-    jclass excClass;
     char* subject;
     jstring retString;
-
+    WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
+    (void)sslPtr;
     (void)jcl;
 
-    if (!x509)
-        return NULL;
-
-    if (!ssl) {
-        excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-        if ((*jenv)->ExceptionOccurred(jenv)) {
-            (*jenv)->ExceptionDescribe(jenv);
-            (*jenv)->ExceptionClear(jenv);
-            return NULL;
-        }
-        (*jenv)->ThrowNew(jenv, excClass,
-                "Input WolfSSLSession object was null in "
-                "getPeerX509Subject");
+    if (x509 == NULL) {
         return NULL;
     }
 
     subject = wolfSSL_X509_NAME_oneline(
-            wolfSSL_X509_get_subject_name(
-                (WOLFSSL_X509*)(uintptr_t)x509), 0, 0);
+            wolfSSL_X509_get_subject_name(x509), 0, 0);
 
     retString = (*jenv)->NewStringUTF(jenv, subject);
     XFREE(subject, 0, DYNAMIC_TYPE_OPENSSL);
@@ -1688,39 +1674,27 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_getPeerX509Subject
 #else
     (void)jenv;
     (void)jcl;
-    (void)ssl;
-    (void)x509;
+    (void)sslPtr;
+    (void)x509Ptr;
     return NULL;
 #endif
 }
 
 JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_getPeerX509AltName
-  (JNIEnv* jenv, jobject jcl, jlong ssl, jlong x509)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jlong x509Ptr)
 {
 #if defined(KEEP_PEER_CERT) || defined(SESSION_CERTS)
-    jclass excClass;
     char* altname;
     jstring retString;
-
+    WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
     (void)jcl;
+    (void)sslPtr;
 
-    if (!x509)
-        return NULL;
-
-    if (!ssl) {
-        excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-        if ((*jenv)->ExceptionOccurred(jenv)) {
-            (*jenv)->ExceptionDescribe(jenv);
-            (*jenv)->ExceptionClear(jenv);
-            return NULL;
-        }
-        (*jenv)->ThrowNew(jenv, excClass,
-                "Input WolfSSLSession object was null in "
-                "getPeerX509AltName");
+    if (x509 == NULL) {
         return NULL;
     }
 
-    altname = wolfSSL_X509_get_next_altname((WOLFSSL_X509*)(uintptr_t)x509);
+    altname = wolfSSL_X509_get_next_altname(x509);
 
     retString = (*jenv)->NewStringUTF(jenv, altname);
     return retString;
@@ -1728,20 +1702,20 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_getPeerX509AltName
 #else
     (void)jenv;
     (void)jcl;
-    (void)ssl;
-    (void)x509;
+    (void)sslPtr;
+    (void)x509Ptr;
     return NULL;
 #endif
 }
 
 JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_getVersion
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
     jclass excClass;
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (!ssl) {
+    if (ssl == NULL) {
         excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
@@ -1754,18 +1728,17 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_getVersion
         return NULL;
     }
 
-    return (*jenv)->NewStringUTF(jenv,
-                                 wolfSSL_get_version((WOLFSSL*)(uintptr_t)ssl));
+    return (*jenv)->NewStringUTF(jenv, wolfSSL_get_version(ssl));
 }
 
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_getCurrentCipher
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
     jclass excClass;
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (!ssl) {
+    if (ssl == NULL) {
         excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
@@ -1778,23 +1751,23 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_getCurrentCipher
         return SSL_FAILURE;
     }
 
-    return (jlong)(uintptr_t)wolfSSL_get_current_cipher(
-                                (WOLFSSL*)(uintptr_t)ssl);
+    return (jlong)(uintptr_t)wolfSSL_get_current_cipher(ssl);
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_checkDomainName
-  (JNIEnv* jenv, jobject jcl, jlong ssl, jstring dn)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jstring dn)
 {
     int ret;
     const char* dname;
     jclass excClass;
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if(!dn)
+    if(dn == NULL) {
         return SSL_FAILURE;
+    }
 
-    if (!ssl) {
+    if (ssl == NULL) {
         excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
@@ -1809,7 +1782,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_checkDomainName
 
     dname = (*jenv)->GetStringUTFChars(jenv, dn, 0);
 
-    ret = wolfSSL_check_domain_name((WOLFSSL*)(uintptr_t)ssl, dname);
+    ret = wolfSSL_check_domain_name(ssl, dname);
 
     (*jenv)->ReleaseStringUTFChars(jenv, dn, dname);
 
@@ -1817,21 +1790,21 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_checkDomainName
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setTmpDH
-  (JNIEnv* jenv, jobject jcl, jlong ssl, jbyteArray p, jint pSz, jbyteArray g,
-   jint gSz)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jbyteArray p, jint pSz,
+   jbyteArray g, jint gSz)
 {
 #ifndef NO_DH
     unsigned char pBuf[pSz];
     unsigned char gBuf[gSz];
     jclass excClass;
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (!jenv || !p || !g) {
+    if (jenv == NULL || p == NULL || g == NULL) {
         return BAD_FUNC_ARG;
     }
 
-    if (!ssl) {
+    if (ssl == NULL) {
         excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
@@ -1858,11 +1831,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setTmpDH
         return SSL_FAILURE;
     }
 
-    return wolfSSL_SetTmpDH((WOLFSSL*)(uintptr_t)ssl, pBuf, pSz, gBuf, gSz);
+    return wolfSSL_SetTmpDH(ssl, pBuf, pSz, gBuf, gSz);
 #else
     (void)jenv;
     (void)jcl;
-    (void)ssl;
+    (void)sslPtr;
     (void)p;
     (void)pSz;
     (void)g;
@@ -1872,19 +1845,20 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setTmpDH
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setTmpDHFile
-  (JNIEnv* jenv, jobject jcl, jlong ssl, jstring file, jint format)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jstring file, jint format)
 {
 #ifndef NO_DH
     int ret;
     const char* fname;
     jclass excClass;
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (!file)
+    if (file == NULL) {
         return SSL_BAD_FILE;
+    }
 
-    if (!ssl) {
+    if (ssl == NULL) {
         excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
@@ -1899,7 +1873,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setTmpDHFile
 
     fname = (*jenv)->GetStringUTFChars(jenv, file, 0);
 
-    ret = wolfSSL_SetTmpDH_file((WOLFSSL*)(uintptr_t)ssl, fname, format);
+    ret = wolfSSL_SetTmpDH_file(ssl, fname, format);
 
     (*jenv)->ReleaseStringUTFChars(jenv, file, fname);
 
@@ -1907,7 +1881,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setTmpDHFile
 #else
     (void)jenv;
     (void)jcl;
-    (void)ssl;
+    (void)sslPtr;
     (void)file;
     (void)format;
     return NOT_COMPILED_IN;
@@ -1915,17 +1889,19 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setTmpDHFile
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useCertificateBuffer
-  (JNIEnv* jenv, jobject jcl, jlong ssl, jbyteArray in, jlong sz, jint format)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jbyteArray in, jlong sz,
+   jint format)
 {
     unsigned char buff[sz];
     jclass excClass;
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (!jenv || !in)
+    if (jenv == NULL || in == NULL) {
         return BAD_FUNC_ARG;
+    }
 
-    if (!ssl) {
+    if (ssl == NULL) {
         excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
@@ -1945,22 +1921,23 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useCertificateBuffer
         return SSL_FAILURE;
     }
 
-    return wolfSSL_use_certificate_buffer((WOLFSSL*)(uintptr_t)ssl, buff, sz,
-                                          format);
+    return wolfSSL_use_certificate_buffer(ssl, buff, sz, format);
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_usePrivateKeyBuffer
-  (JNIEnv* jenv, jobject jcl, jlong ssl, jbyteArray in, jlong sz, jint format)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jbyteArray in, jlong sz,
+   jint format)
 {
     unsigned char buff[sz];
     jclass excClass;
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (!jenv || !in)
+    if (jenv == NULL || in == NULL) {
         return BAD_FUNC_ARG;
+    }
 
-    if (!ssl) {
+    if (ssl == NULL) {
         excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
@@ -1980,22 +1957,22 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_usePrivateKeyBuffer
         return SSL_FAILURE;
     }
 
-    return wolfSSL_use_PrivateKey_buffer((WOLFSSL*)(uintptr_t)ssl, buff, sz,
-                                         format);
+    return wolfSSL_use_PrivateKey_buffer(ssl, buff, sz, format);
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useCertificateChainBuffer
-  (JNIEnv* jenv, jobject jcl, jlong ssl, jbyteArray in, jlong sz)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jbyteArray in, jlong sz)
 {
     unsigned char buff[sz];
     jclass excClass;
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (!jenv || !in)
+    if (jenv == NULL || in == NULL) {
         return BAD_FUNC_ARG;
+    }
 
-    if (!ssl) {
+    if (ssl == NULL) {
         excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
@@ -2015,18 +1992,17 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useCertificateChainBuffer
         return SSL_FAILURE;
     }
 
-    return wolfSSL_use_certificate_chain_buffer((WOLFSSL*)(uintptr_t)ssl, buff,
-                                                sz);
+    return wolfSSL_use_certificate_chain_buffer(ssl, buff, sz);
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setGroupMessages
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
     jclass excClass;
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (!ssl) {
+    if (ssl == NULL) {
         excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
@@ -2038,21 +2014,22 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setGroupMessages
                 "setGroupMessages");
         return BAD_FUNC_ARG;
     }
-    return wolfSSL_set_group_messages((WOLFSSL*)(uintptr_t)ssl);
+    return wolfSSL_set_group_messages(ssl);
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_enableCRL
-  (JNIEnv* jenv, jobject jcl, jlong ssl, jint options)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jint options)
 {
 #ifdef HAVE_CRL
     jclass excClass;
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (!jenv)
+    if (jenv == NULL) {
         return BAD_FUNC_ARG;
+    }
 
-    if (!ssl) {
+    if (ssl == NULL) {
         excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
@@ -2065,28 +2042,29 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_enableCRL
         return SSL_FAILURE;
     }
 
-    return wolfSSL_EnableCRL((WOLFSSL*)(uintptr_t)ssl, options);
+    return wolfSSL_EnableCRL(ssl, options);
 #else
     (void)jenv;
     (void)jcl;
-    (void)ssl;
+    (void)sslPtr;
     (void)options;
     return NOT_COMPILED_IN;
 #endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_disableCRL
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
 #ifdef HAVE_CRL
     jclass excClass;
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (!jenv)
+    if (jenv == NULL) {
         return BAD_FUNC_ARG;
+    }
 
-    if (!ssl) {
+    if (ssl == NULL) {
         excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
@@ -2099,29 +2077,31 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_disableCRL
         return SSL_FAILURE;
     }
 
-    return wolfSSL_DisableCRL((WOLFSSL*)(uintptr_t)ssl);
+    return wolfSSL_DisableCRL(ssl);
 #else
     (void)jenv;
     (void)jcl;
-    (void)ssl;
+    (void)sslPtr;
     return NOT_COMPILED_IN;
 #endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_loadCRL
-  (JNIEnv* jenv, jobject jcl, jlong ssl, jstring path, jint type, jint monitor)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jstring path, jint type,
+   jint monitor)
 {
 #ifdef HAVE_CRL
     int ret;
     const char* crlPath;
     jclass excClass;
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (!jenv || !path)
+    if (jenv == NULL || path == NULL) {
         return BAD_FUNC_ARG;
+    }
 
-    if (!ssl) {
+    if (ssl == NULL) {
         excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
@@ -2136,7 +2116,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_loadCRL
 
     crlPath = (*jenv)->GetStringUTFChars(jenv, path, 0);
 
-    ret = wolfSSL_LoadCRL((WOLFSSL*)(uintptr_t)ssl, crlPath, type, monitor);
+    ret = wolfSSL_LoadCRL(ssl, crlPath, type, monitor);
 
     (*jenv)->ReleaseStringUTFChars(jenv, path, crlPath);
 
@@ -2144,6 +2124,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_loadCRL
 #else
     (void)jenv;
     (void)jcl;
+    (void)sslPtr;
     (void)path;
     (void)type;
     (void)monitor;
@@ -2152,12 +2133,12 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_loadCRL
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setCRLCb
-  (JNIEnv* jenv, jobject jcl, jlong ssl, jobject cb)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jobject cb)
 {
 #ifdef HAVE_CRL
     int    ret = 0;
     jclass excClass;
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
     if (jenv == NULL) {
@@ -2172,9 +2153,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setCRLCb
         return SSL_FAILURE;
     }
 
-    if (ssl == 0) {
+    if (ssl == NULL) {
         (*jenv)->ThrowNew(jenv, excClass,
-            "Input WolfSSLSession object was null in "
+            "Input WolfSSLSession object was NULL in "
             "setCRLCb");
         return SSL_FAILURE;
     }
@@ -2193,15 +2174,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setCRLCb
                    "Error storing global missingCRLCallback interface");
         }
 
-        ret = wolfSSL_SetCRL_Cb((WOLFSSL*)(uintptr_t)ssl,
-                                NativeMissingCRLCallback);
+        ret = wolfSSL_SetCRL_Cb(ssl, NativeMissingCRLCallback);
     }
 
     return ret;
 #else
     (void)jenv;
     (void)jcl;
-    (void)ssl;
+    (void)sslPtr;
     (void)cb;
     return NOT_COMPILED_IN;
 #endif
@@ -2291,15 +2271,15 @@ void NativeMissingCRLCallback(const char* url)
 #endif /* HAVE_CRL */
 
 JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_cipherGetName
-  (JNIEnv* jenv, jclass jcl, jlong ssl)
+  (JNIEnv* jenv, jclass jcl, jlong sslPtr)
 {
     const char* cipherName;
     WOLFSSL_CIPHER* cipher;
     jclass excClass;
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (!ssl) {
+    if (ssl == NULL) {
         excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
@@ -2312,7 +2292,7 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_cipherGetName
         return NULL;
     }
 
-    cipher = wolfSSL_get_current_cipher((WOLFSSL*)(uintptr_t)ssl);
+    cipher = wolfSSL_get_current_cipher(ssl);
 
     if (cipher != NULL) {
         cipherName = wolfSSL_CIPHER_get_name(cipher);
@@ -2323,7 +2303,7 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_cipherGetName
 }
 
 JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getMacSecret
-  (JNIEnv* jenv, jobject jcl, jlong ssl, jint verify)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jint verify)
 {
     jclass excClass;
 #ifdef ATOMIC_USER
@@ -2331,7 +2311,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getMacSecret
     jbyteArray retSecret;
     const unsigned char* secret;
 #endif
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
     /* find exception class */
@@ -2343,20 +2323,19 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getMacSecret
     }
 
 #ifdef ATOMIC_USER
-
-    if (!ssl) {
+    if (ssl == NULL) {
         (*jenv)->ThrowNew(jenv, excClass,
             "Input WolfSSLSession object was null in "
             "getMacSecret");
         return NULL;
     }
 
-    secret = wolfSSL_GetMacSecret((WOLFSSL*)(uintptr_t)ssl, (int)verify);
+    secret = wolfSSL_GetMacSecret(ssl, (int)verify);
 
     if (secret != NULL) {
 
         /* get mac size */
-        macLength = wolfSSL_GetHmacSize((WOLFSSL*)(uintptr_t)ssl);
+        macLength = wolfSSL_GetHmacSize(ssl);
 
         /* create byte array to return */
         retSecret = (*jenv)->NewByteArray(jenv, macLength);
@@ -2387,7 +2366,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getMacSecret
 }
 
 JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getClientWriteKey
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
     jclass excClass;
 #ifdef ATOMIC_USER
@@ -2395,7 +2374,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getClientWriteKey
     jbyteArray retKey;
     const unsigned char* key;
 #endif
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
     /* find exception class */
@@ -2407,20 +2386,18 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getClientWriteKey
     }
 
 #ifdef ATOMIC_USER
-
-    if (!ssl) {
+    if (ssl == NULL) {
         (*jenv)->ThrowNew(jenv, excClass,
             "Input WolfSSLSession object was null in "
             "getClientWriteKey");
         return NULL;
     }
 
-    key = wolfSSL_GetClientWriteKey((WOLFSSL*)(uintptr_t)ssl);
-
+    key = wolfSSL_GetClientWriteKey(ssl);
     if (key != NULL) {
 
         /* get key size */
-        keyLength = wolfSSL_GetKeySize((WOLFSSL*)(uintptr_t)ssl);
+        keyLength = wolfSSL_GetKeySize(ssl);
 
         /* create byte array to return */
         retKey = (*jenv)->NewByteArray(jenv, keyLength);
@@ -2451,7 +2428,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getClientWriteKey
 }
 
 JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getClientWriteIV
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
     jclass excClass;
 #ifdef ATOMIC_USER
@@ -2459,7 +2436,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getClientWriteIV
     const unsigned char* iv;
     int ivLength;
 #endif
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
     /* find exception class */
@@ -2471,20 +2448,18 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getClientWriteIV
     }
 
 #ifdef ATOMIC_USER
-
-    if (!ssl) {
+    if (ssl == NULL) {
         (*jenv)->ThrowNew(jenv, excClass,
             "Input WolfSSLSession object was null in "
             "getClientWriteIV");
         return NULL;
     }
 
-    iv = wolfSSL_GetClientWriteIV((WOLFSSL*)(uintptr_t)ssl);
-
+    iv = wolfSSL_GetClientWriteIV(ssl);
     if (iv != NULL) {
 
         /* get iv size, is block size for what wolfSSL supports */
-        ivLength = wolfSSL_GetCipherBlockSize((WOLFSSL*)(uintptr_t)ssl);
+        ivLength = wolfSSL_GetCipherBlockSize(ssl);
 
         /* create byte array to return */
         retIV = (*jenv)->NewByteArray(jenv, ivLength);
@@ -2515,7 +2490,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getClientWriteIV
 }
 
 JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getServerWriteKey
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
     jclass excClass;
 #ifdef ATOMIC_USER
@@ -2523,7 +2498,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getServerWriteKey
     const unsigned char* key;
     int keyLength;
 #endif
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
     /* find exception class */
@@ -2535,20 +2510,18 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getServerWriteKey
     }
 
 #ifdef ATOMIC_USER
-
-    if (!ssl) {
+    if (ssl == NULL) {
         (*jenv)->ThrowNew(jenv, excClass,
             "Input WolfSSLSession object was null in "
             "getServerWriteKey");
         return NULL;
     }
 
-    key = wolfSSL_GetServerWriteKey((WOLFSSL*)(uintptr_t)ssl);
-
+    key = wolfSSL_GetServerWriteKey(ssl);
     if (key != NULL) {
 
         /* get key size */
-        keyLength = wolfSSL_GetKeySize((WOLFSSL*)(uintptr_t)ssl);
+        keyLength = wolfSSL_GetKeySize(ssl);
 
         /* create byte array to return */
         retKey = (*jenv)->NewByteArray(jenv, keyLength);
@@ -2579,7 +2552,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getServerWriteKey
 }
 
 JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getServerWriteIV
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
     jclass excClass;
 #ifdef ATOMIC_USER
@@ -2587,7 +2560,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getServerWriteIV
     const unsigned char* iv;
     int ivLength;
 #endif
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
     /* find exception class */
@@ -2599,20 +2572,18 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getServerWriteIV
     }
 
 #ifdef ATOMIC_USER
-
-    if (!ssl) {
+    if (ssl == NULL) {
         (*jenv)->ThrowNew(jenv, excClass,
             "Input WolfSSLSession object was null in "
             "getServerWriteIV");
         return NULL;
     }
 
-    iv = wolfSSL_GetServerWriteIV((WOLFSSL*)(uintptr_t)ssl);
-
+    iv = wolfSSL_GetServerWriteIV(ssl);
     if (iv != NULL) {
 
         /* get iv size, is block size for what wolfSSL supports */
-        ivLength = wolfSSL_GetCipherBlockSize((WOLFSSL*)(uintptr_t)ssl);
+        ivLength = wolfSSL_GetCipherBlockSize(ssl);
 
         /* create byte array to return */
         retIV = (*jenv)->NewByteArray(jenv, ivLength);
@@ -2765,15 +2736,15 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getCipherType
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setTlsHmacInner
-  (JNIEnv* jenv, jobject jcl, jlong ssl, jbyteArray inner, jlong sz,
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jbyteArray inner, jlong sz,
    jint content, jint verify)
 {
     int ret = 0;
     unsigned char hmacInner[WOLFSSL_TLS_HMAC_INNER_SZ];
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (!jenv || inner == NULL || !ssl) {
+    if (jenv == NULL || inner == NULL || ssl == NULL) {
         return BAD_FUNC_ARG;
     }
 
@@ -2785,8 +2756,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setTlsHmacInner
         return -1;
     }
 
-    ret = wolfSSL_SetTlsHmacInner((WOLFSSL*)(uintptr_t)ssl, hmacInner, sz,
-            content, verify);
+    ret = wolfSSL_SetTlsHmacInner(ssl, hmacInner, sz, content, verify);
 
     /* copy hmacInner back into inner jbyteArray */
     (*jenv)->SetByteArrayRegion(jenv, inner, 0, WOLFSSL_TLS_HMAC_INNER_SZ,
@@ -2803,7 +2773,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setTlsHmacInner
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSignCtx
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
     jclass         excClass;
 #if defined(HAVE_PK_CALLBACKS) && defined(HAVE_ECC)
@@ -2812,6 +2782,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSignCtx
     void*          eccSignCtx;
     internCtx*     myCtx;
 #endif
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
 
     /* find exception class in case we need it */
     excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
@@ -2822,8 +2793,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSignCtx
     }
 
 #if defined(HAVE_PK_CALLBACKS) && defined(HAVE_ECC)
-
-    if (!ssl) {
+    if (ssl == NULL) {
         (*jenv)->ThrowNew(jenv, excClass,
             "Input WolfSSLSession object was null in "
             "setEccSignCtx");
@@ -2839,7 +2809,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSignCtx
     }
 
     /* free existing memory if it already exists, before we malloc again */
-    eccSignCtx = (internCtx*) wolfSSL_GetEccSignCtx((WOLFSSL*)(uintptr_t)ssl);
+    eccSignCtx = (internCtx*) wolfSSL_GetEccSignCtx(ssl);
 
     /* note: if CTX has not been set up yet, wolfSSL defaults to NULL */
     if (eccSignCtx != NULL) {
@@ -2871,7 +2841,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSignCtx
         return;
     }
 
-    wolfSSL_SetEccSignCtx((WOLFSSL*)(uintptr_t)ssl, myCtx);
+    wolfSSL_SetEccSignCtx(ssl, myCtx);
 #else
     (*jenv)->ThrowNew(jenv, excClass,
         "wolfSSL not compiled with PK Callbacks and/or ECC");
@@ -2880,7 +2850,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSignCtx
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccVerifyCtx
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
     jclass         excClass;
 #if defined(HAVE_PK_CALLBACKS) && defined(HAVE_ECC)
@@ -2889,6 +2859,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccVerifyCtx
     void*          eccVerifyCtx;
     internCtx*     myCtx;
 #endif
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
 
     /* find exception class in case we need it */
     excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
@@ -2899,8 +2870,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccVerifyCtx
     }
 
 #if defined(HAVE_PK_CALLBACKS) && defined(HAVE_ECC)
-
-    if (!ssl) {
+    if (ssl == NULL) {
         (*jenv)->ThrowNew(jenv, excClass,
             "Input WolfSSLSession object was null in "
             "setEccVerifyCtx");
@@ -2916,8 +2886,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccVerifyCtx
     }
 
     /* free existing memory if it already exists, before we malloc again */
-    eccVerifyCtx = (internCtx*)wolfSSL_GetEccVerifyCtx(
-                                (WOLFSSL*)(uintptr_t)ssl);
+    eccVerifyCtx = (internCtx*)wolfSSL_GetEccVerifyCtx(ssl);
 
     /* note: if CTX has not been set up yet, wolfSSL defaults to NULL */
     if (eccVerifyCtx != NULL) {
@@ -2949,7 +2918,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccVerifyCtx
         return;
     }
 
-    wolfSSL_SetEccVerifyCtx((WOLFSSL*)(uintptr_t)ssl, myCtx);
+    wolfSSL_SetEccVerifyCtx(ssl, myCtx);
 #else
     (*jenv)->ThrowNew(jenv, excClass,
         "wolfSSL not compiled with PK Callbacks and/or ECC");
@@ -2958,7 +2927,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccVerifyCtx
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSharedSecretCtx
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
     jclass         excClass;
 #if defined(HAVE_PK_CALLBACKS) && defined(HAVE_ECC)
@@ -2967,6 +2936,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSharedSecretCtx
     void*          eccSharedSecretCtx;
     internCtx*     myCtx;
 #endif
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
 
     /* find exception class in case we need it */
     excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
@@ -2977,8 +2947,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSharedSecretCtx
     }
 
 #if defined(HAVE_PK_CALLBACKS) && defined(HAVE_ECC)
-
-    if (!ssl) {
+    if (ssl == NULL) {
         (*jenv)->ThrowNew(jenv, excClass,
             "Input WolfSSLSession object was null in "
             "setEccSharedSecretCtx");
@@ -2994,8 +2963,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSharedSecretCtx
     }
 
     /* free existing memory if it already exists, before we malloc again */
-    eccSharedSecretCtx =
-        (internCtx*) wolfSSL_GetEccSharedSecretCtx((WOLFSSL*)(uintptr_t)ssl);
+    eccSharedSecretCtx = (internCtx*) wolfSSL_GetEccSharedSecretCtx(ssl);
 
     /* note: if CTX has not been set up yet, wolfSSL defaults to NULL */
     if (eccSharedSecretCtx != NULL) {
@@ -3027,7 +2995,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSharedSecretCtx
         return;
     }
 
-    wolfSSL_SetEccSharedSecretCtx((WOLFSSL*)(uintptr_t)ssl, myCtx);
+    wolfSSL_SetEccSharedSecretCtx(ssl, myCtx);
 #else
     (*jenv)->ThrowNew(jenv, excClass,
         "wolfSSL not compiled with PK Callbacks and/or ECC");
@@ -3036,7 +3004,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSharedSecretCtx
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaSignCtx
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
     jclass         excClass;
 #if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
@@ -3045,6 +3013,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaSignCtx
     void*          rsaSignCtx;
     internCtx*     myCtx;
 #endif
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
 
     /* find exception class in case we need it */
     excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
@@ -3055,8 +3024,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaSignCtx
     }
 
 #if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
-
-    if (!ssl) {
+    if (ssl == NULL) {
         (*jenv)->ThrowNew(jenv, excClass,
             "Input WolfSSLSession object was null in "
             "setRsaSignCtx");
@@ -3072,7 +3040,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaSignCtx
     }
 
     /* free existing memory if it already exists, before we malloc again */
-    rsaSignCtx = (internCtx*) wolfSSL_GetRsaSignCtx((WOLFSSL*)(uintptr_t)ssl);
+    rsaSignCtx = (internCtx*) wolfSSL_GetRsaSignCtx(ssl);
 
     /* note: if CTX has not been set up yet, wolfSSL defaults to NULL */
     if (rsaSignCtx != NULL) {
@@ -3104,7 +3072,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaSignCtx
         return;
     }
 
-    wolfSSL_SetRsaSignCtx((WOLFSSL*)(uintptr_t)ssl, myCtx);
+    wolfSSL_SetRsaSignCtx(ssl, myCtx);
 #else
     (*jenv)->ThrowNew(jenv, excClass,
         "wolfSSL not compiled with PK Callbacks and/or RSA support");
@@ -3113,7 +3081,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaSignCtx
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaVerifyCtx
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
     jclass         excClass;
 #if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
@@ -3122,6 +3090,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaVerifyCtx
     void*          rsaVerifyCtx;
     internCtx*     myCtx;
 #endif
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
 
     /* find exception class in case we need it */
     excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
@@ -3132,8 +3101,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaVerifyCtx
     }
 
 #if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
-
-    if (!ssl) {
+    if (ssl == NULL) {
         (*jenv)->ThrowNew(jenv, excClass,
             "Input WolfSSLSession object was null in "
             "setRsaVerifyCtx");
@@ -3149,8 +3117,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaVerifyCtx
     }
 
     /* free existing memory if it already exists, before we malloc again */
-    rsaVerifyCtx = (internCtx*)wolfSSL_GetRsaVerifyCtx(
-                                (WOLFSSL*)(uintptr_t)ssl);
+    rsaVerifyCtx = (internCtx*)wolfSSL_GetRsaVerifyCtx(ssl);
 
     /* note: if CTX has not been set up yet, wolfSSL defaults to NULL */
     if (rsaVerifyCtx != NULL) {
@@ -3182,7 +3149,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaVerifyCtx
         return;
     }
 
-    wolfSSL_SetRsaVerifyCtx((WOLFSSL*)(uintptr_t)ssl, myCtx);
+    wolfSSL_SetRsaVerifyCtx(ssl, myCtx);
 #else
     (*jenv)->ThrowNew(jenv, excClass,
         "wolfSSL not compiled with PK Callbacks and/or RSA support");
@@ -3191,7 +3158,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaVerifyCtx
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaEncCtx
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
     jclass         excClass;
 #if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
@@ -3200,6 +3167,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaEncCtx
     void*          rsaEncCtx;
     internCtx*     myCtx;
 #endif
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
 
     /* find exception class in case we need it */
     excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
@@ -3211,7 +3179,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaEncCtx
 
 #if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
 
-    if (!ssl) {
+    if (ssl == NULL) {
         (*jenv)->ThrowNew(jenv, excClass,
             "Input WolfSSLSession object was null in "
             "setRsaEncCtx");
@@ -3227,7 +3195,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaEncCtx
     }
 
     /* free existing memory if it already exists, before we malloc again */
-    rsaEncCtx = (internCtx*) wolfSSL_GetRsaEncCtx((WOLFSSL*)(uintptr_t)ssl);
+    rsaEncCtx = (internCtx*) wolfSSL_GetRsaEncCtx(ssl);
 
     /* note: if CTX has not been set up yet, wolfSSL defaults to NULL */
     if (rsaEncCtx != NULL) {
@@ -3259,7 +3227,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaEncCtx
         return;
     }
 
-    wolfSSL_SetRsaEncCtx((WOLFSSL*)(uintptr_t)ssl, myCtx);
+    wolfSSL_SetRsaEncCtx(ssl, myCtx);
 #else
     (*jenv)->ThrowNew(jenv, excClass,
         "wolfSSL not compiled with PK Callbacks and/or RSA support");
@@ -3268,7 +3236,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaEncCtx
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaDecCtx
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
     jclass         excClass;
 #if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
@@ -3277,6 +3245,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaDecCtx
     void*          rsaDecCtx;
     internCtx*     myCtx;
 #endif
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
 
     /* find exception class in case we need it */
     excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
@@ -3287,8 +3256,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaDecCtx
     }
 
 #if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
-
-    if (!ssl) {
+    if (ssl == NULL) {
         (*jenv)->ThrowNew(jenv, excClass,
             "Input WolfSSLSession object was null in "
             "setRsaDecCtx");
@@ -3304,7 +3272,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaDecCtx
     }
 
     /* free existing memory if it already exists, before we malloc again */
-    rsaDecCtx = (internCtx*) wolfSSL_GetRsaDecCtx((WOLFSSL*)(uintptr_t)ssl);
+    rsaDecCtx = (internCtx*) wolfSSL_GetRsaDecCtx(ssl);
 
     /* note: if CTX has not been set up yet, wolfSSL defaults to NULL */
     if (rsaDecCtx != NULL) {
@@ -3336,7 +3304,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaDecCtx
         return;
     }
 
-    wolfSSL_SetRsaDecCtx((WOLFSSL*)(uintptr_t)ssl, myCtx);
+    wolfSSL_SetRsaDecCtx(ssl, myCtx);
 #else
     (*jenv)->ThrowNew(jenv, excClass,
         "wolfSSL not compiled with PK Callbacks and/or RSA support");
@@ -3345,8 +3313,9 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaDecCtx
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setPskClientCb
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
     /* find exception class */
@@ -3359,11 +3328,9 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setPskClientCb
     }
 
 #ifndef NO_PSK
-
-    if (ssl) {
+    if (ssl != NULL) {
         /* set PSK client callback */
-        wolfSSL_set_psk_client_callback((WOLFSSL*)(uintptr_t)ssl,
-                                        NativePskClientCb);
+        wolfSSL_set_psk_client_callback(ssl, NativePskClientCb);
     } else {
         (*jenv)->ThrowNew(jenv, excClass,
                 "Input WolfSSLSession object was null when setting "
@@ -3379,8 +3346,9 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setPskClientCb
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setPskServerCb
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
     /* find exception class */
@@ -3393,11 +3361,9 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setPskServerCb
     }
 
 #ifndef NO_PSK
-
-    if (ssl) {
+    if (ssl != NULL) {
         /* set PSK server callback */
-        wolfSSL_set_psk_server_callback((WOLFSSL*)(uintptr_t)ssl,
-                                        NativePskServerCb);
+        wolfSSL_set_psk_server_callback(ssl, NativePskServerCb);
     } else {
         (*jenv)->ThrowNew(jenv, excClass,
                 "Input WolfSSLSession object was null when setting "
@@ -3413,76 +3379,84 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setPskServerCb
 }
 
 JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_getPskIdentityHint
-  (JNIEnv* jenv, jobject obj, jlong ssl)
+  (JNIEnv* jenv, jobject obj, jlong sslPtr)
 {
-    (void)obj;
 #ifndef NO_PSK
-    if (!jenv || !ssl)
-        return NULL;
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
+    (void)obj;
 
-    return (*jenv)->NewStringUTF(jenv,
-            wolfSSL_get_psk_identity_hint((WOLFSSL*)(uintptr_t)ssl));
+    if (jenv == NULL || ssl == NULL) {
+        return NULL;
+    }
+
+    return (*jenv)->NewStringUTF(jenv, wolfSSL_get_psk_identity_hint(ssl));
 #else
     (void)jenv;
-    (void)ssl;
+    (void)obj;
+    (void)sslPtr;
     return NULL;
 #endif
 }
 
 JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_getPskIdentity
-  (JNIEnv* jenv, jobject obj, jlong ssl)
+  (JNIEnv* jenv, jobject obj, jlong sslPtr)
 {
-    (void)obj;
 #ifndef NO_PSK
-    if (!jenv || !ssl)
-        return NULL;
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
+    (void)obj;
 
-    return (*jenv)->NewStringUTF(jenv,
-            wolfSSL_get_psk_identity((WOLFSSL*)(uintptr_t)ssl));
+    if (jenv == NULL || ssl == NULL) {
+        return NULL;
+    }
+
+    return (*jenv)->NewStringUTF(jenv, wolfSSL_get_psk_identity(ssl));
 #else
     (void)jenv;
-    (void)ssl;
+    (void)obj;
+    (void)sslPtr;
     return NULL;
 #endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_usePskIdentityHint
-  (JNIEnv* jenv, jobject obj, jlong ssl, jstring hint)
+  (JNIEnv* jenv, jobject obj, jlong sslPtr, jstring hint)
 {
 #ifndef NO_PSK
     jint ret;
     const char* nativeHint;
-
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)obj;
 
-    if (!jenv || !ssl || !hint)
+    if (jenv == NULL || ssl == NULL || hint == NULL) {
         return SSL_FAILURE;
+    }
 
     nativeHint = (*jenv)->GetStringUTFChars(jenv, hint, 0);
 
-    ret = (jint)wolfSSL_use_psk_identity_hint((WOLFSSL*)(uintptr_t)ssl,
-                                              nativeHint);
+    ret = (jint)wolfSSL_use_psk_identity_hint(ssl, nativeHint);
 
     (*jenv)->ReleaseStringUTFChars(jenv, hint, nativeHint);
 
     return ret;
 #else
     (void)jenv;
-    (void)ssl;
+    (void)sslPtr;
     (void)hint;
     return NOT_COMPILED_IN;
 #endif
 }
 
 JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSLSession_handshakeDone
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (!jenv || !ssl)
+    if (jenv == NULL || ssl == NULL) {
         return JNI_FALSE;
+    }
 
-    if (wolfSSL_is_init_finished((WOLFSSL*)(uintptr_t)ssl)) {
+    if (wolfSSL_is_init_finished(ssl)) {
         return JNI_TRUE;
     }
     else {
@@ -3491,43 +3465,49 @@ JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSLSession_handshakeDone
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setConnectState
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (!jenv || !ssl)
+    if (jenv == NULL || ssl == NULL) {
         return;
+    }
 
-    wolfSSL_set_connect_state((WOLFSSL*)(uintptr_t)ssl);
+    wolfSSL_set_connect_state(ssl);
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setAcceptState
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (!jenv || !ssl)
+    if (jenv == NULL || ssl == NULL) {
         return;
+    }
 
-    wolfSSL_set_accept_state((WOLFSSL*)(uintptr_t)ssl);
+    wolfSSL_set_accept_state(ssl);
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setVerify
-  (JNIEnv* jenv, jobject jcl, jlong ssl, jint mode, jobject callbackIface)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jint mode, jobject callbackIface)
 {
-    (void)jcl;
     jobject* verifyCb;
     SSLAppData* appData;
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
+    (void)jcl;
 
-    if (!jenv || !ssl)
+    if (jenv == NULL || ssl == NULL) {
         return;
+    }
 
     if (!callbackIface) {
-        wolfSSL_set_verify((WOLFSSL*)(uintptr_t)ssl, mode, NULL);
+        wolfSSL_set_verify(ssl, mode, NULL);
     }
     else {
         /* get app data to store verify callback jobject */
-        appData = (SSLAppData*)wolfSSL_get_app_data((WOLFSSL*)(uintptr_t)ssl);
+        appData = (SSLAppData*)wolfSSL_get_app_data(ssl);
         if (appData == NULL) {
             printf("Error getting app data from WOLFSSL\n");
         }
@@ -3550,54 +3530,59 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setVerify
                 appData->g_verifySSLCbIfaceObj = verifyCb;
 
                 /* set verify mode, register Java callback with wolfSSL */
-                wolfSSL_set_verify((WOLFSSL*)(uintptr_t)ssl, mode,
-                                   NativeSSLVerifyCallback);
+                wolfSSL_set_verify(ssl, mode, NativeSSLVerifyCallback);
             }
         }
     }
 }
 
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_setOptions
-  (JNIEnv* jenv, jobject jcl, jlong ssl, jlong op)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jlong op)
 {
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (!jenv || !ssl)
+    if (jenv == NULL || ssl == NULL) {
         return 0;
+    }
 
-    return wolfSSL_set_options((WOLFSSL*)(uintptr_t)ssl, op);
+    return wolfSSL_set_options(ssl, op);
 }
 
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_getOptions
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (!jenv || !ssl)
+    if (jenv == NULL || ssl == NULL) {
         return 0;
+    }
 
-    return wolfSSL_get_options((WOLFSSL*)(uintptr_t)ssl);
+    return wolfSSL_get_options(ssl);
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getShutdown
-  (JNIEnv *jenv, jobject jcl, jlong ssl)
+  (JNIEnv *jenv, jobject jcl, jlong sslPtr)
 {
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jenv;
     (void)jcl;
 
-    return (jint)wolfSSL_get_shutdown((WOLFSSL*)(uintptr_t)ssl);
+    return (jint)wolfSSL_get_shutdown(ssl);
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useSNI
-  (JNIEnv* jenv, jobject jcl, jlong ssl, jbyte type, jbyteArray data)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jbyte type, jbyteArray data)
 {
     int ret = SSL_FAILURE;
     (void)jcl;
 #ifdef HAVE_SNI
     byte* dataBuf = NULL;
     word32 dataSz = 0;
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
 
-    if (jenv == NULL || ssl <= 0) {
+    if (jenv == NULL || ssl == NULL) {
         return BAD_FUNC_ARG;
     }
 
@@ -3605,8 +3590,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useSNI
     dataSz = (*jenv)->GetArrayLength(jenv, data);
 
     if (dataBuf != NULL && dataSz > 0) {
-        ret = wolfSSL_UseSNI((WOLFSSL*)(uintptr_t)ssl, (byte)type,
-                             dataBuf, (word16)dataSz);
+        ret = wolfSSL_UseSNI(ssl, (byte)type, dataBuf, (word16)dataSz);
     }
 
     (*jenv)->ReleaseByteArrayElements(jenv, data, (jbyte*)dataBuf, JNI_ABORT);
@@ -3614,7 +3598,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useSNI
 #else
     ret = NOT_COMPILED_IN;
     (void)jenv;
-    (void)ssl;
+    (void)sslPtr;
     (void)type;
     (void)data;
 #endif /* HAVE_SNI */
@@ -3624,19 +3608,20 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useSNI
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useSessionTicket
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
     int ret = SSL_FAILURE;
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 #ifdef HAVE_SESSION_TICKET
-    if (jenv == NULL || ssl <= 0) {
+    if (jenv == NULL || ssl == NULL) {
         return BAD_FUNC_ARG;
     }
 
-    ret = wolfSSL_UseSessionTicket((WOLFSSL*)(uintptr_t)ssl);
+    ret = wolfSSL_UseSessionTicket(ssl);
 #else
     (void)jenv;
-    (void)ssl;
+    (void)sslPtr;
     ret = NOT_COMPILED_IN;
 #endif
     return ret;
@@ -3644,17 +3629,18 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useSessionTicket
 
 /* return 1 if last alert received was a close_notify alert, otherwise 0 */
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_gotCloseNotify
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
     int ret, gotCloseNotify = 0;
     WOLFSSL_ALERT_HISTORY alert_history;
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
     if (jenv == NULL || ssl <= 0) {
         return gotCloseNotify;
     }
 
-    ret = wolfSSL_get_alert_history((WOLFSSL*)(uintptr_t)ssl, &alert_history);
+    ret = wolfSSL_get_alert_history(ssl, &alert_history);
     if (ret == WOLFSSL_SUCCESS) {
         if (alert_history.last_rx.code == 0) {
             gotCloseNotify = 1;
@@ -3665,15 +3651,16 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_gotCloseNotify
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_sslSetAlpnProtos
-  (JNIEnv* jenv, jobject jcl, jlong ssl, jbyteArray alpnProtos)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jbyteArray alpnProtos)
 {
     int ret = SSL_FAILURE;
-    (void)jcl;
 #ifdef HAVE_ALPN
     byte* buff = NULL;
     word32 buffSz = 0;
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
+    (void)jcl;
 
-    if (jenv == NULL || ssl <= 0 || alpnProtos == NULL) {
+    if (jenv == NULL || ssl == NULL || alpnProtos == NULL) {
         return BAD_FUNC_ARG;
     }
 
@@ -3681,14 +3668,15 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_sslSetAlpnProtos
     buffSz = (*jenv)->GetArrayLength(jenv, alpnProtos);
 
     if (buff != NULL && buffSz > 0) {
-        ret = wolfSSL_set_alpn_protos((WOLFSSL*)(uintptr_t)ssl, buff, buffSz);
+        ret = wolfSSL_set_alpn_protos(ssl, buff, buffSz);
     }
 
     (*jenv)->ReleaseByteArrayElements(jenv, alpnProtos,
                                       (jbyte*)buff, JNI_ABORT);
 #else
     (void)jenv;
-    (void)ssl;
+    (void)jcl;
+    (void)sslPtr;
     (void)alpnProtos;
     ret = NOT_COMPILED_IN;
 #endif
@@ -3696,16 +3684,17 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_sslSetAlpnProtos
 }
 
 JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_sslGet0AlpnSelected
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
-    (void)jcl;
 #ifdef HAVE_ALPN
     int err = 0;
     char* protocol_name = NULL;
     word16 protocol_nameSz = 0;
     jbyteArray alpnArray;
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
+    (void)jcl;
 
-    if (jenv == NULL || ssl <= 0) {
+    if (jenv == NULL || ssl == NULL) {
         return NULL;
     }
 
@@ -3713,8 +3702,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_sslGet0AlpnSelected
      * WOLFSSL_SUCCESS - on success
      * WOLFSSL_ALPN_NOT_FOUND - no ALPN received (no match with server)
      * other - error case */
-    err = wolfSSL_ALPN_GetProtocol((WOLFSSL*)(uintptr_t)ssl,
-                                   &protocol_name, &protocol_nameSz);
+    err = wolfSSL_ALPN_GetProtocol(ssl, &protocol_name, &protocol_nameSz);
     if (err != WOLFSSL_SUCCESS) {
         return NULL;
     }
@@ -3737,14 +3725,16 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_sslGet0AlpnSelected
     return alpnArray;
 #else
     (void)jenv;
-    (void)ssl;
+    (void)jcl;
+    (void)sslPtr;
     return NULL;
 #endif
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setSSLIORecv
-    (JNIEnv* jenv, jobject jcl, jlong ssl)
+    (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
     /* find exception class */
@@ -3756,9 +3746,9 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setSSLIORecv
         return;
     }
 
-    if (ssl) {
+    if (ssl != NULL) {
         /* set I/O recv callback */
-        wolfSSL_SSLSetIORecv((WOLFSSL*)(uintptr_t)ssl, NativeSSLIORecvCb);
+        wolfSSL_SSLSetIORecv(ssl, NativeSSLIORecvCb);
 
     } else {
         (*jenv)->ThrowNew(jenv, excClass,
@@ -3896,8 +3886,9 @@ int NativeSSLIORecvCb(WOLFSSL *ssl, char *buf, int sz, void *ctx)
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setSSLIOSend
-  (JNIEnv* jenv, jobject jcl, jlong ssl)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
     /* find exception class in case we need it */
@@ -3908,9 +3899,9 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setSSLIOSend
         (*jenv)->ExceptionClear(jenv);
     }
 
-    if (ssl) {
+    if (ssl != NULL) {
         /* set I/O send callback */
-        wolfSSL_SSLSetIOSend((WOLFSSL*)(uintptr_t)ssl, NativeSSLIOSendCb);
+        wolfSSL_SSLSetIOSend(ssl, NativeSSLIOSendCb);
 
     } else {
         (*jenv)->ThrowNew(jenv, excClass,
@@ -4046,5 +4037,4 @@ int NativeSSLIOSendCb(WOLFSSL *ssl, char *buf, int sz, void *ctx)
 
     return retval;
 }
-
 

--- a/native/com_wolfssl_WolfSSLX509StoreCtx.c
+++ b/native/com_wolfssl_WolfSSLX509StoreCtx.c
@@ -38,7 +38,7 @@ JNIEXPORT jobjectArray JNICALL Java_com_wolfssl_WolfSSLX509StoreCtx_X509_1STORE_
     int derSz = 0, skNum = 0, i = 0;
     (void)jcl;
 
-    if (!jenv || !ctx) {
+    if (jenv == NULL || store == NULL) {
         return NULL;
     }
 


### PR DESCRIPTION
This PR fixes a few typecasting issues, cleans up native argument checking, and handles initial type casting of wolfSSL structure pointers up front in native functions before use or doing argument checking.

Most of this PR is cleanup as described above.  Doing the structure pointer casting once on function enter will make it less likely casting issues will come up in the future.  In some cases this also reduces the number of casts done in a single function.

This PR does fix runtime issues that can be seen on some platforms when the representation of a pointer stored in a jlong happens to be negative, but we check the value of it against "<= 0" before type casting it back to a structure pointer type.

For example, below is one bug that existed prior to this PR. `sslPtr` was being passed in from Java (wrapping a native pointer).  Since jlong is a signed type, and we checked `sslPtr <= 0` before casting back to a pointer, this could erroneously return SSL_FATAL_ERROR:

```
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_connect
   (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
     ...
     WOLFSSL* ssl = NULL;
     ...

     if (jenv == NULL || sslPtr <= 0) {
         return SSL_FATAL_ERROR;
     }
     ssl = (WOLFSSL*)(uintptr_t)sslPtr;
```

This PR reworks this to move the type cast before the argument check:

```
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_connect
   (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
     ...
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     ...

     if (jenv == NULL || sslPtr == NULL) {
         return SSL_FATAL_ERROR;
     }
```

