### PR TITLE
Add implementation of javax.net.ssl.X509ExtendedTrustManager

### DIFF
--- a/native/com_wolfssl_WolfSSLCertificate.c
+++ b/native/com_wolfssl_WolfSSLCertificate.c
@@ -760,6 +760,42 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1load_1certific
 #endif
 }
 
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1check_1host
+  (JNIEnv* jenv, jclass jcl, jlong x509Ptr, jstring chk, jlong flags, jlong peerNamePtr)
+{
+#ifndef NO_ASN
+    int ret = WOLFSSL_FAILURE;
+    const char* hostname = NULL;
+    WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
+    (void)jcl;
+    (void)peerNamePtr;
+
+    if (jenv == NULL || chk == NULL) {
+        return WOLFSSL_FAILURE;
+    }
+
+    hostname = (*jenv)->GetStringUTFChars(jenv, chk, 0);
+    if (hostname != NULL) {
+        /* flags and peerNamePtr not used */
+        ret = wolfSSL_X509_check_host(x509, hostname,
+            XSTRLEN(hostname), (unsigned int)flags, NULL);
+    }
+
+    (*jenv)->ReleaseStringUTFChars(jenv, chk, hostname);
+
+    return (jint)ret;
+
+#else
+    (void)jenv;
+    (void)jcl;
+    (void)x509Ptr;
+    (void)chk;
+    (void)flags;
+    (void)peerNamePtr;
+    return (jint)NOT_COMPILED_IN;
+#endif
+}
+
 JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1der
   (JNIEnv* jenv, jclass jcl, jlong x509Ptr)
 {

--- a/native/com_wolfssl_WolfSSLCertificate.h
+++ b/native/com_wolfssl_WolfSSLCertificate.h
@@ -221,6 +221,14 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1load_1certific
 
 /*
  * Class:     com_wolfssl_WolfSSLCertificate
+ * Method:    X509_check_host
+ * Signature: (JLjava/lang/String;JJ)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1check_1host
+  (JNIEnv *, jclass, jlong, jstring, jlong, jlong);
+
+/*
+ * Class:     com_wolfssl_WolfSSLCertificate
  * Method:    X509_new
  * Signature: ()J
  */

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -3964,7 +3964,52 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useSNI
 #endif /* HAVE_SNI */
 
     return (jint)ret;
+}
 
+JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getSNIRequest
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jbyte type)
+{
+#ifdef HAVE_SNI
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
+    void* request = NULL;
+    jbyteArray sniRequest;
+    word16 ret = 0;
+    (void)jcl;
+
+    if (jenv == NULL || ssl == NULL) {
+        return NULL;
+    }
+
+    ret = wolfSSL_SNI_GetRequest(ssl, (byte)type, &request);
+
+    if (ret > 0) {
+        sniRequest = (*jenv)->NewByteArray(jenv, ret);
+        if (sniRequest == NULL) {
+            (*jenv)->ThrowNew(jenv, jcl,
+                "Failed to create byte array in native getSNIRequest");
+            return NULL;
+        }
+
+        (*jenv)->SetByteArrayRegion(jenv, sniRequest, 0, ret,
+                                    (jbyte*)request);
+        if ((*jenv)->ExceptionOccurred(jenv)) {
+            (*jenv)->ExceptionDescribe(jenv);
+            (*jenv)->ExceptionClear(jenv);
+            return NULL;
+        }
+
+        return sniRequest;
+    }
+
+    return NULL;
+
+#else
+    (void)jenv;
+    (void)jcl;
+    (void)sslPtr;
+    (void)type;
+    return NULL;
+#endif /* HAVE_SNI */
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useSessionTicket

--- a/native/com_wolfssl_WolfSSLSession.h
+++ b/native/com_wolfssl_WolfSSLSession.h
@@ -713,6 +713,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useSNI
 
 /*
  * Class:     com_wolfssl_WolfSSLSession
+ * Method:    getSNIRequest
+ * Signature: (JB)[B
+ */
+JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getSNIRequest
+  (JNIEnv *, jobject, jlong, jbyte);
+
+/*
+ * Class:     com_wolfssl_WolfSSLSession
  * Method:    useSessionTicket
  * Signature: (J)I
  */

--- a/src/java/com/wolfssl/WolfSSLCertificate.java
+++ b/src/java/com/wolfssl/WolfSSLCertificate.java
@@ -98,6 +98,8 @@ public class WolfSSLCertificate {
     static native String X509_get_next_altname(long x509);
     static native long X509_load_certificate_buffer(byte[] buf, int format);
     static native long X509_load_certificate_file(String path, int format);
+    static native int X509_check_host(long x509, String chk, long flags,
+        long peerName);
 
     /* native functions used for X509v3 certificate generation */
     static native long X509_new();
@@ -1388,6 +1390,28 @@ public class WolfSSLCertificate {
 
         synchronized (x509Lock) {
             return X509_is_extension_set(this.x509Ptr, oid);
+        }
+    }
+
+    /**
+     * Checks that given hostname matches this certificate SubjectAltName
+     * or CommonName entries.
+     *
+     * @param hostname Hostname to check certificate against
+     *
+     * @return WolfSSL.SSL_SUCCESS on successful hostname match,
+     *         WolfSSL.SSL_FAILURE on invalid match or error, or
+     *         WolfSSL.NOT_COMPILED_IN if native wolfSSL has been compiled
+     *         with NO_ASN defined and native API is not available.
+     *
+     * @throws IllegalStateException if WolfSSLCertificate has been freed.
+     */
+    public int checkHost(String hostname) throws IllegalStateException {
+
+        confirmObjectIsActive();
+
+        synchronized (x509Lock) {
+            return X509_check_host(this.x509Ptr, hostname, 0, 0);
         }
     }
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
@@ -31,12 +31,20 @@ import java.security.cert.X509Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateEncodingException;
 import java.util.Date;
+import java.util.List;
+import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.Collections;
 import java.io.ByteArrayInputStream;
+import java.io.UnsupportedEncodingException;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
+import javax.net.ssl.ExtendedSSLSession;
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLSessionBindingEvent;
 import javax.net.ssl.SSLSessionBindingListener;
 import javax.net.ssl.SSLSessionContext;
@@ -48,7 +56,9 @@ import javax.net.ssl.X509KeyManager;
  * @author wolfSSL
  */
 @SuppressWarnings("deprecation")
-public class WolfSSLImplementSSLSession implements SSLSession {
+public class WolfSSLImplementSSLSession extends ExtendedSSLSession
+    implements SSLSession {
+
     private WolfSSLSession ssl = null;
     private final WolfSSLAuthStore authStore;
     private WolfSSLSessionContext ctx = null;
@@ -124,6 +134,9 @@ public class WolfSSLImplementSSLSession implements SSLSession {
 
         creation = new Date();
         accessed = new Date();
+
+        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+            "created new session (port: " + port + ", host: " + host + ")");
     }
 
     /**
@@ -145,6 +158,9 @@ public class WolfSSLImplementSSLSession implements SSLSession {
 
         creation = new Date();
         accessed = new Date();
+
+        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+            "created new session (no host/port yet)");
     }
 
     /**
@@ -163,6 +179,9 @@ public class WolfSSLImplementSSLSession implements SSLSession {
 
         creation = new Date();
         accessed = new Date();
+
+        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+            "created new session (WolfSSLAuthStore)");
     }
 
     /**
@@ -219,6 +238,9 @@ public class WolfSSLImplementSSLSession implements SSLSession {
 
         /* Not copying binding, not needed */
         this.binding = null;
+
+        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+            "created new session (WolfSSLImplementSSLSession)");
     }
 
     /**
@@ -776,6 +798,51 @@ public class WolfSSLImplementSSLSession implements SSLSession {
      */
     protected int getPort() {
         return this.port;
+    }
+
+    @Override
+    public String[] getLocalSupportedSignatureAlgorithms() {
+        /* TODO */
+        return null;
+    }
+
+    @Override
+    public String[] getPeerSupportedSignatureAlgorithms() {
+        /* TODO */
+        return null;
+    }
+
+    /**
+     * Return a list of all SNI server names of the requested Server Name
+     * Indication (SNI) extension.
+     *
+     * @return non-null immutable List of SNIServerNames. List may be emtpy
+     *         if no SNI names were requested.
+     */
+    @Override
+    public List<SNIServerName> getRequestedServerNames()
+        throws UnsupportedOperationException {
+
+        byte[] sniRequestArr = null;
+        List<SNIServerName> sniNames = new ArrayList<>(1);
+
+        if (this.ssl == null) {
+            return Collections.emptyList();
+        }
+
+        try {
+            sniRequestArr = this.ssl.getClientSNIRequest();
+            if (sniRequestArr != null) {
+                SNIHostName sniName = new SNIHostName(sniRequestArr);
+                sniNames.add(sniName);
+
+                return sniNames;
+            }
+        } catch (IllegalArgumentException e) {
+            throw new UnsupportedOperationException(e);
+        }
+
+        return Collections.emptyList();
     }
 
     @SuppressWarnings("deprecation")

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLInternalVerifyCb.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLInternalVerifyCb.java
@@ -28,7 +28,10 @@ import com.wolfssl.WolfSSLX509StoreCtx;
 import com.wolfssl.provider.jsse.WolfSSLInternalVerifyCb;
 import java.security.cert.X509Certificate;
 import java.security.cert.CertificateException;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLEngine;
 import javax.net.ssl.X509TrustManager;
+import javax.net.ssl.X509ExtendedTrustManager;
 import java.io.IOException;
 
 /**
@@ -43,16 +46,72 @@ public class WolfSSLInternalVerifyCb implements WolfSSLVerifyCallback {
 
     private X509TrustManager tm = null;
     private boolean clientMode;
+    private SSLSocket callingSocket = null;
+    private SSLEngine callingEngine = null;
 
     /**
      * Create new WolfSSLInternalVerifyCb
      *
      * @param xtm X509TrustManager to use with this object
      * @param client boolean representing if this is client side
+     * @param socket SSLSocket associated with this callback, or null
+     * @param engine SSLEngine associated with this callback, or null
      */
-    public WolfSSLInternalVerifyCb(X509TrustManager xtm, boolean client) {
+    public WolfSSLInternalVerifyCb(X509TrustManager xtm, boolean client,
+        SSLSocket socket, SSLEngine engine) {
         this.tm = xtm;
         this.clientMode = client;
+        this.callingSocket = socket;
+        this.callingEngine = engine;
+    }
+
+    /**
+     * Verify hostname of provided peer certificate using
+     * Endpoint Identification Algorithm if set in SSLParameters.
+     *
+     * Used by verifyCallback() only for case where internal native wolfSSL
+     * peer verification is done. Otherwise, hostname is verified as part
+     * of full cert validation later in verifyCallback().
+     *
+     * @param peer peer certificate to use for hostname verification
+     *
+     * @return 1 if hostname verification was successful (allows verify
+     *         callback to proceed, otherwise 0 if verification was not
+     *         successful (or not able to do it since Endpoitn Identification
+     *         Algorithm has not been set).
+     */
+    private int verifyHostnameOnly(X509Certificate peer) {
+
+        WolfSSLTrustX509 wolfTM = (WolfSSLTrustX509)tm;
+
+        try {
+            if (this.callingSocket != null) {
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    "checking hostname verification using SSLSocket");
+                /* Throws CertificateException when verify fails */
+                wolfTM.verifyHostname(peer, this.callingSocket,
+                    null, clientMode);
+            }
+            else if (this.callingEngine != null) {
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    "checking hostname verification using SSLEngine");
+                /* Throws CertificateException when verify fails */
+                wolfTM.verifyHostname(peer, null,
+                    this.callingEngine, clientMode);
+            }
+            else {
+                throw new CertificateException(
+                    "Both SSLSocket and SSLEngine null when trying to " +
+                    "do hostname verification");
+            }
+        } catch (CertificateException e) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                "X509ExtendedTrustManager hostname verification failed");
+            return 0;
+        }
+
+        /* Hostname verification successful */
+        return 1;
     }
 
     /**
@@ -73,6 +132,14 @@ public class WolfSSLInternalVerifyCb implements WolfSSLVerifyCallback {
         String authType = null;
 
         if (preverify_ok == 1) {
+            /* When using WolfSSLTrustX509 implementation of
+             * X509TrustManager, we use internal wolfSSL verification logic
+             * but register this verify callback (always called) so that
+             * we can do additional hostname verification if user has set
+             * the Endpoint Identification Algorithm in SSLParameters.
+             * Note that certificate verification has already been done and
+             * passed if preverify_ok == 1, so we skip doing it again here
+             * later on for this case */
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                     "Native wolfSSL peer verification passed");
         } else {
@@ -133,17 +200,81 @@ public class WolfSSLInternalVerifyCb implements WolfSSLVerifyCallback {
             }
         }
 
+        /* Case where native wolfSSL verification was already done and passed
+         * and we only want to do hostname verification if needed additionally.
+         * We do that here and return before going on to additional
+         * checkServerTrusted/checkClientTrusted() so that we do not
+         * duplicate verification. */
+        if (preverify_ok == 1 && (tm instanceof WolfSSLTrustX509)) {
+            return verifyHostnameOnly(x509certs[0]);
+        }
+
         try {
             /* poll TrustManager for cert verification, should throw
              * CertificateException if verification fails */
             if (clientMode) {
-                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "Calling TrustManager.checkServerTrusted()");
-                tm.checkServerTrusted(x509certs, authType);
+                if (tm instanceof X509ExtendedTrustManager) {
+                    X509ExtendedTrustManager xtm = (X509ExtendedTrustManager)tm;
+                    if (this.callingSocket != null) {
+                        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                          "Calling TrustManager.checkServerTrusted(SSLSocket)");
+                        xtm.checkServerTrusted(x509certs, authType,
+                            this.callingSocket);
+                    }
+                    else if (this.callingEngine != null) {
+                        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                          "Calling TrustManager.checkServerTrusted(SSLEngine)");
+                        xtm.checkServerTrusted(x509certs, authType,
+                            this.callingEngine);
+                    }
+                    else {
+                        /* If we do have access to X509ExtendedTrustManager,
+                         * but don't have SSLSocket/Engine, error out instead
+                         * of falling back to verify without hostname. */
+                        throw new Exception(
+                            "SSLSocket/SSLEngine null during server peer " +
+                            "verification, failed to verify");
+                    }
+                }
+                else {
+                    /* Basic X509TrustManager does not support HTTPS
+                     * hostname verification, no SSLSocket/Engine needed */
+                    WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                        "Calling TrustManager.checkServerTrusted()");
+                    tm.checkServerTrusted(x509certs, authType);
+                }
+
             } else {
-                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "Calling TrustManager.checkClientTrusted()");
-                tm.checkClientTrusted(x509certs, authType);
+                if (tm instanceof X509ExtendedTrustManager) {
+                    X509ExtendedTrustManager xtm = (X509ExtendedTrustManager)tm;
+                    if (this.callingSocket != null) {
+                        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                          "Calling TrustManager.checkClientTrusted(SSLSocket)");
+                        xtm.checkClientTrusted(x509certs, authType,
+                            this.callingSocket);
+                    }
+                    else if (this.callingEngine != null) {
+                        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                          "Calling TrustManager.checkClientTrusted(SSLEngine)");
+                        xtm.checkClientTrusted(x509certs, authType,
+                            this.callingEngine);
+                    }
+                    else {
+                        /* If we do have access to X509ExtendedTrustManager,
+                         * but don't have SSLSocket/Engine, error out instead
+                         * of falling back to verify without hostname. */
+                        throw new Exception(
+                            "SSLSocket/SSLEngine null during client peer " +
+                            "verification, failed to verify");
+                    }
+                }
+                else {
+                    /* Basic X509TrustManager does not support HTTPS
+                     * hostname verification, no SSLSocket/Engine needed */
+                    WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                        "Calling TrustManager.checkClientTrusted()");
+                    tm.checkClientTrusted(x509certs, authType);
+                }
             }
         } catch (Exception e) {
             /* TrustManager rejected certificate, not valid */

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLParameters.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLParameters.java
@@ -43,7 +43,7 @@ final class WolfSSLParameters {
     private String[] protocols;
     private boolean wantClientAuth = false;
     private boolean needClientAuth = false;
-    private String endpointIdAlgorithm;
+    private String endpointIdAlgorithm = null;
     private List<WolfSSLSNIServerName> serverNames;
     private boolean useCipherSuiteOrder = true;
     String[] applicationProtocols = new String[0];
@@ -59,6 +59,7 @@ final class WolfSSLParameters {
         cp.needClientAuth = this.needClientAuth;
         cp.setServerNames(this.getServerNames());
         cp.useSessionTickets = this.useSessionTickets;
+        cp.endpointIdAlgorithm = this.endpointIdAlgorithm;
 
         /* TODO: duplicate other properties here when WolfSSLParameters
          * can handle them */
@@ -124,7 +125,7 @@ final class WolfSSLParameters {
         return this.endpointIdAlgorithm;
     }
 
-    void setEndPointIdentificationAlgorithm(String algorithm) {
+    void setEndpointIdentificationAlgorithm(String algorithm) {
         this.endpointIdAlgorithm = algorithm;
     }
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLParametersHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLParametersHelper.java
@@ -35,6 +35,8 @@ public class WolfSSLParametersHelper
     private static Method setServerNames = null;
     private static Method getApplicationProtocols = null;
     private static Method setApplicationProtocols = null;
+    private static Method getEndpointIdentificationAlgorithm = null;
+    private static Method setEndpointIdentificationAlgorithm = null;
 
     /** Default WolfSSLParametersHelper constructor */
     public WolfSSLParametersHelper() { }
@@ -64,6 +66,12 @@ public class WolfSSLParametersHelper
                                     continue;
                                 case "setApplicationProtocols":
                                     setApplicationProtocols = m;
+                                    continue;
+                                case "getEndpointIdentificationAlgorithm":
+                                    getEndpointIdentificationAlgorithm = m;
+                                    continue;
+                                case "setEndpointIdentificationAlgorithm":
+                                    setEndpointIdentificationAlgorithm = m;
                                     continue;
                                 default:
                                     continue;
@@ -107,7 +115,8 @@ public class WolfSSLParametersHelper
         /* Methods added as of JDK 1.8, older JDKs will not have them. Using
          * Java reflection to detect availability. */
 
-        if (setServerNames != null || setApplicationProtocols != null) {
+        if (setServerNames != null || setApplicationProtocols != null ||
+            setEndpointIdentificationAlgorithm != null) {
 
             try {
                 /* load WolfSSLJDK8Helper at runtime, not compiled on older JDKs */
@@ -125,7 +134,11 @@ public class WolfSSLParametersHelper
                 }
                 if (setApplicationProtocols != null) {
                     mth = cls.getDeclaredMethod("setApplicationProtocols", paramList);
-                    mth.invoke(obj, ret, setServerNames, in);
+                    mth.invoke(obj, ret, setApplicationProtocols, in);
+                }
+                if (setEndpointIdentificationAlgorithm != null) {
+                    mth = cls.getDeclaredMethod("setEndpointIdentificationAlgorithm", paramList);
+                    mth.invoke(obj, ret, setEndpointIdentificationAlgorithm, in);
                 }
 
             } catch (Exception e) {
@@ -139,8 +152,6 @@ public class WolfSSLParametersHelper
          * conditionally to wolfJSSE when supported. */
         /*ret.setAlgorithmConstraints(in.getAlgorithmConstraints());
         ret.setEnableRetransmissions(in.getEnableRetransmissions());
-        ret.setEndpointIdentificationAlgorithm(
-            in.getEndpointIdentificationAlgorithm());
         ret.setMaximumPacketSize(in.getMaximumPacketSize());
         ret.setSNIMatchers(in.getSNIMatchers());
         ret.setUseCipherSuitesOrder(in.getUseCipherSuitesOrder());
@@ -183,7 +194,8 @@ public class WolfSSLParametersHelper
         /* Methods added as of JDK 1.8, older JDKs will not have them. Using
          * Java reflection to detect availability. */
 
-        if (getServerNames != null || getApplicationProtocols != null) {
+        if (getServerNames != null || getApplicationProtocols != null ||
+            getEndpointIdentificationAlgorithm != null) {
             try {
                 /* load WolfSSLJDK8Helper at runtime, not compiled on older JDKs */
                 Class<?> cls = Class.forName("com.wolfssl.provider.jsse.WolfSSLJDK8Helper");
@@ -201,6 +213,10 @@ public class WolfSSLParametersHelper
                     mth = cls.getDeclaredMethod("getApplicationProtocols", paramList);
                     mth.invoke(obj, in, out);
                 }
+                if (getEndpointIdentificationAlgorithm != null) {
+                    mth = cls.getDeclaredMethod("getEndpointIdentificationAlgorithm", paramList);
+                    mth.invoke(obj, in, out);
+                }
 
             } catch (Exception e) {
                 /* ignore, class not found */
@@ -213,8 +229,6 @@ public class WolfSSLParametersHelper
          * conditionally to wolfJSSE when supported. */
         /*out.setAlgorithmConstraints(in.getAlgorithmConstraints());
         out.setEnableRetransmissions(in.getEnableRetransmissions());
-        out.setEndpointIdentificationAlgorithm(
-            in.getEndpointIdentificationAlgorithm());
         out.setMaximumPacketSize(in.getMaximumPacketSize());
         out.setSNIMatchers(in.getSNIMatchers());
         out.setUseCipherSuitesOrder(in.getUseCipherSuitesOrder());

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -1791,6 +1791,7 @@ public class WolfSSLSocket extends SSLSocket {
             EngineHelper.setHostAndPort(
                 address.getAddress().getHostAddress(),
                 address.getPort());
+            EngineHelper.setPeerAddress(address.getAddress());
         }
 
         /* if user is calling after WolfSSLSession creation, register
@@ -1841,6 +1842,7 @@ public class WolfSSLSocket extends SSLSocket {
             EngineHelper.setHostAndPort(
                 address.getAddress().getHostAddress(),
                 address.getPort());
+            EngineHelper.setPeerAddress(address.getAddress());
         }
 
         /* if user is calling after WolfSSLSession creation, register

--- a/src/java/com/wolfssl/provider/jsse/adapter/WolfSSLJDK8Helper.java
+++ b/src/java/com/wolfssl/provider/jsse/adapter/WolfSSLJDK8Helper.java
@@ -62,7 +62,8 @@ public class WolfSSLJDK8Helper
         List<WolfSSLSNIServerName> wsni = in.getServerNames();
         if (wsni != null) {
             /* convert WolfSSLSNIServerName list to SNIServerName */
-            final ArrayList<SNIServerName> sni = new ArrayList<SNIServerName>(wsni.size());
+            final ArrayList<SNIServerName> sni =
+                new ArrayList<SNIServerName>(wsni.size());
             for (WolfSSLSNIServerName name : wsni) {
                 sni.add(new SNIHostName(name.getEncoded()));
             }
@@ -100,9 +101,11 @@ public class WolfSSLJDK8Helper
         List<SNIServerName> sni = in.getServerNames();
         if (sni != null) {
             /* convert SNIServerName list to WolfSSLSNIServerName */
-            final ArrayList<WolfSSLSNIServerName> wsni = new ArrayList<WolfSSLSNIServerName>(sni.size());
+            final ArrayList<WolfSSLSNIServerName> wsni =
+                new ArrayList<WolfSSLSNIServerName>(sni.size());
             for (SNIServerName name : sni) {
-                wsni.add(new WolfSSLGenericHostName(name.getType(), name.getEncoded()));
+                wsni.add(new WolfSSLGenericHostName(name.getType(),
+                         name.getEncoded()));
             }
 
             /* call WolfSSLParameters.setServerNames() */
@@ -127,12 +130,13 @@ public class WolfSSLJDK8Helper
         }
 
         final String[] appProtos = in.getApplicationProtocols();
+        final Object[] appProtoArr = {appProtos};
         if (appProtos != null) {
             /* call SSLParameters.setApplicationProtocols() */
             AccessController.doPrivileged(new PrivilegedAction<Object>() {
                 public Object run() {
                     try {
-                        m.invoke(out, (Object[])appProtos);
+                        m.invoke(out, appProtoArr);
                     } catch (Exception e) {
                         throw new RuntimeException(e);
                     }
@@ -162,6 +166,65 @@ public class WolfSSLJDK8Helper
         if (appProtos != null) {
             /* call WolfSSLParameters.setApplicationProtocols() */
             out.setApplicationProtocols(appProtos);
+        }
+    }
+
+    /**
+     * Call SSLParameters.setEndpointIdentificationAlgorithm() to set
+     * Endpoint Identification algo from WolfSSLParameters into
+     * SSLParameters.
+     *
+     * @param out output SSLParameters to store endpoint ID algo into
+     * @param m method to invoke to set endpoint ID algo
+     * @param in input WolfSSLParameters to read endpoint ID algo from
+     */
+    protected static void setEndpointIdentificationAlgorithm(
+        final SSLParameters out, final Method m, WolfSSLParameters in) {
+
+        if (out == null || m == null || in == null) {
+            throw new NullPointerException("input arguments to " +
+                "WolfSSLJDK8Helper.setEndpointIdentificationAlgorithm() " +
+                "cannot be null");
+        }
+
+        final String idAlgo = in.getEndpointIdentificationAlgorithm();
+        if (idAlgo != null) {
+            /* call SSLParameters.setEndpointIdentificationAlgorithm() */
+            AccessController.doPrivileged(new PrivilegedAction<Object>() {
+                public Object run() {
+                    try {
+                        m.invoke(out, idAlgo);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+
+                    return null;
+                }
+            });
+        }
+    }
+
+    /**
+     * Call SSLParameters.getEndpointIdentificationAlgorithm() to get
+     * Endpoint Identification Algorithm from SSLParameters into
+     * WolfSSLParameters.
+     *
+     * @param in input SSLParameters to read Endpoint ID algo from
+     * @param out output WolfSSLParameters to store Endpoint ID algo into
+     */
+    protected static void getEndpointIdentificationAlgorithm(
+        final SSLParameters in, WolfSSLParameters out) {
+
+        if (out == null || in == null) {
+            throw new NullPointerException("input arguments to " +
+                "WolfSSLJDK8Helper.getEndpointIdentificationAlgorithm() " +
+                "cannot be null");
+        }
+
+        String idAlgo = in.getEndpointIdentificationAlgorithm();
+        if (idAlgo != null) {
+            /* call WolfSSLParameters.setEndpointIdentificationAlgorithm() */
+            out.setEndpointIdentificationAlgorithm(idAlgo);
         }
     }
 }


### PR DESCRIPTION
This PR implements `javax.net.ssl.X509ExtendedTrustManager`, which will automatically do internal hostname verification when the Endpoint Identification Algorithm has been set to `HTTPS` inside `SSLParameters`, ie:

```
SSLSocket sock = ...
SSLParameters params = sock.getSSLParameters();
params.setEndpointIdentificationAlgorithm("HTTPS");
sock.setSSLParameters(params);
```

Hostname verification matches SunJSSE behavior and if available compares the value set into the Server Name Indication (SNI) first, then falls back to compare against the peer hostname.

A few success/failure tests have been added in `src/test/com/wolfssl/provider/jsse/test/WolfSSLTrustX509Test.java` for both `SSLSocket` and `SSLEngine` use cases.

This PR also makes some supporting changes including:
- Wrap native `wolfSSL_X509_check_host()` in `com.wolfssl.WolfSSLCertificate` class
- Wrap native `wolfSSL_SNI_GetRequest()` in `com.wolfssl.WolfSSLSession` class
- Adds non-standard `sessionResumed()` method to `WolfSSLEngine.java`
- Adds implementation of `getSSLParameters()` to `WolfSSLSocket` and `WolfSSLEngine`
- Add implementation of `getHandshakeSession()` to `WolfSSLSocket`
- Converts `WolfSSLImplementSSLSession` from normal `SSLSession` to `ExtendedSSLSession`, adding API for `getRequestedServerNames()`
- Use peer InetAddress in `WolfSSLSocket.connect()` as first choice for SNI if `jdk.tls.trustNameService` is set to "true", fall back to use hostname/IP or if system property is not set.
- Remove extraneous `ioLock` in `WolfSSLInputStream`/`WolfSSLOutputStream`. We already have a mutex lock protecting `WOLFSSL` read/write calls at the native JNI layer here. This lock was causing problems for applications that split `InputStream` and `OutputStream` between two threads operating simultaneously.

NOTE: This PR leaves the following two methods as stubs in `WolfSSLImplementSSLSession`. A follow up PR will address implementations of these.

```
    @Override
    public String[] getLocalSupportedSignatureAlgorithms() {
        /* TODO */
        return null;
    }

    @Override
    public String[] getPeerSupportedSignatureAlgorithms() {
        /* TODO */
        return null;
    }
```

ZD #16990