### PR TITLE
JSSE: add SSLSocket/Engine support get/setHandshakeApplicationProtocolSelector()

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -161,8 +161,8 @@
         <property name="java.debuglevel" value="source,lines,vars"/>
         <property name="java.deprecation" value="true"/>
         <property name="java.optimize" value="false"/>
-        <property name="java.source" value="1.7"/>
-        <property name="java.target" value="1.7"/>
+        <property name="java.source" value="1.8"/>
+        <property name="java.target" value="1.8"/>
     </target>
 
     <target name="jar">

--- a/examples/MyALPNSelectCallback.java
+++ b/examples/MyALPNSelectCallback.java
@@ -1,0 +1,51 @@
+/* MyALPNSelectCallback.java
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+import java.io.*;
+import java.net.*;
+import java.nio.*;
+import com.wolfssl.*;
+
+class MyALPNSelectCallback implements WolfSSLALPNSelectCallback
+{
+    public int alpnSelectCallback(WolfSSLSession ssl, String[] out,
+        String[] in, Object arg) {
+
+        System.out.println("Entered MyALPNSelectCallback");
+        System.out.println("... out.length = " + out.length);
+        if (out.length > 0) {
+            System.out.println("out[0] = " + out[0]);
+        }
+        System.out.println("... in.length = " + in.length);
+        if (in.length > 0) {
+            System.out.println("in[0] = " + in[0]);
+        }
+        System.out.println("... arg = " + arg);
+
+        if (in.length > 0 && in[0].equals("h2")) {
+            out[0] = "h22";
+            return WolfSSL.SSL_TLSEXT_ERR_OK;
+        }
+
+        return WolfSSL.SSL_TLSEXT_ERR_ALERT_FATAL;
+    }
+}
+

--- a/examples/Server.java
+++ b/examples/Server.java
@@ -469,6 +469,15 @@ public class Server {
                     }
                 }
 
+                /* ALPN select callback */
+                MyALPNSelectCallback alpnSelectCb = new MyALPNSelectCallback();
+                ret = ssl.setAlpnSelectCb(alpnSelectCb, null);
+                if (ret != WolfSSL.SSL_SUCCESS) {
+                    System.out.println("failed to set ALPN select callback, " +
+                        "ret = " + ret);
+                    System.exit(1);
+                }
+
                 if (useIOCallbacks || (doDTLS == 1)) {
                     /* register I/O callback user context */
                     MyIOCtx ioctx = new MyIOCtx(outstream, instream,

--- a/native/com_wolfssl_WolfSSL.h
+++ b/native/com_wolfssl_WolfSSL.h
@@ -81,6 +81,8 @@ extern "C" {
 #define com_wolfssl_WolfSSL_SSL_ERROR_SSL 85L
 #undef com_wolfssl_WolfSSL_SSL_ERROR_SOCKET_PEER_CLOSED
 #define com_wolfssl_WolfSSL_SSL_ERROR_SOCKET_PEER_CLOSED -397L
+#undef com_wolfssl_WolfSSL_UNKNOWN_ALPN_PROTOCOL_NAME_E
+#define com_wolfssl_WolfSSL_UNKNOWN_ALPN_PROTOCOL_NAME_E -405L
 #undef com_wolfssl_WolfSSL_WOLFSSL_CRL_CHECKALL
 #define com_wolfssl_WolfSSL_WOLFSSL_CRL_CHECKALL 1L
 #undef com_wolfssl_WolfSSL_WOLFSSL_OCSP_URL_OVERRIDE
@@ -167,6 +169,12 @@ extern "C" {
 #define com_wolfssl_WolfSSL_CACHE_MATCH_ERROR -280L
 #undef com_wolfssl_WolfSSL_WOLFSSL_SNI_HOST_NAME
 #define com_wolfssl_WolfSSL_WOLFSSL_SNI_HOST_NAME 0L
+#undef com_wolfssl_WolfSSL_SSL_TLSEXT_ERR_OK
+#define com_wolfssl_WolfSSL_SSL_TLSEXT_ERR_OK 0L
+#undef com_wolfssl_WolfSSL_SSL_TLSEXT_ERR_NOACK
+#define com_wolfssl_WolfSSL_SSL_TLSEXT_ERR_NOACK 3L
+#undef com_wolfssl_WolfSSL_SSL_TLSEXT_ERR_ALERT_FATAL
+#define com_wolfssl_WolfSSL_SSL_TLSEXT_ERR_ALERT_FATAL 2L
 #undef com_wolfssl_WolfSSL_MEMORY_E
 #define com_wolfssl_WolfSSL_MEMORY_E -125L
 #undef com_wolfssl_WolfSSL_BUFFER_E

--- a/native/com_wolfssl_WolfSSLSession.h
+++ b/native/com_wolfssl_WolfSSLSession.h
@@ -761,6 +761,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useALPN
 
 /*
  * Class:     com_wolfssl_WolfSSLSession
+ * Method:    setALPNSelectCb
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setALPNSelectCb
+  (JNIEnv *, jobject, jlong);
+
+/*
+ * Class:     com_wolfssl_WolfSSLSession
  * Method:    useSecureRenegotiation
  * Signature: (J)I
  */

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -174,6 +174,8 @@ public class WolfSSL {
     public static final int SSL_ERROR_SSL              = 85;
     /** Peer closed socket */
     public static final int SSL_ERROR_SOCKET_PEER_CLOSED = -397;
+    /** Unrecognized ALPN protocol name */
+    public static final int UNKNOWN_ALPN_PROTOCOL_NAME_E = -405;
 
     /* extra definitions from ssl.h */
     /** CertManager: check all cert CRLs */
@@ -301,6 +303,15 @@ public class WolfSSL {
     /* ------------------ TLS extension specific  ------------------------ */
     /** SNI Host name type, for UseSNI() */
     public static final int WOLFSSL_SNI_HOST_NAME = 0;
+
+    /** ALPN ERR OK, ALPN protocol match */
+    public static final int SSL_TLSEXT_ERR_OK = 0;
+
+    /** ALPN ERR NOACK, ALPN callback no match but not fatal */
+    public static final int SSL_TLSEXT_ERR_NOACK = 3;
+
+    /** ALPN ERR FATAL, ALPN callback no match and fatal */
+    public static final int SSL_TLSEXT_ERR_ALERT_FATAL = 2;
 
     /* ---------------------- wolfCrypt codes ---------------------------- */
 

--- a/src/java/com/wolfssl/WolfSSLALPNSelectCallback.java
+++ b/src/java/com/wolfssl/WolfSSLALPNSelectCallback.java
@@ -1,0 +1,63 @@
+/* WolfSSLALPNSelectCallback.java
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+package com.wolfssl;
+
+/**
+ * wolfSSL ALPN Select Callback Interface.
+ * This interface specifies how applications should implement the ALPN
+ * select callback class to be used by wolfSSL.
+ * <p>
+ * After implementing this interface, it should be passed as a parameter
+ * to the {@link WolfSSLSession#setAlpnSelectCb(WolfSSLALPNSelectCallback,
+ * Object) WolfSSLSession.setALPNSelectCb()} method to be registered with the
+ * native wolfSSL session.
+ *
+ * @author wolfSSL
+ */
+public interface WolfSSLALPNSelectCallback {
+
+    /**
+     * ALPN select callback method.
+     * This method acts as the selection callback for Application Layer
+     * Negotiation Protocol (ALPN). This will be called during the handshake
+     * and gives the ALPN protocols proposed by the peer, allowing the server
+     * to select the desired protocol.
+     *
+     * @param ssl the current SSL session object from which the callback was
+     *            initiated.
+     * @param out output array; the selected ALPN protocol should be placed as
+     *            a String into the first array element, ie out[0].
+     * @param in  input array containing the ALPN values sent by the client
+     *            in the ClientHello message.
+     * @param arg Object set by user when registering callback, passed back
+     *            to user inside callback in case needed to select ALPN.
+     * @return WolfSSL.SSL_TLSEXT_ERR_OK if ALPN protocol has been selected,
+     *         WolfSSL.SSL_TLSEXT_ERR_NOACK if ALPN protocol was not selected
+     *             but handshake should proceed without ALPN,
+     *         WolfSSL.SSL_TLSEXT_ERR_ALERT_FATAL if no ALPN match can be found
+     *             and a fatal alert should be sent to peer to end the
+     *             handshake.
+     */
+    public int alpnSelectCallback(WolfSSLSession ssl, String[] out,
+        String[] in, Object arg);
+}
+

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
@@ -455,19 +455,22 @@ public class WolfSSLEngineHelper {
     /**
      * Get selected ALPN protocol string
      *
-     * @return String representation of selected ALPN protocol or null
-     *         if handshake has not finished
+     * @return String representation of selected ALPN protocol, null
+     *         if protocol is not available yet, or empty String if
+     *         ALPN will not be used for this connection.
      */
     protected String getAlpnSelectedProtocolString() {
-        if (this.ssl.handshakeDone()) {
-            String proto = ssl.getAlpnSelectedString();
+        String proto = ssl.getAlpnSelectedString();
 
-            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "selected ALPN protocol = " + proto);
+        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+            "selected ALPN protocol = " + proto);
 
-            return proto;
+        if (proto == null && this.ssl.handshakeDone()) {
+            /* ALPN not used if proto is null and handshake is done */
+            return "";
         }
-        return null;
+
+        return proto;
     }
 
     /********** Calls to transfer over parameter to wolfSSL before connection */
@@ -800,9 +803,9 @@ public class WolfSSLEngineHelper {
                     "\t" + i + ": " + applicationProtocols[i]);
             }
 
-            /* continue on mismatch */
+            /* fail on mismatch */
             this.ssl.useALPN(applicationProtocols,
-                             WolfSSL.WOLFSSL_ALPN_CONTINUE_ON_MISMATCH);
+                             WolfSSL.WOLFSSL_ALPN_FAILED_ON_MISMATCH);
         }
 
         if (alpnProtos == null && applicationProtocols == null) {


### PR DESCRIPTION
This PR implements support for the following ALPN API's from the `SSLEngine` and `SSLSocket` classes, as well as supporting JNI level changes and test cases.

```
    public synchronized String getHandshakeApplicationProtocol();
    public synchronized BiFunction<SSLEngine,List<String>,String>
            getHandshakeApplicationProtocolSelector();
    public synchronized void setHandshakeApplicationProtocolSelector(
            BiFunction<SSLEngine,List<String>,String> selector);
```

Tested against added JUnit tests as well as the following SunJSSE tests:

```
ALPN/SSLEngineAlpnTest.java
ALPN/SSLSocketAlpnTest.java
``` 

This fixes compatibility with Netty.

ZD #16581