### PR TITLE
JNI: wrap wolfSSL_CTX_set_groups(), wolfTLSv1_3_client/server_method()

### DIFF
--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -585,6 +585,32 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_TLSv1_13_1Method
 #endif
 }
 
+JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_TLSv1_13_1ServerMethod
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+#ifdef WOLFSSL_TLS13
+    return (jlong)(uintptr_t)wolfTLSv1_3_server_method();
+#else
+    return NOT_COMPILED_IN;
+#endif
+}
+
+JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_TLSv1_13_1ClientMethod
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+#ifdef WOLFSSL_TLS13
+    return (jlong)(uintptr_t)wolfTLSv1_3_client_method();
+#else
+    return NOT_COMPILED_IN;
+#endif
+}
+
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_DTLSv1_1Method
   (JNIEnv* jenv, jclass jcl)
 {

--- a/native/com_wolfssl_WolfSSL.h
+++ b/native/com_wolfssl_WolfSSL.h
@@ -641,6 +641,22 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_TLSv1_13_1Method
 
 /*
  * Class:     com_wolfssl_WolfSSL
+ * Method:    TLSv1_3_ServerMethod
+ * Signature: ()J
+ */
+JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_TLSv1_13_1ServerMethod
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    TLSv1_3_ClientMethod
+ * Signature: ()J
+ */
+JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_TLSv1_13_1ClientMethod
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
  * Method:    DTLSv1_Method
  * Signature: ()J
  */

--- a/native/com_wolfssl_WolfSSLContext.c
+++ b/native/com_wolfssl_WolfSSLContext.c
@@ -5473,6 +5473,42 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useSupportedCurve
 #endif
 }
 
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setGroups
+  (JNIEnv* jenv, jobject jcl, jlong ctxPtr, jintArray groups)
+{
+#ifdef HAVE_SUPPORTED_CURVES
+    int ret = WOLFSSL_FAILURE;
+    int groupsSz = 0;
+    int* jniGroups = NULL;
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
+    (void)jcl;
+
+    if (jenv == NULL || ctx == NULL || groups == NULL) {
+        return (jint)SSL_FAILURE;
+    }
+
+    groupsSz = (*jenv)->GetArrayLength(jenv, groups);
+    jniGroups = (*jenv)->GetIntArrayElements(jenv, groups, NULL);
+
+    if (groupsSz == 0 || groupsSz > WOLFSSL_MAX_GROUP_COUNT ||
+        jniGroups == NULL) {
+        return (jint)BAD_FUNC_ARG;
+    }
+
+    ret = wolfSSL_CTX_set_groups(ctx, jniGroups, groupsSz);
+
+    (*jenv)->ReleaseIntArrayElements(jenv, groups, jniGroups, JNI_ABORT);
+
+    return (jint)ret;
+#else
+    (void)jenv;
+    (void)jcl;
+    (void)ctxPtr;
+    (void)groups;
+    return (jint)NOT_COMPILED_IN;
+#endif
+}
+
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useSecureRenegotiation
   (JNIEnv* jenv, jobject jcl, jlong ctx)
 {

--- a/native/com_wolfssl_WolfSSLContext.h
+++ b/native/com_wolfssl_WolfSSLContext.h
@@ -377,6 +377,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useSupportedCurve
 
 /*
  * Class:     com_wolfssl_WolfSSLContext
+ * Method:    setGroups
+ * Signature: (J[I)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setGroups
+  (JNIEnv *, jobject, jlong, jintArray);
+
+/*
+ * Class:     com_wolfssl_WolfSSLContext
  * Method:    useSecureRenegotiation
  * Signature: (J)I
  */

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -871,6 +871,32 @@ public class WolfSSL {
     public static final native long TLSv1_3_Method();
 
     /**
+     * Indicates that the application is a server and will only support the
+     * TLS 1.3 protocol.
+     * This method allocates memory for and initializes a new native
+     * WOLFSSL_METHOD structure to be used when creating the SSL/TLS
+     * context with newContext().
+     *
+     * @return  A pointer to the created WOLFSSL_METHOD structure if
+     *          successful, null on failure.
+     * @see     WolfSSLContext#newContext(long)
+     */
+    public final static native long TLSv1_3_ServerMethod();
+
+    /**
+     * Indicates that the application is a client and will only support the
+     * TLS 1.3 protocol.
+     * This method allocates memory for and initializes a new native
+     * WOLFSSL_METHOD structure to be used when creating the SSL/TLS
+     * context with newContext().
+     *
+     * @return  A pointer to the created WOLFSSL_METHOD structure if
+     *          successful, null on failure.
+     * @see     WolfSSLContext#newContext(long)
+     */
+    public final static native long TLSv1_3_ClientMethod();
+
+    /**
      * Indicates that the application will only support the DTLS 1.0 protocol.
      * Application is side-independent at this time, and client/server side
      * will be determined at connect/accept stage.

--- a/src/java/com/wolfssl/WolfSSLContext.java
+++ b/src/java/com/wolfssl/WolfSSLContext.java
@@ -382,6 +382,7 @@ public class WolfSSLContext {
     private native void setPskServerCb(long ctx);
     private native int usePskIdentityHint(long ssl, String hint);
     private native int useSupportedCurve(long ctx, int name);
+    private native int setGroups(long ctx, int[] groups);
     private native int useSecureRenegotiation(long ctx);
     private native int setMinDhKeySz(long ctx, int keySzBits);
     private native int setMinRsaKeySz(long ctx, int keySzBits);
@@ -1886,7 +1887,7 @@ public class WolfSSLContext {
      * @throws IllegalStateException WolfSSLContext has been freed
      */
     public int useSupportedCurves(String[] curveNames)
-        throws IllegalStateException  {
+        throws IllegalStateException {
 
         int ret = 0;
         int curveEnum = 0;
@@ -1899,6 +1900,63 @@ public class WolfSSLContext {
         }
 
         return ret;
+    }
+
+    /**
+     * Sets the key exchange groups in rank order on this WolfSSLContext.
+     *
+     * @param groups Array of key exchange groups to be set. Values should
+     *        come from com.wolfssl.WolfSSL section for Named Groups, for
+     *        example:
+     *                WOLFSSL_ECC_SECT163R1
+     *                WOLFSSL_ECC_SECT163R2
+     *                WOLFSSL_ECC_SECT193R1
+     *                WOLFSSL_ECC_SECT193R2
+     *                WOLFSSL_ECC_SECT233K1
+     *                WOLFSSL_ECC_SECT233R1
+     *                WOLFSSL_ECC_SECT239K1
+     *                WOLFSSL_ECC_SECT283K1
+     *                WOLFSSL_ECC_SECT283R1
+     *                WOLFSSL_ECC_SECT409K1
+     *                WOLFSSL_ECC_SECT409R1
+     *                WOLFSSL_ECC_SECT571K1
+     *                WOLFSSL_ECC_SECT571R1
+     *                WOLFSSL_ECC_SECP160K1
+     *                WOLFSSL_ECC_SECP160R1
+     *                WOLFSSL_ECC_SECP160R2
+     *                WOLFSSL_ECC_SECP192K1
+     *                WOLFSSL_ECC_SECP192R1
+     *                WOLFSSL_ECC_SECP224K1
+     *                WOLFSSL_ECC_SECP224R1
+     *                WOLFSSL_ECC_SECP256K1
+     *                WOLFSSL_ECC_SECP256R1
+     *                WOLFSSL_ECC_SECP384R1
+     *                WOLFSSL_ECC_SECP521R1
+     *                WOLFSSL_ECC_BRAINPOOLP256R1
+     *                WOLFSSL_ECC_BRAINPOOLP384R1
+     *                WOLFSSL_ECC_BRAINPOOLP512R1
+     *                WOLFSSL_ECC_X25519
+     *                WOLFSSL_ECC_X448
+     *                WOLFSSL_ECC_SM2P256V1
+     *                WOLFSSL_FFDHE_2048
+     *                WOLFSSL_FFDHE_3072
+     *                WOLFSSL_FFDHE_4096
+     *                WOLFSSL_FFDHE_6144
+     *                WOLFSSL_FFDHE_8192
+     * @return <code>WolfSSL.SSL_SUCCESS</code> on success, otherwise negative
+     *         value on error. BAD_FUNC_ARG when groups is null, not using
+     *         TLS 1.3 or size is greater than WOLFSSL_MAX_GROUP_COUNT (which
+     *         defaults to 10, unless HAVE_PQC is defined then is 36.
+     * @throws IllegalStateException WolfSSLContext has been freed
+     */
+    public int setGroups(int[] groups)
+        throws IllegalStateException {
+
+        confirmObjectIsActive();
+
+        synchronized (ctxLock) {
+            return setGroups(getContextPtr(), groups);
+        }
     }
 
     /**

--- a/src/test/com/wolfssl/test/WolfSSLContextTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLContextTest.java
@@ -76,6 +76,7 @@ public class WolfSSLContextTest {
         test_WolfSSLContext_usePskIdentityHint();
         test_WolfSSLContext_useSecureRenegotiation();
         test_WolfSSLContext_useSupportedCurves();
+        test_WolfSSLContext_setGroups();
         test_WolfSSLContext_setMinRSAKeySize();
         test_WolfSSLContext_setMinECCKeySize();
         test_WolfSSLContext_free();
@@ -377,20 +378,20 @@ public class WolfSSLContextTest {
             ret = ctx.useSupportedCurves(singleEccSecp256r1);
             if (ret != WolfSSL.SSL_SUCCESS &&
                 ret != WolfSSL.NOT_COMPILED_IN) {
-                System.out.println("\t... failed");
+                System.out.println("\t\t... failed");
                 fail("useSupportedCurves(singleEccSecp256r1) failed");
             }
             ret = ctx.useSupportedCurves(allEccCurves);
             if (ret != WolfSSL.SSL_SUCCESS &&
                 ret != WolfSSL.NOT_COMPILED_IN) {
-                System.out.println("\t... failed");
+                System.out.println("\t\t... failed");
                 fail("useSupportedCurves(allEccCurves) failed");
             }
             if (WolfSSL.Curve25519Enabled()) {
                 ret = ctx.useSupportedCurves(x25519Curve);
                 if (ret != WolfSSL.SSL_SUCCESS &&
                     ret != WolfSSL.NOT_COMPILED_IN) {
-                    System.out.println("\t... failed");
+                    System.out.println("\t\t... failed");
                     fail("useSupportedCurves(x25519Curve) failed");
                 }
             }
@@ -398,15 +399,70 @@ public class WolfSSLContextTest {
                 ret = ctx.useSupportedCurves(x448Curve);
                 if (ret != WolfSSL.SSL_SUCCESS &&
                     ret != WolfSSL.NOT_COMPILED_IN) {
-                    System.out.println("\t... failed");
+                    System.out.println("\t\t... failed");
                     fail("useSupportedCurves(x448Curve) failed");
                 }
             }
-            System.out.println("\t...passed");
+            System.out.println("\t\t... passed");
 
         } catch (IllegalStateException e) {
-            System.out.println("\t... failed");
+            System.out.println("\t\t... failed");
             fail("useSupportedCurves failed");
+            e.printStackTrace();
+        }
+    }
+
+    public void test_WolfSSLContext_setGroups() {
+
+        int ret;
+        int[] singleItem = { WolfSSL.WOLFSSL_ECC_SECP256R1 };
+        int[] twoItems = {
+            WolfSSL.WOLFSSL_ECC_SECP256R1,
+            WolfSSL.WOLFSSL_ECC_SECP256R1
+        };
+        int[] tooLong = new int[50];
+        int[] badGroups = { (int)0xDEAD, (int)0xBEEF };
+
+        System.out.print("\tsetGroups()");
+        try {
+            ret = ctx.setGroups(null);
+            if (ret != WolfSSL.NOT_COMPILED_IN &&
+                ret == WolfSSL.SSL_SUCCESS) {
+                System.out.println("\t\t\t... failed");
+                fail("setGroups() should fail with null arg");
+            }
+            if (WolfSSL.EccEnabled()) {
+                ret = ctx.setGroups(singleItem);
+                if (ret != WolfSSL.NOT_COMPILED_IN &&
+                    ret != WolfSSL.SSL_SUCCESS) {
+                    System.out.println("\t\t\t... failed");
+                    fail("setGroups() failed with WOLFSSL_ECC_SECP256R1");
+                }
+                ret = ctx.setGroups(twoItems);
+                if (ret != WolfSSL.NOT_COMPILED_IN &&
+                    ret != WolfSSL.SSL_SUCCESS) {
+                    System.out.println("\t\t\t... failed");
+                    fail("setGroups() failed with two entries");
+                }
+            }
+            ret = ctx.setGroups(tooLong);
+            if (ret != WolfSSL.NOT_COMPILED_IN &&
+                ret != WolfSSL.BAD_FUNC_ARG) {
+                System.out.println("\t\t\t... failed");
+                fail("setGroups() should fail with too long array");
+            }
+            ret = ctx.setGroups(badGroups);
+            if (ret != WolfSSL.NOT_COMPILED_IN &&
+                ret != WolfSSL.BAD_FUNC_ARG) {
+                System.out.println("\t\t\t... failed");
+                fail("setGroups() should fail with bad/invalid values");
+            }
+
+            System.out.println("\t\t\t... passed");
+
+        } catch (IllegalStateException e) {
+            System.out.println("\t\t\t... failed");
+            fail("setGroups() failed");
             e.printStackTrace();
         }
     }

--- a/src/test/com/wolfssl/test/WolfSSLTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLTest.java
@@ -93,6 +93,8 @@ public class WolfSSLTest {
         tstMethod(lib.TLSv1_1_ClientMethod(), "TLSv1_1_ClientMethod()");
         tstMethod(lib.TLSv1_2_ServerMethod(), "TLSv1_2_ServerMethod()");
         tstMethod(lib.TLSv1_2_ClientMethod(), "TLSv1_2_ClientMethod()");
+        tstMethod(lib.TLSv1_3_ServerMethod(), "TLSv1_3_ServerMethod()");
+        tstMethod(lib.TLSv1_3_ClientMethod(), "TLSv1_3_ClientMethod()");
         tstMethod(lib.DTLSv1_ServerMethod(), "DTLSv1_ServerMethod()");
         tstMethod(lib.DTLSv1_ClientMethod(), "DTLSv1_ClientMethod()");
         tstMethod(lib.DTLSv1_2_ServerMethod(), "DTLSv1_2_ServerMethod()");


### PR DESCRIPTION
This PR wraps three native wolfSSL APIs in the thin wolfSSL JNI layer:
- `wolfSSL_CTX_set_groups()` inside `com.wolfssl.WolfSSLContext`
- `wolfTLSv1_3_client_method()` inside `com.wolfssl.WolfSSL`
- `wolfTLSv1_3_server_method()` inside `com.wolfssl.WolfSSL`