### PR TITLE
Fix varargs warning in WolfSSLJDK8Helper.java

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/adapter/WolfSSLJDK8Helper.java
+++ b/src/java/com/wolfssl/provider/jsse/adapter/WolfSSLJDK8Helper.java
@@ -132,7 +132,7 @@ public class WolfSSLJDK8Helper
             AccessController.doPrivileged(new PrivilegedAction<Object>() {
                 public Object run() {
                     try {
-                        m.invoke(out, appProtos);
+                        m.invoke(out, (Object[])appProtos);
                     } catch (Exception e) {
                         throw new RuntimeException(e);
                     }


### PR DESCRIPTION
This PR fixes one warning that may show up in WolfSSLJDK8Helper.java:

```
compile-nativeheaderdir:
    [javac] Compiling 54 source files to /var/lib/jenkins/workspace/nightly-wolfssljni-jsse-extra/wolfjsse_tests/wolfssljni/build
    [javac] /var/lib/jenkins/workspace/nightly-wolfssljni-jsse-extra/wolfjsse_tests/wolfssljni/src/java/com/wolfssl/provider/jsse/adapter/WolfSSLJDK8Helper.java:135: warning: non-varargs call of varargs method with inexact argument type for last parameter;
    [javac]                         m.invoke(out, appProtos);
    [javac]                                       ^
    [javac]   cast to Object for a varargs call
    [javac]   cast to Object[] for a non-varargs call and to suppress this warning
    [javac] 1 warning
```