### PR TITLE
Throw SocketTimeoutException from WolfSSLSession.connect()

### DIFF
--- a/native/com_wolfssl_WolfSSL.h
+++ b/native/com_wolfssl_WolfSSL.h
@@ -9,6 +9,8 @@ extern "C" {
 #endif
 #undef com_wolfssl_WolfSSL_JNI_SESSION_UNAVAILABLE
 #define com_wolfssl_WolfSSL_JNI_SESSION_UNAVAILABLE -10001L
+#undef com_wolfssl_WolfSSL_WOLFJNI_TIMEOUT
+#define com_wolfssl_WolfSSL_WOLFJNI_TIMEOUT -11L
 #undef com_wolfssl_WolfSSL_SSL_ERROR_NONE
 #define com_wolfssl_WolfSSL_SSL_ERROR_NONE 0L
 #undef com_wolfssl_WolfSSL_SSL_FAILURE

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -554,7 +554,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getFd
 /* enum values used in socketSelect() */
 enum {
     WOLFJNI_SELECT_FAIL = -10,
-    WOLFJNI_TIMEOUT     = -11,
+    WOLFJNI_TIMEOUT     = -11,  /* also in WolfSSL.java */
     WOLFJNI_RECV_READY  = -12,
     WOLFJNI_SEND_READY  = -13,
     WOLFJNI_ERROR_READY = -14
@@ -623,7 +623,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_connect
     (void)jcl;
 
     if (jenv == NULL || ssl == NULL) {
-        return SSL_FATAL_ERROR;
+        return SSL_FAILURE;
     }
 
     /* make sure we don't have any outstanding exceptions pending */
@@ -674,8 +674,12 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_connect
             if (ret == WOLFJNI_RECV_READY || ret == WOLFJNI_SEND_READY) {
                 /* I/O ready, continue handshake and try again */
                 continue;
+            } else if (ret == WOLFJNI_TIMEOUT) {
+                /* Java will throw SocketTimeoutException */
+                break;
             } else {
-                /* error or timeout */
+                /* error */
+                ret = SSL_FAILURE;
                 break;
             }
         }

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -56,6 +56,11 @@ public class WolfSSL {
     /** Session unavailable */
     public final static int JNI_SESSION_UNAVAILABLE = -10001;
 
+    /**
+     * Socket timed out, matches com_wolfssl_WolfSSLSession.c socketSelect()
+     * return value */
+    public final static int WOLFJNI_TIMEOUT = -11;
+
     /* ----------------------- wolfSSL codes ---------------------------- */
 
     /** Error code: no error */

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -508,16 +508,26 @@ public class WolfSSLSession {
      * before calling <code>newSSL()</code>, though it's not recommended.
      *
      * @return <code>SSL_SUCCESS</code> if successful, otherwise
-     *         <code>SSL_FATAL_ERROR</code> if an error occurred. To get
+     *         <code>SSL_FAILURE</code> if an error occurred. To get
      *         a more detailed error code, call <code>getError()</code>.
      * @throws IllegalStateException WolfSSLContext has been freed
+     * @throws SocketTimeoutException if underlying socket timed out
      */
-    public int connect() throws IllegalStateException {
+    public int connect() throws IllegalStateException, SocketTimeoutException {
+
+        int ret = 0;
 
         if (this.active == false)
             throw new IllegalStateException("Object has been freed");
 
-        return connect(getSessionPtr(), 0);
+        ret = connect(getSessionPtr(), 0);
+
+        if (ret == WolfSSL.WOLFJNI_TIMEOUT) {
+            throw new SocketTimeoutException(
+                    "Native socket timed out during SSL_connect()");
+        }
+
+        return ret;
     }
 
     /**

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -65,6 +65,9 @@ public class WolfSSLSession {
     private WolfSSLIORecvCallback internRecvSSLCb;
     private WolfSSLIOSendCallback internSendSSLCb;
 
+    /* have session tickets been enabled for this session? */
+    private boolean sessionTicketsEnabled = true;
+
     /* is this context active, or has it been freed? */
     private boolean active = false;
 
@@ -2720,10 +2723,33 @@ public class WolfSSLSession {
      */
     public int useSessionTicket() throws IllegalStateException {
 
+        int ret;
+
         if (this.active == false)
             throw new IllegalStateException("Object has been freed");
 
-        return useSessionTicket(getSessionPtr());
+        ret = useSessionTicket(getSessionPtr());
+        if (ret == WolfSSL.SSL_SUCCESS) {
+            this.sessionTicketsEnabled = true;
+        }
+
+        return ret;
+    }
+
+    /**
+     * Determine if session tickets have been enabled for this session.
+     * Session tickets can be enabled for this session by calling
+     * WolfSSLSession.useSessionTicket().
+     *
+     * @return true if enabled, otherwise false.
+     * @throws IllegalStateException WolfSSLSession has been freed
+     */
+    public boolean sessionTicketsEnabled() throws IllegalStateException {
+
+        if (this.active == false)
+            throw new IllegalStateException("Object has been freed");
+
+        return this.sessionTicketsEnabled;
     }
 
     /**

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
@@ -203,7 +203,11 @@ public class WolfSSLEngine extends SSLEngine {
             this.outBoundOpen = false;
             hs = SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING;
         }
-        else if (ret == WolfSSL.SSL_SHUTDOWN_NOT_DONE) {
+        /* wolfSSL_shutdown() will return either SSL_SHUTDOWN_NOT_DONE (2), or
+         * will map that to 0 if WOLFSSL_ERROR_CODE_OPENSSL is defined. Either
+         * should indicate that the full bidirectional shutdown has not
+         * completed. */
+        else if (ret == WolfSSL.SSL_SHUTDOWN_NOT_DONE || ret == 0) {
             hs = SSLEngineResult.HandshakeStatus.NEED_UNWRAP;
         }
         else {

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
@@ -697,6 +697,7 @@ public class WolfSSLEngineHelper {
             if (this.clientMode) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                         "calling native wolfSSL_connect()");
+                /* may throw SocketTimeoutException on socket timeout */
                 ret = this.ssl.connect(timeout);
 
             } else {

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
@@ -137,7 +137,9 @@ public class WolfSSLImplementSSLSession implements SSLSession {
             return new byte[0];
         }
         try {
-            if (this.ssl.getVersion().equals("TLSv1.3")) {
+            /* use pseudo session ID if session tickets are being used */
+            if (this.ssl.getVersion().equals("TLSv1.3") ||
+                this.ssl.sessionTicketsEnabled()) {
                  return this.pseudoSessionID;
             }
             else {

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -1130,20 +1130,22 @@ public class WolfSSLSocket extends SSLSocket {
             "entered startHandshake()");
 
         synchronized (handshakeLock) {
-            if (handshakeInitCalled == true || handshakeComplete == true) {
-                /* handshake already started or finished */
+            if (handshakeComplete == true) {
+                /* handshake already finished */
                 return;
+            }
+
+            if (handshakeInitCalled == false) {
+                /* will throw SSLHandshakeException if session creation is
+                   not allowed */
+                EngineHelper.initHandshake();
+                handshakeInitCalled = true;
             }
         }
 
         synchronized (ioLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                              "thread got ioLock (handshake)");
-
-            /* will throw SSLHandshakeException if session creation is
-               not allowed */
-            EngineHelper.initHandshake();
-            handshakeInitCalled = true;
 
             try {
                 ret = EngineHelper.doHandshake(0, this.getSoTimeout());

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLServerSocketTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLServerSocketTest.java
@@ -525,8 +525,10 @@ public class WolfSSLServerSocketTest {
             fail();
 
         } catch (SSLHandshakeException e) {
-            /* expected */
-            if (!e.toString().contains("ASN no signer")) {
+            /* Expected. Different versions of wolfSSL can display
+             * varying error strings. Check for either here. */
+            if (!e.toString().contains("ASN no signer") &&
+                !e.toString().contains("certificate verify failed")) {
                 System.out.println("\t\t... failed");
                 fail();
             }

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLTestFactory.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLTestFactory.java
@@ -466,8 +466,8 @@ class WolfSSLTestFactory {
                         printHex(serToCli);
                     }
 
-                    System.out.println("cliToSer remaning = " + cliToSer.remaining());
-                    System.out.println("serToCli remaning = " + serToCli.remaining());
+                    System.out.println("cliToSer remaining = " + cliToSer.remaining());
+                    System.out.println("serToCli remaining = " + serToCli.remaining());
                 }
                 result = client.unwrap(serToCli, cliPlain);
                 if (extraDebug) {

--- a/src/test/com/wolfssl/test/WolfSSLSessionTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLSessionTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.*;
 import java.net.Socket;
 import java.net.UnknownHostException;
 import java.net.ConnectException;
+import java.net.SocketTimeoutException;
 
 import com.wolfssl.WolfSSL;
 import com.wolfssl.WolfSSLContext;
@@ -458,6 +459,10 @@ public class WolfSSLSessionTest {
             ret = ssl.connect();
         } catch (IllegalStateException ise) {
             System.out.println("\t\t... passed");
+            return;
+        } catch (SocketTimeoutException e) {
+            System.out.println("\t\t... failed");
+            e.printStackTrace();
             return;
         }
 


### PR DESCRIPTION
This PR adjusts WolfSSLSession.connect() to correctly throw a SocketTimeoutException when the underlying native call to `socketSelect()` detects a socket timeout and returns `WOLFJNI_TIMEOUT`. This will result in correct behavior at the JSSE level from WolfSSLSocket.startHandshake(), which was previously not detecting the timeout correctly.

This PR also fixes `ant test` issues when tested against wolfSSL master, including:
- Generate pseudo session ID values if session tickets are being used. Not only for TLS 1.3, as before.
- Fix SSLEngine behavior for SSL_shutdown() now that newer wolfSSL's define `WOLFSSL_ERROR_CODE_OPENSSL` automatically when `OPENSSL_ALL` is defined.
- Correct error string detection for test in WolfSSLServerSocketTest. Newer wolfSSL has modified the error string returned.