### PR TITLE
Update example instructions in README

### DIFF
--- a/examples/provider/README.md
+++ b/examples/provider/README.md
@@ -55,7 +55,7 @@ Example usage for connecting to the wolfSSL example server is:
 
 ```
 $ ./examples/provider/ClientSSLSocket.sh 127.0.0.1 11111 \
-  ./examples/provider/client.jks ./examples/provider/client.jks
+  ./examples/provider/client.jks ./examples/provider/ca-server.jks
 ```
 
 The password for client.jks is: "wolfSSL test"


### PR DESCRIPTION
Same fix as in the documentation: update example instructions for ClientSSLSocket.java example to reflect appropriate truststore to run example.