### PR TITLE
Additional Security Property Support

### DIFF
--- a/examples/provider/MultiThreadedSSLClient.java
+++ b/examples/provider/MultiThreadedSSLClient.java
@@ -219,8 +219,10 @@ public class MultiThreadedSSLClient
         System.out.println("All Client Connections Finished");
         System.out.println("Successful = " + successClientConnections);
         System.out.println("Failed = " + failedClientConnections);
-        System.out.println("Avg handshake time = " +
-                totalConnectionTimeMs / successClientConnections + " ms");
+        if (successClientConnections > 0) {
+            System.out.println("Avg handshake time = " +
+                    totalConnectionTimeMs / successClientConnections + " ms");
+        }
         System.out.println("================================================");
     }
 

--- a/native/com_wolfssl_WolfSSLContext.c
+++ b/native/com_wolfssl_WolfSSLContext.c
@@ -176,7 +176,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setTmpDH
     (void)jcl;
 
     if (jenv == NULL || p == NULL || g == NULL) {
-        return BAD_FUNC_ARG;
+        return (jint)BAD_FUNC_ARG;
     }
 
     if (ctx == NULL) {
@@ -184,12 +184,12 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setTmpDH
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
             (*jenv)->ExceptionClear(jenv);
-            return SSL_FAILURE;
+            return (jint)SSL_FAILURE;
         }
         (*jenv)->ThrowNew(jenv, excClass,
                 "Input WolfSSLContext object was null in "
                 "setTmpDH");
-        return SSL_FAILURE;
+        return (jint)SSL_FAILURE;
     }
 
     pBuf = (unsigned char*)XMALLOC((int)pSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
@@ -233,7 +233,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setTmpDH
     XFREE(pBuf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     XFREE(gBuf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 
-    return ret;
+    return (jint)ret;
 #else
     (void)jenv;
     (void)jcl;
@@ -242,7 +242,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setTmpDH
     (void)pSz;
     (void)g;
     (void)gSz;
-    return NOT_COMPILED_IN;
+    return (jint)NOT_COMPILED_IN;
 #endif /* !NO_DH */
 }
 
@@ -257,7 +257,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setTmpDHFile
     (void)jcl;
 
     if (file == NULL) {
-        return SSL_BAD_FILE;
+        return (jint)SSL_BAD_FILE;
     }
 
     if (ctx == NULL) {
@@ -265,12 +265,12 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setTmpDHFile
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
             (*jenv)->ExceptionClear(jenv);
-            return SSL_FAILURE;
+            return (jint)SSL_FAILURE;
         }
         (*jenv)->ThrowNew(jenv, excClass,
                 "Input WolfSSLContext object was null in "
                 "setTmpDHFile");
-        return SSL_FAILURE;
+        return (jint)SSL_FAILURE;
     }
 
     fname = (*jenv)->GetStringUTFChars(jenv, file, 0);
@@ -279,14 +279,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setTmpDHFile
 
     (*jenv)->ReleaseStringUTFChars(jenv, file, fname);
 
-    return ret;
+    return (jint)ret;
 #else
     (void)jenv;
     (void)jcl;
     (void)ctxPtr;
     (void)file;
     (void)format;
-    return NOT_COMPILED_IN;
+    return (jint)NOT_COMPILED_IN;
 #endif /* !NO_DH && !NO_FILESYSTEM */
 }
 
@@ -301,7 +301,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useCertificateFile
     (void)jcl;
 
     if (jenv == NULL) {
-        return SSL_FAILURE;
+        return (jint)SSL_FAILURE;
     }
 
     if (file == NULL) {
@@ -314,7 +314,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useCertificateFile
         (*jenv)->ThrowNew(jenv, excClass,
                 "Input certificate file is NULL");
 
-        return SSL_FAILURE;
+        return (jint)SSL_FAILURE;
     }
 
     certFile = (*jenv)->GetStringUTFChars(jenv, file, 0);
@@ -330,7 +330,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useCertificateFile
     (void)ctxPtr;
     (void)file;
     (void)format;
-    return NOT_COMPILED_IN;
+    return (jint)NOT_COMPILED_IN;
 #endif
 }
 
@@ -345,7 +345,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_usePrivateKeyFile
     (void)jcl;
 
     if (jenv == NULL) {
-        return SSL_FAILURE;
+        return (jint)SSL_FAILURE;
     }
 
     if (file == NULL) {
@@ -358,7 +358,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_usePrivateKeyFile
         (*jenv)->ThrowNew(jenv, excClass,
                 "Input private key file is NULL");
 
-        return SSL_FAILURE;
+        return (jint)SSL_FAILURE;
     }
 
     keyFile = (*jenv)->GetStringUTFChars(jenv, file, 0);
@@ -374,7 +374,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_usePrivateKeyFile
     (void)ctxPtr;
     (void)file;
     (void)format;
-    return NOT_COMPILED_IN;
+    return (jint)NOT_COMPILED_IN;
 #endif
 }
 
@@ -390,7 +390,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_loadVerifyLocations
     (void)jcl;
 
     if (jenv == NULL) {
-        return SSL_FAILURE;
+        return (jint)SSL_FAILURE;
     }
 
     if (file == NULL && path == NULL) {
@@ -403,7 +403,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_loadVerifyLocations
         (*jenv)->ThrowNew(jenv, excClass,
                 "Input file and path are both NULL");
 
-        return SSL_FAILURE;
+        return (jint)SSL_FAILURE;
     }
 
     if (file) {
@@ -432,7 +432,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_loadVerifyLocations
     (void)ctxPtr;
     (void)file;
     (void)path;
-    return NOT_COMPILED_IN;
+    return (jint)NOT_COMPILED_IN;
 #endif
 }
 
@@ -447,7 +447,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useCertificateChainFile
     (void)jcl;
 
     if (jenv == NULL) {
-        return SSL_FAILURE;
+        return (jint)SSL_FAILURE;
     }
 
     /* throw exception if no input file */
@@ -461,7 +461,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useCertificateChainFile
         (*jenv)->ThrowNew(jenv, excClass,
                 "Input certificate chain file is NULL");
 
-        return SSL_FAILURE;
+        return (jint)SSL_FAILURE;
     }
 
     chainFile = (*jenv)->GetStringUTFChars(jenv, file, 0);
@@ -476,7 +476,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useCertificateChainFile
     (void)jcl;
     (void)ctxPtr;
     (void)file;
-    return NOT_COMPILED_IN;
+    return (jint)NOT_COMPILED_IN;
 #endif
 }
 
@@ -638,7 +638,7 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLContext_setOptions
         return 0;
     }
 
-    return wolfSSL_CTX_set_options(ctx, (long)op);
+    return (jlong)wolfSSL_CTX_set_options(ctx, (long)op);
 }
 
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLContext_getOptions
@@ -651,7 +651,7 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLContext_getOptions
         return 0;
     }
 
-    return wolfSSL_CTX_get_options(ctx);
+    return (jlong)wolfSSL_CTX_get_options(ctx);
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_memsaveCertCache
@@ -667,7 +667,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_memsaveCertCache
     (void)jcl;
 
     if (jenv == NULL || ctx == NULL || mem == NULL || sz <= 0) {
-        return BAD_FUNC_ARG;
+        return (jint)BAD_FUNC_ARG;
     }
 
     /* find exception class */
@@ -675,12 +675,12 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_memsaveCertCache
     if ((*jenv)->ExceptionOccurred(jenv)) {
         (*jenv)->ExceptionDescribe(jenv);
         (*jenv)->ExceptionClear(jenv);
-        return SSL_FAILURE;
+        return (jint)SSL_FAILURE;
     }
 
     memBuf = (unsigned char*)XMALLOC((int)sz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if (memBuf == NULL) {
-        return MEMORY_E;
+        return (jint)MEMORY_E;
     }
     XMEMSET(memBuf, 0, (int)sz);
 
@@ -697,7 +697,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_memsaveCertCache
         (*jenv)->ThrowNew(jenv, excClass,
                 "Failed to set array region in native memsaveCertCache");
 
-        return SSL_FAILURE;
+        return (jint)SSL_FAILURE;
     }
 
     /* set jbyteArray for return */
@@ -712,13 +712,13 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_memsaveCertCache
             (*jenv)->ThrowNew(jenv, excClass,
                     "Failed to set byte region in native memsaveCertCache");
 
-            return SSL_FAILURE;
+            return (jint)SSL_FAILURE;
         }
     }
 
     XFREE(memBuf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 
-    return ret;
+    return (jint)ret;
 #else
     (void)jenv;
     (void)jcl;
@@ -726,7 +726,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_memsaveCertCache
     (void)mem;
     (void)sz;
     (void)used;
-    return NOT_COMPILED_IN;
+    return (jint)NOT_COMPILED_IN;
 #endif
 }
 
@@ -761,7 +761,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_memrestoreCertCache
     (void)ctxPtr;
     (void)mem;
     (void)sz;
-    return NOT_COMPILED_IN;
+    return (jint)NOT_COMPILED_IN;
 #endif
 }
 
@@ -772,9 +772,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_getCertCacheMemsize
     (void)jcl;
 #ifdef PERSIST_CERT_CACHE
     /* wolfSSL checks for null pointer */
-    return wolfSSL_CTX_get_cert_cache_memsize((WOLFSSL_CTX*)(uintptr_t)ctx);
+    return (jint)wolfSSL_CTX_get_cert_cache_memsize((WOLFSSL_CTX*)(uintptr_t)ctx);
 #else
-    return NOT_COMPILED_IN;
+    return (jint)NOT_COMPILED_IN;
 #endif
 }
 
@@ -784,7 +784,8 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLContext_setCacheSize
     (void)jenv;
     (void)jcl;
 
-    return wolfSSL_CTX_sess_set_cache_size((WOLFSSL_CTX*)(uintptr_t)ctx, (long)sz);
+    return (jlong)wolfSSL_CTX_sess_set_cache_size(
+                    (WOLFSSL_CTX*)(uintptr_t)ctx, (long)sz);
 }
 
 
@@ -794,7 +795,7 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLContext_getCacheSize
     (void)jenv;
     (void)jcl;
 
-    return wolfSSL_CTX_sess_get_cache_size((WOLFSSL_CTX*)(uintptr_t)ctx);
+    return (jlong)wolfSSL_CTX_sess_get_cache_size((WOLFSSL_CTX*)(uintptr_t)ctx);
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setCipherList
@@ -807,7 +808,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setCipherList
     (void)jcl;
 
     if (jenv == NULL) {
-        return SSL_FAILURE;
+        return (jint)SSL_FAILURE;
     }
 
     if (list == NULL) {
@@ -821,7 +822,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setCipherList
         (*jenv)->ThrowNew(jenv, excClass,
                 "Input cipher list is NULL");
 
-        return SSL_FAILURE;
+        return (jint)SSL_FAILURE;
     }
 
     cipherList = (*jenv)->GetStringUTFChars(jenv, list, 0);
@@ -976,7 +977,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setGroupMessages
         return (jint)BAD_FUNC_ARG;
     }
 
-    return wolfSSL_CTX_set_group_messages((WOLFSSL_CTX*)(uintptr_t)ctx);
+    return (jint)wolfSSL_CTX_set_group_messages((WOLFSSL_CTX*)(uintptr_t)ctx);
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setIORecv(JNIEnv* jenv,
@@ -1660,11 +1661,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_enableCRL
     (void)jcl;
 #ifdef HAVE_CRL
     if (!ctx)
-        return BAD_FUNC_ARG;
+        return (jint)BAD_FUNC_ARG;
 
-    return wolfSSL_CTX_EnableCRL((WOLFSSL_CTX*)(uintptr_t)ctx, options);
+    return (jint)wolfSSL_CTX_EnableCRL((WOLFSSL_CTX*)(uintptr_t)ctx, options);
 #else
-    return NOT_COMPILED_IN;
+    return (jint)NOT_COMPILED_IN;
 #endif
 }
 
@@ -1675,11 +1676,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_disableCRL
     (void)jcl;
 #ifdef HAVE_CRL
     if (!ctx)
-        return BAD_FUNC_ARG;
+        return (jint)BAD_FUNC_ARG;
 
-    return wolfSSL_CTX_DisableCRL((WOLFSSL_CTX*)(uintptr_t)ctx);
+    return (jint)wolfSSL_CTX_DisableCRL((WOLFSSL_CTX*)(uintptr_t)ctx);
 #else
-    return NOT_COMPILED_IN;
+    return (jint)NOT_COMPILED_IN;
 #endif
 }
 
@@ -1694,7 +1695,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_loadCRL
     (void)jcl;
 
     if (jenv == NULL || ctx == NULL || path == NULL) {
-        return BAD_FUNC_ARG;
+        return (jint)BAD_FUNC_ARG;
     }
 
     crlPath = (*jenv)->GetStringUTFChars(jenv, path, 0);
@@ -1703,7 +1704,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_loadCRL
 
     (*jenv)->ReleaseStringUTFChars(jenv, path, crlPath);
 
-    return ret;
+    return (jint)ret;
 #else
     (void)jenv;
     (void)jcl;
@@ -1711,7 +1712,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_loadCRL
     (void)path;
     (void)type;
     (void)monitor;
-    return NOT_COMPILED_IN;
+    return (jint)NOT_COMPILED_IN;
 #endif
 }
 
@@ -1725,7 +1726,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setCRLCb
     (void)jcl;
 
     if (jenv == NULL || ctx == NULL) {
-        return BAD_FUNC_ARG;
+        return (jint)BAD_FUNC_ARG;
     }
 
     /* release global CRL callback object if set */
@@ -1752,13 +1753,13 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setCRLCb
         ret = wolfSSL_CTX_SetCRL_Cb(ctx, NativeCtxMissingCRLCallback);
     }
 
-    return ret;
+    return (jint)ret;
 #else
     (void)jenv;
     (void)jcl;
     (void)ctxPtr;
     (void)cb;
-    return NOT_COMPILED_IN;
+    return (jint)NOT_COMPILED_IN;
 #endif
 }
 
@@ -1855,9 +1856,10 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_enableOCSP
     (void)jcl;
 #ifdef HAVE_OCSP
     /* wolfSSL checks for null pointer */
-    return wolfSSL_CTX_EnableOCSP((WOLFSSL_CTX*)(uintptr_t)ctx, (long)options);
+    return (jint)wolfSSL_CTX_EnableOCSP((WOLFSSL_CTX*)(uintptr_t)ctx,
+                                        (long)options);
 #else
-    return NOT_COMPILED_IN;
+    return (jint)NOT_COMPILED_IN;
 #endif
 }
 
@@ -1868,9 +1870,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_disableOCSP
     (void)jcl;
 #ifdef HAVE_OCSP
     /* wolfSSL checks for null pointer */
-    return wolfSSL_CTX_DisableOCSP((WOLFSSL_CTX*)(uintptr_t)ctx);
+    return (jint)wolfSSL_CTX_DisableOCSP((WOLFSSL_CTX*)(uintptr_t)ctx);
 #else
-    return NOT_COMPILED_IN;
+    return (jint)NOT_COMPILED_IN;
 #endif
 }
 
@@ -1886,7 +1888,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setOCSPOverrideUrl
 
     /* wolfSSL checks ctx for NULL */
     if (jenv == NULL)
-        return BAD_FUNC_ARG;
+        return (jint)BAD_FUNC_ARG;
 
     if (urlString == NULL)
     {
@@ -1900,7 +1902,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setOCSPOverrideUrl
         (*jenv)->ThrowNew(jenv, excClass,
                 "Input URL is NULL in setOCSPOverrideUrl()");
 
-        return SSL_FAILURE;
+        return (jint)SSL_FAILURE;
     }
 
     url = (*jenv)->GetStringUTFChars(jenv, urlString, 0);
@@ -1915,7 +1917,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setOCSPOverrideUrl
     (void)jcl;
     (void)ctxPtr;
     (void)urlString;
-    return NOT_COMPILED_IN;
+    return (jint)NOT_COMPILED_IN;
 #endif
 }
 
@@ -5424,7 +5426,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_usePskIdentityHint
     (void)obj;
 
     if (jenv == NULL || ctx == NULL || hint == NULL) {
-        return SSL_FAILURE;
+        return (jint)SSL_FAILURE;
     }
 
     nativeHint = (*jenv)->GetStringUTFChars(jenv, hint, 0);
@@ -5439,7 +5441,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_usePskIdentityHint
     (void)obj;
     (void)ctxPtr;
     (void)hint;
-    return NOT_COMPILED_IN;
+    return (jint)NOT_COMPILED_IN;
 #endif
 }
 
@@ -5453,7 +5455,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useSecureRenegotiation
                     (WOLFSSL_CTX*)(uintptr_t)ctx);
 #else
     (void)ctx;
-    return NOT_COMPILED_IN;
+    return (jint)NOT_COMPILED_IN;
 #endif
 }
 
@@ -5466,16 +5468,16 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setMinDhKeySz
 
     /* wolfSSL_CTX_SetMinDhKey_Sz() sanitizes ctx and keySzBits */
     if (jenv == NULL) {
-        return BAD_FUNC_ARG;
+        return (jint)BAD_FUNC_ARG;
     }
 
-    return wolfSSL_CTX_SetMinDhKey_Sz(ctx, (word16)keySzBits);
+    return (jint)wolfSSL_CTX_SetMinDhKey_Sz(ctx, (word16)keySzBits);
 #else
     (void)jenv;
     (void)obj;
     (void)ctxPtr;
     (void)keySzBits;
-    return NOT_COMPILED_IN;
+    return (jint)NOT_COMPILED_IN;
 #endif
 }
 
@@ -5488,16 +5490,16 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setMinRsaKeySz
 
     /* wolfSSL_CTX_SetMinRsaKey_Sz() sanitizes ctx and keySzBits */
     if (jenv == NULL) {
-        return BAD_FUNC_ARG;
+        return (jint)BAD_FUNC_ARG;
     }
 
-    return wolfSSL_CTX_SetMinRsaKey_Sz(ctx, (short)keySzBits);
+    return (jint)wolfSSL_CTX_SetMinRsaKey_Sz(ctx, (short)keySzBits);
 #else
     (void)jenv;
     (void)obj;
     (void)ctxPtr;
     (void)keySzBits;
-    return NOT_COMPILED_IN;
+    return (jint)NOT_COMPILED_IN;
 #endif
 }
 
@@ -5510,16 +5512,16 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setMinEccKeySz
 
     /* wolfSSL_CTX_SetMinEccKey_Sz() sanitizes ctx and keySzBits */
     if (jenv == NULL) {
-        return BAD_FUNC_ARG;
+        return (jint)BAD_FUNC_ARG;
     }
 
-    return wolfSSL_CTX_SetMinEccKey_Sz(ctx, (short)keySzBits);
+    return (jint)wolfSSL_CTX_SetMinEccKey_Sz(ctx, (short)keySzBits);
 #else
     (void)jenv;
     (void)obj;
     (void)ctxPtr;
     (void)keySzBits;
-    return NOT_COMPILED_IN;
+    return (jint)NOT_COMPILED_IN;
 #endif
 }
 

--- a/native/com_wolfssl_WolfSSLContext.h
+++ b/native/com_wolfssl_WolfSSLContext.h
@@ -17,6 +17,22 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLContext_newContext
 
 /*
  * Class:     com_wolfssl_WolfSSLContext
+ * Method:    setTmpDH
+ * Signature: (J[BI[BI)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setTmpDH
+  (JNIEnv *, jobject, jlong, jbyteArray, jint, jbyteArray, jint);
+
+/*
+ * Class:     com_wolfssl_WolfSSLContext
+ * Method:    setTmpDHFile
+ * Signature: (JLjava/lang/String;I)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setTmpDHFile
+  (JNIEnv *, jobject, jlong, jstring, jint);
+
+/*
+ * Class:     com_wolfssl_WolfSSLContext
  * Method:    useCertificateFile
  * Signature: (JLjava/lang/String;I)I
  */
@@ -358,6 +374,30 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_usePskIdentityHint
  */
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useSecureRenegotiation
   (JNIEnv *, jobject, jlong);
+
+/*
+ * Class:     com_wolfssl_WolfSSLContext
+ * Method:    setMinDhKeySz
+ * Signature: (JI)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setMinDhKeySz
+  (JNIEnv *, jobject, jlong, jint);
+
+/*
+ * Class:     com_wolfssl_WolfSSLContext
+ * Method:    setMinRsaKeySz
+ * Signature: (JI)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setMinRsaKeySz
+  (JNIEnv *, jobject, jlong, jint);
+
+/*
+ * Class:     com_wolfssl_WolfSSLContext
+ * Method:    setMinEccKeySz
+ * Signature: (JI)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setMinEccKeySz
+  (JNIEnv *, jobject, jlong, jint);
 
 #ifdef __cplusplus
 }

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -3944,6 +3944,33 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_rehandshake
 #endif
 }
 
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_set1SigAlgsList
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jstring list)
+{
+#ifdef OPENSSL_EXTRA
+    int ret = 0;
+    const char* sigAlgList = NULL;
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
+
+    if (jenv == NULL || ssl == NULL || list == NULL) {
+        return SSL_FAILURE;
+    }
+
+    sigAlgList = (*jenv)->GetStringUTFChars(jenv, list, 0);
+
+    ret = wolfSSL_set1_sigalgs_list(ssl, sigAlgList);
+
+    (*jenv)->ReleaseStringUTFChars(jenv, list, sigAlgList);
+#else
+    (void)jenv;
+    (void)ssl;
+    (void)list;
+    return NOT_COMPILED_IN;
+#endif
+    (void)jcl;
+    return (jint)ret;
+}
+
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setSSLIORecv
     (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {

--- a/native/com_wolfssl_WolfSSLSession.h
+++ b/native/com_wolfssl_WolfSSLSession.h
@@ -743,6 +743,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useSecureRenegotiation
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_rehandshake
   (JNIEnv *, jobject, jlong);
 
+/*
+ * Class:     com_wolfssl_WolfSSLSession
+ * Method:    set1SigAlgsList
+ * Signature: (JLjava/lang/String;)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_set1SigAlgsList
+  (JNIEnv *, jobject, jlong, jstring);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/java/com/wolfssl/WolfSSLContext.java
+++ b/src/java/com/wolfssl/WolfSSLContext.java
@@ -787,7 +787,6 @@ public class WolfSSLContext {
      *              SSL client instead of an SSL server.
      * @throws IllegalStateException WolfSSLContext has been freed
      * @throws WolfSSLJNIException Internal JNI error
-     * @see    #accept()
      */
     public int setTmpDH(byte[] p, int pSz, byte[] g, int gSz)
         throws IllegalStateException, WolfSSLJNIException {

--- a/src/java/com/wolfssl/WolfSSLContext.java
+++ b/src/java/com/wolfssl/WolfSSLContext.java
@@ -323,6 +323,8 @@ public class WolfSSLContext {
     /* ------------------ native method declarations -------------------- */
 
     private native long newContext(long method);
+    private native int setTmpDH(long ctx, byte[] p, int pSz, byte[] g, int gSz);
+    private native int setTmpDHFile(long ctx, String fname, int format);
     private native int useCertificateFile(long ctx, String file, int format);
     private native int usePrivateKeyFile(long ctx, String file, int format);
     private native int loadVerifyLocations(long ctx, String file, String path);
@@ -371,6 +373,9 @@ public class WolfSSLContext {
     private native void setPskServerCb(long ctx);
     private native int usePskIdentityHint(long ssl, String hint);
     private native int useSecureRenegotiation(long ctx);
+    private native int setMinDhKeySz(long ctx, int keySzBits);
+    private native int setMinRsaKeySz(long ctx, int keySzBits);
+    private native int setMinEccKeySz(long ctx, int keySzBits);
 
     /* ------------------- context-specific methods --------------------- */
 
@@ -766,6 +771,57 @@ public class WolfSSLContext {
         confirmObjectIsActive();
 
         return setCipherList(getContextPtr(), list);
+    }
+
+    /**
+     * Sets up the group parameters to be used if the server negotiates
+     * a cipher suite that uses DHE.
+     *
+     * @param p     Diffie-Hellman prime number parameter
+     * @param pSz   size of <code>p</code>
+     * @param g     Diffie-Hellman "generator" parameter
+     * @param gSz   size of <code>g</code>
+     * @return      <code>SSL_SUCCESS</code> on success. <code>MEMORY_E
+     *              </code> if a memory error was encountered. <code>
+     *              SIDE_ERROR</code> if this function is called on an
+     *              SSL client instead of an SSL server.
+     * @throws IllegalStateException WolfSSLContext has been freed
+     * @throws WolfSSLJNIException Internal JNI error
+     * @see    #accept()
+     */
+    public int setTmpDH(byte[] p, int pSz, byte[] g, int gSz)
+        throws IllegalStateException, WolfSSLJNIException {
+
+        confirmObjectIsActive();
+
+        return setTmpDH(getContextPtr(), p, pSz, g, gSz);
+    }
+
+    /**
+     * Sets up the group parameters from the specified file to be used if the
+     * server negotiates a cipher suite that uses DHE.
+     *
+     * @param fname     path to Diffie-Hellman parameter file
+     * @param format    format of DH parameter file, either
+     *                  <code>SSL_FILETYPE_ASN1</code> or <code>
+     *                  SSL_FILETYPE_PEM</code>.
+     * @return          <code>SSL_SUCCESS</code> on success. <code>MEMORY_E
+     *                  </code> if a memory error was encountered. <code>
+     *                  SIDE_ERROR</code> if this function is called on an
+     *                  SSL client instead of an SSL server, <code>
+     *                  SSL_BAD_FILETYPE</code> if the specified format is
+     *                  incorrect, <code>SSL_BAD_FILE</code> if there is a
+     *                  problem with the input file.
+     * @throws IllegalStateException WolfSSLContext has been freed
+     * @throws WolfSSLJNIException Internal JNI error
+     * @see    #setTmpDH(byte[], int, byte[], int)
+     */
+    public int setTmpDHFile(String fname, int format)
+        throws IllegalStateException, WolfSSLJNIException {
+
+        confirmObjectIsActive();
+
+        return setTmpDHFile(getContextPtr(), fname, format);
     }
 
     /**
@@ -1716,6 +1772,63 @@ public class WolfSSLContext {
         confirmObjectIsActive();
 
         return useSecureRenegotiation(getContextPtr());
+    }
+
+    /**
+     * Set minimum supported DH key size for this WOLFSSL_CTX.
+     *
+     * @param minKeySizeBits Minimum DH key size in bits (ex: 1024)
+     *
+     * @return <code>WolfSSL.SSL_SUCCESS</code> upon success,
+     *         <code>WolfSSL.SSL_FAILURE</code> or negative upon error.
+     * @throws IllegalStateException WolfSSLContext has been freed
+     * @see    WolfSSLContext#setMinRSAKeySize(int)
+     * @see    WolfSSLContext#setMinECCKeySize(int)
+     */
+    public int setMinDHKeySize(int minKeySizeBits)
+        throws IllegalStateException {
+
+        confirmObjectIsActive();
+
+        return setMinDhKeySz(getContextPtr(), minKeySizeBits);
+    }
+
+    /**
+     * Set minimum supported RSA key size for this WOLFSSL_CTX.
+     *
+     * @param minKeySizeBits Minimum RSA key size in bits (ex: 2048)
+     *
+     * @return <code>WolfSSL.SSL_SUCCESS</code> upon success,
+     *         <code>WolfSSL.SSL_FAILURE</code> or negative upon error.
+     * @throws IllegalStateException WolfSSLContext has been freed
+     * @see    WolfSSLContext#setMinDHKeySize(int)
+     * @see    WolfSSLContext#setMinECCKeySize(int)
+     */
+    public int setMinRSAKeySize(int minKeySizeBits)
+        throws IllegalStateException {
+
+        confirmObjectIsActive();
+
+        return setMinRsaKeySz(getContextPtr(), minKeySizeBits);
+    }
+
+    /**
+     * Set minimum supported ECC key size for this WOLFSSL_CTX.
+     *
+     * @param minKeySizeBits Minimum ECC key size in bits (ex: 224)
+     *
+     * @return <code>WolfSSL.SSL_SUCCESS</code> upon success,
+     *         <code>WolfSSL.SSL_FAILURE</code> or negative upon error.
+     * @throws IllegalStateException WolfSSLContext has been freed
+     * @see    WolfSSLContext#setMinDHKeySize(int)
+     * @see    WolfSSLContext#setMinRSAKeySize(int)
+     */
+    public int setMinECCKeySize(int minKeySizeBits)
+        throws IllegalStateException {
+
+        confirmObjectIsActive();
+
+        return setMinEccKeySz(getContextPtr(), minKeySizeBits);
     }
 
     @SuppressWarnings("deprecation")

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -285,6 +285,7 @@ public class WolfSSLSession {
     private native int useALPN(long ssl, String protocols, int options);
     private native int useSecureRenegotiation(long ssl);
     private native int rehandshake(long ssl);
+    private native int set1SigAlgsList(long ssl, String list);
 
     /* ------------------- session-specific methods --------------------- */
 
@@ -1111,10 +1112,10 @@ public class WolfSSLSession {
      *
      * @param list  null-terminated text string and colon-delimited list
      *              of cipher suites to use with the specified SSL
-     *              context.
+     *              session.
      * @return      <code>SSL_SUCCESS</code> upon success. <code>
      *              SSL_FAILURE</code> upon failure.
-     * @throws IllegalStateException WolfSSLContext has been freed
+     * @throws IllegalStateException WolfSSLSession has been freed
      * @see    WolfSSLContext#setCipherList(String)
      */
     public int setCipherList(String list) throws IllegalStateException {
@@ -1124,6 +1125,58 @@ public class WolfSSLSession {
         return setCipherList(getSessionPtr(), list);
     }
 
+    /**
+     * Sets the supported signature algorithms for the given SSL session.
+     * By default, without calling this method, native wolfSSL will add the
+     * signature-hash algorithms automatically to the ClientHello message
+     * based on which algorithms and modes are compiled into the native library.
+     *
+     * Calling this function will override the defualt list with the specified
+     * list.
+     *
+     * The signature algorithm list, <b>list</b>, is a null-terminated text
+     * String, and colon delimited list. Each list item is a combination of
+     * public key algorithm and MAC algorithm, concatenated with a plus
+     * sign (+).
+     *
+     * Possible public key algorithms include the following, but are dependent
+     * on which algorithms are compiled into the native library:
+     *
+     *    "RSA"     - available if NO_RSA is not defined
+     *    "RSA-PSS" - available if !NO_RSA and WC_RSA_PSS
+     *    "PSS"     - available if !NO_RSA and WC_RSA_PSS
+     *    "ECDSA"   - available if HAVE_ECC
+     *    "ED25519" - available if HAVE_ED25519
+     *    "ED448"   - available if HAVE_ED448
+     *    "DSA"     - available if !NO_DSA
+     *
+     * Possible MAC/hash algorithms include the following, but are also
+     * dependent on which algorithms are compiled into the native library:
+     *
+     *    "SHA1"    - available if !NO_SHA and (!NO_OLD_TLS or WOLFSSL_ALLOW_TLS_SHA1)
+     *    "SHA224"  - available if WOLFSSL_SHA224
+     *    "SHA256"  - available if WOLFSSL_SHA256
+     *    "SHA384"  - available if WOLFSSL_SHA384
+     *    "SHA512"  - available if WOLFSSL_SHA512
+     *
+     * When put together as list items these would look similar to:
+     *
+     *    "RSA+SHA256:ECDSA+SHA256"
+     *
+     * @param list  null-terminated text string and colon-delimited list
+     *              of signature algorithms to use with the specified SSL
+     *              session.
+     * @return      <code>SSL_SUCCESS</code> upon success. <code>
+     *              SSL_FAILURE</code> upon failure.
+     * @throws IllegalStateException WolfSSLSession has been freed
+     */
+    public int setSignatureAlgorithms(String list)
+        throws IllegalStateException {
+
+        confirmObjectIsActive();
+
+        return set1SigAlgsList(getSessionPtr(), list);
+    }
 
     /* ---------------- Nonblocking DTLS helper functions  -------------- */
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLContext.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLContext.java
@@ -154,6 +154,7 @@ public class WolfSSLContext extends SSLContextSpi {
             ciphersIana = WolfSSL.getCiphersIana();
         }
 
+        /* Set minimum allowed RSA/DH/ECC key sizes */
         enforceKeySizeLimitations();
 
         /* TODO: filter cipher suite list and protocols to conform to
@@ -170,9 +171,37 @@ public class WolfSSLContext extends SSLContextSpi {
             this.getProtocolsMask(ctxAttr.noOptions)));
     }
 
-    private void enforceKeySizeLimitations() {
-        /* TODO: call WOLFSSL_CTX APIs to limit key sizes based on
-         * jdk.tls.disabledAlgorithms settings */
+    /**
+     * Set minimum supported key sizes for RSA/DH/ECC based on values
+     * set by user in jdk.tls.disabledAlgorithms security property.
+     *
+     * @throws WolfSSLException Key size limitation fails to set in CTX
+     */
+    private void enforceKeySizeLimitations() throws WolfSSLException {
+
+        int minKeySize = 0;
+        int ret = 0;
+
+        minKeySize = WolfSSLUtil.getDisabledAlgorithmsKeySizeLimit("RSA");
+        ret = this.ctx.setMinRSAKeySize(minKeySize);
+        if (ret != WolfSSL.SSL_SUCCESS) {
+            throw new WolfSSLException(
+                "Error setting SSLContext min RSA key size");
+        }
+
+        minKeySize = WolfSSLUtil.getDisabledAlgorithmsKeySizeLimit("EC");
+        ret = this.ctx.setMinECCKeySize(minKeySize);
+        if (ret != WolfSSL.SSL_SUCCESS) {
+            throw new WolfSSLException(
+                "Error setting SSLContext min ECC key size");
+        }
+
+        minKeySize = WolfSSLUtil.getDisabledAlgorithmsKeySizeLimit("DH");
+        ret = this.ctx.setMinDHKeySize(minKeySize);
+        if (ret != WolfSSL.SSL_SUCCESS) {
+            throw new WolfSSLException(
+                "Error setting SSLContext min DH key size");
+        }
     }
 
     private void LoadTrustedRootCerts() {

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLCustomUser.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLCustomUser.java
@@ -23,53 +23,63 @@ package com.wolfssl.provider.jsse;
 import  com.wolfssl.WolfSSL.TLS_VERSION;
 
 /**
- * Base class is intended to give some customizing points.
- * Currently it is limited to be invoked from WolfSSLContext.Create
+ * This class is intended to give some customization points to wolfJSSE
+ * for users who want to hard-code certain limitations for wolfJSSE in terms
+ * of protocol version support, cipher suite list, or native wolfSSL
+ * SSL_NO_* type options.
+ *
+ * Most users will want to take other approaches to limiting these features,
+ * as this approach will require modification of this class and a
+ * recompilation/reinstallation of the wolfJSSE JAR file.
+ *
+ * Currently these limitations are enforced upon invocation of the
+ * WolfSSLContext.init() method (createCtx()).
  *
  * @author  wolfSSL
  */
 public class WolfSSLCustomUser {
-    /** SSL/TLS version */
+    /** SSL/TLS version to be used with new SSLContext objects. */
     public TLS_VERSION version;
-    /** String array of allowed cipher suites */
+    /** String array of allowed cipher suites for new SSLContext objects */
     public String[] list;
-    /** Mask of options to set for the associated WOLFSSL_CTX */
+    /** Mask of options to set for the associated native WOLFSSL_CTX */
     public long noOptions;
 
     /** Default WolfSSLCustomUser constructor */
     public WolfSSLCustomUser() { }
 
     /**
-     * callback for getting Context attributes before creating context,
-     *                                     TLS protocol and Cipher list
+     * Factory method for getting SSLContext attributes before creating context,
+     * TLS protocol and Cipher list. wolfJSSE calls this internally to get
+     * values set below by the user, or passes defaults through from what
+     * was otherwise going to be used by wolfJSSE when creating the SSLContext.
      *
-     *      WARNING: inappropriate code or use of this callback may cause
-     *               serious security issue.
+     *      WARNING: Inappropriate code or use of this feature may cause
+     *               serious security issues!
      *
-     * @param version default version of TLS for refernce.
-     * @param list    default cipher list for refernce.
+     * @param version Default version of TLS for reference.
+     * @param list    Default cipher list for reference.
      * @return        version: TLS protocol version to the context. The value
-     *                         has to be one compiled in.
-     *                list: Cipher list allowed to the context. list has to
-     *                      contain subset of default cipher list. If it is
-     *                      null, default list is applied.
+     *                         needs to be one compiled into native wolfSSL.
+     *                list: Cipher list allowed for use in the SSLContext.
+     *                      list needs to contain a subset of the default cipher
+     *                      list. If it is null, default list is applied.
      */
     public static WolfSSLCustomUser GetCtxAttributes(TLS_VERSION version,
                                                      String[] list) {
 
         WolfSSLCustomUser ctxAttr = new WolfSSLCustomUser();
 
-        /***
-         custom code
-
+        /**
+         Insert custom code here, and remove/modify defaults below.
          Example:
             ctxAttr.NoOptions = WolfSSL.SSL_OP_NO_TLSv1 | WolfSSL.SSL_OP_NO_TLSv1_3;
-
-        ***/
+        */
 
         ctxAttr.version = version;
         ctxAttr.list   = list;
         ctxAttr.noOptions = 0;
+
         return ctxAttr;
     }
 }

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
@@ -144,21 +144,24 @@ public class WolfSSLEngineHelper {
     }
 
     /**
-     * Get all supported cipher suites in native wolfSSL library
+     * Get all supported cipher suites in native wolfSSL library, which
+     * are also allowed by "wolfjsse.enabledCipherSuites" system Security
+     * property, if set.
      *
      * @return String array of all supported cipher suites
      */
     protected String[] getAllCiphers() {
-        return WolfSSL.getCiphersIana();
+        return WolfSSLUtil.sanitizeSuites(WolfSSL.getCiphersIana());
     }
 
     /**
-     * Get all enabled cipher suites
+     * Get all enabled cipher suites, and allowed via
+     * wolfjsse.enabledCipherSuites system Security property (if set).
      *
      * @return String array of all enabled cipher suites
      */
     protected String[] getCiphers() {
-        return this.params.getCipherSuites();
+        return WolfSSLUtil.sanitizeSuites(this.params.getCipherSuites());
     }
 
     /**
@@ -191,7 +194,7 @@ public class WolfSSLEngineHelper {
             }
         }
 
-        this.params.setCipherSuites(suites);
+        this.params.setCipherSuites(WolfSSLUtil.sanitizeSuites(suites));
     }
 
     /**
@@ -666,7 +669,8 @@ public class WolfSSLEngineHelper {
     }
 
     private void setLocalParams() throws SSLException {
-        this.setLocalCiphers(this.params.getCipherSuites());
+        this.setLocalCiphers(
+            WolfSSLUtil.sanitizeSuites(this.params.getCipherSuites()));
         this.setLocalProtocol(
             WolfSSLUtil.sanitizeProtocols(this.params.getProtocols()));
         this.setLocalAuth();

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
@@ -668,6 +668,31 @@ public class WolfSSLEngineHelper {
         }
     }
 
+    private void setLocalSigAlgorithms() {
+
+        int ret = 0;
+
+        if (this.clientMode) {
+            /* Get restricted signature algorithms for ClientHello if set by
+             * user in "wolfjsse.enabledSigAlgorithms" Security property */
+            String sigAlgos = WolfSSLUtil.getSignatureAlgorithms();
+
+            if (sigAlgos != null) {
+                ret = this.ssl.setSignatureAlgorithms(sigAlgos);
+                if (ret != WolfSSL.SSL_SUCCESS &&
+                    ret != WolfSSL.NOT_COMPILED_IN) {
+                    WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                        "error restricting signature algorithms based on " +
+                        "wolfjsse.enabledSignatureAlgorithms property");
+                } else if (ret == WolfSSL.SSL_SUCCESS) {
+                    WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                        "restricted signature algorithms based on " +
+                        "wolfjsse.enabledSignatureAlgorithms property");
+                }
+            }
+        }
+    }
+
     private void setLocalParams() throws SSLException {
         this.setLocalCiphers(
             WolfSSLUtil.sanitizeSuites(this.params.getCipherSuites()));
@@ -678,6 +703,7 @@ public class WolfSSLEngineHelper {
         this.setLocalSessionTicket();
         this.setLocalAlpnProtocols();
         this.setLocalSecureRenegotiation();
+        this.setLocalSigAlgorithms();
     }
 
     /**

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLServerSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLServerSocket.java
@@ -163,7 +163,7 @@ public class WolfSSLServerSocket extends SSLServerSocket {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getEnabledCipherSuites()");
 
-        return params.getCipherSuites();
+        return WolfSSLUtil.sanitizeSuites(params.getCipherSuites());
     }
 
     @Override
@@ -182,7 +182,8 @@ public class WolfSSLServerSocket extends SSLServerSocket {
         }
 
         /* sanitize cipher array for unsupported strings */
-        List<String> supported = Arrays.asList(WolfSSL.getCiphersIana());
+        List<String> supported = Arrays.asList(
+            WolfSSLUtil.sanitizeSuites(WolfSSL.getCiphersIana()));
         for (int i = 0; i < suites.length; i++) {
             if (!supported.contains(suites[i])) {
                 throw new IllegalArgumentException("Unsupported CipherSuite: " +
@@ -202,7 +203,7 @@ public class WolfSSLServerSocket extends SSLServerSocket {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getSupportedCipherSuites()");
 
-        return WolfSSL.getCiphersIana();
+        return WolfSSLUtil.sanitizeSuites(WolfSSL.getCiphersIana());
     }
 
     @Override
@@ -211,7 +212,7 @@ public class WolfSSLServerSocket extends SSLServerSocket {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getSupportedProtocols()");
 
-        return params.getProtocols();
+        return WolfSSLUtil.sanitizeProtocols(params.getProtocols());
     }
 
     @Override
@@ -220,7 +221,7 @@ public class WolfSSLServerSocket extends SSLServerSocket {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getEnabledProtocols()");
 
-        return params.getProtocols();
+        return WolfSSLUtil.sanitizeProtocols(params.getProtocols());
     }
 
     @Override
@@ -240,7 +241,8 @@ public class WolfSSLServerSocket extends SSLServerSocket {
 
         /* sanitize protocol array for unsupported strings */
         List<String> supported;
-        supported = Arrays.asList(WolfSSL.getProtocols());
+        supported = Arrays.asList(
+            WolfSSLUtil.sanitizeProtocols(WolfSSL.getProtocols()));
 
         for (int i = 0; i < protocols.length; i++) {
             if (!supported.contains(protocols[i])) {

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLServerSocketFactory.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLServerSocketFactory.java
@@ -69,7 +69,7 @@ public class WolfSSLServerSocketFactory extends SSLServerSocketFactory {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getDefaultCipherSuites()");
 
-        return WolfSSL.getCiphers();
+        return WolfSSLUtil.sanitizeSuites(WolfSSL.getCiphersIana());
     }
 
     /**

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocketFactory.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocketFactory.java
@@ -125,7 +125,7 @@ public class WolfSSLSocketFactory extends SSLSocketFactory {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getDefaultCipherSuites()");
 
-        return WolfSSL.getCiphersIana();
+        return WolfSSLUtil.sanitizeSuites(WolfSSL.getCiphersIana());
     }
 
     /**

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLUtil.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLUtil.java
@@ -160,6 +160,33 @@ public class WolfSSLUtil {
     }
 
     /**
+     * Return TLS signature algorithms allowed if set in
+     * wolfjsse.enabledSignatureAlgorithms system Security property.
+     *
+     * @return Colon delimited list of signature algorithms to be set
+     *         in the ClientHello.
+     */
+    protected static String getSignatureAlgorithms() {
+
+        String sigAlgos =
+            Security.getProperty("wolfjsse.enabledSignatureAlgorithms");
+
+        if (sigAlgos == null || sigAlgos.isEmpty()) {
+            return null;
+        }
+
+        WolfSSLDebug.log(WolfSSLUtil.class, WolfSSLDebug.INFO,
+            "restricting enabled ClientHello signature algorithms");
+        WolfSSLDebug.log(WolfSSLUtil.class, WolfSSLDebug.INFO,
+            "wolfjsse.enabledSigAlgos: " + sigAlgos);
+
+        /* Remove spaces between colons if present */
+        sigAlgos = sigAlgos.replaceAll(" : ", ":");
+
+        return sigAlgos;
+    }
+
+    /**
      * Return maximum key size allowed if minimum is set in
      * jdk.tls.disabledAlgorithms security property for specified algorithm.
      *

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLUtil.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLUtil.java
@@ -1,0 +1,148 @@
+/* WolfSSLUtil.java
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+package com.wolfssl.provider.jsse;
+
+import java.util.List;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.security.Security;
+
+import com.wolfssl.WolfSSLException;
+
+/**
+ * Utility class to help with JSSE-level functionality.
+ *
+ * @author wolfSSL
+ */
+public class WolfSSLUtil {
+
+    /**
+     * Sanitize or filter protocol list based on system property limitations.
+     *
+     * Supported system properties which limit protocol list are:
+     *    - java.security.Security:
+     *        jdk.tls.disabledAlgorithms
+     *
+     * These system properties should contain a comma-separated list of
+     * values, for example:
+     *
+     *    jdk.tls.disabledAlgorithms="TLSv1, TLSv1.1"
+     *
+     * @param protocols Full list of protocols to sanitize/filter, should be
+     *                  in a format similar to: "TLSv1", "TLSv1.1", etc.
+     *
+     * @return New filtered String array of protocol strings
+     */
+    protected static String[] sanitizeProtocols(String[] protocols) {
+        ArrayList<String> filtered = new ArrayList<String>();
+
+        String disabledAlgos =
+            Security.getProperty("jdk.tls.disabledAlgorithms");
+        List disabledList = null;
+
+        /* If system property not set, no filtering needed */
+        if (disabledAlgos == null) {
+            return protocols;
+        }
+
+        WolfSSLDebug.log(WolfSSLUtil.class, WolfSSLDebug.INFO,
+            "sanitizing enabled protocols");
+        WolfSSLDebug.log(WolfSSLUtil.class, WolfSSLDebug.INFO,
+            "jdk.tls.disabledAlgorithms: " + disabledAlgos);
+
+        /* Remove spaces after commas, split into List */
+        disabledAlgos = disabledAlgos.replaceAll(", ",",");
+        disabledList = Arrays.asList(disabledAlgos.split(","));
+
+        for (int i = 0; i < protocols.length; i++) {
+            if (!disabledList.contains(protocols[i])) {
+                filtered.add(protocols[i]);
+            }
+        }
+
+        return filtered.toArray(new String[filtered.size()]);
+    }
+
+    /**
+     * Return maximum key size allowed if minimum is set in
+     * jdk.tls.disabledAlgorithms security property for specified algorithm.
+     *
+     * @param algo Algorithm to search for key size limitation for, options
+     *             are "RSA", "DH", and "EC".
+     *
+     * @return maximum RSA key size allowed, or 0 if not set in property
+     *
+     * @throws WolfSSLException if algorithm string does not match
+     *         a supported string.
+     */
+    protected static int getDisabledAlgorithmsKeySizeLimit(String algo)
+        throws WolfSSLException {
+
+        int ret = 0;
+        List<String> disabledList = null;
+        Pattern p = Pattern.compile("\\d+");
+        Matcher match = null;
+        String needle = null;
+
+        String disabledAlgos =
+            Security.getProperty("jdk.tls.disabledAlgorithms");
+
+        if (disabledAlgos == null) {
+            return ret;
+        }
+
+        switch (algo) {
+            case "RSA":
+                needle = "RSA keySize <";
+                break;
+            case "DH":
+                needle = "DH keySize <";
+                break;
+            case "EC":
+                needle = "EC keySize <";
+                break;
+            default:
+                throw new WolfSSLException(
+                    "Invalid algorithm string for key size limitation");
+        }
+
+        /* Remove spaces after commas, split into List */
+        disabledAlgos = disabledAlgos.replaceAll(", ",",");
+        disabledList = Arrays.asList(disabledAlgos.split(","));
+
+        for (String s: disabledList) {
+            if (s.contains(needle)) {
+                match = p.matcher(s);
+                if (match.find()) {
+                    ret = Integer.parseInt(match.group());
+                    WolfSSLDebug.log(WolfSSLUtil.class, WolfSSLDebug.INFO,
+                        algo + " key size limitation found " +
+                        "[jdk.tls.disabledAlgorithms]: " + ret);
+                }
+            }
+        } 
+
+        return ret;
+    }
+}
+

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
@@ -396,6 +396,50 @@ public class WolfSSLSocketTest {
                 System.out.println("\t... failed");
                 fail("SSLSocket.setEnabledProtocols() failed");
             }
+
+            /* test that removing protocols with jdk.tls.disabledAlgorithms
+             * behaves as expected */
+            String originalProperty =
+                Security.getProperty("jdk.tls.disabledAlgorithms");
+
+            try {
+                Security.setProperty("jdk.tls.disabledAlgorithms", "TLSv1");
+                s.setEnabledProtocols(new String[] {"TLSv1"});
+                System.out.println("\t\t... failed");
+                fail("SSLSocket.setEnabledProtocols() failed");
+            } catch (IllegalArgumentException e) {
+                /* expected */
+            }
+
+            try {
+                Security.setProperty("jdk.tls.disabledAlgorithms", "TLSv1.1");
+                s.setEnabledProtocols(new String[] {"TLSv1.1"});
+                System.out.println("\t\t... failed");
+                fail("SSLSocket.setEnabledProtocols() failed");
+            } catch (IllegalArgumentException e) {
+                /* expected */
+            }
+
+            try {
+                Security.setProperty("jdk.tls.disabledAlgorithms", "TLSv1.2");
+                s.setEnabledProtocols(new String[] {"TLSv1.2"});
+                System.out.println("\t\t... failed");
+                fail("SSLSocket.setEnabledProtocols() failed");
+            } catch (IllegalArgumentException e) {
+                /* expected */
+            }
+
+            try {
+                Security.setProperty("jdk.tls.disabledAlgorithms", "TLSv1.3");
+                s.setEnabledProtocols(new String[] {"TLSv1.3"});
+                System.out.println("\t\t... failed");
+                fail("SSLSocket.setEnabledProtocols() failed");
+            } catch (IllegalArgumentException e) {
+                /* expected */
+            }
+
+            /* restore original property value */
+            System.setProperty("jdk.tls.disabledAlgorithms", originalProperty);
         }
 
         System.out.println("\t... passed");
@@ -1206,7 +1250,9 @@ public class WolfSSLSocketTest {
         System.out.print("\tTLS 1.0 connection test");
 
         /* skip if TLS 1.0 is not compiled in at native level */
-        if (WolfSSL.TLSv1Enabled() == false) {
+        if (WolfSSL.TLSv1Enabled() == false ||
+            WolfSSLTestFactory.securityPropContains(
+                "jdk.tls.disabledAlgorithms", "TLS")) {
             System.out.println("\t\t... skipped");
             return;
         }
@@ -1220,7 +1266,9 @@ public class WolfSSLSocketTest {
         System.out.print("\tTLS 1.1 connection test");
 
         /* skip if TLS 1.1 is not compiled in at native level */
-        if (WolfSSL.TLSv11Enabled() == false) {
+        if (WolfSSL.TLSv11Enabled() == false ||
+            WolfSSLTestFactory.securityPropContains(
+                "jdk.tls.disabledAlgorithms", "TLSv1.1")) {
             System.out.println("\t\t... skipped");
             return;
         }
@@ -1234,7 +1282,9 @@ public class WolfSSLSocketTest {
         System.out.print("\tTLS 1.2 connection test");
 
         /* skip if TLS 1.2 is not compiled in at native level */
-        if (WolfSSL.TLSv12Enabled() == false) {
+        if (WolfSSL.TLSv12Enabled() == false ||
+            WolfSSLTestFactory.securityPropContains(
+                "jdk.tls.disabledAlgorithms", "TLSv1.2")) {
             System.out.println("\t\t... skipped");
             return;
         }
@@ -1248,7 +1298,9 @@ public class WolfSSLSocketTest {
         System.out.print("\tTLS 1.3 connection test");
 
         /* skip if TLS 1.3 is not compiled in at native level */
-        if (WolfSSL.TLSv13Enabled() == false) {
+        if (WolfSSL.TLSv13Enabled() == false ||
+            WolfSSLTestFactory.securityPropContains(
+                "jdk.tls.disabledAlgorithms", "TLSv1.3")) {
             System.out.println("\t\t... skipped");
             return;
         }
@@ -1299,6 +1351,60 @@ public class WolfSSLSocketTest {
         ss.close();
 
         System.out.println("\t\t... passed");
+    }
+
+    @Test
+    public void testConnectionWithDisabledAlgorithms() throws Exception {
+
+        System.out.print("\tConnection with disabled algorithms");
+
+        /* create new CTX */
+        this.ctx = tf.createSSLContext("TLS", ctxProvider);
+
+        /* save current system property value */
+        String originalProperty =
+            Security.getProperty("jdk.tls.disabledAlgorithms");
+
+        for (int i = 0; i < enabledProtocols.size(); i++) {
+
+            /* skip generic "TLS" */
+            if (enabledProtocols.get(i).equals("TLS")) {
+                continue;
+            }
+
+            /* create SSLServerSocket first to get ephemeral port */
+            SSLServerSocket ss = (SSLServerSocket)ctx.getServerSocketFactory()
+                .createServerSocket(0);
+
+            SSLSocket cs = (SSLSocket)ctx.getSocketFactory().createSocket();
+            /* restrict to single protocol that is being disabled */
+            cs.setEnabledProtocols(new String[] {enabledProtocols.get(i)});
+
+            /* disable protocol after socket setup, should fail connection */
+            Security.setProperty("jdk.tls.disabledAlgorithms",
+                    enabledProtocols.get(i));
+
+            /* don't need server since should throw exception before */
+            cs.connect(new InetSocketAddress(ss.getLocalPort()));
+
+            try {
+                cs.startHandshake();
+                System.out.println("\t... failed");
+                fail();
+
+            } catch (SSLException e) {
+                /* expected, should fail with
+                 * "No protocols enabled or available" */
+            }
+
+            cs.close();
+            ss.close();
+        }
+
+        /* restore system property */
+        Security.setProperty("jdk.tls.disabledAlgorithms", originalProperty);
+
+        System.out.println("\t... passed");
     }
 
     @Test

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
@@ -1356,7 +1356,7 @@ public class WolfSSLSocketTest {
     @Test
     public void testConnectionWithDisabledAlgorithms() throws Exception {
 
-        System.out.print("\tConnection with disabled algorithms");
+        System.out.print("\tConnect with disabled algos");
 
         /* create new CTX */
         this.ctx = tf.createSSLContext("TLS", ctxProvider);

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLTestFactory.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLTestFactory.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.security.Security;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -36,6 +37,8 @@ import java.security.NoSuchProviderException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
+import java.util.List;
+import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -785,6 +788,36 @@ class WolfSSLTestFactory {
         if (System.getProperty("java.runtime.name").contains("Android")) {
             return true;
         }
+        return false;
+    }
+
+    /**
+     * Check if Security property contains a specific value.
+     *
+     * @param prop System Security property to check
+     * @param needle String value to search for in Security property
+     *
+     * @return true if found, otherwise false
+     */
+    protected static boolean securityPropContains(String prop, String needle) {
+
+        String secProp = null;
+        List propList = null;
+
+        if (prop == null || needle == null) {
+            return false;
+        }
+
+        /* make sure protocol has not been disabled at system level */
+        secProp = Security.getProperty(prop);
+        /* Remove spaces after commas, split into List */
+        secProp = secProp.replaceAll(", ",",");
+        propList = Arrays.asList(secProp.split(","));
+
+        if (propList.contains(needle)) {
+            return true;
+        }
+
         return false;
     }
 }


### PR DESCRIPTION
This PR adds support for:

1. Partial support for `jdk.tls.disabledAlgorithms` security property, including the ability to disable SSL/TLS protocol versions and set RSA/ECC/DH minimum key sizes. This security property would be set in the OS-level `java.security` file and is a comma-delimited string.  For example:

```
jdk.tls.disabledAlgorithms=SSLv3, TLSv1.1, DH keySize < 1024, EC keySize < 224, RSA keySize < 1024
```

2. New wolfJSSE-specific security property `wolfjsse.enabledCipherSuites`, which allows a user to restrict the enabled cipher suites to those listed in this system property. Suites used may be a subset of the ones included in this property, but the user/application will not be able to override or add additional suites at runtime without changing the system property.  This security property would be set in the OS-level `java.security` file and is a comma-delimited string.  For example:

```
wolfjsse.enabledCipherSuites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
```

3. New wolfJSSE-specific security property `wolfjsse.enabledSignatureAlgorithms`, which allows a user to restrict the signature algorithms sent in the TLS ClientHello Signature Algorithms Extension.  By using/setting this property, native wolfSSL will not populate the extension with the default values, which are based on what algorithms have been compiled into the native wolfSSL library.  This security property would be set in the OS-level `java.security` file and is a comma-delimited string of signature algorithm + MAC combinations, for example:

```
wolfjsse.enabledSignatureAlgorithms=RSA+SHA256:ECDSA+SHA256
```

Other changes included as part of the above additions include:

- Wrap native `wolfSSL_CTX_SetTmpDH()` and `wolfSSL_CTX_SetTmpDH_file()`, to allow for SSLContext-level testing of the above minimum DH key size support.
- Wrap native `wolfSSL_CTX_SetMinDhKey_Sz()`, `wolfSSL_CTX_SetMinRsaKey_Sz()`, and `wolfSSL_CTX_SetMinEccKey_Sz()` to support the above min key size limitation.
- Wrap native `wolfSSL_set1_sigalgs_list()`