### PR TITLE
Fixes for SSLSocket, SSLEngine, session resumption, and synchronization

### DIFF
--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -1247,13 +1247,34 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_get1Session
   (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
+    WOLFSSL_SESSION* sess = NULL;
+    WOLFSSL_SESSION* dup = NULL;
+    /* tmpBuf is only 1 byte since wolfSSL_peek() doesn't need to read
+     * any app data, only session ticket internally */
+    char tmpBuf[1];
     (void)jenv;
     (void)jcl;
 
+    /* Use wolfSSL_get_session() only as an indicator if we need to call
+     * wolfSSL_peek() for TLS 1.3 connections to potentially get the
+     * session ticket message. */
+    sess = wolfSSL_get_session(ssl);
+    if (sess == NULL) {
+        /* session not available yet (TLS 1.3), try peeking to get ticket */
+        wolfSSL_peek(ssl, tmpBuf, (int)sizeof(tmpBuf));
+
+        sess = wolfSSL_get_session(ssl);
+    }
+
     /* wolfSSL checks ssl for NULL, returns pointer to new WOLFSSL_SESSION,
-     * instead of pointer into WOLFSSL like wolfSSL_get_session(). Needs to
-     * be freed with wolfSSL_SESSION_free() when finished with pointer. */
-    return (jlong)(uintptr_t)wolfSSL_get1_session(ssl);
+     * Returns new duplicated WOLFSSL_SESSION. Needs to be freed with
+     * wolfSSL_SESSION_free() when finished with pointer. */
+    if (sess != NULL) {
+        /* Guarantee that we own the WOLFSSL_SESSION, make a copy */
+        dup = wolfSSL_SESSION_dup(sess);
+    }
+
+    return (jlong)(uintptr_t)dup;
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_freeNativeSession

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -1341,6 +1341,49 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_getTimeout
     return wolfSSL_get_timeout(ssl);
 }
 
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setServerID
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jbyteArray id, jint len, jint newSess)
+{
+#if !defined(NO_SESSION_CACHE) && !defined(NO_CLIENT_CACHE)
+    int ret = WOLFSSL_SUCCESS;
+    byte* idBuf = NULL;
+    int idBufSz = 0;
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
+    (void)jcl;
+
+    if (jenv == NULL || ssl == NULL || id == NULL) {
+        return WOLFSSL_FAILURE;
+    }
+
+    idBuf = (byte*)(*jenv)->GetByteArrayElements(jenv, id, NULL);
+    if ((*jenv)->ExceptionOccurred(jenv)) {
+        (*jenv)->ExceptionDescribe(jenv);
+        (*jenv)->ExceptionClear(jenv);
+        return SSL_FAILURE;
+    }
+    idBufSz = (*jenv)->GetArrayLength(jenv, id);
+
+    if (idBuf == NULL || idBufSz <= 0) {
+        ret = WOLFSSL_FAILURE;
+    }
+    else {
+        ret = wolfSSL_SetServerID(ssl, idBuf, idBufSz, (int)newSess);
+    }
+
+    (*jenv)->ReleaseByteArrayElements(jenv, id, (jbyte*)idBuf, JNI_ABORT);
+
+    return ret;
+#else
+    (void)jenv;
+    (void)jcl;
+    (void)sslPtr;
+    (void)id;
+    (void)len;
+    (void)newSess;
+    return NOT_COMPILED_IN;
+#endif
+}
+
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setSessTimeout
   (JNIEnv* jenv, jobject jcl, jlong sessionPtr, jlong sz)
 {

--- a/native/com_wolfssl_WolfSSLSession.h
+++ b/native/com_wolfssl_WolfSSLSession.h
@@ -177,6 +177,14 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getSessionID
 
 /*
  * Class:     com_wolfssl_WolfSSLSession
+ * Method:    setServerID
+ * Signature: (J[BII)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setServerID
+  (JNIEnv *, jobject, jlong, jbyteArray, jint, jint);
+
+/*
+ * Class:     com_wolfssl_WolfSSLSession
  * Method:    setTimeout
  * Signature: (JJ)I
  */

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -221,6 +221,7 @@ public class WolfSSLSession {
     private native long get1Session(long ssl);
     private static native void freeNativeSession(long session);
     private native byte[] getSessionID(long session);
+    private native int setServerID(long ssl, byte[] id, int len, int newSess);
     private native int setTimeout(long ssl, long t);
     private native long getTimeout(long ssl);
     private native int setSessTimeout(long session, long t);
@@ -1114,10 +1115,30 @@ public class WolfSSLSession {
     }
 
     /**
+     * Associate client session with serverID, find existing or store
+     * for saving. If newSess flag is on, don't reuse existing session.
+     *
+     * @param id server ID to associate client session with
+     * @param newSess if 1, don't reuse existing session, otherwise 0
+     *
+     * @return WolfSSL.SSL_SUCCESS on success, WolfSSL.SSL_FAILURE on
+     *         error. Or WolfSSL.NOT_COMPILED_IN if native API is not
+     *         compiled into library.
+     * @throws IllegalStateException WolfSSLSession has been freed
+     */
+    public int setServerID(byte[] id, int newSess)
+        throws IllegalStateException {
+
+        confirmObjectIsActive();
+
+        return setServerID(getSessionPtr(), id, id.length, newSess);
+    }
+
+    /**
      * Sets the timeout in seconds in the given WOLFSSL_SESSION.
      *
      * @param t time in seconds to set
-     * @throws IllegalStateException WolfSSLContext has been freed
+     * @throws IllegalStateException WolfSSLSession has been freed
      * @return WolfSSL.SSL_SUCCESS on success, WolfSSL.JNI_SESSION_UNAVAILABLE
      *         if underlying session is unavailable, or negative values
      *         on failure.
@@ -1143,7 +1164,7 @@ public class WolfSSLSession {
     /**
      * Gets the timeout in seconds in the given WOLFSSL_SESSION.
      *
-     * @throws IllegalStateException WolfSSLContext has been freed
+     * @throws IllegalStateException WolfSSLSession has been freed
      * @return current timeout in seconds
      * @see         #setSession(long)
      * @see         #getSession(long)
@@ -1161,7 +1182,7 @@ public class WolfSSLSession {
      * Sets the timeout in seconds in the given SSL object.
      *
      * @param t time in seconds to set
-     * @throws IllegalStateException WolfSSLContext has been freed
+     * @throws IllegalStateException WolfSSLSession has been freed
      * @return WOLFSSL_SUCCESS on success, negative values on failure.
      * @see         #setSession(long)
      * @see         #getSession(long)

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -657,9 +657,12 @@ public class WolfSSLSession {
 
         confirmObjectIsActive();
 
-        synchronized (sslLock) {
-            return write(getSessionPtr(), data, length, 0);
-        }
+        /* not synchronizing on sslLock here since JNI write() locks
+         * session mutex around native wolfSSL_write() call. If sslLock
+         * is locked here, since we call select() inside native JNI we
+         * could timeout waiting for corresponding read() operation to
+         * occur if needed */
+        return write(getSessionPtr(), data, length, 0);
     }
 
     /**
@@ -703,9 +706,12 @@ public class WolfSSLSession {
 
         confirmObjectIsActive();
 
-        synchronized (sslLock) {
-            ret = write(getSessionPtr(), data, length, timeout);
-        }
+        /* not synchronizing on sslLock here since JNI write() locks
+         * session mutex around native wolfSSL_write() call. If sslLock
+         * is locked here, since we call select() inside native JNI we
+         * could timeout waiting for corresponding read() operation to
+         * occur if needed */
+        ret = write(getSessionPtr(), data, length, timeout);
 
         if (ret == WOLFJNI_TIMEOUT) {
             throw new SocketTimeoutException("Socket write timeout");
@@ -752,9 +758,12 @@ public class WolfSSLSession {
 
         confirmObjectIsActive();
 
-        synchronized (sslLock) {
-            return read(getSessionPtr(), data, sz, 0);
-        }
+        /* not synchronizing on sslLock here since JNI read() locks
+         * session mutex around native wolfSSL_read() call. If sslLock
+         * is locked here, since we call select() inside native JNI we
+         * could timeout waiting for corresponding write() operation to
+         * occur if needed */
+        return read(getSessionPtr(), data, sz, 0);
     }
 
     /**
@@ -800,9 +809,12 @@ public class WolfSSLSession {
 
         confirmObjectIsActive();
 
-        synchronized (sslLock) {
-            ret = read(getSessionPtr(), data, sz, timeout);
-        }
+        /* not synchronizing on sslLock here since JNI read() locks
+         * session mutex around native wolfSSL_read() call. If sslLock
+         * is locked here, since we call select() inside native JNI we
+         * could timeout waiting for corresponding write() operation to
+         * occur if needed */
+        ret = read(getSessionPtr(), data, sz, timeout);
 
         if (ret == WOLFJNI_TIMEOUT) {
             throw new SocketTimeoutException("Socket read timeout");

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLAuthStore.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLAuthStore.java
@@ -75,7 +75,10 @@ public class WolfSSLAuthStore {
     protected WolfSSLAuthStore(KeyManager[] keyman, TrustManager[] trustman,
         SecureRandom random, TLS_VERSION version)
         throws IllegalArgumentException, KeyManagementException {
-            int defaultCacheSize = 10;
+
+            /* default session cache size of 33 to match native wolfSSL
+             * default cache size */
+            int defaultCacheSize = 33;
 
         if (version == TLS_VERSION.INVALID) {
             throw new IllegalArgumentException("Invalid SSL/TLS version");

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLAuthStore.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLAuthStore.java
@@ -542,5 +542,15 @@ public class WolfSSLAuthStore {
             return size() > maxSz;
         }
     }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    protected synchronized void finalize() throws Throwable {
+        /* Clear LinkedHashMap and set to null to allow
+         * for garbage collection */
+        store.clear();
+        store = null;
+        super.finalize();
+    }
 }
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLAuthStore.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLAuthStore.java
@@ -61,7 +61,7 @@ public class WolfSSLAuthStore {
     private WolfSSLSessionContext clientCtx = null;
 
     private SessionStore<Integer, WolfSSLImplementSSLSession> store = null;
-    private final Object storeLock = new Object();
+    private static final Object storeLock = new Object();
 
     /**
      * Protected constructor to create new WolfSSLAuthStore
@@ -194,7 +194,6 @@ public class WolfSSLAuthStore {
         sr = random;
     }
 
-
     /**
      * Get X509KeyManager for this object
      * @return get the key manager used
@@ -261,7 +260,6 @@ public class WolfSSLAuthStore {
         return this.clientCtx;
     }
 
-
     /**
      * Reset the size of the array to cache sessions
      * @param sz new array size
@@ -278,59 +276,81 @@ public class WolfSSLAuthStore {
         }
     }
 
-    /** Returns either an existing session to use or creates a new session. Can
-     * return null on error case or the case where session could not be created.
-     * @param ssl WOLFSSL class to set in session
-     * @param port port number connecting to
-     * @param host host connecting to
-     * @param clientMode if is client side then true
-     * @return a new or reused SSLSession on success, null on failure
+    /**
+     * Get and return either an existing session from the Java session cache
+     * table, or create a new session if one does not exist.
+     *
+     * This method can return null if ether an error occurs getting a session,
+     * or a new session could not be created.
+     *
+     * If called on the server side (clientMode == false), a new
+     * WolfSSLImplementSSLSession will be created and returned, since the
+     * server-side session cache is managed and maintained interal to native
+     * wolfSSL.
+     *
+     * @param ssl WolfSSLSession (WOLFSSL) for which the returned session
+     *            is stored back into (ie: wolfSSL_set_session(ssl, session))
+     * @param port port number of peer being connected to
+     * @param host host of the peer being connected to
+     * @param clientMode if is client side then true, otherwise false
+     * @return an existing SSLSession from Java session cache, or a new
+     *         object if not in cache, called on server side, or host
+     *         is null
      */
-    protected WolfSSLImplementSSLSession getSession(WolfSSLSession ssl,
-        int port, String host, boolean clientMode) {
+    protected synchronized WolfSSLImplementSSLSession getSession(
+        WolfSSLSession ssl, int port, String host, boolean clientMode) {
 
-        WolfSSLImplementSSLSession ses;
-        String toHash;
+        WolfSSLImplementSSLSession ses = null;
+        String toHash = null;
 
         if (ssl == null) {
             return null;
         }
 
-        /* server mode, or client mode with no host */
+        /* Return new session if in server mode, or if host is null */
         if (!clientMode || host == null) {
             return this.getSession(ssl);
         }
+
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                 "attempting to look up session (" +
                 "host: " + host + ", port: " + port + ")");
 
-        /* check if is in table */
-        toHash = host.concat(Integer.toString(port));
-
+        /* Lock on static/global storeLock, since Java session cache table
+         * is shared between all threads */
         synchronized (storeLock) {
+
+            /* generate cache key hash (host:port) */
+            toHash = host.concat(Integer.toString(port));
+
+            /* try getting session out of Java store */
             ses = store.get(toHash.hashCode());
+
+            if (ses == null) {
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                        "session not found in cache table, creating new");
+                /* not found in stored sessions create a new one */
+                ses = new WolfSSLImplementSSLSession(ssl, port, host, this);
+                ses.setValid(true); /* new sessions marked as valid */
+                ses.setPseudoSessionId(
+                    Integer.toString(ssl.hashCode()).getBytes());
+            }
+            else {
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                        "session found in cache, trying to resume");
+                ses.resume(ssl);
+            }
+            return ses;
         }
-        if (ses == null) {
-            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "session not found in cache table, creating new");
-            /* not found in stored sessions create a new one */
-            ses = new WolfSSLImplementSSLSession(ssl, port, host, this);
-            ses.setValid(true); /* new sessions marked as valid */
-            ses.setPseudoSessionId(Integer.toString(ssl.hashCode()).getBytes());
-        }
-        else {
-            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "session found in cache, trying to resume");
-            ses.resume(ssl);
-        }
-        return ses;
     }
 
     /** Returns a new session, does not check/save for resumption
      * @param ssl WOLFSSL class to reference with new session
      * @return a new SSLSession on success
      */
-    protected WolfSSLImplementSSLSession getSession(WolfSSLSession ssl) {
+    protected synchronized WolfSSLImplementSSLSession getSession(
+        WolfSSLSession ssl) {
+
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                 "creating new session");
 
@@ -367,45 +387,62 @@ public class WolfSSLAuthStore {
     }
 
     /**
-     * Add the session for possible resumption
-     * @param session the session to add to stored session map
+     * Add SSLSession into wolfJSSE Java session cache table, to be used
+     * for session resumption.
+     *
+     * Session is stored into the session table using a hash code as the key.
+     * If the peer host is not null, the hash code is based on a concatenation
+     * of the peer host and port. If the peer host is null, the hash code
+     * is based on the session ID (if ID is not null, and non-zero length).
+     * Otherwise, no hash code is generated and the session is not stored into
+     * the session cache table.
+     *
+     * This method synchronizes on the static/global storeLock object, since
+     * the session cache is global and shared amongst all threads.
+     *
+     * @param session SSLSession to be stored in Java session cache
      * @return SSL_SUCCESS on success
      */
     protected int addSession(WolfSSLImplementSSLSession session) {
+
         String toHash;
         int    hashCode = 0;
 
-        if (session.getPeerHost() != null) {
-            /* register into session table for resumption */
-            session.fromTable = true;
-            toHash = session.getPeerHost().concat(Integer.toString(
-                     session.getPeerPort()));
-            hashCode = toHash.hashCode();
-        }
-        else {
-            /* if no peer host is available then create hash key from
-             * session ID if not null, not zero length, and not all zeros */
-            byte[] sessionId = session.getId();
-            if (sessionId != null && sessionId.length > 0 &&
-                (idAllZeros(sessionId) == false)) {
-                hashCode = Arrays.toString(session.getId()).hashCode();
-            }
-        }
-
+        /* Lock access to store while adding new session, store is global */
         synchronized (storeLock) {
-            if (hashCode != 0 && !store.containsKey(hashCode)) {
+            if (session.getPeerHost() != null) {
+                /* Generate key for storing into session table (host:port) */
+                session.fromTable = true;
+                toHash = session.getPeerHost().concat(Integer.toString(
+                         session.getPeerPort()));
+                hashCode = toHash.hashCode();
+            }
+            else {
+                /* If no peer host is available then create hash key from
+                 * session ID if not null, not zero length, and not all zeros */
+                byte[] sessionId = session.getId();
+                if (sessionId != null && sessionId.length > 0 &&
+                    (idAllZeros(sessionId) == false)) {
+                    hashCode = Arrays.toString(session.getId()).hashCode();
+                }
+            }
+
+            /* Always try to store session into cache table, as long as we
+             * have a hashCode. If session already exists for hashCode, it
+             * will be overwritten with new/refreshed version */
+            if (hashCode != 0) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                         "stored session in cache table (host: " +
                         session.getPeerHost() + ", port: " +
                         session.getPeerPort() + ") " +
                         "hashCode = " + hashCode + " side = " +
                         session.getSide());
-                    store.put(hashCode, session);
+                store.put(hashCode, session);
             }
         }
+
         return WolfSSL.SSL_SUCCESS;
     }
-
 
     /**
      * Internal function to return a list of all session ID's
@@ -423,10 +460,10 @@ public class WolfSSLAuthStore {
                     ret.add(current.getId());
                 }
             }
-        }
-        return Collections.enumeration(ret);
-    }
 
+            return Collections.enumeration(ret);
+        }
+    }
 
     /**
      * Getter function for session with session id 'ID'
@@ -447,10 +484,10 @@ public class WolfSSLAuthStore {
                     break;
                 }
             }
-        }
-        return ret;
-    }
 
+            return ret;
+        }
+    }
 
     /**
      * Goes through the list of sessions and checks for timeouts. If timed out
@@ -485,7 +522,6 @@ public class WolfSSLAuthStore {
             }
         }
     }
-
 
     private class SessionStore<K, V> extends LinkedHashMap<K, V> {
         /**

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
@@ -1223,19 +1223,25 @@ public class WolfSSLEngine extends SSLEngine {
      */
     protected synchronized int internalSendCb(byte[] in, int sz) {
         int totalSz = sz, idx = 0;
-        byte[] tmp;
+        byte[] prevToSend = null;
 
         synchronized (toSendLock) {
+            /* Make copy of existing toSend array before expanding */
             if (this.toSend != null) {
+                prevToSend = this.toSend.clone();
                 totalSz += this.toSend.length;
             }
-            tmp = new byte[totalSz];
-            if (this.toSend != null) {
-                System.arraycopy(this.toSend, 0, tmp, idx, this.toSend.length);
-                idx += this.toSend.length;
+
+            /* Allocate new array to hold data to be sent */
+            this.toSend = new byte[totalSz];
+
+            /* Copy existing toSend data over */
+            if (prevToSend != null) {
+                System.arraycopy(prevToSend, 0, this.toSend, idx,
+                                 prevToSend.length);
+                idx += prevToSend.length;
             }
-            System.arraycopy(in, 0, tmp, idx, in.length);
-            this.toSend = tmp;
+            System.arraycopy(in, 0, this.toSend, idx, sz);
         }
 
         if (ioDebugEnabled == true) {

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
@@ -776,6 +776,12 @@ public class WolfSSLEngine extends SSLEngine {
              * WANT_WRAP since we'll need to send a ClientHello first */
             hs = SSLEngineResult.HandshakeStatus.NEED_WRAP;
         }
+        else if (hs == SSLEngineResult.HandshakeStatus.NEED_WRAP &&
+                 this.toSend.length > 0) {
+            /* Already have data buffered to send and in NEED_WRAP state,
+             * just return so wrap() can be called */
+            hs = SSLEngineResult.HandshakeStatus.NEED_WRAP;
+        }
         else {
 
             if (needInit) {

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
@@ -805,6 +805,7 @@ public class WolfSSLEngineHelper {
         throws SSLException, SocketTimeoutException {
 
         int ret, err;
+        byte[] serverId = null;
 
         if (!modeSet) {
             throw new SSLException("setUseClientMode has not been called");
@@ -833,6 +834,19 @@ public class WolfSSLEngineHelper {
                 return WolfSSL.SSL_HANDSHAKE_FAILURE;
             }
             this.session = this.authStore.getSession(ssl);
+        }
+
+        if (this.clientMode) {
+            /* Associate host:port as serverID for client session cache,
+             * helps native wolfSSL for TLS 1.3 sessions with no session ID.
+             * Setting newSession to 1 for setServerID since we are controlling
+             * get/set session from Java */
+            serverId = this.hostname.concat(
+                Integer.toString(this.port)).getBytes();
+            ret = this.ssl.setServerID(serverId, 1);
+            if (ret != WolfSSL.SSL_SUCCESS) {
+                return WolfSSL.SSL_HANDSHAKE_FAILURE;
+            }
         }
 
         do {

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
@@ -769,7 +769,7 @@ public class WolfSSLEngineHelper {
                 this.session.setSide(WolfSSL.WOLFSSL_SERVER_END);
             }
 
-            if (this.sessionCreation == false && !this.session.fromTable) {
+            if (this.sessionCreation == false && !this.session.isFromTable) {
                 /* new handshakes can not be made in this case. */
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                         "session creation not allowed");
@@ -811,7 +811,7 @@ public class WolfSSLEngineHelper {
             throw new SSLException("setUseClientMode has not been called");
         }
 
-        if (this.sessionCreation == false && !this.session.fromTable) {
+        if (this.sessionCreation == false && !this.session.isFromTable) {
             /* new handshakes can not be made in this case. */
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                     "session creation not allowed");

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
@@ -42,9 +42,9 @@ import java.security.Security;
  * @author wolfSSL
  */
 public class WolfSSLEngineHelper {
-    private final WolfSSLSession ssl;
+    private volatile WolfSSLSession ssl = null;
     private WolfSSLImplementSSLSession session = null;
-    private WolfSSLParameters params;
+    private WolfSSLParameters params = null;
     private int port;
     private String hostname = null;  /* used for session lookup and SNI */
     private WolfSSLAuthStore authStore = null;
@@ -896,6 +896,21 @@ public class WolfSSLEngineHelper {
             }
             this.authStore.addSession(this.session);
         }
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    protected synchronized void finalize() throws Throwable {
+
+        /* Reset this.ssl to null, but don't explicitly free. This object
+         * may be used by wrapper object to WolfSSLEngineHelper and should
+         * be freed there */
+        this.ssl = null;
+
+        this.session = null;
+        this.params = null;
+        this.authStore = null;
+        super.finalize();
     }
 }
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
@@ -148,7 +148,14 @@ public class WolfSSLImplementSSLSession implements SSLSession {
             else {
                 return this.ssl.getSessionID();
             }
-        } catch (IllegalStateException | WolfSSLJNIException e) {
+
+        } catch (IllegalStateException e) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                "In getId(), WolfSSLSession has been freed, returning null");
+            return null;
+
+        } catch (WolfSSLJNIException e) {
+            /* print stack trace of native JNI error for debugging */
             e.printStackTrace();
             return null;
         }

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
@@ -60,6 +60,12 @@ public class WolfSSLImplementSSLSession implements SSLSession {
     byte[] pseudoSessionID = null; /* used with TLS 1.3*/
     private int side = 0;
 
+    /* Cache peer certificates after received. Applications assume that
+     * SSLSocket.getSession().getPeerCertificates() will return the peer
+     * certificate even on a resumed connection where the cert has not been
+     * sent during the handshake. */
+    private Certificate[] peerCerts = null;
+
     /** Has this session been registered */
     protected boolean fromTable = false;
 
@@ -87,6 +93,7 @@ public class WolfSSLImplementSSLSession implements SSLSession {
         this.host = host;
         this.authStore = params;
         this.valid = false; /* flag if joining or resuming session is allowed */
+        this.peerCerts = null;
         binding = new HashMap<String, Object>();
 
         creation = new Date();
@@ -106,6 +113,7 @@ public class WolfSSLImplementSSLSession implements SSLSession {
         this.host = null;
         this.authStore = params;
         this.valid = false; /* flag if joining or resuming session is allowed */
+        this.peerCerts = null;
         binding = new HashMap<String, Object>();
 
         creation = new Date();
@@ -122,6 +130,7 @@ public class WolfSSLImplementSSLSession implements SSLSession {
         this.host = null;
         this.authStore = params;
         this.valid = false; /* flag if joining or resuming session is allowed */
+        this.peerCerts = null;
         binding = new HashMap<String, Object>();
 
         creation = new Date();
@@ -317,6 +326,11 @@ public class WolfSSLImplementSSLSession implements SSLSession {
             throw new SSLPeerUnverifiedException("handshake not complete");
         }
 
+        /* If peer cert is already cached, just return that */
+        if (this.peerCerts != null) {
+            return this.peerCerts.clone();
+        }
+
         try {
             x509 = this.ssl.getPeerCertificate();
         } catch (IllegalStateException | WolfSSLJNIException ex) {
@@ -366,7 +380,10 @@ public class WolfSSLImplementSSLSession implements SSLSession {
         /* release native memory */
         cert.free();
 
-        return new Certificate[] { exportCert };
+        /* cache peer cert for use by app in resumed session */
+        this.peerCerts = new Certificate[] { exportCert };
+
+        return this.peerCerts.clone();
     }
 
     @Override

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -41,6 +41,7 @@ import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLException;
 
 import com.wolfssl.WolfSSL;
 import com.wolfssl.WolfSSLException;
@@ -1438,6 +1439,32 @@ public class WolfSSLSocket extends SSLSocket {
         if (params != null) {
             WolfSSLParametersHelper.importParams(params, this.params);
         }
+    }
+
+    /**
+     * Has the underlying WOLFSSL / WolfSSLSession been resumed / reused.
+     * This calls down to native wolfSSL_session_reused()
+     *
+     * NON-STANDARD API, not part of JSSE. Must cast SSLSocket back
+     * to WolfSSLSocke to use.
+     *
+     * @return true if session has been resumed, otherwise false
+     * @throws SSLException if native JNI call fails or underlying
+     *         WolfSSLSession has been freed
+     */
+    public boolean sessionResumed() throws SSLException {
+        if (this.ssl != null) {
+            try {
+                int resume = this.ssl.sessionReused();
+                if (resume == 1) {
+                    return true;
+                }
+            } catch (IllegalStateException | WolfSSLJNIException e) {
+                throw new SSLException(e);
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -1516,6 +1516,9 @@ public class WolfSSLSocket extends SSLSocket {
                         EngineHelper.saveSession();
                     }
 
+                    WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                        "thread trying to get ioLock (shutdown)");
+
                     synchronized (ioLock) {
                         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                                          "thread got ioLock (shutdown)");
@@ -1532,7 +1535,12 @@ public class WolfSSLSocket extends SSLSocket {
                                          "thread exiting ioLock (shutdown)");
                     }
 
+                    WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                        "thread trying to get handshakeLock");
+
                     synchronized (handshakeLock) {
+                        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                            "thread got handshakeLock");
                         this.connectionClosed = true;
 
                         /* Connection is closed, free native WOLFSSL session
@@ -1542,8 +1550,12 @@ public class WolfSSLSocket extends SSLSocket {
                         if (readCtx != null &&
                             readCtx instanceof ConsumedRecvCtx) {
                             ConsumedRecvCtx rctx = (ConsumedRecvCtx)readCtx;
+                            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                                "calling ConsumedRecvCtx.closeDataStreams()");
                             rctx.closeDataStreams();
                         }
+                        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                            "calling this.ssl.freeSSL()");
                         this.ssl.freeSSL();
                         this.ssl = null;
                     }

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineTest.java
@@ -54,6 +54,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicIntegerArray;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import org.junit.BeforeClass;
@@ -585,10 +586,10 @@ public class WolfSSLEngineTest {
         boolean returnWithoutTimeout = true;
 
         /* Keep track of failure and success count */
-        final int[] failures = new int[1];
-        final int[] success = new int[1];
-        failures[0] = 0;
-        success[0] = 0;
+        final AtomicIntegerArray failures = new AtomicIntegerArray(1);
+        final AtomicIntegerArray success = new AtomicIntegerArray(1);
+        failures.set(0, 0);
+        success.set(0, 0);
 
         System.out.print("\tTesting ExtendedThreadingUse");
 
@@ -611,9 +612,9 @@ public class WolfSSLEngineTest {
                         client.connect();
                     } catch (Exception e) {
                         e.printStackTrace();
-                        failures[0] = failures[0] + 1;
+                        failures.incrementAndGet(0);
                     }
-                    success[0] = success[0] + 1;
+                    success.incrementAndGet(0);
 
                     latch.countDown();
                 }
@@ -625,11 +626,14 @@ public class WolfSSLEngineTest {
         server.join(1000);
 
         /* check failure count and success count against thread count */
-        if (failures[0] == 0 && success[0] == numThreads) {
+        if (failures.get(0) == 0 && success.get(0) == numThreads) {
             pass("\t... passed");
         } else {
             if (returnWithoutTimeout == true) {
-                fail("SSLEngine threading error");
+                fail("SSLEngine threading error: " +
+                     failures.get(0) + " failures, " +
+                     success.get(0) + " success, " +
+                     numThreads + " num threads total");
             } else {
                 fail("SSLEngine threading error, threads timed out");
             }

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSessionContextTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSessionContextTest.java
@@ -237,7 +237,7 @@ public class WolfSSLSessionContextTest {
         if (ctx.getProvider() == Security.getProvider("wolfJSSE")) {
             SSLSessionContext sesCtx = ses.getSessionContext();
 
-            if (sesCtx.getSessionCacheSize() != 10) {
+            if (sesCtx.getSessionCacheSize() != 33) {
                 error("\t\t... failed");
                 fail("session default cache size wrong");
             }


### PR DESCRIPTION
This PR contains a variety of JSSE-level fixes which help fix compatibility with Spring Boot, RabbitMQ, session resumption, and SSLEngine usage.

- Previous PR (https://github.com/wolfSSL/wolfssljni/pull/142) added synchronization around native pointer use. We need to loosen locking on WolfSSLSession.read/write() since it's already locking/unlocking a mutex at the native JNI layer.  With the existing sslLock synchronization around write/read(), we can get stuck in a timeout situation where we are waiting on read() for example, but data needs to be written with write() before state can continue. This can lead to the peer timing out and closing the socket too early (https://github.com/wolfSSL/wolfssljni/pull/144/commits/4f2df6db81b1b6b78ebf4f54454bff7f410a0aa1)
- Cache the peer certificate inside the SSLSession object after the first successful connection. Java applications who do session resumption expect access to the peer certificate after the resumed session. Native wolfSSL does not keep the session, since cert is not sent in resumed connection. Previously this was in https://github.com/wolfSSL/wolfssljni/pull/135. (https://github.com/wolfSSL/wolfssljni/pull/144/commits/cdcea7505e18e850dfa51da01377dc2714265590)
- Fix for TLS 1.3 session resumption, need to call wolfSSL_peek() before wolfSSL_get_session() to ensure ticket has been received into session. (https://github.com/wolfSSL/wolfssljni/pull/144/commits/577438057b3e6ac09d947d89134b9be5ff00d84b)
- Add non-JSSE method for detecting if WolfSSLSocket session has been resumed (https://github.com/wolfSSL/wolfssljni/pull/144/commits/f7523b217ed933019ccf0f08d587269d63bcd577).
- Wrap native `wolfSSL_SetServerID()` and call on client side to help resumption and client-side session cache (https://github.com/wolfSSL/wolfssljni/pull/144/commits/4db4c2bdcf1e00440113eb29e5185d3fc6bac334).
- Make lock in `WolfSSLImplementSSLSession` for access to native `WOLFSSL_SESSION` pointer static, since there could be multiple `WolfSSLSocket` objects referencing the same `WOLFSSL_SESSION` (https://github.com/wolfSSL/wolfssljni/pull/144/commits/d98260d1aa7ab66d6a115cdccf8e98cfb9398217).
- Make lock in `WolfSSLAuthStore` around Java session cache static, since used globally and shared between all threads (https://github.com/wolfSSL/wolfssljni/pull/144/commits/b5bffbdee1534202f88b1efaa9933d047ac45a23).
- Synchronize read/write calls in `WolfSSLInputStream/WolfSSLOutputStream` and add more debug logs (https://github.com/wolfSSL/wolfssljni/pull/144/commits/e7fd6d4fc4d703e61ece90ef54645916755ddc08).
- Add finalizer to `WolfSSLAuthStore`, clear and set LinkedHashMap back to null (https://github.com/wolfSSL/wolfssljni/pull/144/commits/a688fd2be5ad300694698136da3cbaf9dc601783).
- Add finalizer to `WolfSSLEngineHelper`, reset some class variables back to null (https://github.com/wolfSSL/wolfssljni/pull/144/commits/8b22fde8fa9486297a0d8a30cb7eba171b0887dc).

SSLEngine specific changes and fixes:
- Only try to save session after successful handshake. Pass host and port to super constructor during object creation. Fix edge case where `NEED_WRAP` status should be returned when client-side `unwrap()` is called before handshake has began (since `wrap()` should be called on the client side first to start a handshake) (https://github.com/wolfSSL/wolfssljni/pull/144/commits/63ce0506eaff75bd5670a62e206d456b4d1f3fe4).
- If `unwrap()` is called but there is buffered data to be sent, return `NEED_WRAP` status to allow for proper application behavior (https://github.com/wolfSSL/wolfssljni/pull/144/commits/4cc47047ac41e5c4bd2a9321e101bd25d28694d3).
- Re-allocate/size larger `toSend[]` directly when needed in internal send callback (https://github.com/wolfSSL/wolfssljni/pull/144/commits/8e99040b2c631bf909bc6519f9234730d56e275e).
- Fix behavior of SSLEngine when sending and receiving `close_notify` alerts, based on interop testing with SunJSSE (https://github.com/wolfSSL/wolfssljni/pull/144/commits/b04c1b141b107405b0172f4644d9b5835b573354).
- Set and unset internal I/O callbacks on-demand when needed. This avoids a scenario where a two-way reference between WolfSSLEngine and WolfSSLSession caused neither to be garbage collected (https://github.com/wolfSSL/wolfssljni/pull/144/commits/bc0742e4c5926009c216e4082c716599e854e7e7).

These fixes have been tested in customer environment and seem to resolve issues with Spring Boot / RabbitMQ and memory usage.

ZD 16514