### PR TITLE
Refactor SSLEngine unwrap() Operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,23 +111,34 @@ directory and given one argument which is the path to a wolfSSL certs directory.
 
 ## Debugging
 
-wolfJSSE debug logging can be enabled by using `-Dwolfjsse.debug=true` at
-runtime.
+wolfSSL JNI/JSSE supports several System properties for enabling debug
+logging. The table below describes the currently-supported debug properties
+and what each enables.
 
-wolfSSL native debug logging can be enabled by using `-Dwolfssl.debug=true` at
-runtime, if native wolfSSL has been compiled with `--enable-debug`.
+| System Property | Default | To Enable | Description |
+| --- | --- | --- | --- |
+| wolfssl.debug | "false" | "true" | Enables native wolfSSL debug logging |
+| wolfjsse.debug | "false" | "true | Enables wolfJSSE debug logging |
+| wolfsslengine.debug | "false" | "true" | Enables SSLEngine debug logging |
+| wolfsslengine.io.debug | "false" | "true" | Enables SSLEngine I/O bytes log |
 
-More verbose SSLEngine debug logs can be enabled by using the
-`-Dwolfsslengine.debug=true` system property.
+Native wolfSSL logging (`wolfssl.debug`) will only output messages if
+native wolfSSL has been configured with `--enable-debug`.
 
-JDK debug logging can be enabled using the `-Djavax.net.debug=all` option.
+These System properties can be defined at runtime, ie:
 
-These system properties can also be set programmatically at runtime:
+```
+java -Dwolfjsse.debug=true App
+```
+
+Or these system properties can also be set programmatically at runtime, ie:
 
 ```
 System.setProperty("wolfjsse.debug", "true");
 System.setProperty("wolfsslengine.debug", "true);
 ```
+
+JDK debug logging can be enabled using the `-Djavax.net.debug=all` option.
 
 ## Building for Android
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLDebug.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLDebug.java
@@ -105,7 +105,7 @@ public class WolfSSLDebug {
             System.out.print("[wolfJSSE " + tag + ": TID " + tid + ": " +
                              clName + "] " + label + " [" + sz + "]: ");
             for (i = 0; i < printSz; i++) {
-                if ((i % 8) == 0) {
+                if ((i % 16) == 0) {
                     System.out.printf("\n[wolfJSSE " + tag + ": TID " +
                                       tid + ": " + clName + "] %06X", j * 8);
                     j++;

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
@@ -96,6 +96,11 @@ public class WolfSSLEngine extends SSLEngine {
     /** Turn on extra/verbose SSLEngine debug logging */
     public boolean extraDebugEnabled = false;
 
+    /** Turn on Send/Recv callback debug to print out bytes sent/received.
+     * WARNING: enabling this will slow down sending and receiving data,
+     * enough so that app may run into timeouts. Enable with caution. */
+    public boolean ioDebugEnabled = false;
+
     /**
      * Turns on additional debugging based on system properties set.
      */
@@ -105,6 +110,19 @@ public class WolfSSLEngine extends SSLEngine {
         String engineDebug  = System.getProperty("wolfsslengine.debug");
         if ((engineDebug != null) && (engineDebug.equalsIgnoreCase("true"))) {
             this.extraDebugEnabled = true;
+        }
+    }
+
+    /**
+     * Turns on additional debugging of I/O data based on system properties set.
+     */
+    private void enableIODebug() {
+        /* turn on verbose extra debugging of bytes sent and received if
+         * 'wolfsslengine.io.debug' system property is set */
+        String engineIODebug = System.getProperty("wolfsslengine.io.debug");
+        if ((engineIODebug != null) &&
+            (engineIODebug.equalsIgnoreCase("true"))) {
+            this.ioDebugEnabled = true;
         }
     }
 
@@ -190,6 +208,7 @@ public class WolfSSLEngine extends SSLEngine {
         ssl.setIOWriteCtx(this);
 
         enableExtraDebug();
+        enableIODebug();
     }
 
     /**
@@ -1190,7 +1209,7 @@ public class WolfSSLEngine extends SSLEngine {
             this.toSend = tmp;
         }
 
-        if (extraDebugEnabled == true) {
+        if (ioDebugEnabled == true) {
             WolfSSLDebug.logHex(getClass(), WolfSSLDebug.INFO,
                                 "CB Write", in, sz);
         }
@@ -1213,7 +1232,7 @@ public class WolfSSLEngine extends SSLEngine {
         int max = 0;
 
         synchronized (netDataLock) {
-            if (extraDebugEnabled == true) {
+            if (ioDebugEnabled == true) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                     "CB Read: requesting " + sz + " bytes");
                 if (this.netData != null) {
@@ -1224,7 +1243,7 @@ public class WolfSSLEngine extends SSLEngine {
             }
 
             if (this.netData == null || this.netData.remaining() == 0) {
-                if (extraDebugEnabled == true) {
+                if (ioDebugEnabled == true) {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                         "CB Read: returning WOLFSSL_CBIO_ERR_WANT_READ");
                 }
@@ -1234,7 +1253,7 @@ public class WolfSSLEngine extends SSLEngine {
             max = (sz < this.netData.remaining()) ? sz : this.netData.remaining();
             this.netData.get(toRead, 0, max);
 
-            if (extraDebugEnabled == true) {
+            if (ioDebugEnabled == true) {
                 WolfSSLDebug.logHex(getClass(), WolfSSLDebug.INFO,
                                     "CB Read", toRead, max);
             }

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLTestFactory.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLTestFactory.java
@@ -544,7 +544,6 @@ class WolfSSLTestFactory {
                 cliToSer.compact();
                 serToCli.compact();
 
-
                 if (extraDebug) {
                     s = client.getHandshakeStatus();
                     System.out.println("client status = " + s.toString());
@@ -656,6 +655,7 @@ class WolfSSLTestFactory {
 
         /* server unwraps client close_notify */
         result = server.unwrap(cliToSer, empty);
+        cliToSer.compact();
         if (extraDebug) {
             System.out.println("[server unwrap] consumed = " + result.bytesConsumed() +
                         " produced = " + result.bytesProduced() +
@@ -679,6 +679,7 @@ class WolfSSLTestFactory {
 
         /* server wraps its own close_notify */
         result = server.wrap(empty, serToCli);
+        serToCli.flip();
         if (extraDebug) {
             System.out.println("[server wrap] consumed = " + result.bytesConsumed() +
                         " produced = " + result.bytesProduced() +
@@ -700,8 +701,8 @@ class WolfSSLTestFactory {
         }
 
         /* client unwraps server close_notify */
-        serToCli.flip();
         result = client.unwrap(serToCli, empty);
+        serToCli.compact();
         if (extraDebug) {
             System.out.println("[client unwrap] consumed = " + result.bytesConsumed() +
                         " produced = " + result.bytesProduced() +


### PR DESCRIPTION
This PR refactors `WolfSSLEngine.java` to make the `unwrap()` operation more efficient by reading bytes directly from the incoming `ByteBuffer`, instead of internally copying and buffering incoming data. This should increase performance and reduce memory usage by eliminating local copies/caching.

This also fixes an edge case where `BUFFER_OVERFLOW` status should be returned when there is remaining input data, but no available output space. Returning this status should cause the calling code to clear/reset the output buffer.

Lastly, this PR splits the SSLEngine I/O debugging for bytes sent/received into a new System property (`wolfsslengine.io.debug`). Printing out all bytes sent/received for normal `wolfsslengine.debug` negatively impacts the connection time enough that it causes some calling applications to run into connection/request timeout values.

**Testing**

- This code has been tested with a customer reproducer. Future action items are to try to add junit tests to cover the edge case mentioned above.
- An existing SSLEngine test (`testThreadedUse()`) has been removed, since it doesn't seem to be a valid use case.  This test also failed when used with the default `SunJSSE` provider.  We already have a more recent threaded test case which covers multi-threaded calling of SSLEngine (`testExtendedThreadingUse()`).