### PR TITLE
Support null host with createSocket(Socket, String, int, boolean)

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -333,7 +333,6 @@ public class WolfSSLSocket extends SSLSocket {
         this.params = params.copy();
         this.socket = s;
         this.autoClose = autoClose;
-        this.address = new InetSocketAddress(host, port);
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "creating new WolfSSLSocket(clientMode: " +

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLServerSocketTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLServerSocketTest.java
@@ -528,7 +528,8 @@ public class WolfSSLServerSocketTest {
             /* Expected. Different versions of wolfSSL can display
              * varying error strings. Check for either here. */
             if (!e.toString().contains("ASN no signer") &&
-                !e.toString().contains("certificate verify failed")) {
+                !e.toString().contains("certificate verify failed") &&
+                !e.toString().contains("ASN self-signed certificate error")) {
                 System.out.println("\t\t... failed");
                 fail();
             }

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
@@ -89,6 +89,7 @@ import com.wolfssl.WolfSSLException;
     public void testGetSetEnabledProtocols();
     public void testClientServerThreaded();
     public void testPreConsumedSocket();
+    public void testCreateSocketNullHost();
     public void testEnableSessionCreation();
     public void testSetUseClientMode();
     public void testGetSSLParameters();
@@ -530,6 +531,36 @@ public class WolfSSLSocketTest {
         System.out.println("\t... passed");
     }
 
+    @Test
+    public void testCreateSocketNullHost() throws Exception {
+
+        System.out.print("\tcreateSocket(null host)");
+
+        /* create new CTX */
+        this.ctx = tf.createSSLContext("TLS", ctxProvider);
+
+        /* create new ServerSocket first to get ephemeral port */
+        ServerSocket ss = new ServerSocket(0);
+
+        /* create new Socket, connect() to server */
+        Socket cs = new Socket();
+        cs.connect(new InetSocketAddress(ss.getLocalPort()));
+
+        /* accept client connection, normal java.net.Socket */
+        final Socket socket = ss.accept();
+
+        /* Try to convert client Socket to SSLSocket, with null hostname.
+         * This should not throw any Exceptions, null host is ok. */
+        SSLSocket ssc = (SSLSocket)ctx.getSocketFactory().createSocket(
+                cs, null, cs.getPort(), false);
+
+        ssc.close();
+        cs.close();
+        socket.close();
+        ss.close();
+
+        System.out.println("\t\t... passed");
+    }
 
     @Test
     public void testEnableSessionCreation() throws Exception {


### PR DESCRIPTION
This PR adds support for calling `SSLSocketFactory.createSocket(Socket s, String host, int port, boolean autoClose)` with host as null.

We remove the creation of a `new InetSocketAddress` at that point, since it is never used by wolfJSSE currently.