### PR TITLE
JNI/JSSE: WOLFSSL_TRUST_PEER_CERT support, session resumption fixes

### DIFF
--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -399,6 +399,19 @@ JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_certReqEnabled
 #endif
 }
 
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_trustPeerCertEnabled
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+#ifdef WOLFSSL_TRUST_PEER_CERT
+    return JNI_TRUE;
+#else
+    return JNI_FALSE;
+#endif
+}
+
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_SSLv3_1ServerMethod
   (JNIEnv* jenv, jclass jcl)
 {

--- a/native/com_wolfssl_WolfSSL.h
+++ b/native/com_wolfssl_WolfSSL.h
@@ -521,6 +521,14 @@ JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_certReqEnabled
 
 /*
  * Class:     com_wolfssl_WolfSSL
+ * Method:    trustPeerCertEnabled
+ * Signature: ()Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_trustPeerCertEnabled
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
  * Method:    SSLv3_ServerMethod
  * Signature: ()J
  */

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -33,6 +33,11 @@
 #include <arpa/inet.h>
 #endif
 
+#ifndef WOLFSSL_JNI_DEFAULT_PEEK_TIMEOUT
+    /* Default wolfSSL_peek() timeout for wolfSSL_get_session(), ms */
+    #define WOLFSSL_JNI_DEFAULT_PEEK_TIMEOUT 2000
+#endif
+
 #include <wolfssl/ssl.h>
 #include <wolfssl/error-ssl.h>
 
@@ -898,7 +903,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_read(JNIEnv* jenv,
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_accept
-  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jint timeout)
 {
     int ret = 0, err, sockfd;
     wolfSSL_Mutex* jniSessLock = NULL;
@@ -954,7 +959,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_accept
                 break;
             }
 
-            ret = socketSelect(sockfd, 0, 1);
+            ret = socketSelect(sockfd, (int)timeout, 1);
             if (ret == WOLFJNI_RECV_READY || ret == WOLFJNI_SEND_READY) {
                 /* I/O ready, continue handshake and try again */
                 continue;
@@ -1221,26 +1226,82 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setSession
 {
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     WOLFSSL_SESSION* session = (WOLFSSL_SESSION*)(uintptr_t)sessionPtr;
+    wolfSSL_Mutex* jniSessLock = NULL;
+    SSLAppData* appData = NULL;
+    int ret = 0;
     (void)jcl;
 
     if (jenv == NULL || ssl == NULL) {
         return SSL_FAILURE;
     }
 
+    /* get session mutex from SSL app data */
+    appData = (SSLAppData*)wolfSSL_get_app_data(ssl);
+    if (appData == NULL) {
+        printf("Failed to get SSLAppData* in native setSession()\n");
+        return (jlong)0;
+    }
+
+    jniSessLock = appData->jniSessLock;
+    if (jniSessLock == NULL) {
+        printf("SSLAppData* NULL in native setSession()\n");
+        return (jlong)0;
+    }
+
+    /* get WOLFSSL session I/O lock */
+    if (wc_LockMutex(jniSessLock) != 0) {
+        printf("Failed to lock native jniSessLock in setSession()");
+        return (jlong)0;
+    }
+
     /* wolfSSL checks session for NULL, but not ssl */
-    return wolfSSL_set_session(ssl, session);
+    ret = wolfSSL_set_session(ssl, session);
+
+    if (wc_UnLockMutex(jniSessLock) != 0) {
+        printf("Failed to unlock jniSessLock in setSession()");
+    }
+
+    return ret;
 }
 
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_getSession
   (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
+    WOLFSSL_SESSION* sess = NULL;
+    wolfSSL_Mutex* jniSessLock = NULL;
+    SSLAppData* appData = NULL;
     (void)jenv;
     (void)jcl;
 
+    /* get session mutex from SSL app data */
+    appData = (SSLAppData*)wolfSSL_get_app_data(ssl);
+    if (appData == NULL) {
+        printf("Failed to get SSLAppData* in native getSession()\n");
+        return (jlong)0;
+    }
+
+    jniSessLock = appData->jniSessLock;
+    if (jniSessLock == NULL) {
+        printf("SSLAppData* NULL in native getSession()\n");
+        return (jlong)0;
+    }
+
+    /* get WOLFSSL session I/O lock */
+    if (wc_LockMutex(jniSessLock) != 0) {
+        printf("Failed to lock native jniSessLock in getSession()");
+        return (jlong)0;
+    }
+
     /* wolfSSL checks ssl for NULL, returns pointer into WOLFSSL which is
      * freed when wolfSSL_free() is called. */
-    return (jlong)(uintptr_t)wolfSSL_get_session(ssl);
+    sess = wolfSSL_get_session(ssl);
+
+    if (wc_UnLockMutex(jniSessLock) != 0) {
+        printf("Failed to unlock jniSessLock in getSession()");
+    }
+
+    return (jlong)(uintptr_t)sess;
 }
 
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_get1Session
@@ -1254,6 +1315,9 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_get1Session
     /* tmpBuf is only 1 byte since wolfSSL_peek() doesn't need to read
      * any app data, only session ticket internally */
     char tmpBuf[1];
+    int ret = 0;
+    int err = 0;
+    int sockfd = 0;
     (void)jenv;
     (void)jcl;
 
@@ -1281,8 +1345,32 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_get1Session
      * session ticket message. */
     sess = wolfSSL_get_session(ssl);
     if (sess == NULL) {
+
         /* session not available yet (TLS 1.3), try peeking to get ticket */
-        wolfSSL_peek(ssl, tmpBuf, (int)sizeof(tmpBuf));
+        do {
+            ret = wolfSSL_peek(ssl, tmpBuf, (int)sizeof(tmpBuf));
+            err = wolfSSL_get_error(ssl, ret);
+
+            if (ret <= 0 && (err == SSL_ERROR_WANT_READ)) {
+
+                sockfd = wolfSSL_get_fd(ssl);
+                if (sockfd == -1) {
+                    /* For I/O that does not use sockets, sockfd may be -1,
+                     * skip try to call select() */
+                    break;
+                }
+
+                ret = socketSelect(sockfd,
+                        (int)WOLFSSL_JNI_DEFAULT_PEEK_TIMEOUT, 1);
+                if (ret == WOLFJNI_RECV_READY || ret == WOLFJNI_SEND_READY) {
+                    /* I/O ready, continue handshake and try again */
+                    continue;
+                } else {
+                    /* other error, continue on */
+                    break;
+                }
+            }
+        } while (err == SSL_ERROR_WANT_READ);
 
         sess = wolfSSL_get_session(ssl);
     }

--- a/native/com_wolfssl_WolfSSLSession.h
+++ b/native/com_wolfssl_WolfSSLSession.h
@@ -106,10 +106,10 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_read
 /*
  * Class:     com_wolfssl_WolfSSLSession
  * Method:    accept
- * Signature: (J)I
+ * Signature: (JI)I
  */
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_accept
-  (JNIEnv *, jobject, jlong);
+  (JNIEnv *, jobject, jlong, jint);
 
 /*
  * Class:     com_wolfssl_WolfSSLSession

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -680,6 +680,14 @@ public class WolfSSL {
      */
     public static native boolean certReqEnabled();
 
+    /**
+     * Tests if native wolfSSL has been compiled with WOLFSSL_TRUST_PEER_CERT.
+     *
+     * @return true if enabled, otherwise false if WOLFSSL_TRUST_PEER_CERT
+     *         has not been defined.
+     */
+    public static native boolean trustPeerCertEnabled();
+
     /* ---------------- native SSL/TLS version functions ---------------- */
 
     /**

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLAuthStore.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLAuthStore.java
@@ -348,11 +348,6 @@ public class WolfSSLAuthStore {
                  * after the resumed session completes the handshake, for
                  * subsequent resumption attempts to use. */
                 store.remove(toHash.hashCode());
-
-                /* Make copy/clone of session object so multiple threads
-                 * don't try to use the same cache entry. Cache entry will
-                 * be overwritten when new session with same key is stored */
-                ses = new WolfSSLImplementSSLSession(ses);
                 ses.isFromTable = true;
 
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
@@ -80,7 +80,6 @@ public class WolfSSLEngineHelper {
         this.ssl = ssl;
         this.params = params;
         this.authStore = store;
-        this.session = new WolfSSLImplementSSLSession(store);
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "created new WolfSSLEngineHelper()");
@@ -107,7 +106,6 @@ public class WolfSSLEngineHelper {
         this.port = port;
         this.hostname = hostname;
         this.authStore = store;
-        this.session = new WolfSSLImplementSSLSession(store);
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "created new WolfSSLEngineHelper(port: " + port +
             ", hostname: " + hostname + ")");
@@ -140,7 +138,10 @@ public class WolfSSLEngineHelper {
      * @return WolfSSLImplementSession for this object
      */
     protected WolfSSLImplementSSLSession getSession() {
-        return session;
+        if (this.session == null) {
+            this.session = new WolfSSLImplementSSLSession(authStore);
+        }
+        return this.session;
     }
 
     /**
@@ -823,7 +824,7 @@ public class WolfSSLEngineHelper {
             return WolfSSL.SSL_HANDSHAKE_FAILURE;
         }
 
-        if (!this.session.isValid()) {
+        if ((this.session == null) || !this.session.isValid()) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                     "session is marked as invalid, try creating a new seesion");
             if (this.sessionCreation == false) {

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
@@ -138,7 +138,12 @@ public class WolfSSLEngineHelper {
      * @return WolfSSLImplementSession for this object
      */
     protected WolfSSLImplementSSLSession getSession() {
+
         if (this.session == null) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                "this.session is null, creating new " +
+                "WolfSSLImplementSSLSession");
+
             this.session = new WolfSSLImplementSSLSession(authStore);
         }
         return this.session;
@@ -795,7 +800,6 @@ public class WolfSSLEngineHelper {
      *                    or not.
      * @param timeout socket timeout (milliseconds) for connect(), or 0 for
      *                infinite/no timeout.
-     *
      * @return WolfSSL.SSL_SUCCESS on success or either WolfSSL.SSL_FAILURE
      *         or WolfSSL.SSL_HANDSHAKE_FAILURE on error
      *
@@ -826,7 +830,7 @@ public class WolfSSLEngineHelper {
 
         if ((this.session == null) || !this.session.isValid()) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "session is marked as invalid, try creating a new seesion");
+                    "session is marked as invalid, try creating a new session");
             if (this.sessionCreation == false) {
                 /* new handshakes can not be made in this case. */
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
@@ -834,7 +838,7 @@ public class WolfSSLEngineHelper {
 
                 return WolfSSL.SSL_HANDSHAKE_FAILURE;
             }
-            this.session = this.authStore.getSession(ssl);
+            this.session = this.authStore.getSession(ssl, this.clientMode);
         }
 
         if (this.clientMode) {
@@ -863,7 +867,7 @@ public class WolfSSLEngineHelper {
             } else {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                             "calling native wolfSSL_accept()");
-                ret = this.ssl.accept();
+                ret = this.ssl.accept(timeout);
             }
             err = ssl.getError(ret);
 
@@ -871,32 +875,26 @@ public class WolfSSLEngineHelper {
                  (err == WolfSSL.SSL_ERROR_WANT_READ ||
                   err == WolfSSL.SSL_ERROR_WANT_WRITE));
 
-        if (this.sessionCreation && ret == WolfSSL.SSL_SUCCESS) {
-            /* can only add new sessions to the resumption table if session
-             * creation is allowed */
-            if (this.clientMode) {
-                /* Only need to set resume on client side, server-side
-                 * maintains session cache at native level. */
-                this.session.setResume();
-            }
-            this.authStore.addSession(this.session);
-        }
-
         return ret;
     }
 
     /**
      * Saves session on connection close for resumption
+     *
+     * @return WolfSSL.SSL_SUCCESS if session was saved into cache, otherwise
+     *         WolfSSL.SSL_FAILURE
      */
-    protected synchronized void saveSession() {
+    protected synchronized int saveSession() {
         if (this.session != null && this.session.isValid()) {
             if (this.clientMode) {
                 /* Only need to set resume on client side, server-side
                  * maintains session cache at native level. */
                 this.session.setResume();
             }
-            this.authStore.addSession(this.session);
+            return this.authStore.addSession(this.session);
         }
+
+        return WolfSSL.SSL_FAILURE;
     }
 
     @SuppressWarnings("deprecation")

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLTrustX509.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLTrustX509.java
@@ -483,7 +483,17 @@ public class WolfSSLTrustX509 implements X509TrustManager {
                     cert = (X509Certificate) store.getCertificate(name);
                 }
 
-                if (cert != null && cert.getBasicConstraints() >= 0) {
+                /* Add certificate entry as trusted if either:
+                 * 1. X509v3 Basic Constraint CA:TRUE is set, or
+                 * 2. Native wolfSSL has been compiled with
+                 *    WOLFSSL_TRUST_PEER_CERT defined.
+                 * SunJSSE implementation just adds all certificate entries
+                 * it finds in the provided KeyStore as trusted, so this
+                 * behavior does vary slightly from the default Sun
+                 * implementation. */
+                if (cert != null &&
+                    (cert.getBasicConstraints() >= 0) ||
+                    (WolfSSL.trustPeerCertEnabled())) {
                     CAs.add(cert);
                 }
             }

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLTrustX509Test.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLTrustX509Test.java
@@ -88,9 +88,9 @@ public class WolfSSLTrustX509Test {
         X509TrustManager x509tm;
         X509Certificate cas[];
 
-        String OU[] = { "OU=Programming-2048", "OU=Support",
+        String OU[] = { "OU=ECC", "OU=Programming-2048", "OU=Support",
             "OU=Support_1024", "OU=Consulting", "OU=Development",
-            "OU=Fast", "OU=Consulting_1024", "OU=Programming-1024", "OU=ECC" };
+            "OU=Fast", "OU=Consulting_1024", "OU=Programming-1024" };
 
         int i = 0;
         int expected = OU.length;
@@ -105,7 +105,8 @@ public class WolfSSLTrustX509Test {
 
         /* wolfSSL only returns a list of CA's, server-ecc basic constraint is
          * set to false so it is not added as a CA */
-        if (this.provider != null && this.provider.equals("wolfJSSE")) {
+        if (this.provider != null && this.provider.equals("wolfJSSE") &&
+            !WolfSSL.trustPeerCertEnabled()) {
             /* one less than SunJSSE because of server-ecc */
             expected = expected - 1;
         }
@@ -126,7 +127,8 @@ public class WolfSSLTrustX509Test {
 
         if (cas.length != expected) {
             error("\t\t... failed");
-            fail("wrong number of CAs found");
+            fail("wrong number of CAs found: found " + cas.length +
+                 ", expected " + expected);
         }
 
         for (String x: OU) {
@@ -134,6 +136,9 @@ public class WolfSSLTrustX509Test {
                     provider.equals("wolfJSSE") && x.equals("OU=ECC")) {
                 /* skip checking ECC certs, since not all Java versions
                  * support them */
+                if (WolfSSL.trustPeerCertEnabled()) {
+                    i++;
+                }
                 continue;
             }
 
@@ -216,7 +221,8 @@ public class WolfSSLTrustX509Test {
 
         /* wolfSSL only returns a list of CA's, server-ecc basic constraint is
          * set to false so it is not added as a CA */
-        if (this.provider != null && this.provider.equals("wolfJSSE")) {
+        if (this.provider != null && this.provider.equals("wolfJSSE") &&
+            !WolfSSL.trustPeerCertEnabled()) {
             /* one less than SunJSSE because of server-ecc */
             expected = expected - 1;
         }
@@ -237,7 +243,8 @@ public class WolfSSLTrustX509Test {
 
         if (cas.length != expected) {
             error("\t... failed");
-            fail("wrong number of CAs found");
+            fail("wrong number of CAs found: found " + cas.length +
+                 ", expected " + expected);
         }
 
         for (String x : OU) {
@@ -266,8 +273,8 @@ public class WolfSSLTrustX509Test {
         X509Certificate cas[];
 
         String OU[] = { "OU=Consulting", "OU=Programming-2048", "OU=Fast",
-            "OU=Support", "OU=Programming-1024", "OU=Consulting_1024",
-            "OU=Support_1024", "OU=ECC" };
+            "OU=Support", "OU=ECC", "OU=Programming-1024", "OU=Consulting_1024",
+            "OU=Support_1024" };
 
         int i = 0, j;
         int expected = OU.length;
@@ -281,7 +288,8 @@ public class WolfSSLTrustX509Test {
         }
         /* wolfSSL only returns a list of CA's, server-ecc basic constraint is
          * set to false so it is not added as a CA */
-        if (this.provider != null && this.provider.equals("wolfJSSE")) {
+        if (this.provider != null && this.provider.equals("wolfJSSE") &&
+            !WolfSSL.trustPeerCertEnabled()) {
             /* one less than SunJSSE because of server-ecc */
             expected = expected - 1;
         }
@@ -302,7 +310,8 @@ public class WolfSSLTrustX509Test {
 
         if (cas.length != expected) {
             error("\t... failed");
-            fail("wrong number of CAs found");
+            fail("wrong number of CAs found: found " + cas.length +
+                 ", expected " + expected);
         }
 
         for (j = 0; j < OU.length && i < cas.length; j++) {
@@ -310,6 +319,9 @@ public class WolfSSLTrustX509Test {
                     provider.equals("wolfJSSE") && OU[j].equals("OU=ECC")) {
                 /* skip checking ECC certs, since not all Java versions
                  * support them */
+                if (WolfSSL.trustPeerCertEnabled()) {
+                    i++;
+                }
                 continue;
             }
 


### PR DESCRIPTION
This PR:
- Exposes a JNI method in `WolfSSL.java` that retrieves the status of if `WOLFSSL_TRUST_PEER_CERT` was defined in native wolfSSL or not.
- Modifies `WolfSSLTrustX509.getAcceptedIssuers()` when adding CA/root certs to array to add them if either `CA:TRUE` Basic Constraint is set or `WOLFSSL_TRUST_PEER_CERT` has been defined.

The SunJSSE X509TrustManager.getAcceptedIssuers() implementation simply returns all certificates in the supplied KeyStore. Our wolfJSSE implementation was always more restricted, mandating the `CA:TRUE` extension be set. But for compatibility and interop, this change allows use cases where the peer certificate is self-signed but does not have the CA:TRUE extension set.

- Locks native `WOLFSSL` session lock when `wolfSSL_get_session()` and `wolfSSL_set_session()` are called, needed since we call `wolfSSL_peek()` around `wolfSSL_get_session()` for TLS 1.3 session ticket, and to prevent getting an incomplete session object.
- Optimize creation of `WolfSSLImplementSSLSession` objects to delay creation until needed. Should help reduce overall memory usage of active objects.
- Optimize locking of session pointer lock inside `WolfSSLImplementSSLSession` to reduce time spent inside lock
- Passes the socket timeout value to `select()` which is called around native `wolfSSL_accept()`.  We already did this for `wolfSSL_read/write/connect()`, but had not yet for accept.
- Fix session cache storage into Java cache, only store sessions when they are valid.

ZD #15902
ZD #16487