### PR TITLE
Skip calling InetAddress.getHostName() to avoid DNS lookups when possible

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
@@ -26,6 +26,7 @@ import com.wolfssl.WolfSSLSession;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
+import java.net.InetAddress;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import javax.net.ssl.SSLException;
@@ -34,11 +35,12 @@ import javax.net.ssl.SSLHandshakeException;
 import java.security.Security;
 
 /**
- * This is a helper function to account for similar methods between SSLSocket
+ * This is a helper class to account for similar methods between SSLSocket
  * and SSLEngine.
  *
- * This class wraps a new WOLFSSL object that is created. All methods are
- * protected or private because this class should only be used internally.
+ * This class wraps a new WOLFSSL object that is created (inside
+ * WolfSSLSession). All methods are protected or private because this class
+ * should only be used internally to wolfJSSE.
  *
  * @author wolfSSL
  */
@@ -46,11 +48,31 @@ public class WolfSSLEngineHelper {
     private volatile WolfSSLSession ssl = null;
     private WolfSSLImplementSSLSession session = null;
     private WolfSSLParameters params = null;
+
+    /* Peer hostname, used for session cache lookup (combined with port),
+     * and SNI as secondary if user has not set via SSLParameters */
+    private String hostname = null;
+
+    /* Peer port, used for session cache lookup (combined with hostname) */
     private int port;
-    private String hostname = null;  /* used for session lookup and SNI */
+
+    /* Peer InetAddress, may be set when creating SSLSocket, otherwise
+     * will be null if String host constructor was used instead.
+     * If hostname above is null, and user has not set SSLParameters,
+     * if 'jdk.tls.trustNameService' property has been set will try to set
+     * SNI based on this using peerAddr.getHostName() */
+    private InetAddress peerAddr = null;
+
+    /* Reference to WolfSSLAuthStore, comes from WolfSSLContext */
     private WolfSSLAuthStore authStore = null;
+
+    /* Is this client side (true) or server (false) */
     private boolean clientMode;
+
+    /* Is session creation allowed for this object */
     private boolean sessionCreation = true;
+
+    /* Has setUseClientMode() been called on this object */
     private boolean modeSet = false;
 
     /* Internal Java verify callback, used when user/app is not using
@@ -74,6 +96,7 @@ public class WolfSSLEngineHelper {
      */
     protected WolfSSLEngineHelper(WolfSSLSession ssl, WolfSSLAuthStore store,
             WolfSSLParameters params) throws WolfSSLException {
+
         if (params == null || ssl == null || store == null) {
             throw new WolfSSLException("Bad argument");
         }
@@ -98,6 +121,7 @@ public class WolfSSLEngineHelper {
     protected WolfSSLEngineHelper(WolfSSLSession ssl, WolfSSLAuthStore store,
             WolfSSLParameters params, int port, String hostname)
             throws WolfSSLException {
+
         if (params == null || ssl == null || store == null) {
             throw new WolfSSLException("Bad argument");
         }
@@ -110,6 +134,36 @@ public class WolfSSLEngineHelper {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "created new WolfSSLEngineHelper(port: " + port +
             ", hostname: " + hostname + ")");
+    }
+
+    /**
+     * Allows for new session and resume session by default
+     * @param ssl WOLFSSL session
+     * @param store main auth store holding session tables and managers
+     * @param params default parameters to use on connection
+     * @param port port number as hint for resume
+     * @param peerAddr InetAddress of peer, used for session resumption and
+     *                 SNI if system property is set
+     * @throws WolfSSLException if an exception happens during session resume
+     */
+    protected WolfSSLEngineHelper(WolfSSLSession ssl, WolfSSLAuthStore store,
+            WolfSSLParameters params, int port, InetAddress peerAddr)
+            throws WolfSSLException {
+
+        if (params == null || ssl == null || store == null ||
+            peerAddr == null) {
+            throw new WolfSSLException("Bad argument");
+        }
+
+        this.ssl = ssl;
+        this.params = params;
+        this.port = port;
+        this.peerAddr = peerAddr;
+        this.authStore = store;
+        this.session = new WolfSSLImplementSSLSession(store);
+        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+            "created new WolfSSLEngineHelper(port: " + port +
+            ", IP: " + peerAddr.getHostAddress() + ")");
     }
 
     /**
@@ -523,37 +577,100 @@ public class WolfSSLEngineHelper {
         }
     }
 
-    /* sets SNI server names, if set by application in SSLParameters */
-    private void setLocalServerNames() {
-        if (this.clientMode) {
 
-            /* explicitly set if user has set through SSLParameters */
+    /**
+     * Get the value of a boolean system property.
+     * If not set (property is null), use the default value given.
+     *
+     * @param prop System property to check
+     * @param defaultVal Default value to use if property is null
+     * @return Boolean value of the property, true/false
+     */
+    private static boolean checkBooleanProperty(String prop,
+        boolean defaultVal) {
+
+        String enabled = System.getProperty(prop);
+
+        if (enabled == null) {
+            return defaultVal;
+        }
+
+        if (enabled.equalsIgnoreCase("true")) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Set SNI server names on client side.
+     *
+     * SNI names are only set if the 'jsse.enableSNIExtension' system
+     * property has not been set to false. Default for this property
+     * is defined by Oracle to be true.
+     *
+     * We first try to set SNI names from SSLParameters if set by the user.
+     * If not set in SSLParameters, use the hostname string if set when
+     * SSLSocket was created, and if not set using InetAddress.getHostName()
+     * ONLY if 'jdk.tls.trustNameService' is set to true.
+     */
+    private void setLocalServerNames() {
+
+        /* Do not add SNI if system property has been set to false */
+        boolean enableSNI =
+            checkBooleanProperty("jsse.enableSNIExtension", true);
+
+        /* Have we been instructed to trust the system name service for
+         * reverse DNS lookups? */
+        boolean trustNameService =
+            checkBooleanProperty("jdk.tls.trustNameService", false);
+
+        if (!enableSNI) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                "jsse.enableSNIExtension property set to false, " +
+                "not adding SNI to ClientHello");
+        }
+        else if (this.clientMode) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                "jsse.enableSNIExtension property set to true, " +
+                "enabling SNI");
+
+            /* Explicitly set if user has set through SSLParameters */
             List<WolfSSLSNIServerName> names = this.params.getServerNames();
             if (names != null && names.size() > 0) {
-                /* should only be one server name */
+                /* Should only be one server name */
                 WolfSSLSNIServerName sni = names.get(0);
                 if (sni != null) {
                     this.ssl.useSNI((byte)sni.getType(), sni.getEncoded());
                 }
+
             } else {
-                /* otherwise set based on socket hostname if
-                 * 'jsee.enableSNIExtension' java property is set to true */
-                String enableSNI = System.getProperty("jsse.enableSNIExtension", "true");
-                if (enableSNI.equalsIgnoreCase("true")) {
-
+                if (this.hostname != null) {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "jsse.enableSNIExtension property set to true, " +
-                        "enabling SNI by default");
+                        "setting SNI extension with hostname: " +
+                        this.hostname);
+                    this.ssl.useSNI((byte)0, this.hostname.getBytes());
 
-                    if (this.hostname != null) {
+                }
+                else if (this.peerAddr != null) {
+                    if (trustNameService) {
                         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                            "setting SNI extension with hostname: " +
-                            this.hostname);
-                        this.ssl.useSNI((byte)0, this.hostname.getBytes());
-                    } else {
-                        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                            "hostname is null, not setting SNI");
+                            "setting SNI extension with " +
+                            "InetAddress.getHostName(): " +
+                            this.peerAddr.getHostName());
+
+                        this.ssl.useSNI((byte)0,
+                            this.peerAddr.getHostName().getBytes());
                     }
+                    else {
+                        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                            "jdk.tls.trustNameService not set to true, " +
+                            "not doing reverse DNS lookup to set SNI");
+                    }
+                }
+                else {
+                    WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                        "hostname and peerAddr are null, not setting SNI");
                 }
             }
         }
@@ -759,13 +876,24 @@ public class WolfSSLEngineHelper {
      *
      */
     protected void initHandshake() throws SSLException {
+
+        String sessCacheHostname = this.hostname;
+
         if (!modeSet) {
             throw new SSLException("setUseClientMode has not been called");
         }
 
+        /* If InetAddress was used to create SSLSocket, use IP address for
+         * session resumption to avoid DNS lookup with
+         * InetAddress.getHostName(). Can cause performance issues if DNS server
+         * is not available and timeout is long. */
+        if (sessCacheHostname == null && this.peerAddr != null) {
+            sessCacheHostname = this.peerAddr.getHostAddress();
+        }
+
         /* create non null session */
-        this.session = this.authStore.getSession(ssl, this.port, this.hostname,
-            this.clientMode);
+        this.session = this.authStore.getSession(ssl, this.port,
+            sessCacheHostname, this.clientMode);
 
         if (this.session != null) {
             if (this.clientMode) {
@@ -818,6 +946,7 @@ public class WolfSSLEngineHelper {
 
         int ret, err;
         byte[] serverId = null;
+        String hostAddress = null;
 
         if (!modeSet) {
             throw new SSLException("setUseClientMode has not been called");
@@ -855,13 +984,29 @@ public class WolfSSLEngineHelper {
         if (this.clientMode) {
             /* Associate host:port as serverID for client session cache,
              * helps native wolfSSL for TLS 1.3 sessions with no session ID.
-             * Setting newSession to 1 for setServerID since we are controlling
-             * get/set session from Java */
-            serverId = this.hostname.concat(
-                Integer.toString(this.port)).getBytes();
-            ret = this.ssl.setServerID(serverId, 1);
-            if (ret != WolfSSL.SSL_SUCCESS) {
-                return WolfSSL.SSL_HANDSHAKE_FAILURE;
+             * If host is null and Socket was created with InetAddress only,
+             * try to use IP address:port instead. If both are null, skip
+             * setting serverID. Setting newSession to 1 for setServerID since
+             * we are controlling get/set session from Java */
+            if (hostname != null) {
+                serverId = this.hostname.concat(
+                    Integer.toString(this.port)).getBytes();
+            }
+            else if (peerAddr != null) {
+                hostAddress = this.peerAddr.getHostAddress();
+                if (hostAddress != null) {
+                    serverId = hostAddress.concat(
+                        Integer.toString(this.port)).getBytes();
+                }
+            }
+            if (serverId == null) {
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    "null serverId when trying to generate, not setting");
+            } else {
+                ret = this.ssl.setServerID(serverId, 1);
+                if (ret != WolfSSL.SSL_SUCCESS) {
+                    return WolfSSL.SSL_HANDSHAKE_FAILURE;
+                }
             }
         }
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -165,7 +165,7 @@ public class WolfSSLSocket extends SSLSocket {
 
             /* get helper class for common methods */
             EngineHelper = new WolfSSLEngineHelper(this.ssl, this.authStore,
-                    this.params, port, host.getHostName());
+                    this.params, port, host);
             EngineHelper.setUseClientMode(clientMode);
 
         } catch (WolfSSLException e) {
@@ -210,7 +210,7 @@ public class WolfSSLSocket extends SSLSocket {
 
             /* get helper class for common methods */
             EngineHelper = new WolfSSLEngineHelper(this.ssl, this.authStore,
-                    this.params, port, address.getHostName());
+                    this.params, port, address);
             EngineHelper.setUseClientMode(clientMode);
 
         } catch (WolfSSLException e) {
@@ -791,8 +791,7 @@ public class WolfSSLSocket extends SSLSocket {
 
             /* get helper class for common methods */
             EngineHelper = new WolfSSLEngineHelper(this.ssl, this.authStore,
-                    this.params, s.getPort(),
-                    s.getInetAddress().getHostName());
+                    this.params, s.getPort(), s.getInetAddress());
             EngineHelper.setUseClientMode(clientMode);
 
         } catch (WolfSSLException e) {
@@ -843,8 +842,7 @@ public class WolfSSLSocket extends SSLSocket {
 
             /* get helper class for common methods */
             EngineHelper = new WolfSSLEngineHelper(this.ssl, this.authStore,
-                    this.params, s.getPort(),
-                    s.getInetAddress().getHostName());
+                    this.params, s.getPort(), s.getInetAddress());
             EngineHelper.setUseClientMode(false);
 
             /* register custom receive callback to read consumed first */
@@ -1754,7 +1752,7 @@ public class WolfSSLSocket extends SSLSocket {
            SSLSocket.connect() was explicitly called with SocketAddress */
         if (address != null && EngineHelper != null) {
             EngineHelper.setHostAndPort(
-                address.getAddress().getHostName(),
+                address.getAddress().getHostAddress(),
                 address.getPort());
         }
 
@@ -1804,7 +1802,7 @@ public class WolfSSLSocket extends SSLSocket {
            SSLSocket.connect() was explicitly called with SocketAddress */
         if (address != null && EngineHelper != null) {
             EngineHelper.setHostAndPort(
-                address.getAddress().getHostName(),
+                address.getAddress().getHostAddress(),
                 address.getPort());
         }
 


### PR DESCRIPTION
This PR refactors some `SSLSocket` and `SSLEngineHelper` code around the usage of `InetAddress`.

Sockets created with the host as an `InetAddress` were previously calling `InetAddress.getHostName()` to set the hostname inside `WolfSSLEngineHelper`. This was used as the key into the session cache (concatenated with the port).  The downside to this approach is that `getHostName()` does a DNS lookup, which in some scenarios can cause performance issues when the DNS server is not available and execution needs to wait for a timeout to occur instead.

This PR refactors `InetAddress.getHostName()` to use `InetAddress.getHostAddress()` and use the IP address for session cache key instead of the hostname. SSLSocket's created using a `String host` will still use that as the session cache key.

We also slightly adjust SNI behavior here, to only call `InetAddress.getHostName()` for SNI when the Java `jdk.tls.trustNameService` system property has been set to true.  This indicates that the system trusts the name service / DNS server on that platform.

ZD 16009