### PR TITLE
SSLEngine: update HandshakeStatus inside getHandshakeStatus()

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
@@ -1048,6 +1048,11 @@ public class WolfSSLEngine extends SSLEngine {
     public synchronized SSLEngineResult.HandshakeStatus getHandshakeStatus() {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getHandshakeStatus(): " + hs);
+
+        /* Update status based on internal state. Some calling applications
+         * loop around getHandshakeStatus(), it needs to be up to date. */
+        SetHandshakeStatus(0);
+
         return hs;
     }
 


### PR DESCRIPTION
`SSLEngine.getHandshakeStatus()` should try to update the current status before returning to the caller. Some callers loop around this to take further action based on the value.