### PR TITLE
Casting cleanup, Java side

### DIFF
--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -3637,7 +3637,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_gotCloseNotify
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    if (jenv == NULL || ssl <= 0) {
+    if (jenv == NULL || ssl == NULL) {
         return gotCloseNotify;
     }
 

--- a/src/java/com/wolfssl/WolfSSLCertificate.java
+++ b/src/java/com/wolfssl/WolfSSLCertificate.java
@@ -93,7 +93,7 @@ public class WolfSSLCertificate {
         }
 
         x509Ptr = X509_load_certificate_buffer(der, WolfSSL.SSL_FILETYPE_ASN1);
-        if (x509Ptr <= 0) {
+        if (x509Ptr == 0) {
             throw new WolfSSLException("Failed to create WolfSSLCertificate");
         }
 
@@ -126,7 +126,7 @@ public class WolfSSLCertificate {
         }
 
         x509Ptr = X509_load_certificate_buffer(in, format);
-        if (x509Ptr <= 0) {
+        if (x509Ptr == 0) {
             throw new WolfSSLException("Failed to create WolfSSLCertificate");
         }
 
@@ -149,7 +149,7 @@ public class WolfSSLCertificate {
 
         x509Ptr = X509_load_certificate_file(fileName,
                                              WolfSSL.SSL_FILETYPE_ASN1);
-        if (x509Ptr <= 0) {
+        if (x509Ptr == 0) {
             throw new WolfSSLException("Failed to create WolfSSLCertificate");
         }
 
@@ -183,7 +183,7 @@ public class WolfSSLCertificate {
         }
 
         x509Ptr = X509_load_certificate_file(fileName, format);
-        if (x509Ptr <= 0) {
+        if (x509Ptr == 0) {
             throw new WolfSSLException("Failed to create WolfSSLCertificate");
         }
 
@@ -199,8 +199,8 @@ public class WolfSSLCertificate {
      */
     public WolfSSLCertificate(long x509) throws WolfSSLException {
 
-        if (x509 <= 0) {
-            throw new WolfSSLException("Input pointer may not be <= 0");
+        if (x509 == 0) {
+            throw new WolfSSLException("Input pointer may not be 0/NULL");
         }
         x509Ptr = x509;
         this.active = true;


### PR DESCRIPTION
This PR addresses a few missed casting cleanup issues, related to https://github.com/wolfSSL/wolfssljni/pull/98.

On some platforms, pointers stored into Java long types can make that value negative.  As such, we should be comparing against 0 (NULL) for native failure instead of <= 0.