### PR TITLE
JNI/JSSE: add support for wolfSSL CryptoCb in WolfSSLProvider and WolfSSLContext

### DIFF
--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -1392,7 +1392,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_wc_1CryptoCb_1RegisterDevice
         #include "ccb_vaultic.h"
         if(devId == CCBVAULTIC420_DEVID) {
             return wc_CryptoCb_RegisterDevice((int)devId,
-                                              ccbVaultIc_CryptoDevCb, NULL);
+                                              ccbVaultIc_CryptoCb, NULL);
         }
         #endif
 

--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -1358,7 +1358,7 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSL_getAvailableCipherSuitesIana
 #ifdef WOLFSSLJNI_USE_NATIVE_CRYPTOCB
 /**
  * Default native wolfSSL crypto callback function.
- * This is called by default when wolfJSSE's WolfSSLProvider.setDevId()
+ * This is called by default when wolfJSSE's WolfSSLProvider.registerDevId()
  * is called, and is called by the native JNI API below.
  *
  * This function should be directly edited here to meet required
@@ -1387,8 +1387,19 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_wc_1CryptoCb_1RegisterDevice
     #ifdef WOLFSSLJNI_USE_NATIVE_CRYPTOCB
         return wc_CryptoCb_RegisterDevice((int)devId,
                     DefaultNativeCryptoDevCb, NULL);
-    #else
-        /* could add additional elif blocks for ports / known callbacks */
+    #else /* Lookup the devId and see if it matches a known implementation */
+        #if defined(HAVE_CCBVAULTIC) && defined(WOLF_CRYPTO_CB_CMD)
+        #include "ccb_vaultic.h"
+        if(devId == CCBVAULTIC420_DEVID) {
+            return wc_CryptoCb_RegisterDevice((int)devId,
+                                              ccbVaultIc_CryptoDevCb, NULL);
+        }
+        #endif
+
+         /* could add additional elif blocks for ports / known callbacks */
+
+        /* No matching callback.  Maybe return CRYPTOCB_UNAVAILABLE? */
+
         return 0;
     #endif
 #else

--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -1355,6 +1355,65 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSL_getAvailableCipherSuitesIana
     return retString;
 }
 
+#ifdef WOLFSSLJNI_USE_NATIVE_CRYPTOCB
+/**
+ * Default native wolfSSL crypto callback function.
+ * This is called by default when wolfJSSE's WolfSSLProvider.setDevId()
+ * is called, and is called by the native JNI API below.
+ *
+ * This function should be directly edited here to meet required
+ * functionality, or re-implemented and the registration point in the following
+ * function below should be edited:
+ *
+ * Java_com_wolfssl_WolfSSL_wc_1CryptoCb_1RegisterDevice()
+ */
+int DefaultNativeCryptoDevCb(int devId, wc_CryptoInfo* info, void* ctx)
+{
+    int ret = CRYPTOCB_UNAVAILABLE;
+    (void)devId;
+    (void)info;
+    (void)ctx;
+
+    /* Return CRYPTOCB_UNAVAILABLE to bypass HW and use SW. Edit function
+     * body here for your correct/expected functionality. */
+    return ret;
+}
+#endif /* WOLFSSLJNI_USE_NATIVE_CRYPTOCB */
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_wc_1CryptoCb_1RegisterDevice
+  (JNIEnv* jenv, jclass jcl, jint devId)
+{
+#ifdef WOLF_CRYPTO_CB
+    #ifdef WOLFSSLJNI_USE_NATIVE_CRYPTOCB
+        return wc_CryptoCb_RegisterDevice((int)devId,
+                    DefaultNativeCryptoDevCb, NULL);
+    #else
+        /* could add additional elif blocks for ports / known callbacks */
+        return 0;
+    #endif
+#else
+    /* no-op if crypto callbacks not compiled into native wolfSSL */
+    (void)jenv;
+    (void)jcl;
+    (void)devId;
+    return 0;
+#endif
+}
+
+JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSL_wc_1CryptoCb_1UnRegisterDevice
+  (JNIEnv* jenv, jclass jcl, jint devId)
+{
+#ifdef WOLF_CRYPTO_CB
+    wc_CryptoCb_UnRegisterDevice((int)devId);
+#else
+    /* no-op if crypto callbacks not compiled into native wolfSSL */
+    (void)jenv;
+    (void)jcl;
+    (void)devId;
+    return;
+#endif
+}
+
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_isEnabledCRL
   (JNIEnv* jenv, jclass jcl)
 {

--- a/native/com_wolfssl_WolfSSL.h
+++ b/native/com_wolfssl_WolfSSL.h
@@ -309,6 +309,8 @@ extern "C" {
 #define com_wolfssl_WolfSSL_WOLFSSL_FFDHE_6144 259L
 #undef com_wolfssl_WolfSSL_WOLFSSL_FFDHE_8192
 #define com_wolfssl_WolfSSL_WOLFSSL_FFDHE_8192 260L
+#undef com_wolfssl_WolfSSL_INVALID_DEVID
+#define com_wolfssl_WolfSSL_INVALID_DEVID -2L
 /*
  * Class:     com_wolfssl_WolfSSL
  * Method:    init
@@ -435,6 +437,22 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSL_getEnabledCipherSuitesIana
  * Signature: (I)Ljava/lang/String;
  */
 JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSL_getAvailableCipherSuitesIana
+  (JNIEnv *, jclass, jint);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    wc_CryptoCb_RegisterDevice
+ * Signature: (I)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_wc_1CryptoCb_1RegisterDevice
+  (JNIEnv *, jclass, jint);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    wc_CryptoCb_UnRegisterDevice
+ * Signature: (I)V
+ */
+JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSL_wc_1CryptoCb_1UnRegisterDevice
   (JNIEnv *, jclass, jint);
 
 /*

--- a/native/com_wolfssl_WolfSSLContext.c
+++ b/native/com_wolfssl_WolfSSLContext.c
@@ -5529,3 +5529,17 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setMinEccKeySz
 #endif
 }
 
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setDevId
+  (JNIEnv* jenv, jobject jcl, jlong ctxPtr, jint devId)
+{
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
+    (void)jcl;
+
+    /* wolfSSL_CTX_SetDevId() checks ssl for NULL */
+    if (jenv == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    return (jint)wolfSSL_CTX_SetDevId(ctx, (int)devId);
+}
+

--- a/native/com_wolfssl_WolfSSLContext.h
+++ b/native/com_wolfssl_WolfSSLContext.h
@@ -399,6 +399,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setMinRsaKeySz
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setMinEccKeySz
   (JNIEnv *, jobject, jlong, jint);
 
+/*
+ * Class:     com_wolfssl_WolfSSLContext
+ * Method:    setDevId
+ * Signature: (JI)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setDevId
+  (JNIEnv *, jobject, jlong, jint);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/java/com/wolfssl/WolfSSLContext.java
+++ b/src/java/com/wolfssl/WolfSSLContext.java
@@ -385,6 +385,7 @@ public class WolfSSLContext {
     private native int setMinDhKeySz(long ctx, int keySzBits);
     private native int setMinRsaKeySz(long ctx, int keySzBits);
     private native int setMinEccKeySz(long ctx, int keySzBits);
+    private native int setDevId(long ctx, int devId);
 
     /* ------------------- context-specific methods --------------------- */
 
@@ -1941,6 +1942,23 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             return setMinEccKeySz(getContextPtr(), minKeySizeBits);
         }
+    }
+
+    /**
+     * Set crypto callback devId to be used with this WOLFSSL_CTX.
+     *
+     * Called by com.wolfssl.provider.jsse.WolfSSLContext.
+     *
+     * @param devId devId to use with crypto callback implementation.
+     * @return WolfSSL.SSL_SUCCESS on success, negative on error
+     *
+     * @throws IllegalStateException WolfSSLSession has been freed
+     */
+    public int setDevId(int devId) throws IllegalStateException {
+
+        confirmObjectIsActive();
+
+        return setDevId(getContextPtr(), devId);
     }
 
     @SuppressWarnings("deprecation")

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLContext.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLContext.java
@@ -149,6 +149,9 @@ public class WolfSSLContext extends SSLContextSpi {
         /* Set minimum allowed RSA/DH/ECC key sizes */
         enforceKeySizeLimitations();
 
+        /* Set native wolfSSL device ID (devId) */
+        setGlobalCryptoCallbackDevId();
+
         /* Auto-populate enabled ciphersuites with supported ones. If suites
          * have been restricted with wolfjsse.enabledCipherSuites system
          * security property, the suite list will be filtered in
@@ -173,6 +176,33 @@ public class WolfSSLContext extends SSLContextSpi {
 
         } catch (Exception e) {
             throw new IllegalArgumentException(e);
+        }
+    }
+
+    /**
+     * Set native wolfSSL crypto callback device ID (devId).
+     * The devId used defaults to WolfSSL.INVALID_DEVID but an app may
+     * have set this globally via WolfSSLProvider.setDevId(). If not set
+     * globally, applications may also set this via
+     * SSLContext.setDevId() and SSLSocket.setDevId()
+     *
+     * @throws IllegalStateException if underlying WOLFSSL has been freed
+     * @throws WolfSSLException if native wolfSSL/JNI error occurs
+     */
+    private void setGlobalCryptoCallbackDevId() throws WolfSSLException {
+        int ret = 0;
+
+        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+            "setting wolfSSL devId: " + WolfSSL.devId);
+
+        try {
+            ret = this.ctx.setDevId(WolfSSL.devId);
+            if (ret != WolfSSL.SSL_SUCCESS) {
+                throw new WolfSSLException(
+                    "Error setting native wolfSSL device ID, ret = " + ret);
+            }
+        } catch (IllegalStateException e) {
+            throw new WolfSSLException(e);
         }
     }
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java
@@ -153,12 +153,12 @@ public final class WolfSSLProvider extends Provider {
 
     /**
      * Set the native wolfSSL crypto callback devId for SSLContext
-     * objects. Currently requires custom integration work
-     * at native JNI level to write/register crypto callback.
+     * objects.
      *
      * @param devId crypto callback device ID. Default is
      *        WolfSSL.INVALID_DEVID which will cause software crypto
-     *        to be used
+     *        to be used. To reset global device ID, pass in
+     *        WolfSSL.INVALID_DEVID.
      *
      * @throws WolfSSLException if error registering native crypto callback
      *         function
@@ -170,6 +170,27 @@ public final class WolfSSLProvider extends Provider {
          * WolfSSLContext (SSLContext) */
         sslLib.devId = devId;
 
+    }
+
+    /**
+     * Registers native crypto callback device ID for given devID.
+     *
+     * This currently requires custom modifications to native JNI code.
+     * Please contact support@wolfssl.com to discuss your use case and
+     * get help modifying native code if needed.
+     *
+     * Once this API has been called to register the crypto callback device,
+     * WolfSSLProvider.setDevId() or WolfSSLContext.setDevId() should be
+     * called to set the device ID to be used for new SSLContext objects.
+     *
+     * @param devId crypto callback device ID.
+     *
+     * @throws WolfSSLException if error registering native crypto callback
+     *         function
+     */
+    public void registerDevId(int devId) throws WolfSSLException {
+        int ret = 0;
+
         /* Call native JNI entry point to register native wolfSSL
          * CryptoDevice callback function. See native JNI function in
          * native/com_wolfssl_WolfSSL.c */
@@ -177,6 +198,31 @@ public final class WolfSSLProvider extends Provider {
         if (ret != 0) {
             throw new WolfSSLException(
                 "Error registering native wolfSSL crypto callback, " +
+                "ret = " + ret);
+        }
+    }
+
+    /**
+     * Un-registers native crypto callback device ID for given devID.
+     *
+     * This API can be called after WolfSSLProvider.registerDevId(int devId)
+     * to unregister the native crypto callback device ID for the given devId.
+     *
+     * @param devId crypto callback device ID to unregister device for
+     *
+     * @throws WolfSSLException if error registering native crypto callback
+     *         function
+     */
+    public void unRegisterDevId(int devId) throws WolfSSLException {
+        int ret = 0;
+
+        /* Call native JNI entry point to unregister native wolfSSL
+         * CryptoDevice callback function. See native JNI function in
+         * native/com_wolfssl_WolfSSL.c */
+        ret = sslLib.cryptoCbUnRegisterDevice(devId);
+        if (ret != 0) {
+            throw new WolfSSLException(
+                "Error unregistering native wolfSSL crypto callback, " +
                 "ret = " + ret);
         }
     }

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java
@@ -150,5 +150,35 @@ public final class WolfSSLProvider extends Provider {
         put("TrustManagerFactory.SunX509",
                 "com.wolfssl.provider.jsse.WolfSSLTrustManager");
     }
+
+    /**
+     * Set the native wolfSSL crypto callback devId for SSLContext
+     * objects. Currently requires custom integration work
+     * at native JNI level to write/register crypto callback.
+     *
+     * @param devId crypto callback device ID. Default is
+     *        WolfSSL.INVALID_DEVID which will cause software crypto
+     *        to be used
+     *
+     * @throws WolfSSLException if error registering native crypto callback
+     *         function
+     */
+    public void setDevId(int devId) throws WolfSSLException {
+        int ret = 0;
+
+        /* Store devId into static WolfSSL variable, used by
+         * WolfSSLContext (SSLContext) */
+        sslLib.devId = devId;
+
+        /* Call native JNI entry point to register native wolfSSL
+         * CryptoDevice callback function. See native JNI function in
+         * native/com_wolfssl_WolfSSL.c */
+        ret = sslLib.cryptoCbRegisterDevice(devId);
+        if (ret != 0) {
+            throw new WolfSSLException(
+                "Error registering native wolfSSL crypto callback, " +
+                "ret = " + ret);
+        }
+    }
 }
 


### PR DESCRIPTION
Adds native wolfSSL crypto callback (CryptoCb) support when using wolfJSSE (WolfSSLProvider).

Applications can register a native device and set a device ID (devId) for WolfSSLProvider when creating the provider, ie:

```
WolfSSLProvider wolfProv = new WolfSSLProvider();
wolfProv.registerDevId(1001);
wolfProv.setDevId(1001);
Security.insertProviderAt(wolfProv, 1);
```

This will cause all new SSLContext (WolfSSLContext) objects to be set using this device ID.  It will also call the native JNI API `Java_com_wolfssl_WolfSSL_wc_1CryptoCb_1RegisterDevice()` in `native/com_wolfssl_WolfSSL.c` which will register the native crypto callback function. There is a default callback stub implemented in `native/com_wolfssl_WolfSSL.c` called `DefaultNativeCryptoDevCb()` which will be registered if `WOLFSSLJNI_USE_NATIVE_CRYPTOCB` has been defined when compiling wolfssljni.  This needs to be defined manually, in a CMakeLists.txt if using Android Studio, or in `java.sh` if compiling on Linux/Unix.

Applications can "reset" the global device ID back to use software crypto by setting the device ID to `WolfSSL.INVALID_DEVID`:

```
wolfProv.setDevId(WolfSSL.INVALID_DEVID);
```

Applications can unregister a crypto callback device for a specific dev ID using the following:

```
wolfProv.unRegisterDevId(1001);
```