### PR TITLE
Throw SocketException if native socket select() fails

### DIFF
--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -35,6 +35,9 @@
 #ifdef HAVE_FIPS
     #include <wolfssl/wolfcrypt/fips_test.h>
 #endif
+#ifndef USE_WINDOWS_API
+    #include <sys/errno.h>
+#endif
 
 #include "com_wolfssl_globals.h"
 #include "com_wolfssl_WolfSSL.h"
@@ -1644,4 +1647,14 @@ JNIEXPORT jobjectArray JNICALL Java_com_wolfssl_WolfSSL_getProtocolsMask
     }
 #endif
     return ret;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getErrno
+  (JNIEnv* jenv, jclass jcl)
+{
+#ifndef USE_WINDOWS_API
+    return errno;
+#else
+    return 0;
+#endif
 }

--- a/native/com_wolfssl_WolfSSL.h
+++ b/native/com_wolfssl_WolfSSL.h
@@ -879,6 +879,14 @@ JNIEXPORT jobjectArray JNICALL Java_com_wolfssl_WolfSSL_getProtocols
 JNIEXPORT jobjectArray JNICALL Java_com_wolfssl_WolfSSL_getProtocolsMask
   (JNIEnv *, jclass, jlong);
 
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getErrno
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getErrno
+  (JNIEnv *, jclass);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -1314,6 +1314,21 @@ public class WolfSSL {
      */
     public static native String[] getProtocolsMask(long mask);
 
+    /* ----------------------- native helper methods ------------------------ */
+
+    /**
+     * Return native system errno value.
+     *
+     * Some native system calls, such as select() will set errno when an
+     * error is encountered. This JNI method is a simple getter to retrive
+     * the current system errno value.
+     *
+     * If on Windows, this will return 0 (no errno support on Windows)
+     *
+     * @return System native errno value
+     */
+    public static native int getErrno();
+
     /**
      * Gets the internal wolfSSL named group enum matching provided string.
      *

--- a/src/test/com/wolfssl/test/WolfSSLSessionTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLSessionTest.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.*;
 import java.net.Socket;
 import java.net.UnknownHostException;
 import java.net.ConnectException;
+import java.net.SocketException;
 import java.net.SocketTimeoutException;
 
 import com.wolfssl.WolfSSL;
@@ -537,7 +538,7 @@ public class WolfSSLSessionTest {
         } catch (IllegalStateException ise) {
             System.out.println("\t\t... passed");
             return;
-        } catch (SocketTimeoutException e) {
+        } catch (SocketTimeoutException | SocketException e) {
             System.out.println("\t\t... failed");
             e.printStackTrace();
             return;

--- a/src/test/com/wolfssl/test/WolfSSLTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLTest.java
@@ -53,6 +53,7 @@ public class WolfSSLTest {
         test_WolfSSL_protocol();
         test_WolfSSL_Method_Allocators(lib);
         test_WolfSSL_getLibVersionHex();
+        test_WolfSSL_getErrno();
         testGetCiphersAvailableIana();
     }
 
@@ -140,6 +141,15 @@ public class WolfSSLTest {
         }
 
         System.out.println("\t\t... passed");
+    }
+
+    public void test_WolfSSL_getErrno() {
+        System.out.print("\tgetErrno()");
+
+        /* Just make sure we don't seg fault or crash here */
+        int errno = WolfSSL.getErrno();
+
+        System.out.println("\t\t\t... passed");
     }
 }
 


### PR DESCRIPTION
This PR modified JNI/JSSE code to throw a `SocketException` (or propagated as `SSLException` in JSSE) if the native socket `select()` call fails. Previously this was not handled gracefully and ended up in vague error logs. This adds the system `errno` to the `SocketException` message for easier debugging and error resolution for these scenarios.

Related to ZD #16581