### PR TITLE
return null for cert array if trust manager is not initialized

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLTrustX509.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLTrustX509.java
@@ -463,7 +463,7 @@ public class WolfSSLTrustX509 implements X509TrustManager {
         if (store == null) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.ERROR,
                     "Trust Manager was not initialized");
-            return null;
+            return new X509Certificate[0];
         }
 
         try {

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLTrustX509.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLTrustX509.java
@@ -460,6 +460,12 @@ public class WolfSSLTrustX509 implements X509TrustManager {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getAcceptedIssuers()");
 
+        if (store == null) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.ERROR,
+                    "Trust Manager was not initialized");
+            return null;
+        }
+
         try {
             List<X509Certificate> CAs = new ArrayList<X509Certificate>();
             /* Store the alias of all CAs */

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLTrustX509Test.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLTrustX509Test.java
@@ -43,6 +43,7 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
 
 import static org.junit.Assert.assertNotNull;
@@ -144,6 +145,47 @@ public class WolfSSLTrustX509Test {
 
         }
         pass("\t\t... passed");
+    }
+
+    @Test
+    public void testUseBeforeInit()
+        throws NoSuchProviderException, NoSuchAlgorithmException {
+        TrustManagerFactory tmf;
+        TrustManager[] tm;
+        X509TrustManager x509tm;
+        X509Certificate cas[];
+
+        System.out.print("\tTesting use before init()");
+
+        if (tf.isAndroid()) {
+            /* @TODO finding that BKS has different order of certs */
+            pass("\t... skipped");
+            return;
+        }
+
+        tmf = TrustManagerFactory.getInstance("SunX509", provider);
+        if (tmf == null) {
+            error("\t... failed");
+            fail("failed to get instance of trustmanager factory");
+            return;
+        }
+
+        tm = tmf.getTrustManagers();
+        if (tm == null) {
+            error("\t... failed");
+            fail("failed to get instance of trustmanager");
+            return;
+        }
+
+        x509tm = (X509TrustManager) tm[0];
+        cas = x509tm.getAcceptedIssuers();
+        if (cas != null) {
+            error("\t... failed");
+            fail("found a CA even though not initialized");
+            return;
+        }
+
+        pass("\t... passed");
     }
 
     /* Testing WolfSSLTrustX509.getAcceptedIssuers() with server.jks */

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLTrustX509Test.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLTrustX509Test.java
@@ -179,10 +179,15 @@ public class WolfSSLTrustX509Test {
 
         x509tm = (X509TrustManager) tm[0];
         cas = x509tm.getAcceptedIssuers();
-        if (cas != null) {
+        if (cas == null) {
             error("\t... failed");
-            fail("found a CA even though not initialized");
+            fail("get accepted issuers returned null");
             return;
+        }
+
+        if (cas.length != 0) {
+            error("\t... failed");
+            fail("cas should be empty");
         }
 
         pass("\t... passed");


### PR DESCRIPTION
Returns null now in the case that the trust manager is used before initialized. Note that this is not exactly how SunJSSE does it. For example the following was the result of removing the init() call in examples/provider/ClientJSSE.java and using the SunJSSE provider on Ubuntu:

```
$ ./examples/provider/ClientJSSE.sh 
Unable to set FIPS callback without wolfCrypt FIPS code
java.lang.IllegalStateException: TrustManagerFactoryImpl is not initialized
	at java.base/sun.security.ssl.TrustManagerFactoryImpl.engineGetTrustManagers(TrustManagerFactoryImpl.java:102)
	at java.base/javax.net.ssl.TrustManagerFactory.getTrustManagers(TrustManagerFactory.java:317)
	at ClientJSSE.run(ClientJSSE.java:209)
	at ClientJSSE.main(ClientJSSE.java:329)
```

With the change in this pull request we try to continue on with the connection and error out on certificate verification.

```
$ ./examples/provider/ClientJSSE.sh 
Unable to set FIPS callback without wolfCrypt FIPS code
Using SSLContext provider wolfJSSE
javax.net.ssl.SSLHandshakeException: certificate verify failed (error code: -188)
	at com.wolfssl.provider.jsse.WolfSSLSocket.startHandshake(WolfSSLSocket.java:1164)
	at ClientJSSE.run(ClientJSSE.java:248)
	at ClientJSSE.main(ClientJSSE.java:327)

```