### PR TITLE
JNI: remove extraneous unable to set FIPS callback debug print

### DIFF
--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -958,7 +958,6 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_setFIPSCb
 #else
     (void)jenv;
     (void)callback;
-    printf("Unable to set FIPS callback without wolfCrypt FIPS code\n");
 #endif
 
     return ret;


### PR DESCRIPTION
Simple PR to remove a debug printf in `Java_com_wolfssl_WolfSSL_setFIPSCb()` that regularly causes questions from new users.  Not needed, since enabling debug logging will give much more info.