### PR TITLE
Standardize JNI library name on OSX to .dylib

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -92,7 +92,7 @@
 
     <target name="cleanjni">
         <delete>
-            <fileset dir="${lib.dir}" includes="*.jnilib"/>
+            <fileset dir="${lib.dir}" includes="*.dylib"/>
             <fileset dir="${lib.dir}" includes="*.so"/>
             <fileset dir="${native.dir}" includes="*.o"/>
         </delete>

--- a/java.sh
+++ b/java.sh
@@ -74,7 +74,7 @@ if [ "$OS" == "Darwin" ] ; then
     fi
     javaIncludes="-I$javaHome/include -I$javaHome/include/darwin -I$WOLFSSL_INSTALL_DIR/include"
     javaLibs="-dynamiclib"
-    jniLibName="libwolfssljni.jnilib"
+    jniLibName="libwolfssljni.dylib"
     cflags=""
 elif [ "$OS" == "Linux" ] ; then
     echo "    Detected Linux host OS"


### PR DESCRIPTION
This PR standardizes the native JNI shared library on OSX to `.dylib` extension, which matches OSX shared library naming. Some Java versions won't find `libwolfssljni.jnilib` if installed unless it is named `libwolfssljni.dylib` instead.