### PR TITLE
JSSE: SSLEngine: save session only on connection shutdown

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
@@ -371,24 +371,6 @@ public class WolfSSLEngine extends SSLEngine {
                     ssl.getError(ret));
             }
 
-            if (ret == WolfSSL.SSL_SUCCESS) {
-                /* Once handshake is finished, save session for resumption in
-                 * case caller does not explicitly close connection. Saves
-                 * session in WolfSSLAuthStore cache, and gets/saves session
-                 * pointer for resumption if on client side. Protected with
-                 * ioLock since underlying get1Session can use I/O for peek. */
-                synchronized (ioLock) {
-                    WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "calling EngineHelper.saveSession()");
-                    int ret2 = EngineHelper.saveSession();
-                    WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "return from saveSession(), ret = " + ret2);
-                    if (ret2 == WolfSSL.SSL_SUCCESS) {
-                        this.sessionStored = true;
-                    }
-                }
-            }
-
         } catch (SocketTimeoutException | SocketException e) {
             throw new SSLException(e);
         }


### PR DESCRIPTION
This PR modifies `WolfSSLEngine (SSLEngine)` to remove the attempt to save the session right after `ssl.accept/connect()`. We already store the session on connection closure, which is the proper way to do it since in TLS 1.3 the Session Ticket can come after the handshake finishes and may not be available yet.

This matches behavior of `WolfSSLSocket (SSLSocket)`, and also fixes the sporadically failing ExtendedSSLEngineTest with `ant test`.