### PR TITLE
SSLSession fix for getPeerCertificates() and cached cert

### DIFF
--- a/native/com_wolfssl_WolfSSLContext.c
+++ b/native/com_wolfssl_WolfSSLContext.c
@@ -5567,3 +5567,12 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setDevId
     return (jint)wolfSSL_CTX_SetDevId(ctx, (int)devId);
 }
 
+void JNICALL Java_com_wolfssl_WolfSSLContext_flushSessions
+  (JNIEnv* jenv, jobject jcl, jlong ctxPtr, jint tm)
+{
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
+    (void)jcl;
+
+    wolfSSL_CTX_flush_sessions(ctx, (int)tm);
+}
+

--- a/native/com_wolfssl_WolfSSLContext.h
+++ b/native/com_wolfssl_WolfSSLContext.h
@@ -415,6 +415,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setMinEccKeySz
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setDevId
   (JNIEnv *, jobject, jlong, jint);
 
+/*
+ * Class:     com_wolfssl_WolfSSLContext
+ * Method:    flushSessions
+ * Signature: (JI)V
+ */
+JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_flushSessions
+  (JNIEnv *, jobject, jlong, jint);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/java/com/wolfssl/WolfSSLContext.java
+++ b/src/java/com/wolfssl/WolfSSLContext.java
@@ -387,6 +387,7 @@ public class WolfSSLContext {
     private native int setMinRsaKeySz(long ctx, int keySzBits);
     private native int setMinEccKeySz(long ctx, int keySzBits);
     private native int setDevId(long ctx, int devId);
+    private native void flushSessions(long ctx, int tm);
 
     /* ------------------- context-specific methods --------------------- */
 
@@ -1998,6 +1999,22 @@ public class WolfSSLContext {
         confirmObjectIsActive();
 
         return setDevId(getContextPtr(), devId);
+    }
+
+    /**
+     * Remove / flush expired sessions from the native wolfSSL session cache.
+     *
+     * @param tm the time used to determine the expiration date for sessions,
+     *           should be result of equivalent of native time(0), or
+     *           desired expiration time in seconds from the unix epoch
+     *           (Jan 1, 1970).
+     * @throws IllegalStateException WolfSSLSession has been freed
+     */
+    public void flushSessions(int tm) throws IllegalStateException {
+
+        confirmObjectIsActive();
+
+        flushSessions(getContextPtr(), tm);
     }
 
     @SuppressWarnings("deprecation")

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLAuthStore.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLAuthStore.java
@@ -506,6 +506,7 @@ public class WolfSSLAuthStore {
                         session.getSideString());
                 store.put(hashCode, session);
                 session.isInTable = true;
+                printSessionStoreStatus();
             }
         }
 


### PR DESCRIPTION
This PR fixes `SSLSession.getPeerCertificates()` to correctly call `ssl.getPeerCertificate()` first before returning the cached peer certificate from a previous successful handshake on the same `WOLFSSL_SESSION`.

In cases where the client tries to resume using a `WOLFSSL_SESSION` from a previous successful connection, the `WolfSSLImplementSSLSession` will have the peer certificate cached (on purpose for resume cases where no peer cert is sent, but Java callers still need access to the peer cert).  But, since that session/connection may fall back to a new handshake, we need to call `ssl.getPeerCertificate()` first to see if we have a peer certificate at our native wolfSSL level first, before defaulting back to the Java cached version.

Test case has been included here for this scenario, and preventing regressions.

ZD #17147 (confirmed fixed)