### PR TITLE
Native JNI fixes for NO_FILESYSTEM

### DIFF
--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -362,6 +362,19 @@ JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_RsaEnabled
 #endif
 }
 
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_FileSystemEnabled
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+#ifdef NO_FILESYSTEM
+    return JNI_FALSE;
+#else
+    return JNI_TRUE;
+#endif
+}
+
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_SSLv3_1ServerMethod
   (JNIEnv* jenv, jclass jcl)
 {

--- a/native/com_wolfssl_WolfSSL.h
+++ b/native/com_wolfssl_WolfSSL.h
@@ -377,6 +377,14 @@ JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_RsaEnabled
 
 /*
  * Class:     com_wolfssl_WolfSSL
+ * Method:    FileSystemEnabled
+ * Signature: ()Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_FileSystemEnabled
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
  * Method:    SSLv3_ServerMethod
  * Signature: ()J
  */

--- a/native/com_wolfssl_WolfSSLCertManager.c
+++ b/native/com_wolfssl_WolfSSLCertManager.c
@@ -50,6 +50,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLCertManager_CertManagerFree
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertManager_CertManagerLoadCA
   (JNIEnv* jenv, jclass jcl, jlong cmPtr, jstring f, jstring d)
 {
+#ifndef NO_FILESYSTEM
     int ret;
     const char* certFile = NULL;
     const char* certPath = NULL;
@@ -69,6 +70,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertManager_CertManagerLoadCA
     (*jenv)->ReleaseStringUTFChars(jenv, d, certPath);
 
     return (jint)ret;
+#else
+    (void)jenv;
+    (void)jcl;
+    (void)cmPtr;
+    (void)f;
+    (void)d;
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertManager_CertManagerLoadCABuffer

--- a/native/com_wolfssl_WolfSSLCertificate.c
+++ b/native/com_wolfssl_WolfSSLCertificate.c
@@ -63,6 +63,7 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1load_1certific
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1load_1certificate_1file
   (JNIEnv* jenv, jclass jcl, jstring filename, jint format)
 {
+#ifndef NO_FILESYSTEM
     WOLFSSL_X509* x509 = NULL;
     const char* path = NULL;
     (void)jcl;
@@ -80,6 +81,13 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1load_1certific
     (*jenv)->ReleaseStringUTFChars(jenv, filename, path);
 
     return (jlong)(uintptr_t)x509;
+#else
+    (void)jenv;
+    (void)jcl;
+    (void)filename;
+    (void)format;
+    return 0;
+#endif
 }
 
 JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1der

--- a/native/com_wolfssl_WolfSSLContext.c
+++ b/native/com_wolfssl_WolfSSLContext.c
@@ -162,6 +162,7 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLContext_newContext(JNIEnv* jenv,
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useCertificateFile
   (JNIEnv* jenv, jobject jcl, jlong ctxPtr, jstring file, jint format)
 {
+#ifndef NO_FILESYSTEM
     jint ret = 0;
     jclass excClass;
     const char* certFile;
@@ -192,11 +193,20 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useCertificateFile
     (*jenv)->ReleaseStringUTFChars(jenv, file, certFile);
 
     return ret;
+#else
+    (void)jenv;
+    (void)jcl;
+    (void)ctxPtr;
+    (void)file;
+    (void)format;
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_usePrivateKeyFile
   (JNIEnv* jenv, jobject jcl, jlong ctxPtr, jstring file, jint format)
 {
+#ifndef NO_FILESYSTEM
     jint ret = 0;
     jclass excClass;
     const char* keyFile;
@@ -227,11 +237,20 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_usePrivateKeyFile
     (*jenv)->ReleaseStringUTFChars(jenv, file, keyFile);
 
     return ret;
+#else
+    (void)jenv;
+    (void)jcl;
+    (void)ctxPtr;
+    (void)file;
+    (void)format;
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_loadVerifyLocations
   (JNIEnv* jenv, jobject jcl, jlong ctxPtr, jstring file, jstring path)
 {
+#ifndef NO_FILESYSTEM
     jint ret = 0;
     jclass excClass;
     const char* caFile;
@@ -276,11 +295,20 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_loadVerifyLocations
         (*jenv)->ReleaseStringUTFChars(jenv, path, caPath);
 
     return ret;
+#else
+    (void)jenv;
+    (void)jcl;
+    (void)ctxPtr;
+    (void)file;
+    (void)path;
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useCertificateChainFile
   (JNIEnv* jenv, jobject jcl, jlong ctxPtr, jstring file)
 {
+#ifndef NO_FILESYSTEM
     jint ret = 0;
     jclass excClass;
     const char* chainFile;
@@ -312,6 +340,13 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useCertificateChainFile
     (*jenv)->ReleaseStringUTFChars(jenv, file, chainFile);
 
     return ret;
+#else
+    (void)jenv;
+    (void)jcl;
+    (void)ctxPtr;
+    (void)file;
+    return NOT_COMPILED_IN;
+#endif
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_freeContext
@@ -1503,7 +1538,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_loadCRL
   (JNIEnv* jenv, jobject jcl, jlong ctxPtr, jstring path, jint type,
    jint monitor)
 {
-#ifdef HAVE_CRL
+#if defined(HAVE_CRL) && !defined(NO_FILESYSTEM)
     int ret;
     const char* crlPath;
     WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -377,7 +377,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setFd(JNIEnv* jenv,
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useCertificateFile
   (JNIEnv* jenv, jobject jcl, jlong sslPtr, jstring file, jint format)
 {
-#ifdef OPENSSL_EXTRA
+#if defined(OPENSSL_EXTRA) && !defined(NO_FILESYSTEM)
     jint ret = 0;
     const char* certFile;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
@@ -411,7 +411,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useCertificateFile
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_usePrivateKeyFile
   (JNIEnv* jenv, jobject jcl, jlong sslPtr, jstring file, jint format)
 {
-#ifdef OPENSSL_EXTRA
+#if defined(OPENSSL_EXTRA) && !defined(NO_FILESYSTEM)
     jint ret = 0;
     const char* keyFile;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
@@ -445,7 +445,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_usePrivateKeyFile
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useCertificateChainFile
   (JNIEnv* jenv, jobject jcl, jlong sslPtr, jstring file)
 {
-#ifdef OPENSSL_EXTRA
+#if defined(OPENSSL_EXTRA) && !defined(NO_FILESYSTEM)
     jint ret = 0;
     const char* chainFile;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
@@ -1855,7 +1855,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setTmpDH
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setTmpDHFile
   (JNIEnv* jenv, jobject jcl, jlong sslPtr, jstring file, jint format)
 {
-#ifndef NO_DH
+#if !defined(NO_DH) && !defined(NO_FILESYSTEM)
     int ret;
     const char* fname;
     jclass excClass;
@@ -2098,7 +2098,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_loadCRL
   (JNIEnv* jenv, jobject jcl, jlong sslPtr, jstring path, jint type,
    jint monitor)
 {
-#ifdef HAVE_CRL
+#if defined(HAVE_CRL) && !defined(NO_FILESYSTEM)
     int ret;
     const char* crlPath;
     jclass excClass;

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -507,6 +507,13 @@ public class WolfSSL {
      */
     public static native boolean RsaEnabled();
 
+    /**
+     * Tests if filesystem support has been compiled into the wolfSSL library.
+     *
+     * @return 1 if enabled, otherwise 0 if NO_FILESYSTEM has been defined.
+     */
+    public static native boolean FileSystemEnabled();
+
     /* ---------------- native SSL/TLS version functions ---------------- */
 
     /**

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLX509Test.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLX509Test.java
@@ -54,6 +54,7 @@ import javax.net.ssl.SSLPeerUnverifiedException;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.wolfssl.WolfSSL;
 import com.wolfssl.WolfSSLException;
 import com.wolfssl.provider.jsse.WolfSSLProvider;
 import com.wolfssl.provider.jsse.WolfSSLX509;
@@ -145,6 +146,12 @@ public class WolfSSLX509Test {
 
         System.out.print("\tTesting x509 ext");
 
+        /* skip if wolfSSL compiled with NO_FILESYSTEM */
+        if (WolfSSL.FileSystemEnabled() == false) {
+            pass("\t\t... skipped");
+            return;
+        }
+
         try {
             x509 = new WolfSSLX509(tf.googleCACert);
 
@@ -220,6 +227,13 @@ public class WolfSSLX509Test {
         WolfSSLX509X x509;
 
         System.out.print("\tTesting X509X validity");
+
+        /* skip if wolfSSL compiled with NO_FILESYSTEM */
+        if (WolfSSL.FileSystemEnabled() == false) {
+            pass("\t\t... skipped");
+            return;
+        }
+
         try {
             x509 = new WolfSSLX509X(tf.googleCACert);
             x509.checkValidity();
@@ -239,6 +253,13 @@ public class WolfSSLX509Test {
         WolfSSLX509 x509;
 
         System.out.print("\tTesting TBS");
+
+        /* skip if wolfSSL compiled with NO_FILESYSTEM */
+        if (WolfSSL.FileSystemEnabled() == false) {
+            pass("\t\t\t... skipped");
+            return;
+        }
+
         try {
             x509 = new WolfSSLX509(tf.googleCACert);
             tbs = x509.getTBSCertificate();
@@ -574,6 +595,12 @@ public class WolfSSLX509Test {
         int ALT_DNS_NAME = 2; /* dNSName type */
 
         System.out.print("\tTesting getting alt names");
+
+        /* skip if wolfSSL compiled with NO_FILESYSTEM */
+        if (WolfSSL.FileSystemEnabled() == false) {
+            pass("\t... skipped");
+            return;
+        }
 
         /* populate known alt name list for example.com cert, for comparison */
         List<String> expected = new ArrayList<>();

--- a/src/test/com/wolfssl/test/WolfSSLCertificateTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLCertificateTest.java
@@ -68,13 +68,15 @@ public class WolfSSLCertificateTest {
         test_WolfSSLCertificate_new_pemArray();
         test_runCertTestsAfterConstructor();
 
-        /* WolfSSLCertificate(byte[] pem) */
-        test_WolfSSLCertificate_new_derFile();
-        test_runCertTestsAfterConstructor();
+        if (WolfSSL.FileSystemEnabled() == true) {
+            /* WolfSSLCertificate(byte[] pem) */
+            test_WolfSSLCertificate_new_derFile();
+            test_runCertTestsAfterConstructor();
 
-        /* WolfSSLCertificate(String pem) */
-        test_WolfSSLCertificate_new_pemFile();
-        test_runCertTestsAfterConstructor();
+            /* WolfSSLCertificate(String pem) */
+            test_WolfSSLCertificate_new_pemFile();
+            test_runCertTestsAfterConstructor();
+        }
     }
 
 
@@ -189,6 +191,19 @@ public class WolfSSLCertificateTest {
                                 Level.SEVERE, null, ex);
         }
         System.out.println("\t... passed");
+    }
+
+    private byte[] fileToByteArray(String filePath)
+        throws IOException {
+        File f = new File(filePath);
+        byte[] fBytes = null;
+
+        InputStream stream = new FileInputStream(f);
+        fBytes = new byte[(int) f.length()];
+        stream.read(fBytes, 0, fBytes.length);
+        stream.close();
+
+        return fBytes;
     }
 
 
@@ -501,7 +516,13 @@ public class WolfSSLCertificateTest {
             int i;
             boolean[] kuse;
 
-            ext = new WolfSSLCertificate(this.external);
+            if (WolfSSL.FileSystemEnabled() == true) {
+                ext = new WolfSSLCertificate(this.external);
+            } else {
+                ext = new WolfSSLCertificate(fileToByteArray(this.external),
+                                             WolfSSL.SSL_FILETYPE_ASN1);
+            }
+
             kuse = ext.getKeyUsage();
             if (kuse == null) {
                 System.out.println("\t\t... failed");
@@ -516,8 +537,9 @@ public class WolfSSLCertificateTest {
                 }
             }
             ext.free();
-        } catch (WolfSSLException ex) {
-            Logger.getLogger(WolfSSLCertificateTest.class.getName()).log(Level.SEVERE, null, ex);
+        } catch (Exception ex) {
+            Logger.getLogger(WolfSSLCertificateTest.class.getName()).log(
+                                Level.SEVERE, null, ex);
             System.out.println("\t\t... failed");
             fail("Error loading external certificate");
         }

--- a/src/test/com/wolfssl/test/WolfSSLContextTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLContextTest.java
@@ -102,15 +102,18 @@ public class WolfSSLContextTest {
         test_ucf(null, null, 9999, WolfSSL.SSL_FAILURE,
                  "useCertificateFile(null, null, 9999)");
 
-        test_ucf(ctx, bogusFile, WolfSSL.SSL_FILETYPE_PEM, WolfSSL.SSL_FAILURE,
-                 "useCertificateFile(ctx, bogusFile, SSL_FILETYPE_PEM)");
+        if (WolfSSL.FileSystemEnabled() == true) {
+            test_ucf(ctx, bogusFile, WolfSSL.SSL_FILETYPE_PEM,
+                     WolfSSL.SSL_FAILURE,
+                     "useCertificateFile(ctx, bogusFile, SSL_FILETYPE_PEM)");
 
-        test_ucf(ctx, cliCert, 9999, WolfSSL.SSL_FAILURE,
-                 "useCertificateFile(ctx, cliCert, 9999)");
+            test_ucf(ctx, cliCert, 9999, WolfSSL.SSL_FAILURE,
+                     "useCertificateFile(ctx, cliCert, 9999)");
 
-        test_ucf(ctx, cliCert, WolfSSL.SSL_FILETYPE_PEM,
-                 WolfSSL.SSL_SUCCESS,
-                 "useCertificateFile(ctx, cliCert, SSL_FILETYPE_PEM)");
+            test_ucf(ctx, cliCert, WolfSSL.SSL_FILETYPE_PEM,
+                     WolfSSL.SSL_SUCCESS,
+                     "useCertificateFile(ctx, cliCert, SSL_FILETYPE_PEM)");
+        }
 
         System.out.println("\t\t... passed");
     }
@@ -148,15 +151,18 @@ public class WolfSSLContextTest {
         test_upkf(null, null, 9999, WolfSSL.SSL_FAILURE,
                  "usePrivateKeyFile(null, null, 9999)");
 
-        test_upkf(ctx, bogusFile, WolfSSL.SSL_FILETYPE_PEM,
-                  WolfSSL.SSL_FAILURE,
-                 "usePrivateKeyFile(ctx, bogusFile, SSL_FILETYPE_PEM)");
+        if (WolfSSL.FileSystemEnabled() == true) {
+            test_upkf(ctx, bogusFile, WolfSSL.SSL_FILETYPE_PEM,
+                      WolfSSL.SSL_FAILURE,
+                     "usePrivateKeyFile(ctx, bogusFile, SSL_FILETYPE_PEM)");
 
-        test_upkf(ctx, cliKey, 9999, WolfSSL.SSL_FAILURE,
-                 "usePrivateKeyFile(ctx, cliKey, 9999)");
+            test_upkf(ctx, cliKey, 9999, WolfSSL.SSL_FAILURE,
+                     "usePrivateKeyFile(ctx, cliKey, 9999)");
 
-        test_upkf(ctx, cliKey, WolfSSL.SSL_FILETYPE_PEM, WolfSSL.SSL_SUCCESS,
-                 "usePrivateKeyFile(ctx, cliKey, SSL_FILETYPE_PEM)");
+            test_upkf(ctx, cliKey, WolfSSL.SSL_FILETYPE_PEM,
+                     WolfSSL.SSL_SUCCESS,
+                     "usePrivateKeyFile(ctx, cliKey, SSL_FILETYPE_PEM)");
+        }
 
         System.out.println("\t\t... passed");
     }
@@ -194,14 +200,16 @@ public class WolfSSLContextTest {
         test_lvl(null, null, null, WolfSSL.SSL_FAILURE,
                 "loadVerifyLocations(null, null, null)");
 
-        test_lvl(ctx, null, null, WolfSSL.SSL_FAILURE,
-                "loadVerifyLocations(ctx, null, null)");
+        if (WolfSSL.FileSystemEnabled() == true ) {
+            test_lvl(ctx, null, null, WolfSSL.SSL_FAILURE,
+                    "loadVerifyLocations(ctx, null, null)");
 
-        test_lvl(null, caCert, null, WolfSSL.SSL_FAILURE,
-                "loadVerifyLocations(null, caCert, null)");
+            test_lvl(null, caCert, null, WolfSSL.SSL_FAILURE,
+                    "loadVerifyLocations(null, caCert, null)");
 
-        test_lvl(ctx, caCert, null, WolfSSL.SSL_SUCCESS,
-                "loadVerifyLocations(ctx, caCert, 0)");
+            test_lvl(ctx, caCert, null, WolfSSL.SSL_SUCCESS,
+                    "loadVerifyLocations(ctx, caCert, 0)");
+        }
 
         System.out.println("\t\t... passed");
     }


### PR DESCRIPTION
This PR fixes native JNI builds when wolfSSL has been compiled with `--disable-filesystem`, or `-DNO_FILESYSTEM`.