### PR TITLE
SSLSocket: fall back to I/O callbacks with Input/OutputStream if setting internal file descriptor fails

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocketFactory.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocketFactory.java
@@ -295,8 +295,9 @@ public class WolfSSLSocketFactory extends SSLSocketFactory {
         boolean autoClose) throws IOException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered createSocket(Socket s, host: " + host + ", port: " +
-            port + ", autoClose: " + String.valueOf(autoClose) + ")");
+            "entered createSocket(Socket: " + s.getClass() + ", host: " +
+            host + ", port: " + port + ", autoClose: " +
+            String.valueOf(autoClose) + ")");
 
         try {
             initDefaultContext();
@@ -327,7 +328,8 @@ public class WolfSSLSocketFactory extends SSLSocketFactory {
         boolean autoClose) throws IOException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered createSocket(Socket s, InputStream consumed, autoClose: "
+            "entered createSocket(Socket: " + s.getClass() +
+            ", InputStream consumed, autoClose: "
             + String.valueOf(autoClose) + ")");
 
         try {


### PR DESCRIPTION
This PR modifies wolfJSSE's `WolfSSLSocket` implementation by registering native wolfSSL I/O callbacks which call a wrapped `java.net.Socket` or subclassed object's InputStream and OutputStream if setting the internal `SocketImpl` file descriptor to native wolfSSL fails.

Some subclasses of `java.net.Socket` do not initialize the internal file descriptor if they will be handling I/O differently. For these cases we need to use I/O callbacks to read and write from the provided InputStream and OutputStream.

A test case has been added where we create our own subclass of `java.net.Socket` that does not have the internal file descriptor set.

Related to ZD 15902, where Socket subclass was of type `com.microsoft.sqlserver.jdbc.TDSChannel$ProxySocket`.  Customer confirmed this has fixed the connection issue.