### PR TITLE
Wrap wolfSSL_CTX_UseSupportedCurve() in com.wolfssl.WolfSSLContext

### DIFF
--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -376,6 +376,32 @@ JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_RsaEnabled
 #endif
 }
 
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_Curve25519Enabled
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+#if defined(HAVE_CURVE25519)
+    return JNI_TRUE;
+#else
+    return JNI_FALSE;
+#endif
+}
+
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_Curve448Enabled
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+#if defined(HAVE_CURVE448)
+    return JNI_TRUE;
+#else
+    return JNI_FALSE;
+#endif
+}
+
 JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_FileSystemEnabled
   (JNIEnv* jenv, jclass jcl)
 {

--- a/native/com_wolfssl_WolfSSL.h
+++ b/native/com_wolfssl_WolfSSL.h
@@ -505,6 +505,22 @@ JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_RsaEnabled
 
 /*
  * Class:     com_wolfssl_WolfSSL
+ * Method:    Curve25519Enabled
+ * Signature: ()Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_Curve25519Enabled
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    Curve448Enabled
+ * Signature: ()Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_Curve448Enabled
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
  * Method:    FileSystemEnabled
  * Signature: ()Z
  */

--- a/native/com_wolfssl_WolfSSLContext.c
+++ b/native/com_wolfssl_WolfSSLContext.c
@@ -5449,6 +5449,30 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_usePskIdentityHint
 #endif
 }
 
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useSupportedCurve
+  (JNIEnv* jenv, jobject jcl, jlong ctxPtr, jint name)
+{
+#ifdef HAVE_SUPPORTED_CURVES
+    int ret = 0;
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
+    (void)jcl;
+
+    if (jenv == NULL || ctx == NULL) {
+        return (jint)SSL_FAILURE;
+    }
+
+    ret = wolfSSL_CTX_UseSupportedCurve(ctx, (word16)name);
+
+    return (jint)ret;
+#else
+    (void)jenv;
+    (void)jcl;
+    (void)ctxPtr;
+    (void)name;
+    return (jint)NOT_COMPILED_IN;
+#endif
+}
+
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useSecureRenegotiation
   (JNIEnv* jenv, jobject jcl, jlong ctx)
 {

--- a/native/com_wolfssl_WolfSSLContext.h
+++ b/native/com_wolfssl_WolfSSLContext.h
@@ -369,6 +369,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_usePskIdentityHint
 
 /*
  * Class:     com_wolfssl_WolfSSLContext
+ * Method:    useSupportedCurve
+ * Signature: (JI)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useSupportedCurve
+  (JNIEnv *, jobject, jlong, jint);
+
+/*
+ * Class:     com_wolfssl_WolfSSLContext
  * Method:    useSecureRenegotiation
  * Signature: (J)I
  */

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -665,6 +665,22 @@ public class WolfSSL {
     public static native boolean RsaEnabled();
 
     /**
+     * Tests if Curve25519/X25519 support has been compiled into the native
+     * wolfSSL library.
+     *
+     * @return true if enabled, otherwise false if not compiled in.
+     */
+    public static native boolean Curve25519Enabled();
+
+    /**
+     * Tests if Curve448/X448 support has been compiled into the native
+     * wolfSSL library.
+     *
+     * @return true if enabled, otherwise false if not compiled in.
+     */
+    public static native boolean Curve448Enabled();
+
+    /**
      * Tests if filesystem support has been compiled into the wolfSSL library.
      *
      * @return true if enabled, otherwise false if NO_FILESYSTEM has been

--- a/src/java/com/wolfssl/WolfSSLContext.java
+++ b/src/java/com/wolfssl/WolfSSLContext.java
@@ -381,6 +381,7 @@ public class WolfSSLContext {
     private native void setPskClientCb(long ctx);
     private native void setPskServerCb(long ctx);
     private native int usePskIdentityHint(long ssl, String hint);
+    private native int useSupportedCurve(long ctx, int name);
     private native int useSecureRenegotiation(long ctx);
     private native int setMinDhKeySz(long ctx, int keySzBits);
     private native int setMinRsaKeySz(long ctx, int keySzBits);
@@ -1859,6 +1860,44 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             return usePskIdentityHint(getContextPtr(), hint);
         }
+    }
+
+    /**
+     * Sets the TLS Supported Curves to be used in the ClientHello
+     * extension if enabled in native wolfSSL.
+     *
+     * @param curveNames String array of ECC curve names to set into the
+     *        Supported Curve extension. String values should match names from
+     *        the following list:
+     *            "sect163k1", "sect163r1", "sect163r2", "sect193r1",
+     *            "sect193r2", "sect233k1", "sect233r1", "sect239k1",
+     *            "sect283k1", "sect283r1", "sect409k1", "sect409r1",
+     *            "sect571k1", "sect571r1", "secp160k1", "secp160r1",
+     *            "secp160r2", "secp192k1", "secp192r1", "secp224k1",
+     *            "secp224r1", "secp256k1", "secp256r1", "secp384r1",
+     *            "secp521r1", "brainpoolP256r1", "brainpoolP384r1",
+     *            "brainpoolP512r1", "x25519", "x448", "sm2P256v1",
+     *            "ffdhe2048", "ffdhe3072", "ffdhe4096", "ffdhe6144",
+     *            "ffdhe8192"
+     *
+     * @return <code>WolfSSL.SSL_SUCCESS</code> on success, otherwise
+     *         negative on error.
+     * @throws IllegalStateException WolfSSLContext has been freed
+     */
+    public int useSupportedCurves(String[] curveNames)
+        throws IllegalStateException  {
+
+        int ret = 0;
+        int curveEnum = 0;
+
+        for (String curve : curveNames) {
+            curveEnum = WolfSSL.getNamedGroupFromString(curve);
+            synchronized (ctxLock) {
+                ret = useSupportedCurve(getContextPtr(), curveEnum);
+            }
+        }
+
+        return ret;
     }
 
     /**

--- a/src/test/com/wolfssl/test/WolfSSLContextTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLContextTest.java
@@ -75,6 +75,7 @@ public class WolfSSLContextTest {
         test_WolfSSLContext_setPskServerCb();
         test_WolfSSLContext_usePskIdentityHint();
         test_WolfSSLContext_useSecureRenegotiation();
+        test_WolfSSLContext_useSupportedCurves();
         test_WolfSSLContext_setMinRSAKeySize();
         test_WolfSSLContext_setMinECCKeySize();
         test_WolfSSLContext_free();
@@ -357,6 +358,57 @@ public class WolfSSLContextTest {
             e.printStackTrace();
         }
         System.out.println("\t... passed");
+    }
+
+    public void test_WolfSSLContext_useSupportedCurves() {
+
+        int ret;
+        String[] singleEccSecp256r1 = new String[] { "secp256r1" };
+        String[] allEccCurves =  new String[] {
+            "secp160k1", "secp160r1", "secp160r2", "secp192k1", "secp192r1",
+            "secp224k1", "secp224r1", "secp256k1", "secp256r1", "secp384r1",
+            "secp521r1"
+        };
+        String[] x25519Curve = new String[] { "x25519" };
+        String[] x448Curve = new String[] { "x448" };
+
+        System.out.print("\tuseSupportedCurves()");
+        try {
+            ret = ctx.useSupportedCurves(singleEccSecp256r1);
+            if (ret != WolfSSL.SSL_SUCCESS &&
+                ret != WolfSSL.NOT_COMPILED_IN) {
+                System.out.println("\t... failed");
+                fail("useSupportedCurves(singleEccSecp256r1) failed");
+            }
+            ret = ctx.useSupportedCurves(allEccCurves);
+            if (ret != WolfSSL.SSL_SUCCESS &&
+                ret != WolfSSL.NOT_COMPILED_IN) {
+                System.out.println("\t... failed");
+                fail("useSupportedCurves(allEccCurves) failed");
+            }
+            if (WolfSSL.Curve25519Enabled()) {
+                ret = ctx.useSupportedCurves(x25519Curve);
+                if (ret != WolfSSL.SSL_SUCCESS &&
+                    ret != WolfSSL.NOT_COMPILED_IN) {
+                    System.out.println("\t... failed");
+                    fail("useSupportedCurves(x25519Curve) failed");
+                }
+            }
+            if (WolfSSL.Curve448Enabled()) {
+                ret = ctx.useSupportedCurves(x448Curve);
+                if (ret != WolfSSL.SSL_SUCCESS &&
+                    ret != WolfSSL.NOT_COMPILED_IN) {
+                    System.out.println("\t... failed");
+                    fail("useSupportedCurves(x448Curve) failed");
+                }
+            }
+            System.out.println("\t...passed");
+
+        } catch (IllegalStateException e) {
+            System.out.println("\t... failed");
+            fail("useSupportedCurves failed");
+            e.printStackTrace();
+        }
     }
 
     public void test_WolfSSLContext_setMinRSAKeySize() {


### PR DESCRIPTION
This PR wraps the `wolfSSL_CTX_UseSupportedCurve()` API inside the thin JNI wrapper class `com.wolfssl.WolfSSLContext`. Note this is being added to the wolfSSL JNI wrapper and not integrated into the JSSE provider as of this PR.

User API for this from `com.wolfssl.WolfSSLContext` is:

```
public int useSupportedCurves(String[] curveNames);
```

Where `curveNames` is a String array of Strings from the following options. These Strings have been formatted to use similar naming as Java does:

```
String array of ECC curve names to set into the Supported Curve extension. String values should match names from the following list:

"sect163k1", "sect163r1", "sect163r2", "sect193r1",
"sect193r2", "sect233k1", "sect233r1", "sect239k1",
"sect283k1", "sect283r1", "sect409k1", "sect409r1",
"sect571k1", "sect571r1", "secp160k1", "secp160r1",
"secp160r2", "secp192k1", "secp192r1", "secp224k1",
"secp224r1", "secp256k1", "secp256r1", "secp384r1",
"secp521r1", "brainpoolP256r1", "brainpoolP384r1",
"brainpoolP512r1", "x25519", "x448", "sm2P256v1",
"ffdhe2048", "ffdhe3072", "ffdhe4096", "ffdhe6144",
"ffdhe8192"
```

ZD #16973