### PR TITLE
Check TLS 1.3 session for ticket before saving to Java cache

### DIFF
--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -1390,12 +1390,18 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_get1Session
         sess = wolfSSL_get_session(ssl);
     }
 
-    /* wolfSSL checks ssl for NULL, returns pointer to new WOLFSSL_SESSION,
-     * Returns new duplicated WOLFSSL_SESSION. Needs to be freed with
-     * wolfSSL_SESSION_free() when finished with pointer. */
-    if (sess != NULL) {
-        /* Guarantee that we own the WOLFSSL_SESSION, make a copy */
-        dup = wolfSSL_SESSION_dup(sess);
+    /* Only duplicate / save session if not TLS 1.3 (will be using normal
+     * session IDs), or is TLS 1.3 and we have a session ticket */
+    if ((wolfSSL_version(ssl) != TLS1_3_VERSION) ||
+        (wolfSSL_SESSION_has_ticket((const WOLFSSL_SESSION*)sess))) {
+
+        /* wolfSSL checks ssl for NULL, returns pointer to new WOLFSSL_SESSION,
+         * Returns new duplicated WOLFSSL_SESSION. Needs to be freed with
+         * wolfSSL_SESSION_free() when finished with pointer. */
+        if (sess != NULL) {
+            /* Guarantee that we own the WOLFSSL_SESSION, make a copy */
+            dup = wolfSSL_SESSION_dup(sess);
+        }
     }
 
     if (wc_UnLockMutex(jniSessLock) != 0) {


### PR DESCRIPTION
This PR makes one change in native JNI code when getting and returning the native `WOLFSSL_SESSION` object to be stored into the Java session cache.

If the connection is using TLS 1.3, only return and store the session if we have the ticket.  Otherwise, we may return an incomplete session object which may cause subsequent resumption attempts to fail.

This issue shows up in our ant tests when native wolfSSL is configured with:

```
cd wolfssl
./autogen.sh
./configure --enable-jni --enable-all

cd wolfssljni
./java.sh
ant
ant test

cat build/reports/TEST-com.wolfssl.provider.jsse.test.WolfSSLJSSETestSuite.txt

...
Testcase: testReuseSession took 0.012 sec
	FAILED
failed to create engine
junit.framework.AssertionFailedError: failed to create engine
	at com.wolfssl.provider.jsse.test.WolfSSLEngineTest.testReuseSession(WolfSSLEngineTest.java:539)
...
```