### PR TITLE
X509KeyManager.getCertificateChain(): return null if alias is null

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLKeyX509.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLKeyX509.java
@@ -201,7 +201,7 @@ public class WolfSSLKeyX509 implements X509KeyManager{
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getCertificateChain(), alias: " + alias);
 
-        if (store == null) {
+        if (store == null || alias == null) {
             return null;
         }
 

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLKeyX509Test.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLKeyX509Test.java
@@ -88,6 +88,15 @@ public class WolfSSLKeyX509Test {
             fail("unexpected number of alias found");
         }
 
+        /* Try getting chain with null alias, should return null */
+        chain = km.getCertificateChain(null);
+        if (chain != null) {
+            error("\t... failed");
+            fail("did not return null chain with null alias");
+            return;
+        }
+
+        /* Try getting chain with client alias */
         chain = km.getCertificateChain("client");
         if (chain == null || chain.length < 1) {
             error("\t... failed");


### PR DESCRIPTION
This PR makes one small fix to `X509KeyManager.getCertificateChain()` to correctly return `null` if the input alias is `null`. Without this change a NullPointerException gets thrown.

Also adds a small unit test to protect against regression.