### PR TITLE
Prep for 1.10.0 Release

### DIFF
--- a/IDE/Android/.idea/gradle.xml
+++ b/IDE/Android/.idea/gradle.xml
@@ -13,7 +13,6 @@
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/IDE/Android/.idea/misc.xml
+++ b/IDE/Android/.idea/misc.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="DesignSurface">
+    <option name="filePathToZoomLevelMap">
+      <map>
+        <entry key="app/src/main/res/layout/activity_main.xml" value="0.1983695652173913" />
+      </map>
+    </option>
+  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>

--- a/IDE/Android/README.md
+++ b/IDE/Android/README.md
@@ -6,11 +6,11 @@ project should be used for reference only.
 Tool and version information used when testing this project:
 
 - Ubuntu 20.04.3 LTS
-- Android Studio Bumblebeea 2021.1.1 Patch 3
+- Android Studio Chipmunk 2021.2.1
 - Android Gradle Plugin Version: 4.2.2
 - Gradle Version: 7.1.3
-- API 28: Android 9.0 (Pie)
-- Emulator: Nexus 5X API 28
+- API 30: Android 11
+- Emulator: Pixel 5 API 31
 
 The following sections outline steps required to run this example on an
 Android device or emulator.

--- a/IDE/Android/app/build.gradle
+++ b/IDE/Android/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
     defaultConfig {
         applicationId "com.example.wolfssl"
-        minSdkVersion 23
-        targetSdkVersion 28
+        minSdkVersion 30
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/IDE/Android/app/src/main/AndroidManifest.xml
+++ b/IDE/Android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.wolfssl">
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
@@ -14,7 +14,6 @@
         <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>

--- a/IDE/Android/app/src/main/java/com/example/wolfssl/MainActivity.java
+++ b/IDE/Android/app/src/main/java/com/example/wolfssl/MainActivity.java
@@ -22,11 +22,15 @@
 
 package com.example.wolfssl;
 
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Environment;
+import android.provider.Settings;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
 import android.widget.TextView;
-import android.Manifest;
-import android.content.pm.PackageManager;
 
 import com.wolfssl.WolfSSL;
 import com.wolfssl.WolfSSLException;
@@ -34,7 +38,6 @@ import com.wolfssl.provider.jsse.WolfSSLProvider;
 import com.wolfssl.provider.jsse.WolfSSLX509;
 
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -48,25 +51,38 @@ import javax.net.ssl.SSLEngine;
 
 public class MainActivity extends AppCompatActivity {
 
+    private View.OnClickListener buttonListener = new View.OnClickListener() {
+        @Override
+        public void onClick(View v) {
+            TextView tv = (TextView) findViewById(R.id.sample_text);
+
+            try {
+                testLoadCert(tv);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+    };
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         int permission;
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
+        Button button = (Button) findViewById(R.id.button);
+        button.setOnClickListener(buttonListener);
+
         TextView tv = (TextView) findViewById(R.id.sample_text);
         tv.setText("wolfSSL JNI Android Studio Example App");
 
 
-        permission = checkSelfPermission(Manifest.permission.READ_EXTERNAL_STORAGE);
-        if (permission != PackageManager.PERMISSION_GRANTED) {
-            requestPermissions(new String[] {Manifest.permission.READ_EXTERNAL_STORAGE},1);
-        }
-
-        try {
-            testLoadCert(tv);
-        } catch (Exception e) {
-            e.printStackTrace();
+        if (Environment.isExternalStorageManager()) {
+        } else {
+            Intent intent = new Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION);
+            Uri uri = Uri.fromParts("package", getPackageName(), null);
+            intent.setData(uri);
+            startActivity(intent);
         }
     }
 

--- a/IDE/Android/app/src/main/res/layout/activity_main.xml
+++ b/IDE/Android/app/src/main/res/layout/activity_main.xml
@@ -1,20 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
+    <Button
+        android:id="@+id/button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Load Cert File" />
+
     <TextView
         android:id="@+id/sample_text"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:paddingVertical="16pt"
         android:text="Hello World!"
         app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintHorizontal_bias="0.461"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.067" />
 
 </android.support.constraint.ConstraintLayout>

--- a/README.md
+++ b/README.md
@@ -157,6 +157,30 @@ Additional instructions can be found on the wolfSSL.com website:
 
 ## Release Notes
 
+### wolfSSL JNI Release 1.10.0 (8/11/2022)
+
+Release 1.10.0 has bug fixes and new features including:
+
+**JNI and JSSE Changes:**
+* Add SSLEngine.getApplicationProtocol(), fixes Undertow compatibility (PR 84)
+* Wrap wolfSSL\_UseALPN() at JNI level (PR 84)
+* Fix compile error for wolfSSL < 4.2.0 and wolfSSL\_set\_alpn\_protos() (PR 84)
+* Fix NullPointerException when no selected ALPN is available (PR 84)
+* Fix JNI build when wolfSSL compiled with --disable-filesystem (PR 104)
+* Fix SSLEngine compatibility with data larger than TLS record size (PR 105)
+* Refactor SSLEngine handshake status to be more inline with SunJSSE (PR 105)
+* Add verbose SSLEngine logging with "wolfsslengine.debug" property (PR 105)
+
+**Documentation Changes**
+* Fix missing Javadoc warnings in ALPN code
+
+**Example Changes:**
+* Update Android Studio IDE project to use Android 11 (SDK 30)
+
+The wolfSSL JNI Manual is available at:
+http://www.wolfssl.com/documentation/wolfSSL-JNI-Manual.pdf. For build
+instructions and more detailed comments, please check the manual.
+
 ### wolfSSL JNI Release 1.9.0 (5/5/2022)
 
 Release 1.9.0 has bug fixes and new features including:

--- a/build.xml
+++ b/build.xml
@@ -11,6 +11,11 @@
     $JUNIT_HOME/junit.jar
     </description>
 
+    <!-- versioning/manifest properties -->
+    <property name="implementation.vendor"  value="wolfSSL Inc." />
+    <property name="implementation.title"   value="wolfSSL JNI/JSSE" />
+    <property name="implementation.version" value="1.10" />
+
     <!-- set properties for this build -->
     <property name="src.dir" value="src/java/"/>
     <property name="native.dir" value="native"/>
@@ -157,6 +162,14 @@
 
     <target name="jar">
         <jar jarfile="${lib.dir}/wolfssl.jar">
+            <manifest>
+                <attribute name="Implementation-Title"
+                           value="${implementation.title}" />
+                <attribute name="Implementation-Version"
+                           value="${implementation.version}" />
+                <attribute name="Implementation-Vendor"
+                           value="${implementation.vendor}" />
+            </manifest>
             <fileset dir="${build.dir}">
                 <include name="com/wolfssl/*.class"/>
                 <include name="com/wolfssl/wolfcrypt/*.class"/>
@@ -165,7 +178,16 @@
     </target>
 
     <target name="jar-jsse">
-        <jar jarfile="${lib.dir}/wolfssl-jsse.jar" basedir="${build.dir}"></jar>
+        <jar jarfile="${lib.dir}/wolfssl-jsse.jar" basedir="${build.dir}">
+            <manifest>
+                <attribute name="Implementation-Title"
+                           value="${implementation.title}" />
+                <attribute name="Implementation-Version"
+                           value="${implementation.version}" />
+                <attribute name="Implementation-Vendor"
+                           value="${implementation.vendor}" />
+            </manifest>
+        </jar>
     </target>
 
     <target name="javadoc" description="generate documentation">

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java
@@ -73,8 +73,8 @@ public final class WolfSSLProvider extends Provider {
      * wolfSSL JSSE Provider class
      */
     public WolfSSLProvider() {
-        super("wolfJSSE", 1.8, "wolfSSL JSSE Provider");
-        //super("wolfJSSE", "1.8", "wolfSSL JSSE Provider");
+        super("wolfJSSE", 1.10, "wolfSSL JSSE Provider");
+        //super("wolfJSSE", "1.10", "wolfSSL JSSE Provider");
 
         /* load native wolfSSLJNI library */
         WolfSSL.loadLibrary();


### PR DESCRIPTION
This PR includes fixes from v1.10 release cycle and updates to README for v1.10 changes:

- Updates README.md with v1.10 ChangeLog info
- Bumps version in WolfSSLProvider.java to 1.10
- Adds jar manifest info in build.xml
- Updates Android Studio IDE example project to Android 11 (SDK 30), for SSLParameters ALPN API access