### PR TITLE
JNI/JSSE: call wolfSSL_sk_X509_pop_free() in WolfSSLX509StoreCtx.getDerCerts()

### DIFF
--- a/native/com_wolfssl_WolfSSLX509StoreCtx.c
+++ b/native/com_wolfssl_WolfSSLX509StoreCtx.c
@@ -97,7 +97,7 @@ JNIEXPORT jobjectArray JNICALL Java_com_wolfssl_WolfSSLX509StoreCtx_X509_1STORE_
             (*jenv)->DeleteLocalRef(jenv, derArr);
         }
     }
-    wolfSSL_sk_X509_free(sk);
+    wolfSSL_sk_X509_pop_free(sk, NULL);
 
     (*jenv)->DeleteLocalRef(jenv, arrType);
 


### PR DESCRIPTION
This PR fixes the free function called in `WolfSSLX509StoreCtx.getDerCerts()` when freeing the `WOLFSSL_STACK*` allocated with `wolfSSL_X509_STORE_GetCerts(WOLFSSL_X509_STORE_CTX*)`.

`wolfSSL_sk_X509_free()` just frees the stack structure, where `wolfSSL_sk_X509_pop_free()` frees each node in the stack then the stack.

`WolfSSLX509StoreCtx.getDerCerts()` is called inside the `WolfSSLInternalVerifyCb` class' `verifyCallback()` method, which will be called when peer verification is conducted inside an SSL/TLS connection with wolfJSSE.