### PR TITLE
JNI: wrap SSL_CTX_set1_sigalgs_list(), add resume example to JNI Client

### DIFF
--- a/examples/Client.java
+++ b/examples/Client.java
@@ -112,7 +112,7 @@ public class Client {
                     if (args.length < i+2)
                         printUsage();
                     sslVersion = Integer.parseInt(args[++i]);
-                    if (sslVersion < 0 || sslVersion > 3) {
+                    if (sslVersion < 0 || sslVersion > 4) {
                         printUsage();
                     }
 
@@ -237,6 +237,9 @@ public class Client {
                     break;
                 case 3:
                     method = WolfSSL.TLSv1_2_ClientMethod();
+                    break;
+                case 4:
+                    method = WolfSSL.TLSv1_3_ClientMethod();
                     break;
                 case -1:
                     method = WolfSSL.DTLSv1_ClientMethod();
@@ -726,7 +729,7 @@ public class Client {
         System.out.println("-h <host>\tHost to connect to, default 127.0.0.1");
         System.out.println("-p <num>\tPort to connect to, default 11111");
         System.out.println("-v <num>\tSSL version [0-3], SSLv3(0) - " +
-                "TLS1.2(3)), default 3");
+                "TLS1.3(4)), default 3");
         System.out.println("-l <str>\tCipher list");
         System.out.println("-c <file>\tCertificate file,\t\tdefault " +
                 "../certs/client-cert.pem");

--- a/examples/Client.java
+++ b/examples/Client.java
@@ -72,6 +72,9 @@ public class Client {
         int logCallback = 0;                  /* use test logging callback */
         int usePsk = 0;                       /* use pre shared keys */
 
+        long session = 0;                     /* pointer to WOLFSSL_SESSION */
+        boolean resumeSession = false;        /* try one session resumption */
+
         /* cert info */
         String clientCert = "../certs/client-cert.pem";
         String clientKey  = "../certs/client-key.pem";
@@ -194,6 +197,9 @@ public class Client {
                         System.exit(1);
                     }
                     pkCallbacks = 1;
+
+                } else if (arg.equals("-r")) {
+                    resumeSession = true;
 
                 } else {
                     printUsage();
@@ -433,6 +439,15 @@ public class Client {
                 }
             }
 
+            /* enable use of session tickets if compiled in native wolfSSL */
+            if (WolfSSL.sessionTicketEnabled()) {
+                ret = ssl.useSessionTicket();
+                if (ret != WolfSSL.SSL_SUCCESS) {
+                    System.out.println("Session tickets not enabled for " +
+                        "this WolfSSLSession: ret = " + ret);
+                }
+            }
+
             /* open Socket */
             if (doDTLS == 1) {
                 dsock = new DatagramSocket();
@@ -546,6 +561,122 @@ public class Client {
                 System.out.println("read failed");
             }
 
+            /* save session in case resuming */
+            session = ssl.getSession();
+            if (session == 0) {
+                System.out.println("Failed to get native WOLFSSL_SESSION");
+            } else {
+                System.out.println("Saved native WOLFSSL_SESSION");
+            }
+
+            /* shutdown SSL/TLS session */
+            ssl.shutdownSSL();
+
+            /* free native WOLFSSL session, also done by garbage collector
+             * later if not called explicitly */
+            ssl.freeSSL();
+
+            if (resumeSession) {
+                System.out.println("\nTrying session resumption...");
+
+                /* create SSL object */
+                ssl = new WolfSSLSession(sslCtx);
+
+                /* open Socket */
+                if (doDTLS == 1) {
+                    dsock = new DatagramSocket();
+                    hostAddr = InetAddress.getByName(host);
+                    InetSocketAddress addr =
+                        new InetSocketAddress(hostAddr, port);
+                    ret = ssl.dtlsSetPeer(addr);
+                    if (ret != WolfSSL.SSL_SUCCESS) {
+                        System.out.println("failed to set DTLS peer");
+                        System.exit(1);
+                    }
+                } else {
+                    sock = new Socket(host, port);
+                    System.out.println("Connected to " +
+                            sock.getInetAddress().getHostAddress() +
+                            " on port " +
+                            sock.getPort() + "\n");
+
+                    outstream = new DataOutputStream(sock.getOutputStream());
+                    instream = new DataInputStream(sock.getInputStream());
+                }
+
+                if (useIOCallbacks || (doDTLS == 1)) {
+                    /* register I/O callback user context */
+                    MyIOCtx ioctx = new MyIOCtx(outstream, instream, dsock,
+                            hostAddr, port);
+                    ssl.setIOReadCtx(ioctx);
+                    ssl.setIOWriteCtx(ioctx);
+                    System.out.println("Registered I/O callback user contexts");
+
+                } else {
+
+                    /* if not using DTLS or I/O callbacks, pass Socket
+                     * fd to wolfSSL */
+                    ret = ssl.setFd(sock);
+
+                    if (ret != WolfSSL.SSL_SUCCESS) {
+                        System.out.println("Failed to set file descriptor");
+                        return;
+                    }
+                }
+
+                /* restore saved WOLFSSL_SESSION */
+                ssl.setSession(session);
+
+                /* call wolfSSL_connect */
+                do {
+                    ret = ssl.connect();
+                    err = ssl.getError(ret);
+                } while (ret != WolfSSL.SSL_SUCCESS &&
+                       (err == WolfSSL.SSL_ERROR_WANT_READ ||
+                        err == WolfSSL.SSL_ERROR_WANT_WRITE));
+
+                if (ret != WolfSSL.SSL_SUCCESS) {
+                    err = ssl.getError(ret);
+                    String errString = sslLib.getErrorString(err);
+                    System.out.println("wolfSSL_connect failed. err = " + err +
+                            ", " + errString);
+                    System.exit(1);
+                }
+
+                /* show peer info */
+                showPeer(ssl);
+                System.out.println("Session resumed: " + ssl.sessionReused());
+
+                /* test write(long, byte[], int) */
+                do {
+                    ret = ssl.write(msg.getBytes(), msg.length());
+                    err = ssl.getError(0);
+                } while (ret < 0 &&
+                         (err == WolfSSL.SSL_ERROR_WANT_READ ||
+                          err == WolfSSL.SSL_ERROR_WANT_WRITE));
+
+                /* read response */
+                do {
+                    input = ssl.read(back, back.length);
+                    err = ssl.getError(0);
+                } while (input < 0 &&
+                         (err == WolfSSL.SSL_ERROR_WANT_READ ||
+                          err == WolfSSL.SSL_ERROR_WANT_WRITE));
+
+                if (input > 0) {
+                    System.out.println("got back: " + new String(back));
+                } else {
+                    System.out.println("read failed");
+                }
+
+                /* shutdown SSL/TLS session */
+                ssl.shutdownSSL();
+
+                /* free native WOLFSSL session, also done by garbage collector
+                 * later if not called explicitly */
+                ssl.freeSSL();
+            }
+
             /* free resources */
             sslCtx.free();
 
@@ -605,6 +736,7 @@ public class Client {
                 "../certs/ca-cert.pem");
         System.out.println("-b <num>\tBenchmark <num> connections and print" +
                 " stats");
+        System.out.println("-r\t\tResume session");
         if (WolfSSL.isEnabledPSK() == 1)
             System.out.println("-s\t\tUse pre shared keys");
         System.out.println("-d\t\tDisable peer checks");

--- a/examples/Server.java
+++ b/examples/Server.java
@@ -106,7 +106,7 @@ public class Server {
                     if (args.length < i+2)
                         printUsage();
                     sslVersion = Integer.parseInt(args[++i]);
-                    if (sslVersion < 0 || sslVersion > 3) {
+                    if (sslVersion < 0 || sslVersion > 4) {
                         printUsage();
                     }
 
@@ -237,6 +237,9 @@ public class Server {
                     break;
                 case 3:
                     method = WolfSSL.TLSv1_2_ServerMethod();
+                    break;
+                case 4:
+                    method = WolfSSL.TLSv1_3_ServerMethod();
                     break;
                 case -1:
                     method = WolfSSL.DTLSv1_ServerMethod();
@@ -649,7 +652,7 @@ public class Server {
         System.out.println("-?\t\tHelp, print this usage");
         System.out.println("-p <num>\tPort to connect to, default 11111");
         System.out.println("-v <num>\tSSL version [0-3], SSLv3(0) - " +
-                "TLS1.2(3)), default 3");
+                "TLS1.3(4)), default 3");
         System.out.println("-l <str>\tCipher list");
         System.out.println("-c <file>\tCertificate file,\t\tdefault " +
                 "../certs/client-cert.pem");

--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -506,6 +506,19 @@ JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_trustPeerCertEnabled
 #endif
 }
 
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_sessionTicketEnabled
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+#ifdef HAVE_SESSION_TICKET
+    return JNI_TRUE;
+#else
+    return JNI_FALSE;
+#endif
+}
+
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_SSLv3_1ServerMethod
   (JNIEnv* jenv, jclass jcl)
 {

--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -350,6 +350,71 @@ JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_TLSv13Enabled
 #endif
 }
 
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_ShaEnabled
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+#if !defined(NO_SHA)
+    return JNI_TRUE;
+#else
+    return JNI_FALSE;
+#endif
+}
+
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_Sha224Enabled
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+#if !defined(NO_SHA256) && defined(WOLFSSL_SHA224)
+    return JNI_TRUE;
+#else
+    return JNI_FALSE;
+#endif
+}
+
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_Sha256Enabled
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+#if !defined(NO_SHA256)
+    return JNI_TRUE;
+#else
+    return JNI_FALSE;
+#endif
+}
+
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_Sha384Enabled
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+#if defined(WOLFSSL_SHA512) && defined(WOLFSSL_SHA384)
+    return JNI_TRUE;
+#else
+    return JNI_FALSE;
+#endif
+}
+
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_Sha512Enabled
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+#if defined(WOLFSSL_SHA512)
+    return JNI_TRUE;
+#else
+    return JNI_FALSE;
+#endif
+}
+
 JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_EccEnabled
   (JNIEnv* jenv, jclass jcl)
 {

--- a/native/com_wolfssl_WolfSSL.h
+++ b/native/com_wolfssl_WolfSSL.h
@@ -497,6 +497,46 @@ JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_TLSv13Enabled
 
 /*
  * Class:     com_wolfssl_WolfSSL
+ * Method:    ShaEnabled
+ * Signature: ()Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_ShaEnabled
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    Sha224Enabled
+ * Signature: ()Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_Sha224Enabled
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    Sha256Enabled
+ * Signature: ()Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_Sha256Enabled
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    Sha384Enabled
+ * Signature: ()Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_Sha384Enabled
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    Sha512Enabled
+ * Signature: ()Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_Sha512Enabled
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
  * Method:    EccEnabled
  * Signature: ()Z
  */

--- a/native/com_wolfssl_WolfSSL.h
+++ b/native/com_wolfssl_WolfSSL.h
@@ -593,6 +593,14 @@ JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_trustPeerCertEnabled
 
 /*
  * Class:     com_wolfssl_WolfSSL
+ * Method:    sessionTicketEnabled
+ * Signature: ()Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_sessionTicketEnabled
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
  * Method:    SSLv3_ServerMethod
  * Signature: ()J
  */

--- a/native/com_wolfssl_WolfSSLContext.c
+++ b/native/com_wolfssl_WolfSSLContext.c
@@ -5509,6 +5509,35 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setGroups
 #endif
 }
 
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_set1SigAlgsList
+  (JNIEnv* jenv, jobject jcl, jlong ctxPtr, jstring list)
+{
+#if !defined(WOLFCRYPT_ONLY) && defined(OPENSSL_EXTRA)
+    int ret = WOLFSSL_FAILURE;
+    WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
+    const char* sigAlgList = NULL;
+    (void)jcl;
+
+    if (jenv == NULL || ctx == NULL || list == NULL) {
+        return (jint)WOLFSSL_FAILURE;
+    }
+
+    sigAlgList = (*jenv)->GetStringUTFChars(jenv, list, 0);
+
+    ret = wolfSSL_CTX_set1_sigalgs_list(ctx, sigAlgList);
+
+    (*jenv)->ReleaseStringUTFChars(jenv, list, sigAlgList);
+
+    return (jint)ret;
+#else
+    (void)jenv;
+    (void)jcl;
+    (void)ctxPtr;
+    (void)list;
+    return (jint)NOT_COMPILED_IN;
+#endif
+}
+
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useSecureRenegotiation
   (JNIEnv* jenv, jobject jcl, jlong ctx)
 {

--- a/native/com_wolfssl_WolfSSLContext.h
+++ b/native/com_wolfssl_WolfSSLContext.h
@@ -385,6 +385,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setGroups
 
 /*
  * Class:     com_wolfssl_WolfSSLContext
+ * Method:    set1SigAlgsList
+ * Signature: (JLjava/lang/String;)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_set1SigAlgsList
+  (JNIEnv *, jobject, jlong, jstring);
+
+/*
+ * Class:     com_wolfssl_WolfSSLContext
  * Method:    useSecureRenegotiation
  * Signature: (J)I
  */

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -662,6 +662,41 @@ public class WolfSSL {
     public static native boolean TLSv13Enabled();
 
     /**
+     * Tests if SHA-1 is enabled in the native wolfSSL library.
+     *
+     * @return true if enabled, otherwise false if not compiled in.
+     */
+    public static native boolean ShaEnabled();
+
+    /**
+     * Tests if SHA-224 is enabled in the native wolfSSL library.
+     *
+     * @return true if enabled, otherwise false if not compiled in.
+     */
+    public static native boolean Sha224Enabled();
+
+    /**
+     * Tests if SHA-256 is enabled in the native wolfSSL library.
+     *
+     * @return true if enabled, otherwise false if not compiled in.
+     */
+    public static native boolean Sha256Enabled();
+
+    /**
+     * Tests if SHA-384 is enabled in the native wolfSSL library.
+     *
+     * @return true if enabled, otherwise false if not compiled in.
+     */
+    public static native boolean Sha384Enabled();
+
+    /**
+     * Tests if SHA-512 is enabled in the native wolfSSL library.
+     *
+     * @return true if enabled, otherwise false if not compiled in.
+     */
+    public static native boolean Sha512Enabled();
+
+    /**
      * Tests if ECC support has been compiled into the native wolfSSL library.
      *
      * @return true if enabled, otherwise false if not compiled in.

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -750,6 +750,15 @@ public class WolfSSL {
      */
     public static native boolean trustPeerCertEnabled();
 
+    /**
+     * Tests if native session ticket support has been compiled into wolfSSL
+     * with HAVE_SESSION_TICKET.
+     *
+     * @return true if enabled, otherwise false if HAVE_SESSION_TICKET
+     *         has not been defined.
+     */
+    public static native boolean sessionTicketEnabled();
+
     /* ---------------- native SSL/TLS version functions ---------------- */
 
     /**

--- a/src/java/com/wolfssl/WolfSSLContext.java
+++ b/src/java/com/wolfssl/WolfSSLContext.java
@@ -383,6 +383,7 @@ public class WolfSSLContext {
     private native int usePskIdentityHint(long ssl, String hint);
     private native int useSupportedCurve(long ctx, int name);
     private native int setGroups(long ctx, int[] groups);
+    private native int set1SigAlgsList(long ctx, String list);
     private native int useSecureRenegotiation(long ctx);
     private native int setMinDhKeySz(long ctx, int keySzBits);
     private native int setMinRsaKeySz(long ctx, int keySzBits);
@@ -1956,6 +1957,27 @@ public class WolfSSLContext {
 
         synchronized (ctxLock) {
             return setGroups(getContextPtr(), groups);
+        }
+    }
+
+    /**
+     * Set the supported signature algorithms for this WolfSSLContext. This
+     * replaces the existing or default list in the context.
+     *
+     * @param list Colon-separated list of [public key]+[digest] algorithms,
+     *             for example: "RSA+SHA256", or "RSA+SHA256:ECDSA:SHA256"
+     *
+     * @return <code>WolfSSL.SSL_SUCCESS</code> on success, otherwise
+     *         <code>WolfSSL.SSL_FAILURE</code> on failure
+     * @throws IllegalStateException WolfSSLContext has been freed
+     */
+    public int set1SigAlgsList(String list)
+        throws IllegalStateException {
+
+        confirmObjectIsActive();
+
+        synchronized (ctxLock) {
+            return set1SigAlgsList(getContextPtr(), list);
         }
     }
 

--- a/src/test/com/wolfssl/test/WolfSSLContextTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLContextTest.java
@@ -77,6 +77,7 @@ public class WolfSSLContextTest {
         test_WolfSSLContext_useSecureRenegotiation();
         test_WolfSSLContext_useSupportedCurves();
         test_WolfSSLContext_setGroups();
+        test_WolfSSLContext_set1SigAlgsList();
         test_WolfSSLContext_setMinRSAKeySize();
         test_WolfSSLContext_setMinECCKeySize();
         test_WolfSSLContext_free();
@@ -462,8 +463,107 @@ public class WolfSSLContextTest {
 
         } catch (IllegalStateException e) {
             System.out.println("\t\t\t... failed");
-            fail("setGroups() failed");
             e.printStackTrace();
+            fail("setGroups() failed");
+        }
+    }
+
+    public void test_WolfSSLContext_set1SigAlgsList() {
+
+        int ret;
+
+        System.out.print("\tset1SigAlgsList()");
+        try {
+            /* Expected failure, null list */
+            ret = ctx.set1SigAlgsList(null);
+            if (ret != WolfSSL.NOT_COMPILED_IN &&
+                ret != WolfSSL.SSL_FAILURE) {
+                System.out.println("\t\t... failed");
+                fail("set1SigAlgsList() should fail with null list");
+            }
+
+            /* Expected failure, empty list */
+            ret = ctx.set1SigAlgsList("");
+            if (ret != WolfSSL.NOT_COMPILED_IN &&
+                ret != WolfSSL.SSL_FAILURE) {
+                System.out.println("\t\t... failed");
+                fail("set1SigAlgsList() should fail with empty list");
+            }
+
+            if (WolfSSL.RsaEnabled()) {
+                ret = ctx.set1SigAlgsList("RSA");
+                if (ret != WolfSSL.NOT_COMPILED_IN &&
+                    ret != WolfSSL.SSL_FAILURE) {
+                    System.out.println("\t\t... failed");
+                    fail("set1SigAlgsList() should fail without hash");
+                }
+
+                if (WolfSSL.Sha256Enabled()) {
+                    ret = ctx.set1SigAlgsList("RSA+SHA256");
+                    if (ret != WolfSSL.NOT_COMPILED_IN &&
+                        ret != WolfSSL.SSL_SUCCESS) {
+                        System.out.println("\t\t... failed");
+                        fail("set1SigAlgsList() should pass with given list");
+                    }
+
+                    ret = ctx.set1SigAlgsList("RSA:RSA+SHA256");
+                    if (ret != WolfSSL.NOT_COMPILED_IN &&
+                        ret != WolfSSL.SSL_FAILURE) {
+                        System.out.println("\t\t... failed");
+                        fail("set1SigAlgsList() should fail without hash");
+                    }
+
+                    if (WolfSSL.Sha512Enabled()) {
+                        ret = ctx.set1SigAlgsList("RSA+SHA256:RSA+SHA512");
+                        if (ret != WolfSSL.NOT_COMPILED_IN &&
+                            ret != WolfSSL.SSL_SUCCESS) {
+                            System.out.println("\t\t... failed");
+                            fail("set1SigAlgsList() should pass");
+                        }
+                    }
+                }
+            }
+
+            if (WolfSSL.EccEnabled()) {
+                ret = ctx.set1SigAlgsList("ECDSA");
+                if (ret != WolfSSL.NOT_COMPILED_IN &&
+                    ret != WolfSSL.SSL_FAILURE) {
+                    System.out.println("\t\t... failed");
+                    fail("set1SigAlgsList() should fail without hash");
+                }
+
+                if (WolfSSL.Sha256Enabled()) {
+                    ret = ctx.set1SigAlgsList("ECDSA+SHA256");
+                    if (ret != WolfSSL.NOT_COMPILED_IN &&
+                        ret != WolfSSL.SSL_SUCCESS) {
+                        System.out.println("\t\t... failed");
+                        fail("set1SigAlgsList() should pass with given list");
+                    }
+
+                    ret = ctx.set1SigAlgsList("ECDSA:ECDSA+SHA256");
+                    if (ret != WolfSSL.NOT_COMPILED_IN &&
+                        ret != WolfSSL.SSL_FAILURE) {
+                        System.out.println("\t\t... failed");
+                        fail("set1SigAlgsList() should fail without hash");
+                    }
+
+                    if (WolfSSL.Sha512Enabled()) {
+                        ret = ctx.set1SigAlgsList("ECDSA+SHA256:ECDSA+SHA512");
+                        if (ret != WolfSSL.NOT_COMPILED_IN &&
+                            ret != WolfSSL.SSL_SUCCESS) {
+                            System.out.println("\t\t... failed");
+                            fail("set1SigAlgsList() should pass");
+                        }
+                    }
+                }
+            }
+
+            System.out.println("\t\t... passed");
+
+        } catch (IllegalStateException e) {
+            System.out.println("\t\t... failed");
+            e.printStackTrace();
+            fail("set1SigAlgsList() failed");
         }
     }
 


### PR DESCRIPTION
This PR:
- Wraps the native `SSL_CTX_set1_sigalgs_list()` API inside `WolfSSLContext`
- Adds a few native feature-detection helper methods to `WolfSSL`
- Expands the JNI-level example client `Client.java` to add support for doing one session resumption with session tickets enabled
- Adds TLS 1.3 version to example JNI `Client.java` and `Server.java`

ZD 17211