### PR TITLE
Add SSLSocket.getApplicationProtocol()

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -992,6 +992,24 @@ public class WolfSSLSocket extends SSLSocket {
     }
 
     /**
+     * Returns the most recent application protocol value negotiated
+     * during the SSL/TLS handshake by ALPN.
+     *
+     * Not marked at @Override since this API was added as of
+     * Java SE 8 Maintenance Release 3, and Java 7 SSLSocket will not
+     * have this.
+     *
+     * @return String representating the application protocol negotiated
+     */
+    public synchronized String getApplicationProtocol() {
+
+        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+            "entered getApplicationProtocol()");
+
+        return EngineHelper.getAlpnSelectedProtocolString();
+    }
+
+    /**
      * Returns array of protocols supported by this SSLSocket.
      *
      * @return String array containing supported SSL/TLS protocols


### PR DESCRIPTION
This PR adds `WolfSSLSocket.getApplicationProtocol()` to return the application protocol negotiated via ALPN during the TLS handshake.

`WolfSSLEngine` already had this API added, but `WolfSSLSocket` did not.  This was causing issues with wolfJSSE compatibility with okhttp.

ZD #16581