### PR TITLE
Fixes for SSLEngine.setWant/NeedClientAuth() and choosing key alias chooseEngineClient/ServerAlias()

### DIFF
--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -2358,6 +2358,33 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useCertificateChainBuffer
     return ret;
 }
 
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useCertificateChainBufferFormat
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jbyteArray in, jlong sz, jint format)
+{
+    int ret = WOLFSSL_FAILURE;
+    byte* buff = NULL;
+    word32 buffSz = 0;
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
+    (void)jcl;
+    (void)sz;
+
+    if (jenv == NULL || ssl == NULL || in == NULL) {
+        return (jint)BAD_FUNC_ARG;
+    }
+
+    buff = (byte*)(*jenv)->GetByteArrayElements(jenv, in, NULL);
+    buffSz = (*jenv)->GetArrayLength(jenv, in);
+
+    if (buff != NULL && buffSz > 0) {
+        ret = wolfSSL_use_certificate_chain_buffer_format(
+                ssl, buff, buffSz, format);
+    }
+
+    (*jenv)->ReleaseByteArrayElements(jenv, in, (jbyte*)buff, JNI_ABORT);
+
+    return (jint)ret;
+}
+
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setGroupMessages
   (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {

--- a/native/com_wolfssl_WolfSSLSession.h
+++ b/native/com_wolfssl_WolfSSLSession.h
@@ -369,6 +369,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useCertificateChainBuffer
 
 /*
  * Class:     com_wolfssl_WolfSSLSession
+ * Method:    useCertificateChainBufferFormat
+ * Signature: (J[BJI)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useCertificateChainBufferFormat
+  (JNIEnv *, jobject, jlong, jbyteArray, jlong, jint);
+
+/*
+ * Class:     com_wolfssl_WolfSSLSession
  * Method:    setGroupMessages
  * Signature: (J)I
  */

--- a/src/java/com/wolfssl/WolfSSLContext.java
+++ b/src/java/com/wolfssl/WolfSSLContext.java
@@ -1052,7 +1052,7 @@ public class WolfSSLContext {
      * and start with the subject's certificate, ending with the root
      * certificate.
      *
-     * @param in        the input buffer containing the PEM-formatted
+     * @param in        the input buffer containing the PEM or DER formatted
      *                  certificate chain to be loaded.
      * @param sz        the size of the input buffer, <b>in</b>
      * @param format    format of the certificate buffer being loaded - either

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -297,6 +297,8 @@ public class WolfSSLSession {
             int format);
     private native int useCertificateChainBuffer(long ssl, byte[] in,
             long sz);
+    private native int useCertificateChainBufferFormat(
+            long ssl, byte[] in, long sz, int format);
     private native int setGroupMessages(long ssl);
     private native int enableCRL(long ssl, int options);
     private native int disableCRL(long ssl);
@@ -2007,6 +2009,52 @@ public class WolfSSLSession {
             return useCertificateChainBuffer(getSessionPtr(), in, sz);
         }
     }
+
+    /**
+     * Loads a certificate chain buffer into the SSL object in specific format.
+     * This method behaves like the non-buffered version, only differing
+     * in its ability to be called with a buffer as input instead of a file.
+     * This function is similar to useCertificateChainBuffer(), but allows
+     * the input format to be specified. The format must be either DER or PEM,
+     * and start with the subject's certificate, ending with the root
+     * certificate.
+     *
+     * @param in        the input buffer containing the PEM or DER formatted
+     *                  certificate chain to be loaded.
+     * @param sz        the size of the input buffer, <b>in</b>
+     * @param format    format of the certificate buffer being loaded - either
+     *                  <b>SSL_FILETYPE_PEM</b> or <b>SSL_FILETYPE_ASN1</b>
+     * @return          <b><code>SSL_SUCCESS</code></b> upon success,
+     *                  <b><code>SSL_FAILURE</code></b> upon general failure,
+     *                  <b><code>SSL_BAD_FILETYPE</code></b> if the file is
+     *                  in the wrong format, <b><code>SSL_BAD_FILE</code></b>
+     *                  if the file doesn't exist, can't be read, or is
+     *                  corrupted. <b><code>MEMORY_E</code></b> if an out of
+     *                  memory condition occurs, <b><code>ASN_INPUT_E</code></b>
+     *                  if Base16 decoding fails on the file,
+     *                  <b><code>BUFFER_E</code></b> if a chain buffer is
+     *                  bigger than the receiving buffer, and <b><code>
+     *                  BAD_FUNC_ARG</code></b> if invalid input arguments
+     *                  are provided.
+     * @throws IllegalStateException WolfSSLContext has been freed
+     * @throws WolfSSLJNIException Internal JNI error
+     * @see    #useCertificateBuffer(byte[], long, int)
+     * @see    #usePrivateKeyBuffer(byte[], long, int)
+     * @see    WolfSSLSession#useCertificateBuffer(byte[], long, int)
+     * @see    WolfSSLSession#usePrivateKeyBuffer(byte[], long, int)
+     * @see    WolfSSLSession#useCertificateChainBuffer(byte[], long)
+     */
+    public int useCertificateChainBufferFormat(byte[] in, long sz, int format)
+        throws IllegalStateException, WolfSSLJNIException {
+
+        confirmObjectIsActive();
+
+        synchronized (sslLock) {
+            return useCertificateChainBufferFormat(
+                        getSessionPtr(), in, sz, format);
+        }
+    }
+
 
     /**
      * Turns on grouping of the handshake messages where possible using the

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLParameters.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLParameters.java
@@ -106,9 +106,11 @@ final class WolfSSLParameters {
     }
 
     void setWantClientAuth(boolean wantClientAuth) {
-        /* wantClientAuth OR needClientAuth can be set, not both */
+        /* wantClientAuth OR needClientAuth can be set true, not both */
         this.wantClientAuth = wantClientAuth;
-        this.needClientAuth = false;
+        if (this.wantClientAuth) {
+            this.needClientAuth = false;
+        }
     }
 
     boolean getNeedClientAuth() {
@@ -116,9 +118,11 @@ final class WolfSSLParameters {
     }
 
     void setNeedClientAuth(boolean needClientAuth) {
-        /* wantClientAuth OR needClientAuth can be set, not both */
+        /* wantClientAuth OR needClientAuth can be set true, not both */
         this.needClientAuth = needClientAuth;
-        this.wantClientAuth = false;
+        if (this.needClientAuth) {
+            this.wantClientAuth = false;
+        }
     }
 
     String getEndpointIdentificationAlgorithm() {

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -36,6 +36,7 @@ import java.util.function.BiFunction;
 import java.util.List;
 import java.util.Arrays;
 import java.nio.channels.SocketChannel;
+import java.security.cert.CertificateEncodingException;
 
 import javax.net.ssl.HandshakeCompletedEvent;
 import javax.net.ssl.HandshakeCompletedListener;
@@ -131,8 +132,10 @@ public class WolfSSLSocket extends SSLSocket {
             EngineHelper = new WolfSSLEngineHelper(this.ssl, this.authStore,
                 this.params);
             EngineHelper.setUseClientMode(clientMode);
+            EngineHelper.LoadKeyAndCertChain(this, null);
 
-        } catch (WolfSSLException e) {
+        } catch (WolfSSLException | CertificateEncodingException |
+                 IOException e) {
             throw new IOException(e);
         }
     }
@@ -173,8 +176,10 @@ public class WolfSSLSocket extends SSLSocket {
             EngineHelper = new WolfSSLEngineHelper(this.ssl, this.authStore,
                     this.params, port, host);
             EngineHelper.setUseClientMode(clientMode);
+            EngineHelper.LoadKeyAndCertChain(this, null);
 
-        } catch (WolfSSLException e) {
+        } catch (WolfSSLException | CertificateEncodingException |
+                 IOException e) {
             throw new IOException(e);
         }
    }
@@ -218,8 +223,10 @@ public class WolfSSLSocket extends SSLSocket {
             EngineHelper = new WolfSSLEngineHelper(this.ssl, this.authStore,
                     this.params, port, address);
             EngineHelper.setUseClientMode(clientMode);
+            EngineHelper.LoadKeyAndCertChain(this, null);
 
-        } catch (WolfSSLException e) {
+        } catch (WolfSSLException | CertificateEncodingException |
+                 IOException e) {
             throw new IOException(e);
         }
     }
@@ -260,8 +267,10 @@ public class WolfSSLSocket extends SSLSocket {
             EngineHelper = new WolfSSLEngineHelper(this.ssl, this.authStore,
                     this.params, port, host);
             EngineHelper.setUseClientMode(clientMode);
+            EngineHelper.LoadKeyAndCertChain(this, null);
 
-        } catch (WolfSSLException e) {
+        } catch (WolfSSLException | CertificateEncodingException |
+                 IOException e) {
             throw new IOException(e);
         }
     }
@@ -305,8 +314,10 @@ public class WolfSSLSocket extends SSLSocket {
             EngineHelper = new WolfSSLEngineHelper(this.ssl, this.authStore,
                     this.params, port, host);
             EngineHelper.setUseClientMode(clientMode);
+            EngineHelper.LoadKeyAndCertChain(this, null);
 
-        } catch (WolfSSLException e) {
+        } catch (WolfSSLException | CertificateEncodingException |
+                 IOException e) {
             throw new IOException(e);
         }
     }
@@ -364,8 +375,10 @@ public class WolfSSLSocket extends SSLSocket {
             EngineHelper = new WolfSSLEngineHelper(this.ssl, this.authStore,
                     this.params, port, host);
             EngineHelper.setUseClientMode(clientMode);
+            EngineHelper.LoadKeyAndCertChain(this.socket, null);
 
-        } catch (WolfSSLException e) {
+        } catch (WolfSSLException | CertificateEncodingException |
+                 IOException e) {
             throw new IOException(e);
         }
     }
@@ -799,8 +812,9 @@ public class WolfSSLSocket extends SSLSocket {
             EngineHelper = new WolfSSLEngineHelper(this.ssl, this.authStore,
                     this.params, s.getPort(), s.getInetAddress());
             EngineHelper.setUseClientMode(clientMode);
+            EngineHelper.LoadKeyAndCertChain(s, null);
 
-        } catch (WolfSSLException e) {
+        } catch (WolfSSLException | CertificateEncodingException e) {
             throw new IOException(e);
         }
     }
@@ -850,6 +864,7 @@ public class WolfSSLSocket extends SSLSocket {
             EngineHelper = new WolfSSLEngineHelper(this.ssl, this.authStore,
                     this.params, s.getPort(), s.getInetAddress());
             EngineHelper.setUseClientMode(false);
+            EngineHelper.LoadKeyAndCertChain(s, null);
 
             /* register custom receive callback to read consumed first */
             if (consumed != null) {
@@ -859,10 +874,9 @@ public class WolfSSLSocket extends SSLSocket {
                 this.ssl.setIOReadCtx(recvCtx);
             }
 
-        } catch (WolfSSLException e) {
+        } catch (WolfSSLException | WolfSSLJNIException |
+                 CertificateEncodingException e) {
             throw new IOException(e);
-        } catch (WolfSSLJNIException jnie) {
-            throw new IOException(jnie);
         }
     }
 

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLTestFactory.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLTestFactory.java
@@ -390,7 +390,9 @@ class WolfSSLTestFactory {
     }
 
     /**
-     * Creates a new context using provider passed in and km/tm
+     * Creates a new context using provider passed in and km/tm. Falls back
+     * and creates default TrustManager/KeyManager if those arguments are
+     * null.
      *
      * @param protocol to be used when creating context
      * @param provider to be used when creating context (can be null)
@@ -401,6 +403,42 @@ class WolfSSLTestFactory {
     protected SSLContext createSSLContext(String protocol, String provider,
             TrustManager[] tm, KeyManager[] km) {
         return internalCreateSSLContext(protocol, provider, tm, km);
+    }
+
+    /**
+     * Creates a new context using provider passed in and km/tm, does not
+     * fallback and create default TrustManager/KeyManager if thoes arguments
+     * are null.
+     *
+     * @param protocol to be used when creating context
+     * @param provider to be used when creating context (can be null)
+     * @param tm trust manager to use (can be null)
+     * @param km key manager to use (can be null)
+     * @return new SSLContext on success and null on failure
+     */
+    protected SSLContext createSSLContextNoDefaults(String protocol,
+        String provider, TrustManager[] tm, KeyManager[] km) {
+
+        SSLContext ctx = null;
+
+        try {
+            if (provider != null) {
+                ctx = SSLContext.getInstance(protocol, provider);
+            } else {
+                ctx = SSLContext.getInstance(protocol);
+            }
+
+            ctx.init(km, tm, null);
+            return ctx;
+
+        } catch (NoSuchAlgorithmException ex) {
+            ex.printStackTrace();
+        } catch (KeyManagementException ex) {
+            ex.printStackTrace();
+        } catch (NoSuchProviderException ex) {
+            ex.printStackTrace();
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
This PR makes fixes around how a server-side SSLEngine handles client authentication, as well as how wolfJSSE calls X509KeyManager/X509ExtendedKeyManager objects to choose a private key alias to be used to load the client/server private key:
- `WolfSSLEngine` `setWantClientAuth(true)` was previously too restrictive when `setNeedClientAuth(false)`. This meant that when a server application requested client authentication, but instructed the JSSE layer to not to be a failure if the client did not send a certificate (ie with `setWantClientAuth(true)`, we were requiring the client send a certificate and would error out. This PR loosens that requirement to match expected behavior with `setWantClientAuth()`.
- We recently added support for `X509ExtendedKeyManager`, which has two new methods for selecting the key alias to be used for loading the client/server private key (`chooseEngineClientAlias()`, `chooseEngineServerAlias()`). This PR finishes that support by calling the correct alias selector method where appropriate. Since some of these methods accept a `Socket` or `SSLEngine` as parameter, loading of the private key has been delayed from `SSLContext` creation later to when the `SSLSocket` or `SSLEngine` is created.

ZD 17248