### PR TITLE
Refactor native debug log enablement, register Java native logging callback

### DIFF
--- a/scripts/infer.sh
+++ b/scripts/infer.sh
@@ -57,6 +57,7 @@ infer run -- javac \
     src/java/com/wolfssl/provider/jsse/WolfSSLInternalVerifyCb.java \
     src/java/com/wolfssl/provider/jsse/WolfSSLKeyManager.java \
     src/java/com/wolfssl/provider/jsse/WolfSSLKeyX509.java \
+    src/java/com/wolfssl/provider/jsse/WolfSSLNativeLoggingCallback.java \
     src/java/com/wolfssl/provider/jsse/WolfSSLParametersHelper.java \
     src/java/com/wolfssl/provider/jsse/WolfSSLParameters.java \
     src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java \

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -1482,6 +1482,9 @@ public class WolfSSL {
     {
         synchronized(cleanupLock) {
             if (this.active == true) {
+                /* reset logging callback before calling cleanup() */
+                this.setLoggingCb(null);
+
                 /* free resources, set state */
                 this.cleanup();
                 this.active = false;

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLContext.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLContext.java
@@ -66,6 +66,12 @@ public class WolfSSLContext extends SSLContextSpi {
         long method;
         String[] ciphersIana = null;
 
+        /* Enable native wolfSSL debug logging if 'wolfssl.debug'
+         * System property is set. Also attempted in WolfSSLProvider
+         * but System property may not have been set by user yet at that
+         * point. */
+        WolfSSLDebug.setNativeWolfSSLDebugging();
+
         /* Get available wolfSSL cipher suites in IANA format */
         ciphersIana = WolfSSL.getCiphersAvailableIana(this.currentVersion);
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLDebug.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLDebug.java
@@ -24,6 +24,9 @@ package com.wolfssl.provider.jsse;
 import java.util.Date;
 import java.sql.Timestamp;
 
+import com.wolfssl.WolfSSL;
+import com.wolfssl.WolfSSLLoggingCallback;
+
 /**
  * Central location for all debugging messages
  *
@@ -47,6 +50,13 @@ public class WolfSSLDebug {
      * Info level debug message
      */
     public static final String INFO = "INFO";
+
+    /**
+     * Native wolfSSL logging callback.
+     * Used to print native wolfSSL debug logs when 'wolfssl.debug' System
+     * property is set to "true".
+     */
+    private static WolfSSLNativeLoggingCallback nativeLogCb = null;
 
     private static boolean checkProperty() {
 
@@ -118,6 +128,41 @@ public class WolfSSLDebug {
             }
             System.out.println("");
         }
+    }
+
+    /**
+     * Enable native wolfSSL debug logging based on value of the
+     * 'wolfssl.debug' System property.
+     *
+     * Native wolfSSL must ben compiled with "--enable-debug" or
+     * DEBUG_WOLFSSL defined in order for debug logs to print.
+     */
+    protected static synchronized void setNativeWolfSSLDebugging() {
+
+        String wolfsslDebug = System.getProperty("wolfssl.debug");
+
+        if ((wolfsslDebug != null) && (wolfsslDebug.equalsIgnoreCase("true"))) {
+
+            WolfSSL.debuggingON();
+        }
+
+        /* Register our default logging callback for native wolfSSL logs */
+        setDefaultNativeLoggingCallback();
+    }
+
+    /**
+     * Register default native wolfSSL logging callback.
+     * Default callback class is WolfSSLNativeLoggingCallback. This could be
+     * modified in the future to allow a custom user-registerable callback.
+     */
+    protected static synchronized void setDefaultNativeLoggingCallback() {
+
+        /* Only create one logging callback object */
+        if (nativeLogCb == null) {
+            nativeLogCb = new WolfSSLNativeLoggingCallback();
+        }
+
+        WolfSSL.setLoggingCb(nativeLogCb);
     }
 }
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLNativeLoggingCallback.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLNativeLoggingCallback.java
@@ -1,0 +1,47 @@
+/* WolfSSLNativeLoggingCallback.java
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+package com.wolfssl.provider.jsse;
+
+import java.util.Date;
+import java.sql.Timestamp;
+
+import com.wolfssl.WolfSSLLoggingCallback;
+
+/**
+ * Utility class to help with JSSE-level functionality.
+ *
+ * Native logging callback class, implements com.wolfssl.WolfSSLLoggingCallback.
+ * loggingCallback() method is called by native wolfSSL debug logging
+ * mechanism.
+ *
+ * @author wolfSSL
+ */
+class WolfSSLNativeLoggingCallback implements WolfSSLLoggingCallback
+{
+    public synchronized void loggingCallback(int logLevel, String logMessage) {
+
+        System.out.println(new Timestamp(new java.util.Date().getTime()) +
+                           " [wolfSSL: TID " +
+                           Thread.currentThread().getId() +
+                           "] " + logMessage);
+    }
+}
+

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java
@@ -28,9 +28,7 @@ import com.wolfssl.WolfSSLFIPSErrorCallback;
 
 /**
  * wolfSSL JSSE Provider implementation
- *
  * @author wolfSSL
- * @version 1.8
  */
 public final class WolfSSLProvider extends Provider {
 
@@ -103,12 +101,10 @@ public final class WolfSSLProvider extends Provider {
                 "Failed to initialize native wolfSSL library");
         }
 
-        /* enable native wolfSSL debug logging, native wolfSSL must be
-         * compiled with --enable-debug */
-        String wolfsslDebug = System.getProperty("wolfssl.debug");
-        if ((wolfsslDebug != null) && (wolfsslDebug.equalsIgnoreCase("true"))) {
-            WolfSSL.debuggingON();
-        }
+        /* Enable native wolfSSL debug logging if 'wolfssl.debug' System
+         * property has been set to "true" and native wolfSSL compiled with
+         * '--enable-debug' */
+        WolfSSLDebug.setNativeWolfSSLDebugging();
 
         /* Key Factory */
         put("KeyManagerFactory.PKIX",


### PR DESCRIPTION
Native wolfSSL debug logs are enabled from the Java layer by setting the `wolfssl.debug` System property to "true".  This was previously detected and set inside the `WolfSSLProvider` class which worked well for applications that set the System property before the provider was registered.  But for applications that set the `wolfssl.debug` system property **after** the provider has been registered (ie: when installing at the system level), this was not picked up.

This PR also detects and enables native wolfSSL debug logging when a new `WolfSSLContext / SSLContext` is created, which will allow native debug logs to more easily show up for users who install at a system level.

This PR also registers a default native logging callback from Java with native wolfSSL so that native logs go out through `System.out.println()` just like JSSE-level logs. This allows for a more accurate log, lets us put a timetstamp and thread ID into the logs, and provide a building block for more customizable logging in the future.