### PR TITLE
Add debug method for printing hex with Thread ID

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLDebug.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLDebug.java
@@ -38,12 +38,10 @@ public class WolfSSLDebug {
      */
     public static boolean DEBUG = checkProperty();
 
-
     /**
      * Error level debug message
      */
     public static String ERROR = "ERROR";
-
 
     /**
      * Info level debug message
@@ -76,11 +74,48 @@ public class WolfSSLDebug {
      * @param tag level of debug message i.e. WolfSSLDebug.INFO
      * @param string message to be printed out
      */
-    public static void log(Class cl, String tag, String string) {
+    public static synchronized void log(Class cl, String tag, String string) {
         if (DEBUG) {
             System.out.println("[wolfJSSE " + tag + ": TID " +
                                Thread.currentThread().getId() + ": " +
                                cl.getSimpleName() + "] " + string);
+        }
+    }
+
+    /**
+     * Print out a byte array in hex if debugging is enabled.
+     *
+     * @param cl class this method is being called from
+     * @param tag level of debug message i.e. WolfSSLDebug.INFO
+     * @param label label string to print with hex
+     * @param in byte array to be printed as hex
+     * @param sz number of bytes from in array to be printed
+     */
+    public static synchronized void logHex(Class cl, String tag, String label,
+                                           byte[] in, int sz) {
+        if (DEBUG) {
+            int i = 0, j = 0;
+            int printSz = 0;
+            long tid = Thread.currentThread().getId();
+            String clName = null;
+
+            if (cl == null || in == null || sz == 0) {
+                return;
+            }
+            clName = cl.getSimpleName();
+            printSz = Math.min(in.length, sz);
+
+            System.out.print("[wolfJSSE " + tag + ": TID " + tid + ": " +
+                             clName + "] " + label + " [" + sz + "]: ");
+            for (i = 0; i < printSz; i++) {
+                if ((i % 8) == 0) {
+                    System.out.printf("\n[wolfJSSE " + tag + ": TID " +
+                                      tid + ": " + clName + "] %06X", j * 8);
+                    j++;
+                }
+                System.out.printf(" %02X ", in[i]);
+            }
+            System.out.println("");
         }
     }
 }

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
@@ -1157,7 +1157,8 @@ public class WolfSSLEngine extends SSLEngine {
         this.toSend = tmp;
 
         if (extraDebugEnabled == true) {
-            printHex(in, sz, "CB Write");
+            WolfSSLDebug.logHex(getClass(), WolfSSLDebug.INFO,
+                                "CB Write", in, sz);
         }
 
         return sz;
@@ -1196,7 +1197,8 @@ public class WolfSSLEngine extends SSLEngine {
         }
 
         if (extraDebugEnabled == true) {
-            printHex(toRead, max, "CB Read");
+            WolfSSLDebug.logHex(getClass(), WolfSSLDebug.INFO,
+                                "CB Read", toRead, max);
         }
 
         return max;
@@ -1213,27 +1215,6 @@ public class WolfSSLEngine extends SSLEngine {
         System.arraycopy(in, 0, combined, toReadSz, in.length);
         toRead = combined;
         toReadSz += in.length;
-    }
-
-    /**
-     * Helper function, print byte[] as hex to stdout
-     *
-     * @param in input array to be printed as hex
-     * @param sz number of bytes to print from input array
-     * @param label label String to previx output with
-     */
-    protected void printHex(byte[] in, int sz, String label) {
-        int i = 0, j = 0;
-
-        System.out.print(label + " [" + sz + "]: ");
-        for (i = 0; i < sz; i++) {
-            if ((i % 8) == 0) {
-                System.out.printf("\n%06X", j * 8);
-                j++;
-            }
-            System.out.printf(" %02X ", in[i]);
-        }
-        System.out.println("");
     }
 
     /**


### PR DESCRIPTION
This PR adds a `logHex()` method to the `WolfSSLDebug` class, to be used for printing byte arrays as hex.  Synchronizes this method and prints Thread ID for easier multi-threaded debugging.

Removes a similar private method from WolfSSLEngine, and switches to call new method instead.