### PR TITLE
Add initial GitHub actions (Linux, Mac)

### DIFF
--- a/.github/workflows/linux-common.yml
+++ b/.github/workflows/linux-common.yml
@@ -1,0 +1,63 @@
+name: Common Linux test logic
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+      jdk_distro:
+        required: true
+        type: string
+      jdk_version:
+        required: true
+        type: string
+      wolfssl_configure:
+        required: true
+        type: string
+
+jobs:
+  build_wolfssljni:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download junit-4.13.2.jar
+        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar
+      - name: Download hamcrest-all-1.3.jar
+        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
+
+      - name: Build native wolfSSL
+        uses: wolfSSL/actions-build-autotools-project@v1
+        with:
+          repository: wolfSSL/wolfssl
+          ref: master
+          path: wolfssl
+          configure: ${{ inputs.wolfssl_configure }}
+          check: false
+          install: true
+
+      - name: Setup java
+        uses: actions/setup-java@v4
+        with:
+          distribution: ${{ inputs.jdk_distro }}
+          java-version: ${{ inputs.jdk_version }}
+
+      - name: Set JUNIT_HOME
+        run: |
+          echo "JUNIT_HOME=$GITHUB_WORKSPACE/junit" >> "$GITHUB_ENV"
+      - name: Set LD_LIBRARY_PATH
+        run: |
+          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/build-dir/lib" >> "$GITHUB_ENV"
+
+      - name: Build JNI library
+        run: ./java.sh $GITHUB_WORKSPACE/build-dir
+      - name: Build JAR (ant)
+        run: ant
+      - name: Run Java tests (ant test)
+        run: ant test
+
+      - name: Show logs on failure
+        if: failure() || cancelled()
+        run: |
+          cat build/reports/*.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,13 +1,100 @@
-name: GitHub Actions Demo
+name: CI
 
 on:
   push:
-    branches: [ 'master', 'main', 'testactions', 'release/**' ]
+    branches: [ 'master', 'main', 'release/**' ]
   pull_request:
-    branches: [ '*' ]
+    branches: [ 'master' ]
 
 jobs:
-  testjob:
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Hello World"
+  # Oracle JDK (Linux, Mac)
+  linux-oracle:
+    strategy:
+      matrix:
+        os: [ 'ubuntu-latest', 'macos-latest' ]
+        jdk_version: [ '17', '21' ]
+        wolfssl_configure: [ '--enable-jni' ]
+    name: ${{ matrix.os }} (Oracle JDK ${{ matrix.jdk_version }}, ${{ matrix.wolfssl_configure}})
+    uses: ./.github/workflows/linux-common.yml
+    with:
+      os: ${{ matrix.os }}
+      jdk_distro: "oracle"
+      jdk_version: ${{ matrix.jdk_version }}
+      wolfssl_configure: ${{ matrix.wolfssl_configure }}
+
+  # Zulu JDK (Linux, Mac)
+  linux-zulu:
+    strategy:
+      matrix:
+        os: [ 'ubuntu-latest', 'macos-latest' ]
+        jdk_version: [ '8', '11', '17', '21' ]
+        wolfssl_configure: [ '--enable-jni' ]
+    name: ${{ matrix.os }} (Zulu JDK ${{ matrix.jdk_version }}, ${{ matrix.wolfssl_configure}})
+    uses: ./.github/workflows/linux-common.yml
+    with:
+      os: ${{ matrix.os }}
+      jdk_distro: "zulu"
+      jdk_version: ${{ matrix.jdk_version }}
+      wolfssl_configure: ${{ matrix.wolfssl_configure }}
+
+  # Corretto JDK (Linux, Mac)
+  linux-corretto:
+    strategy:
+      matrix:
+        os: [ 'ubuntu-latest', 'macos-latest' ]
+        jdk_version: [ '8', '11', '17', '21' ]
+        wolfssl_configure: [ '--enable-jni' ]
+    name: ${{ matrix.os }} (Corretto JDK ${{ matrix.jdk_version }}, ${{ matrix.wolfssl_configure}})
+    uses: ./.github/workflows/linux-common.yml
+    with:
+      os: ${{ matrix.os }}
+      jdk_distro: "corretto"
+      jdk_version: ${{ matrix.jdk_version }}
+      wolfssl_configure: ${{ matrix.wolfssl_configure }}
+
+  # Temurin JDK (Linux, Mac)
+  linux-temurin:
+    strategy:
+      matrix:
+        os: [ 'ubuntu-latest', 'macos-latest' ]
+        jdk_version: [ '8', '11', '17', '21' ]
+        wolfssl_configure: [ '--enable-jni' ]
+    name: ${{ matrix.os }} (Temurin JDK ${{ matrix.jdk_version }}, ${{ matrix.wolfssl_configure}})
+    uses: ./.github/workflows/linux-common.yml
+    with:
+      os: ${{ matrix.os }}
+      jdk_distro: "temurin"
+      jdk_version: ${{ matrix.jdk_version }}
+      wolfssl_configure: ${{ matrix.wolfssl_configure }}
+
+  # Microsoft JDK (Linux, Mac)
+  linux-microsoft:
+    strategy:
+      matrix:
+        os: [ 'ubuntu-latest', 'macos-latest' ]
+        jdk_version: [ '11.0.19', '17.0.7', '21.0.0' ]
+        wolfssl_configure: [ '--enable-jni' ]
+    name: ${{ matrix.os }} (Microsoft JDK ${{ matrix.jdk_version }}, ${{ matrix.wolfssl_configure}})
+    uses: ./.github/workflows/linux-common.yml
+    with:
+      os: ${{ matrix.os }}
+      jdk_distro: "microsoft"
+      jdk_version: ${{ matrix.jdk_version }}
+      wolfssl_configure: ${{ matrix.wolfssl_configure }}
+
+  # -------------------- enable-all sanity checks -----------------------
+  # Only check one Linux and Mac JDK version with --enable-jni --enable-all
+  # as sanity. Using Zulu, but this can be expanded if needed.
+  linux-zulu-all:
+    strategy:
+      matrix:
+        os: [ 'ubuntu-latest', 'macos-latest' ]
+        jdk_version: [ '11' ]
+        wolfssl_configure: [ '--enable-jni --enable-all' ]
+    name: ${{ matrix.os }} (Zulu JDK ${{ matrix.jdk_version }}, ${{ matrix.wolfssl_configure}})
+    uses: ./.github/workflows/linux-common.yml
+    with:
+      os: ${{ matrix.os }}
+      jdk_distro: "zulu"
+      jdk_version: ${{ matrix.jdk_version }}
+      wolfssl_configure: ${{ matrix.wolfssl_configure }}


### PR DESCRIPTION
This PR adds GitHub actions for automated testing against various JDK distributions and versions.  Current testing includes:

**wolfSSL ./configure --enable-jni:**
- Test on both Linux (`ubuntu-latest`) and Mac OSX (`macos-latest`)
- Oracle JDK (17, 21)
- Zulu JDK (8, 11, 17, 21)
- Corretto JDK (8, 11, 17, 21)
- Microsoft JDK (11.0.19, 17.0.7, 21.0.0)

**wolfSSL ./configure --enable-jni --enable-all:**
- Test on both Linux (`ubuntu-latest`) and Mac OSX (`macos-latest`)
- Just a sanity check with `--enable-all` used, so only currently testing Zulu JDK 11