### PR TITLE
JSSE: do not return duplicate root CA in chain from X509TrustManager.checkClient/ServerTrusted()

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLTrustX509.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLTrustX509.java
@@ -403,7 +403,9 @@ public class WolfSSLTrustX509 implements X509TrustManager {
 
             fullChain = new ArrayList<X509Certificate>();
             fullChain.addAll(Arrays.asList(sortedCerts));
-            fullChain.add(rootCA);
+            if (!fullChain.contains(rootCA)) {
+                fullChain.add(rootCA);
+            }
         }
 
         return fullChain;


### PR DESCRIPTION
This PR includes a fix for `WolfSSLTrustX509.certManagerVerify()`, which gets called from `X509TrustManager.checkClientTrusted()` and `X509TrustManager.checkServerTrusted()`. If the TrustManager KeyStore contains a root CA, and the peer also sends the root CA in the cert chain, we should not add the root CA twice to the returned `X509Certificate[]`.

ZD 16230