### PR TITLE
JNI/JSSE: call wolfSSL_get1_session() for saving session in WolfSSLAuthStore

### DIFF
--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -1238,8 +1238,36 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_getSession
     (void)jenv;
     (void)jcl;
 
-    /* wolfSSL checks ssl for NULL */
+    /* wolfSSL checks ssl for NULL, returns pointer into WOLFSSL which is
+     * freed when wolfSSL_free() is called. */
     return (jlong)(uintptr_t)wolfSSL_get_session(ssl);
+}
+
+JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_get1Session
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
+{
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
+    (void)jenv;
+    (void)jcl;
+
+    /* wolfSSL checks ssl for NULL, returns pointer to new WOLFSSL_SESSION,
+     * instead of pointer into WOLFSSL like wolfSSL_get_session(). Needs to
+     * be freed with wolfSSL_SESSION_free() when finished with pointer. */
+    return (jlong)(uintptr_t)wolfSSL_get1_session(ssl);
+}
+
+JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_freeNativeSession
+  (JNIEnv* jenv, jclass jcl, jlong sessionPtr)
+{
+    WOLFSSL_SESSION* session = (WOLFSSL_SESSION*)(uintptr_t)sessionPtr;
+    (void)jcl;
+
+    if (jenv == NULL) {
+        return;
+    }
+
+    /* checks session for NULL */
+    wolfSSL_SESSION_free(session);
 }
 
 JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getSessionID

--- a/native/com_wolfssl_WolfSSLSession.h
+++ b/native/com_wolfssl_WolfSSLSession.h
@@ -153,6 +153,22 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_getSession
 
 /*
  * Class:     com_wolfssl_WolfSSLSession
+ * Method:    get1Session
+ * Signature: (J)J
+ */
+JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_get1Session
+  (JNIEnv *, jobject, jlong);
+
+/*
+ * Class:     com_wolfssl_WolfSSLSession
+ * Method:    freeNativeSession
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_freeNativeSession
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_wolfssl_WolfSSLSession
  * Method:    getSessionID
  * Signature: (J)[B
  */

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLAuthStore.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLAuthStore.java
@@ -57,9 +57,11 @@ public class WolfSSLAuthStore {
     private X509TrustManager tm = null;
     private SecureRandom sr = null;
     private String alias = null;
-    private SessionStore<Integer, WolfSSLImplementSSLSession> store;
     private WolfSSLSessionContext serverCtx = null;
     private WolfSSLSessionContext clientCtx = null;
+
+    private SessionStore<Integer, WolfSSLImplementSSLSession> store = null;
+    private final Object storeLock = new Object();
 
     /**
      * Protected constructor to create new WolfSSLAuthStore
@@ -267,8 +269,10 @@ public class WolfSSLAuthStore {
                     new SessionStore<>(sz);
 
         //@TODO check for side server/client, currently a resize is for all
-        store.putAll(newStore);
-        store = newStore;
+        synchronized (storeLock) {
+            store.putAll(newStore);
+            store = newStore;
+        }
     }
 
     /** Returns either an existing session to use or creates a new session. Can
@@ -299,7 +303,10 @@ public class WolfSSLAuthStore {
 
         /* check if is in table */
         toHash = host.concat(Integer.toString(port));
-        ses = store.get(toHash.hashCode());
+
+        synchronized (storeLock) {
+            ses = store.get(toHash.hashCode());
+        }
         if (ses == null) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                     "session not found in cache table, creating new");
@@ -324,12 +331,36 @@ public class WolfSSLAuthStore {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                 "creating new session");
 
-        WolfSSLImplementSSLSession ses = new WolfSSLImplementSSLSession(ssl, this);
+        WolfSSLImplementSSLSession ses =
+            new WolfSSLImplementSSLSession(ssl, this);
 
         ses.setValid(true);
         ses.setPseudoSessionId(Integer.toString(ssl.hashCode()).getBytes());
 
         return ses;
+    }
+
+    /**
+     * Internal helper function to check if session ID is all zeros.
+     * Used by addSession()
+     *
+     * @param id session ID
+     * @return true if array is all zeros (0x00), otherwise false
+     */
+    private boolean idAllZeros(byte[] id) {
+        boolean ret = true;
+
+        if (id == null) {
+            return true;
+        }
+
+        for (int i = 0; i < id.length; i++) {
+            if (id[i] != 0x00) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**
@@ -349,18 +380,25 @@ public class WolfSSLAuthStore {
             hashCode = toHash.hashCode();
         }
         else {
-                /* if no peer host is available then create hash key from
-                 * session id */
+            /* if no peer host is available then create hash key from
+             * session ID if not null, not zero length, and not all zeros */
+            byte[] sessionId = session.getId();
+            if (sessionId != null && sessionId.length > 0 &&
+                (idAllZeros(sessionId) == false)) {
                 hashCode = Arrays.toString(session.getId()).hashCode();
+            }
         }
 
-        if (hashCode != 0 && !store.containsKey(hashCode)) {
-            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "stored session in cache table (host: " +
-                    session.getPeerHost() + ", port: " +
-                    session.getPeerPort() + ") " +
-                    "hashCode = " + hashCode + " side = " + session.getSide());
-                store.put(hashCode, session);
+        synchronized (storeLock) {
+            if (hashCode != 0 && !store.containsKey(hashCode)) {
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                        "stored session in cache table (host: " +
+                        session.getPeerHost() + ", port: " +
+                        session.getPeerPort() + ") " +
+                        "hashCode = " + hashCode + " side = " +
+                        session.getSide());
+                    store.put(hashCode, session);
+            }
         }
         return WolfSSL.SSL_SUCCESS;
     }
@@ -374,10 +412,13 @@ public class WolfSSLAuthStore {
     protected Enumeration<byte[]> getAllIDs(int side) {
         List<byte[]> ret = new ArrayList<>();
 
-        for (Object obj : store.values()) {
-            WolfSSLImplementSSLSession current = (WolfSSLImplementSSLSession)obj;
-            if (current.getSide() == side) {
-                ret.add(current.getId());
+        synchronized (storeLock) {
+            for (Object obj : store.values()) {
+                WolfSSLImplementSSLSession current =
+                    (WolfSSLImplementSSLSession)obj;
+                if (current.getSide() == side) {
+                    ret.add(current.getId());
+                }
             }
         }
         return Collections.enumeration(ret);
@@ -393,12 +434,15 @@ public class WolfSSLAuthStore {
     protected WolfSSLImplementSSLSession getSession(byte[] ID, int side) {
         WolfSSLImplementSSLSession ret = null;
 
-        for (Object obj : store.values()) {
-            WolfSSLImplementSSLSession current = (WolfSSLImplementSSLSession)obj;
-            if (current.getSide() == side &&
-                    java.util.Arrays.equals(ID, current.getId())) {
-                ret = current;
-                break;
+        synchronized (storeLock) {
+            for (Object obj : store.values()) {
+                WolfSSLImplementSSLSession current =
+                    (WolfSSLImplementSSLSession)obj;
+                if (current.getSide() == side &&
+                        java.util.Arrays.equals(ID, current.getId())) {
+                    ret = current;
+                    break;
+                }
             }
         }
         return ret;
@@ -415,24 +459,26 @@ public class WolfSSLAuthStore {
         Date currentDate = new Date();
         long now = currentDate.getTime();
 
-        for (Object obj : store.values()) {
-            long diff;
-            WolfSSLImplementSSLSession current =
-                (WolfSSLImplementSSLSession)obj;
+        synchronized (storeLock) {
+            for (Object obj : store.values()) {
+                long diff;
+                WolfSSLImplementSSLSession current =
+                    (WolfSSLImplementSSLSession)obj;
 
-            if (current.getSide() == side) {
-                /* difference in seconds */
-                diff = (now - current.creation.getTime()) / 1000;
+                if (current.getSide() == side) {
+                    /* difference in seconds */
+                    diff = (now - current.creation.getTime()) / 1000;
 
-                if (diff < 0) {
-                /* session is from the future ... */ //@TODO
+                    if (diff < 0) {
+                    /* session is from the future ... */ //@TODO
 
+                    }
+
+                    if (in > 0 && diff > in) {
+                        current.invalidate();
+                    }
+                    current.setNativeTimeout(in);
                 }
-
-                if (in > 0 && diff > in) {
-                    current.invalidate();
-                }
-                current.setNativeTimeout(in);
             }
         }
     }

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
@@ -274,9 +274,9 @@ public class WolfSSLEngine extends SSLEngine {
     private synchronized int ClosingConnection() {
         int ret;
 
-        if (this.getUseClientMode()) {
-            EngineHelper.saveSession();
-        }
+        /* Save session into WolfSSLAuthStore cache, saves session
+         * pointer for resumption if on client side */
+        EngineHelper.saveSession();
 
         /* get current close_notify state */
         UpdateCloseNotifyStatus();
@@ -317,6 +317,13 @@ public class WolfSSLEngine extends SSLEngine {
                     "ssl.accept() ret:err = " + ret + " : " +
                     ssl.getError(ret));
             }
+
+            /* Once handshake is finished, save session for resumption in
+             * case caller does not explicitly close connection. Saves
+             * session in WolfSSLAuthStore cache, and gets/saves session
+             * pointer for resumption if on client side. */
+            EngineHelper.saveSession();
+
         } catch (SocketTimeoutException e) {
             throw new SSLException(e);
         }

--- a/src/test/com/wolfssl/test/WolfSSLContextTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLContextTest.java
@@ -384,7 +384,11 @@ public class WolfSSLContextTest {
                 fail("setMinRSAKeySize did not pass as expected (1024 limit)");
             }
 
-            /* set min key size to something very large for next test */
+            /* set min key size to something very large for next test. Below
+             * we test ctx.useCertificateFile(), but that API will only fail
+             * based on key size limitations when peer verification is
+             * enabled, set SSL_VERIFY_PEER here. */
+            ctx.setVerify(WolfSSL.SSL_VERIFY_PEER, null);
             ret = ctx.setMinRSAKeySize(8192);
             if (ret != WolfSSL.SSL_SUCCESS) {
                 System.out.println("\t\t... failed");


### PR DESCRIPTION
Prior to this PR, wolfJSSE called down to `wolfSSL_get_session()` for saving session state to be used in the future and re-set for resumption using `wolfSSL_set_session()`.  In versions of wolfSSL after 5.2.0, `wolfSSL_get_session()` returns a pointer that will be freed on `wolfSSL_free()`.  This switches wolfJSSE to call `wolfSSL_get1_session()` instead, and then frees the pointer when finished with `wolfSSL_SESSION_free()`.

Additional changes in this PR include:
- Add synchronization lock around WolfSSLAuthStore store (storeLock)
- Doesn't add session to Java cache if session ID is all zeros
- Correctly add session to Java cache in when `WolfSSLEngineHelper.saveSession()` is called
- Saves session to Java cache when SSLEngine finishes TLS handshake, for proper resumption

Tested with `./configure --enable-jni` and `--enable-jni --enable-all`, on OpenJDK 7, 8, 15, and Amazon Coretto 17.