### PR TITLE
Add wolfJCE WKS KeyStore Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,106 @@ result in undefined behavior when the file descriptor number is larger than
 `FD_SETSIZE` (defaults to 1024 on most systems). For this reason, `poll()` is
 used as the default descriptor monitoring function.
 
+### Security Property Support
+
+wolfJSSE allows for some customization through the `java.security` file
+and use of Security properties.
+
+Support is included for the following pre-existing Java Security properties.
+
+**keystore.type (String)** - Specifies the default KeyStore type. This defaults
+to JKS, but could be set to something else if desired.
+
+**jdk.tls.disabledAlgorithms (String)** - Can be used to disable algorithms,
+TLS protocol versions, and key lengths, among other things. This should be a
+comma-delimited String. wolfJSSE includes partial support for this property,
+with supported items including disabling SSL/TLS protocol versions and setting
+minimum RSA/ECC/DH key sizes. An example of potential use:
+
+```
+jdk.tls.disabledAlgorithms=SSLv3, TLSv1.1, DH keySize < 1024, EC keySize < 224, RSA keySize < 1024
+```
+
+The following custom wolfJSSE-specific Security property settings are supported.
+These can be placed into the `java.security` file and will be parsed and used
+by wolfJSSE.
+
+**wolfjsse.enabledCipherSuites (String)** - Allows restriction of the enabled
+cipher suiets to those listed in this Security property. When set, applications
+wil not be able to override or add additional suites at runtime without
+changing this property. This should be a comma-delimited String. Example use:
+
+```
+wolfjsse.enabledCipherSuites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+```
+
+**wolfjsse.enabledSupportedCurves (String)** - Allows setting of specific ECC
+curves to be enabled for SSL/TLS connections. This propogates down to the native
+wolfSSL API `wolfSSL_UseSupportedCurve()`. If invalid/bad values are found
+when processing this property, connection establishment will fail with an
+SSLException. This should be a comma-delimited String. Example use:
+
+```
+wolfjsse.enabledSupportedCurves=secp256r1, secp521r1
+```
+
+**wolfjsse.enabledSignatureAlgorithms (String)** - Allows restriction of the
+signature algorithms sent in the TLS ClientHello Signature Algorithms
+Extension. By using/setting this property, native wolfSSL will not populate
+the extension with default values, which are based on what algorithms have been
+compiled into the native wolfSSL library. This should be a comma-delimited
+String of signature algorithm + MAC combinations. Example use:
+
+```
+wolfjsse.enabledSignatureAlgorithms=RSA+SHA256:ECDSA+SHA256
+```
+
+**wolfjsse.keystore.type.required (String)** - Can be used to specify a KeyStore
+type that is required to be used. If this is set, wolfJSSE will not allow use
+of any KeyStore instances that are not of this type. One use of this option
+is when using wolfCrypt FIPS 140-2/3 with wolfJCE registered as a JCE provider.
+This option can be used to restrict use of the wolfJCE "WKS" KeyStore type
+to help ensure conformance to using FIPS-validated cryptography. Other
+non-wolfJCE KeyStore implementations may not use/consume FIPS validated crypto.
+
+If there are other Security properties you would like to use with wolfJSSE,
+please contact support@wolfssl.com.
+
+### System Property Support
+
+wolfJSSE allows some customization through the use of System properties. Since
+these are **System** properties and not **Security** properties, they will not
+get picked up if placed in the `java.security` file. That file is only used
+with/for Security properties (see section above).
+
+**javax.net.ssl.keyStore (String)** - Can be used to specify the KeyStore file
+to use for KeyManager objects. An alternative to passing in the KeyStore file
+programatically at runtime.
+
+**javax.net.ssl.keyStoreType (String)** - Can be used to specify the KeyStore
+type to use when getting KeyStore instances inside KeyManager objects.
+
+**javax.net.ssl.keyStorePassword (String)** - Can be used to specify the
+KeyStore password to use for initializing KeyManager instances.
+
+**javax.net.ssl.trustStore (String)** - Can be used to specify the KeyStore
+file to use with TrustManager objects. An alternative to passing in the
+KeyStore file programatically at runtime.
+
+**javax.net.ssl.trustStoreType (String)** - Can be used to specify the KeyStore
+type to use when loading KeyStore inside TrustManager objects.
+
+**javax.net.ssl.trustStorePassword (String)** - Can be used to specify the
+KeyStore password to use when loading KeyStore inside TrustManager objects.
+
+**jdk.tls.client.enableSessionTicketExtension (boolean)** - Session tickets
+are enabled in different ways depending on the JDK implementation. For
+Oracle/OpenJDK and variants, this System property enables session tickets and
+was added in Java 13. Should be set to "true" to enable.
+
+If there are other System properties you would like to use with wolfJSSE,
+please contact support@wolfssl.com.
+
 ## Release Notes
 
 Release notes can be found in [ChangeLog.md](./ChangeLog.md).

--- a/examples/provider/ClientJSSE.java
+++ b/examples/provider/ClientJSSE.java
@@ -104,6 +104,7 @@ public class ClientJSSE {
         String caJKS      = "../provider/ca-server.jks";
         String clientPswd = "wolfSSL test";
         String caPswd = "wolfSSL test";
+        String keyStoreFormat = "JKS";
 
         /* server (peer) info */
         String host = "localhost";
@@ -194,6 +195,9 @@ public class ClientJSSE {
             } else if (arg.equals("-sysca")) {
                 useSysRoots = true;
 
+            } else if (arg.equals("-ksformat")) {
+                keyStoreFormat = args[++i];
+
             } else {
                 printUsage();
             }
@@ -243,14 +247,14 @@ public class ClientJSSE {
                 tm.init((KeyStore)null);
             }
             else {
-                cert = KeyStore.getInstance("JKS");
+                cert = KeyStore.getInstance(keyStoreFormat);
                 cert.load(new FileInputStream(caJKS), caPswd.toCharArray());
                 tm.init(cert);
             }
         }
 
         /* load private key */
-        pKey = KeyStore.getInstance("JKS");
+        pKey = KeyStore.getInstance(keyStoreFormat);
         pKey.load(new FileInputStream(clientJKS), clientPswd.toCharArray());
         km = KeyManagerFactory.getInstance("SunX509", provider);
         km.init(pKey, clientPswd.toCharArray());
@@ -428,11 +432,12 @@ public class ClientJSSE {
         System.out.println("-setp <protocols> \tSet enabled protocols " +
                            "e.g \"TLSv1.1 TLSv1.2\"");
         System.out.println("-c <file>:<password>\tCertificate/key JKS,\t\tdefault " +
-                "../provider/client.jks:wolfSSL test");
+                "../provider/client.jks:\"wolfSSL test\"");
         System.out.println("-A <file>:<password>\tCertificate/key CA JKS file,\tdefault " +
-                "../provider/ca-server.jks:wolfSSL test");
+                "../provider/ca-server.jks:\"wolfSSL test\"");
         System.out.println("-profile\tSleep for 10 sec before/after running " +
                 "to allow profilers to attach");
+        System.out.println("-ksformat <str>\tKeyStore format (default: JKS)");
         System.exit(1);
     }
 }

--- a/examples/provider/ServerJSSE.java
+++ b/examples/provider/ServerJSSE.java
@@ -69,6 +69,7 @@ public class ServerJSSE {
         String caJKS      = "../provider/ca-client.jks";
         String serverPswd = "wolfSSL test";
         String caPswd     = "wolfSSL test";
+        String keyStoreFormat = "JKS";
 
         /* server (peer) info */
         String host = "localhost";
@@ -164,6 +165,9 @@ public class ServerJSSE {
                 } else if (arg.equals("-profile")) {
                     profileSleep = true;
 
+                } else if (arg.equals("-ksformat")) {
+                    keyStoreFormat = args[++i];
+
                 } else {
                     printUsage();
                 }
@@ -201,10 +205,10 @@ public class ServerJSSE {
             }
 
             /* set up keystore and truststore */
-            KeyStore keystore = KeyStore.getInstance("JKS");
+            KeyStore keystore = KeyStore.getInstance(keyStoreFormat);
             keystore.load(new FileInputStream(serverJKS),
                 serverPswd.toCharArray());
-            KeyStore truststore = KeyStore.getInstance("JKS");
+            KeyStore truststore = KeyStore.getInstance(keyStoreFormat);
             truststore.load(new FileInputStream(caJKS), caPswd.toCharArray());
             TrustManagerFactory tm =
                 TrustManagerFactory.getInstance("SunX509", tmfProvider);
@@ -345,6 +349,7 @@ public class ServerJSSE {
                 "../provider/ca-client.jks:\"wolfSSL test\"");
         System.out.println("-profile\tSleep for 10 sec before/after running " +
                 "to allow profilers to attach");
+        System.out.println("-ksformat <str>\tKeyStore format (default: JKS)");
         System.exit(1);
     }
 

--- a/examples/provider/convert-to-wks.sh
+++ b/examples/provider/convert-to-wks.sh
@@ -1,0 +1,56 @@
+
+if [ -z "$1" ]; then
+    echo "Expected provider location for wolfJCE provider JAR directory."
+    echo "Example \"./convert-to-wks.sh ~/wolfcryptjni/lib\""
+    exit 1
+fi
+PROVIDER_DIR="$1"
+
+# Export library paths for Linux and Mac to find shared JNI library
+export LD_LIBRARY_PATH=$PROVIDER_DIR:$LD_LIBRARY_PATH
+export DYLD_LIBRARY_PATH=$PROVIDER_DIR:$DYLD_LIBRARY_PATH
+
+convert () {
+keytool -importkeystore -srckeystore ${1}.jks -destkeystore ${1}.wks -srcstoretype JKS -deststoretype WKS -srcstorepass "wolfSSL test" -deststorepass "wolfSSL test" -provider com.wolfssl.provider.jce.WolfCryptProvider --providerpath "$PROVIDER_DIR/wolfcrypt-jni.jar"
+
+}
+
+rm -f all.bks &> /dev/null
+convert "all"
+
+rm -f all_mixed.bks &> /dev/null
+convert "all_mixed"
+
+rm -f client.bks &> /dev/null
+convert "client"
+
+rm -f client-rsa-1024.bks &> /dev/null
+convert "client-rsa-1024"
+
+rm -f client-rsa.bks &> /dev/null
+convert "client-rsa"
+
+rm -f client-ecc.bks &> /dev/null
+convert "client-ecc"
+
+rm -f server.bks &> /dev/null
+convert "server"
+
+rm -f server-rsa-1024.bks &> /dev/null
+convert "server-rsa-1024"
+
+rm -f server-rsa.bks &> /dev/null
+convert "server-rsa"
+
+rm -f server-ecc.bks &> /dev/null
+convert "server-ecc"
+
+rm -f cacerts.bks &> /dev/null
+convert "cacerts"
+
+rm -f ca-client.bks &> /dev/null
+convert "ca-client"
+
+rm -f ca-server.bks &> /dev/null
+convert "ca-server"
+

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLTrustManager.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLTrustManager.java
@@ -27,10 +27,11 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ByteArrayInputStream;
-import java.security.InvalidAlgorithmParameterException;
+import java.security.Security;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.cert.CertificateException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
@@ -54,304 +55,582 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
     /** Default WolfSSLTrustManager constructor */
     public WolfSSLTrustManager() { }
 
-    /* Initialize TrustManager. Attempts to load CA certifciates as trusted
-     * roots into wolfSSL from user-provided KeyStore. If KeyStore is null,
-     * we attempt to load default system CA certificates in the following
-     * priority order:
-     *   1. javax.net.ssl.trustStore location, if set. Using password
+    /**
+     * Try to load KeyStore from System properties if set.
+     *
+     * If a KeyStore file has been specified in the javax.net.ssl.keyStore
+     * System property, then we try to load it in the following ways:
+     *
+     *   1. Using type specified in javax.net.ssl.keyStoreType. If not given:
+     *   2. Using wolfJCE WKS type, if available
+     *   3. Using BKS type if on Android
+     *   4. Using JKS type if above all fail
+     *
+     * @param wksAvailable Boolean indicating if wolfJCE WKS KeyStore type
+     *        is available, true if so, false if not
+     * @param tsPass javax.net.ssl.trustStorePassword system property
+     *        value, or null
+     * @param tsFile javax.net.ssl.trustStore system property value, or null
+     * @param tsType javax.net.ssl.trustStoreType system property value,
+     *        or null
+     *
+     * @return new KeyStore object that has been created and loaded using
+     *         details specified in System properties.
+     *
+     * @throws KeyStoreException if javax.net.ssl.keyStore property is
+     *         set but KeyStore fails to load
+     */
+    private KeyStore LoadKeyStoreFromSystemProperties(boolean wksAvailable,
+        String tsPass, String tsFile, String tsType)
+        throws KeyStoreException {
+
+        char[] passArr = null;
+        KeyStore sysStore = null;
+
+        if (tsFile != null) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    "Loading certs from: " + tsFile);
+
+            /* Set KeyStore password if javax.net.ssl.keyStorePassword set */
+            if (tsPass != null) {
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    "javax.net.ssl.trustStorePassword system property " +
+                    "set, using password");
+                passArr = tsPass.toCharArray();
+            } else {
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    "javax.net.ssl.trustStorePassword system property " +
+                    "not set");
+            }
+
+            /* System keystore type set, try loading using it first */
+            if (tsType != null && !tsType.trim().isEmpty()) {
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    "javax.net.ssl.trustStoreType set: " + tsType);
+                sysStore = WolfSSLUtil.LoadKeyStoreFileByType(
+                    tsFile, passArr, tsType);
+            }
+            else {
+                /* Try with wolfJCE WKS type first, in case wolfCrypt
+                 * FIPS is being used */
+                if (wksAvailable) {
+                    sysStore = WolfSSLUtil.LoadKeyStoreFileByType(
+                        tsFile, passArr, "WKS");
+                }
+
+                /* Try with BKS, if we're running on Android */
+                if (sysStore == null && WolfSSLUtil.isAndroid()) {
+                    WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                        "Detected Android VM, trying BKS KeyStore type");
+                    sysStore = WolfSSLUtil.LoadKeyStoreFileByType(
+                        tsFile, passArr, "BKS");
+                }
+
+                /* Try falling back to JKS */
+                if (sysStore == null) {
+                    WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    "javax.net.ssl.trustStoreType system property not set, " +
+                    "trying type: JKS");
+                    sysStore = WolfSSLUtil.LoadKeyStoreFileByType(
+                        tsFile, passArr, "JKS");
+                }
+            }
+
+            if (sysStore == null) {
+                throw new KeyStoreException(
+                    "Failed to load KeyStore from System properties, " +
+                    "please double check settings");
+            }
+            else {
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    "Loaded certs from KeyStore via System properties");
+            }
+        }
+
+        return sysStore;
+    }
+
+    /**
+     * Try to load system CA certs from jssecacerts or cacerts KeyStore.
+     *
+     * Java 9+ has cacerts and/or jssecacerts under:
+     *     $JAVA_HOME/lib/security/[jssecacerts | cacerts]
+     * Java 8 and earlier use:
+     *     $JAVA_HOME/jre/lib/security/[jssecacerts | cacerts ]
+     *
+     * If wolfJCE WKS KeyStore type is available (ie: wolfJCE has been
+     * registered on this system), we first try to load jssecacerts.wks
+     * or cacerts.wks as WKS type KeyStore before falling back to trying to
+     * load KeyStore type specified in java.security by 'keystore.type'
+     * Security property. This is "JKS" type by default on my platforms.
+     *
+     * @param jh String value of $JAVA_HOME with trailing slash
+     * @param wksAvailable Boolean if wolfJCE WKS KeyStore typs is available
+     * @param tsPass javax.net.ssl.trustStorePassword, or null if not set
+     * @param certBundleName Name of system certificate bundle, either
+     *        "jssecacerts" or "cacerts"
+     *
+     * @return KeyStore object loaded with CA certs from jssecacerts, or
+     *         null if not able to find KeyStore or load certs
+     */
+    private KeyStore LoadJavaSystemCerts(String jh, boolean wksAvailable,
+        String tsPass, String certBundleName) {
+
+        char[] passArr = null;
+        KeyStore sysStore = null;
+        File f = null;
+        FileInputStream stream = null;
+
+        /* Get default KeyStore type, set in java.security and normally JKS */
+        String storeType = Security.getProperty("keystore.type");
+        if (storeType != null) {
+            storeType = storeType.toUpperCase();
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                "keystore.type Security property set: " + storeType);
+        }
+
+        if (wksAvailable) {
+            /* First try wolfJCE WKS converted version for Java 9+ */
+            f = new File(jh.concat("lib/security/")
+                .concat(certBundleName).concat(".wks"));
+
+            /* Second try wolfJCE WKS converted version for Java <= 8 */
+            if (!f.exists()) {
+                f = new File(jh.concat("jre/lib/security/")
+                    .concat(certBundleName).concat(".wks"));
+            }
+
+            if (f.exists()) {
+                storeType = "WKS";
+            }
+        }
+
+        /* Third try normal Java 9+ location */
+        if ((f == null) || !f.exists()) {
+            f = new File(jh.concat("lib/security/").concat(certBundleName));
+        }
+
+        /* Fourth try normal Java <= 8 location */
+        if (!f.exists()) {
+            f = new File(jh.concat("jre/lib/security/").concat(certBundleName));
+        }
+
+        if (f.exists()) {
+
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                   "Loading certs from " + f.getAbsolutePath());
+
+            try {
+                sysStore = KeyStore.getInstance(storeType);
+            } catch (KeyStoreException e) {
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    "Not able to get KeyStore of type: " + storeType);
+                return null;
+            }
+            try {
+                sysStore.load(null, null);
+            } catch (IOException | NoSuchAlgorithmException |
+                     CertificateException e) {
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    "Not able to load empty KeyStore(" + storeType + ")");
+                return null;
+            }
+
+            if (tsPass != null) {
+                passArr = tsPass.toCharArray();
+            }
+
+            try {
+                stream = new FileInputStream(f);
+            } catch (FileNotFoundException e) {
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    "Not able to open KeyStore file for reading: " +
+                    f.getAbsolutePath());
+            }
+
+            try {
+                sysStore.load(stream, passArr);
+
+            } catch (IOException | NoSuchAlgorithmException |
+                     CertificateException e) {
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    "Not able to load KeyStore with file stream: " +
+                    f.getAbsolutePath());
+
+            } finally {
+                try {
+                    if (stream != null) {
+                        stream.close();
+                    }
+                } catch (IOException e) {
+                }
+            }
+
+        } else {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                "$JAVA_HOME/(jre/)lib/security/" +
+                certBundleName + ": not found");
+        }
+
+        return sysStore;
+    }
+
+    private KeyStore LoadSystemJsseCaCerts(String jh, boolean wksAvailable,
+        String tsPass) {
+
+        return LoadJavaSystemCerts(jh, wksAvailable, tsPass, "jssecacerts");
+    }
+
+    private KeyStore LoadSystemCaCerts(String jh, boolean wksAvailable,
+        String tsPass) {
+
+        return LoadJavaSystemCerts(jh, wksAvailable, tsPass, "cacerts");
+    }
+
+    /**
+     * Try to load system CA certs from common KeyStore locations.
+     *
+     * Currently includes:
+     *     1. /etc/ssl/certs/java/cacerts
+     *
+     */
+    private KeyStore LoadCommonSystemCerts(boolean wksAvailable,
+        String tsPass) {
+
+        char[] passArr = null;
+        File f = null;
+        FileInputStream stream = null;
+        KeyStore sysStore = null;
+
+        f = new File("/etc/ssl/certs/java/cacerts");
+
+        if (f.exists()) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                   "Loading certs from " + f.getAbsolutePath());
+
+            if (tsPass != null) {
+                passArr = tsPass.toCharArray();
+            }
+
+            try {
+                stream = new FileInputStream(f);
+            } catch (FileNotFoundException e) {
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    "Not able to open KeyStore file for reading: " +
+                    f.getAbsolutePath());
+            }
+
+            try {
+                sysStore.load(stream, passArr);
+
+            } catch (IOException | NoSuchAlgorithmException |
+                     CertificateException e) {
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    "Not able to load KeyStore with file stream: " +
+                    f.getAbsolutePath());
+
+            } finally {
+                try {
+                    if (stream != null) {
+                        stream.close();
+                    }
+                } catch (IOException e) {
+                }
+            }
+
+        } else {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                "/etc/ssl/certs/java/cacerts: not found");
+        }
+
+        return sysStore;
+    }
+
+    /**
+     * Try to load Android system CA certs from AndroidCAStore KeyStore.
+     *
+     * The AndroidCAStore KeyStore is pre-loaded with Android system CA
+     * certs. We try to load this first before going on to load root certs
+     * manually, since it's already pre-imported and set up.
+     *
+     * @return KeyStore object referencing AndroidCAStore, or null if not
+     *         found or not able to be loaded
+     */
+    private KeyStore LoadAndroidCAStore() {
+
+        KeyStore sysStore = null;
+
+        try {
+            sysStore = KeyStore.getInstance("AndroidCAStore");
+
+        } catch (KeyStoreException e) {
+            /* Error finding AndroidCAStore */
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                "AndroidCAStore KeyStore not found, not loading");
+            return null;
+        }
+
+        try {
+            sysStore.load(null, null);
+
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                "Using AndroidCAStore KeyStore for default system certs");
+
+        } catch (IOException | NoSuchAlgorithmException |
+                 CertificateException e) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                "Not able to load AndroidCAStore with null args");
+            return null;
+        }
+
+        return sysStore;
+    }
+
+    /**
+     * Try to load Android system root certificates manually by reading
+     * all PEM certificates in [android_root]/etc/security/cacerts directory.
+     *
+     * @return KeyStore object containing Android system CA certificates, or
+     *         null if none found or error loading any certs
+     */
+    private KeyStore LoadAndroidSystemCertsManually() {
+
+        int aliasCnt = 0;
+        byte[] derArray = null;
+        KeyStore sysStore = null;
+        CertificateFactory cfactory = null;
+        ByteArrayInputStream bis = null;
+        Certificate tmpCert = null;
+        String androidRoot = System.getenv("ANDROID_ROOT");
+
+        if (androidRoot != null) {
+
+            /* Android default KeyStore type is BKS */
+            try {
+                sysStore = KeyStore.getInstance("BKS");
+            } catch (KeyStoreException e) {
+                /* Unable to get or load empty BKS KeyStore type */
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    "Unable to get or load BKS KeyStore instance");
+                return null;
+            }
+
+            try {
+                sysStore.load(null, null);
+
+            } catch (IOException | NoSuchAlgorithmException |
+                     CertificateException e) {
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    "Not able to load BKS KeyStore with null args");
+                return null;
+            }
+
+            /* Add trailing slash if not there already */
+            if (!androidRoot.endsWith("/") &&
+                !androidRoot.endsWith("\\")) {
+                androidRoot = androidRoot.concat("/");
+            }
+
+            String caStoreDir = androidRoot.concat("etc/security/cacerts");
+            File cadir = new File(caStoreDir);
+            String[] cafiles = null;
+            try {
+                cafiles = cadir.list();
+            } catch (Exception e) {
+                /* Denied access reading cacerts directory */
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.ERROR,
+                    "Permission error when trying to read system " +
+                    "CA certificates");
+                return null;
+            }
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                "Found " + cafiles.length + " CA files to load into KeyStore");
+
+            /* Get factory for cert creation */
+            try {
+                cfactory = CertificateFactory.getInstance("X.509");
+            } catch (CertificateException e) {
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    "Not able to get X.509 CertificateFactory instance");
+                return null;
+            }
+
+            /* Loop over all PEM certs */
+            for (String cafile : cafiles) {
+
+                WolfSSLCertificate certPem = null;
+                String fullCertPath = caStoreDir.concat("/");
+                fullCertPath = fullCertPath.concat(cafile);
+
+                try {
+                    certPem = new WolfSSLCertificate(
+                        fullCertPath, WolfSSL.SSL_FILETYPE_PEM);
+                } catch (WolfSSLException we) {
+                    /* skip, error parsing PEM */
+                    WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                        "Skipped loading cert: " + fullCertPath);
+                    if (certPem != null) {
+                        certPem.free();
+                    }
+                    continue;
+                }
+
+                try {
+                    derArray = certPem.getDer();
+                } catch (WolfSSLJNIException e) {
+                    WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                        "Error getting DER from PEM cert, skipping: " +
+                        fullCertPath);
+                } finally {
+                    certPem.free();
+                }
+
+                bis = new ByteArrayInputStream(derArray);
+
+                try {
+                    tmpCert = cfactory.generateCertificate(bis);
+
+                } catch (CertificateException ce) {
+                    WolfSSLDebug.log(getClass(), WolfSSLDebug.ERROR,
+                        "Error generating certificate from " +
+                        "ByteArrayInputStream, skipped loading cert: " +
+                        fullCertPath);
+                    continue;
+
+                } finally {
+                    try {
+                        if (bis != null) {
+                            bis.close();
+                        }
+                    } catch (IOException e) {
+                    }
+                }
+
+                String aliasString = "alias" + aliasCnt;
+                try {
+                    sysStore.setCertificateEntry(aliasString, tmpCert);
+                } catch (KeyStoreException kse) {
+                    WolfSSLDebug.log(getClass(), WolfSSLDebug.ERROR,
+                        "Error setting certificate entry in " +
+                        "KeyStore, skipping loading cert: " +
+                        fullCertPath);
+                    continue;
+                }
+
+                /* increment alias counter for unique aliases */
+                aliasCnt++;
+            }
+
+            if (aliasCnt == 0) {
+                /* No certs loaded, don't return empty KeyStore */
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    "No root certificates loaded from etc/security/cacerts");
+                return null;
+            }
+        }
+
+        return sysStore;
+    }
+
+    /**
+     * Initialize TrustManager, loading root/CA certs.
+     *
+     * Attempts to load CA certifciates as trusted roots into wolfSSL from
+     * user-provided KeyStore. If KeyStore is null, we attempt to load default
+     * system CA certificates. Certs are loaded in the following priority order:
+     *
+     *   1. User-provided KeyStore passed in
+     *   2. javax.net.ssl.trustStore location, if set. Using password
      *      in javax.net.ssl.trustStorePassword.
-     *   2. $JAVA_HOME/lib/security/jssecacerts     (JDK 9+)
-     *   3. $JAVA_HOME/jre/lib/security/jssecacerts (JDK <= 8)
-     *   4. $JAVA_HOME/lib/security/cacerts         (JDK 9+)
-     *   5. $JAVA_HOME/jre/lib/security/cacerts     (JDK <= 8)
-     *   6. /etc/ssl/certs/java/cacerts
-     *   7. Android: AndroidCAStore system KeyStore
-     *   8. Android: $ANDROID_ROOT/etc/security/cacerts
+     *   3. Java installation 'jssecacerts' bundle:
+     *        a. $JAVA_HOME/lib/security/jssecacerts     (JDK 9+)
+     *        b. $JAVA_HOME/jre/lib/security/jssecacerts (JDK less than 9)
+     *   4. Java installation 'cacerts' bundle:
+     *        a. $JAVA_HOME/lib/security/cacerts         (JDK 9+)
+     *        b. $JAVA_HOME/jre/lib/security/cacerts     (JDK less than 9)
+     *   5. Common system CA certs locations:
+     *        a. /etc/ssl/certs/java/cacerts
+     *   6. Android: AndroidCAStore system KeyStore
+     *   7. Android: $ANDROID_ROOT/etc/security/cacerts
+     *
+     * If none of the locations above work for finding/loading CA certs,
+     * none are loaded into this TrustManager.
+     *
+     * @param in KeyStore from which to load trusted root/CA certificates, may
+     *        be null
      */
     @Override
     protected void engineInit(KeyStore in) throws KeyStoreException {
+
         KeyStore certs = in;
+        String javaHome = null;
+        boolean wksAvailable = false;
+        String pass = System.getProperty("javax.net.ssl.trustStorePassword");
+        String file = System.getProperty("javax.net.ssl.trustStore");
+        String type = System.getProperty("javax.net.ssl.trustStoreType");
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered engineInit()");
+            "entered engineInit(KeyStore in)");
 
+        /* [1] Just use KeyStore passed in by user if available */
         if (in == null) {
-            String pass = System.getProperty("javax.net.ssl.trustStorePassword");
-            String file = System.getProperty("javax.net.ssl.trustStore");
-            String type = System.getProperty("javax.net.ssl.trustStoreType");
-            String vmVendor = System.getProperty("java.vm.vendor");
-            String javaHome = System.getenv("JAVA_HOME");
-            String androidRoot = System.getenv("ANDROID_ROOT");
-            char[] passAr = null;
-            InputStream stream = null;
-            boolean systemCertsFound = false;
-            int aliasCnt = 0;
 
-            try {
-                if (pass != null) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                "input KeyStore null, trying to load system CA certs");
+
+            /* Check if wolfJCE WKS KeyStore is registered and available */
+            wksAvailable = WolfSSLUtil.WKSAvailable();
+
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                "wolfJCE WKS KeyStore type available: " + wksAvailable);
+
+            /* [2] Try to load from system property details */
+            certs = LoadKeyStoreFromSystemProperties(
+                wksAvailable, pass, file, type);
+
+            /* Get JAVA_HOME for trying to load system certs next */
+            if (certs == null) {
+                javaHome = WolfSSLUtil.GetJavaHome();
+                if (javaHome == null) {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "javax.net.ssl.trustStorePassword system property " +
-                        "set, using password");
-                    passAr = pass.toCharArray();
-                } else {
-                    WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "javax.net.ssl.trustStorePassword system property " +
-                        "not set");
-                }
-
-                /* default to JKS KeyStore type if not set at system level */
-                /* We default to use a JKS KeyStore type if not set at the
-                 * system level, except on Android we use BKS */
-                try {
-                    if (type != null && !type.trim().isEmpty()) {
-                        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                            "javax.net.ssl.trustStoreType system property " +
-                            "set: " + type);
-                        certs = KeyStore.getInstance(type);
-                    } else {
-                        if (vmVendor != null &&
-                                vmVendor.equals("The Android Project")) {
-                            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                                "Detected Android VM, using BKS KeyStore type");
-                            certs = KeyStore.getInstance("BKS");
-                        } else {
-                            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                            "javax.net.ssl.trustStoreType system property " +
-                            "not set, using type: JKS");
-                            certs = KeyStore.getInstance("JKS");
-                        }
-                    }
-                } catch (KeyStoreException kse) {
-                    WolfSSLDebug.log(getClass(), WolfSSLDebug.ERROR,
-                        "Unsupported KeyStore type: " + type);
-                    throw kse;
-                }
-
-                try {
-                    /* initialize KeyStore, loading certs below will
-                     * overwrite if needed, otherwise Android needs
-                     * this to be initialized here */
-                    certs.load(null, null);
-
-                } catch (Exception e) {
-                    WolfSSLDebug.log(getClass(), WolfSSLDebug.ERROR,
-                        "Error initializing KeyStore with load(null, null)");
-                    throw new KeyStoreException(e);
-                }
-
-                if (file == null) {
-                    WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "javax.net.ssl.trustStore system property not set, " +
-                        "trying to load system certs");
-
-                    /* try to load trusted system certs if possible */
-                    if (javaHome != null) {
-                        if (!javaHome.endsWith("/") &&
-                            !javaHome.endsWith("\\")) {
-                            /* add trailing slash if not there already */
-                            javaHome = javaHome.concat("/");
-                        }
-
-                        /* Java 9+ have cacerts under:
-                         *     $JAVA_HOME/lib/security/cacerts
-                         * Java 8 and earlier use:
-                         *     $JAVA_HOME/jre/lib/security/cacerts
-                         */
-                        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                                "$JAVA_HOME = " + javaHome);
-
-                        /* trying: "lib/security/jssecacerts" */
-                        File f = new File(javaHome.concat(
-                                          "lib/security/jssecacerts"));
-                        if (!f.exists()) {
-                            f = new File(javaHome.concat(
-                                         "jre/lib/security/jssecacerts"));
-                        }
-                        if (f.exists()) {
-                            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                                   "Loading certs from " + f.getAbsolutePath());
-                            stream = new FileInputStream(f);
-                            certs.load(stream, passAr);
-                            stream.close();
-                            systemCertsFound = true;
-                        } else {
-                            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                                "$JAVA_HOME/(jre/)lib/security/jssecacerts: " +
-                                "not found");
-                        }
-
-                        /* trying: "lib/security/cacerts" */
-                        f = new File(javaHome.concat("lib/security/cacerts"));
-                        if (!f.exists()) {
-                            f = new File(javaHome.concat(
-                                         "jre/lib/security/cacerts"));
-                        }
-                        if (f.exists()) {
-                            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                                    "Loading certs from " + f.getAbsolutePath());
-                            stream = new FileInputStream(f);
-                            certs.load(stream, passAr);
-                            stream.close();
-                            systemCertsFound = true;
-                        } else {
-                            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                                "$JAVA_HOME/(jre/)lib/security/cacerts: " +
-                                "not found");
-                        }
-                    } else {
-                        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                            "$JAVA_HOME not set, unable to load system certs");
-                    }
-
-                    if (systemCertsFound == false) {
-                        /* try loading from common system paths */
-                        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                            "Trying to load system certs from common " +
-                            "system paths");
-
-                        /* trying: "/etc/ssl/certs/java/cacerts" */
-                        File f = new File("/etc/ssl/certs/java/cacerts");
-                        if (f.exists()) {
-                            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                                   "Loading certs from " + f.getAbsolutePath());
-                            stream = new FileInputStream(f);
-                            certs.load(stream, passAr);
-                            stream.close();
-                            systemCertsFound = true;
-                        } else {
-                            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                                "/etc/ssl/certs/java/cacerts: not found");
-                        }
-                    }
-
-                    if (androidRoot != null) {
-
-                        /* first try to use AndroidCAStore KeyStore, this is
-                         * pre-loaded with Android system CA certs */
-                        try {
-                            certs = KeyStore.getInstance("AndroidCAStore");
-                            certs.load(null, null);
-                            systemCertsFound = true;
-                            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                                "Using AndroidCAStore KeyStore for default " +
-                                "system certs");
-                        } catch (KeyStoreException e) {
-                            /* error finding AndroidCAStore */
-                            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                                "AndroidCAStore KeyStore not found, trying " +
-                                "to manually load system certs");
-                            systemCertsFound = false;
-                        }
-
-                        /* Otherwise, try to manually load system certs */
-                        if (systemCertsFound == false) {
-                            if (!androidRoot.endsWith("/") &&
-                                !androidRoot.endsWith("\\")) {
-                                /* add trailing slash if not there already */
-                                androidRoot = androidRoot.concat("/");
-                            }
-
-                            String caStoreDir = androidRoot.concat(
-                                                    "etc/security/cacerts");
-                            File cadir = new File(caStoreDir);
-                            String[] cafiles = null;
-                            try {
-                                cafiles = cadir.list();
-                            } catch (Exception e) {
-                                /* denied access reading cacerts directory */
-                                WolfSSLDebug.log(getClass(), WolfSSLDebug.ERROR,
-                                    "Permission error when trying to read " +
-                                    "system CA certificates");
-                                throw new KeyStoreException(e);
-                            }
-                            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                                "Found " + cafiles.length + " CA files to load " +
-                                "into KeyStore");
-
-                            /* get factory for cert creation */
-                            CertificateFactory cfactory =
-                                CertificateFactory.getInstance("X.509");
-
-                            /* loop over all PEM certs */
-                            for (String cafile : cafiles) {
-
-                                WolfSSLCertificate certPem = null;
-                                String fullCertPath = caStoreDir.concat("/");
-                                fullCertPath = fullCertPath.concat(cafile);
-
-                                try {
-                                    certPem = new WolfSSLCertificate(
-                                        fullCertPath, WolfSSL.SSL_FILETYPE_PEM);
-                                } catch (WolfSSLException we) {
-                                    /* skip, error parsing PEM */
-                                    WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                                        "Skipped loading cert: " + fullCertPath);
-                                    if (certPem != null) {
-                                        certPem.free();
-                                    }
-                                    continue;
-                                }
-
-                                byte[] derArray = certPem.getDer();
-                                certPem.free();
-                                ByteArrayInputStream bis =
-                                    new ByteArrayInputStream(derArray);
-                                Certificate tmpCert = null;
-
-                                try {
-                                    tmpCert = cfactory.generateCertificate(bis);
-                                    bis.close();
-                                } catch (CertificateException ce) {
-                                    WolfSSLDebug.log(getClass(), WolfSSLDebug.ERROR,
-                                        "Error generating certificate from " +
-                                        "ByteArrayInputStream");
-                                    bis.close();
-                                    throw new KeyStoreException(ce);
-                                }
-
-                                String aliasString = "alias" + aliasCnt;
-                                try {
-                                    certs.setCertificateEntry(aliasString, tmpCert);
-                                } catch (KeyStoreException kse) {
-                                    WolfSSLDebug.log(getClass(), WolfSSLDebug.ERROR,
-                                        "Error setting certificate entry in " +
-                                        "KeyStore, skipping loading cert");
-                                    continue;
-                                }
-
-                                /* increment alias counter for unique aliases */
-                                aliasCnt++;
-                            }
-                            systemCertsFound = true;
-
-                        } /* end Android manual load */
-                    }
-
-                    if (systemCertsFound == false) {
-                        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                                "No trusted system certs found, none " +
-                                "loaded by default");
-                    }
+                        "$JAVA_HOME not set, unable to load system CA certs");
                 }
                 else {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                            "Loading certs from " + file);
-                    stream = new FileInputStream(file);
-                    certs.load(stream, passAr);
-                    stream.close();
+                        "$JAVA_HOME = " + javaHome);
                 }
-            } catch (FileNotFoundException ex) {
-                throw new KeyStoreException(ex);
-            } catch (IOException ex) {
-                throw new KeyStoreException(ex);
-            } catch (NoSuchAlgorithmException ex) {
-                throw new KeyStoreException(ex);
-            } catch (CertificateException ex) {
-                throw new KeyStoreException(ex);
-            } catch (WolfSSLJNIException ex) {
-                throw new KeyStoreException(ex);
+            }
+
+            /* [3] Try to load system jssecacerts */
+            if ((certs == null) && (javaHome != null)) {
+                certs = LoadSystemJsseCaCerts(javaHome, wksAvailable, pass);
+            }
+
+            /* [4] Try to load system cacerts */
+            if ((certs == null) && (javaHome != null)) {
+                certs = LoadSystemCaCerts(javaHome, wksAvailable, pass);
+            }
+
+            /* [5] Try to load common CA cert locations */
+            if (certs == null) {
+                certs = LoadCommonSystemCerts(wksAvailable, pass);
+            }
+
+            /* [6] Try to load system certs if on Android */
+            if ((certs == null) && WolfSSLUtil.isAndroid()) {
+                certs = LoadAndroidCAStore();
+            }
+
+            /* [7] Try to load Android system root certs manually */
+            if ((certs == null) && WolfSSLUtil.isAndroid()) {
+                certs = LoadAndroidSystemCertsManually();
             }
         }
+        else {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                "input KeyStore provided, using for trusted certs");
+        }
+
         this.store = certs;
         this.initialized = true;
     }

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLUtil.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLUtil.java
@@ -220,6 +220,57 @@ public class WolfSSLUtil {
     }
 
     /**
+     * Return KeyStore type restriction if set in java.security
+     * with 'wolfjsse.keystore.type.required' Security property.
+     *
+     * @return String with required KeyStore type, or null if no
+     *         requirement set
+     */
+    protected static String getRequiredKeyStoreType() {
+
+        String requiredType =
+            Security.getProperty("wolfjsse.keystore.type.required");
+
+        if (requiredType == null || requiredType.isEmpty()) {
+            return null;
+        }
+        else {
+            requiredType = requiredType.toUpperCase();
+        }
+
+        return requiredType;
+    }
+
+    /**
+     * Check given KeyStore against any pre-defind requirements for
+     * KeyStore use, including the following.
+     *
+     * Restricted KeyStore type: wolfjsse.keystore.type.required
+     *
+     * @param store Input KeyStore to check against requirements
+     *
+     * @throws KeyStoreException if KeyStore given does not meet wolfJSSE
+     *         requirements
+     */
+    protected static void checkKeyStoreRequirements(
+        KeyStore store) throws KeyStoreException {
+
+        String requiredType = null;
+
+        if (store == null) {
+            return;
+        }
+
+        requiredType = getRequiredKeyStoreType();
+        if ((requiredType != null) &&
+            (!store.getType().equals(requiredType))) {
+            throw new KeyStoreException(
+                "KeyStore does not match required type, got " +
+                store.getType() + ", required " + requiredType);
+        }
+    }
+
+    /**
      * Return maximum key size allowed if minimum is set in
      * jdk.tls.disabledAlgorithms security property for specified algorithm.
      *


### PR DESCRIPTION
This PR adds support for using wolfJCE's `WKS` KeyStore type, which is in review on wolfcrypt-jni here (https://github.com/wolfSSL/wolfcrypt-jni/pull/67).  Specifically this PR:

- Gives preference to try and load `WKS` KeyStore type first before falling back to try and load others (BKS, JKS, etc).
- When auto-loading the system CA/root certificates (ex: jssecacerts, cacerts), wolfJSSE first tries to find and load a WKS equivalent file at the same location (ex: jssecacerts.wks, cacerts.wks)
- New Security property added (`wolfjsse.keystore.type.required`) which can be used to restrict use of KeyStore type to the one set in this property. This can be used for example to help conform to wolfCrypt FIPS 140-2/3 crypto usage by setting to "WKS" when wolfJCE is also used and installed on the system.
- Updates JSSE provider example `ClientJSSE.java` and `ServerJSSE.java` with new option to specify the KeyStore type (`-ksformat`)
- Add new option to example JSSE `ClientJSSE.java` to try and load system root/CA certs rather than using the provided KeyStore file (`-sysca`)
- Refactors `WolfSSLKeyManager.java` and `WolfSSLTrustManager.java` around attempting to find and load system root/CA certs, making it easier to maintain in the future and adding support for WKS type stores.
- Adds a script to convert example JKS files to wolfJCE WKS format (`examples/provider/convert-to-wks.sh`)
- Refactor `X509Certificate.getPublicKey()` to use JCE classes to generate `PublicKey`, fixes edge test case when wolfJCE is installed alongside wolfJSSE.