### PR TITLE
Fix example JSSE client for resume case when sending HTTP GET

### DIFF
--- a/examples/provider/ClientJSSE.java
+++ b/examples/provider/ClientJSSE.java
@@ -295,8 +295,8 @@ public class ClientJSSE {
                     sock.setEnabledProtocols(protocols);
             }
 
-            System.out.printf("Using SSLContext provider %s\n", ctx.getProvider().
-                    getName());
+            System.out.printf("Using SSLContext provider %s\n",
+                ctx.getProvider().getName());
 
             if (cipherList != null) {
                 sock.setEnabledCipherSuites(cipherList.split(":"));
@@ -311,7 +311,13 @@ public class ClientJSSE {
             } else {
                 System.out.println("Session NOT resumed");
             }
-            sock.getOutputStream().write(msg.getBytes());
+
+            if (sendGET) {
+                sock.getOutputStream().write(httpGetMsg.getBytes());
+            }
+            else {
+                sock.getOutputStream().write(msg.getBytes());
+            }
             sock.getInputStream().read(back);
             System.out.println("Server message : " + new String(back));
             sock.close();


### PR DESCRIPTION
This PR makes a small fix to the example JSSE client (`ClientJSSE.java`) to correctly send an HTTP GET message when the user has used the `-g` option.