### PR TITLE
Fix SunJSSE test issues

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -1397,8 +1397,12 @@ public class WolfSSLSocket extends SSLSocket {
                 throw new SocketException("Connection already shutdown");
             }
 
-            if (handshakeComplete == true) {
-                /* handshake already finished */
+            if (handshakeComplete == true && getSession().isValid()) {
+                /* Handshake already finished:
+                 *   - Return early if session still valid.
+                 *   - Otherwise proceed with new handshake. */
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    "handshake already finished, returning early");
                 return;
             }
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -1389,6 +1389,10 @@ public class WolfSSLSocket extends SSLSocket {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                 "thread got handshakeLock (initHandshake)");
 
+            if (!this.isConnected()) {
+                throw new SocketException("Socket is not connected");
+            }
+
             if (connectionClosed == true) {
                 throw new SocketException("Connection already shutdown");
             }


### PR DESCRIPTION
# Description
- Don't proceed with handshake on an unconnected socket.
- Don't return early from handshake if session has been invalidated.


# Fixes:
- SSLSocketImpl/UnconnectedSocketWrongExceptions.java
- SSLSocketImpl/InvalidateServerSessionRenegotiate.java
- SSLSocketImpl/ServerRenegoWithTwoVersions.java