### PR TITLE
Release native verify callback with SSLEngine is closed

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
@@ -606,7 +606,12 @@ public class WolfSSLEngine extends SSLEngine {
          */
         if (produced >= 0 &&
             (!outBoundOpen || (!inBoundOpen && this.closeNotifySent))) {
+            /* Mark SSLEngine status as CLOSED */
             status = SSLEngineResult.Status.CLOSED;
+            /* Handshake has finished and SSLEngine is closed, release
+             * global JNI verify callback pointer */
+            this.EngineHelper.unsetVerifyCallback();
+
             try {
                 ClosingConnection();
             } catch (SocketException e) {
@@ -962,7 +967,11 @@ public class WolfSSLEngine extends SSLEngine {
             if (outBoundOpen == false) {
                 try {
                     if (ClosingConnection() == WolfSSL.SSL_SUCCESS) {
+                        /* Mark SSLEngine status as CLOSED */
                         status = SSLEngineResult.Status.CLOSED;
+                        /* Handshake has finished and SSLEngine is closed,
+                         * release, global JNI verify callback pointer */
+                        this.EngineHelper.unsetVerifyCallback();
                     }
                 } catch (SocketException e) {
                     throw new SSLException(e);
@@ -1030,7 +1039,11 @@ public class WolfSSLEngine extends SSLEngine {
                 }
 
                 if (outBoundOpen == false || this.closeNotifySent) {
+                    /* Mark SSLEngine status as CLOSED */
                     status = SSLEngineResult.Status.CLOSED;
+                    /* Handshake has finished and SSLEngine is closed,
+                     * release, global JNI verify callback pointer */
+                    this.EngineHelper.unsetVerifyCallback();
                 }
 
                 int err = ssl.getError(ret);
@@ -1773,7 +1786,7 @@ public class WolfSSLEngine extends SSLEngine {
             this.ssl.freeSSL();
             this.ssl = null;
         }
-        EngineHelper = null;
+        this.EngineHelper = null;
         super.finalize();
     }
 }

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLInternalVerifyCb.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLInternalVerifyCb.java
@@ -69,6 +69,16 @@ public class WolfSSLInternalVerifyCb implements WolfSSLVerifyCallback {
     }
 
     /**
+     * Reset internal variables back to null/default.
+     */
+    protected void clearInternalVars() {
+        this.callingSocket = null;
+        this.callingEngine = null;
+        this.params = null;
+        this.tm = null;
+    }
+
+    /**
      * Verify hostname of provided peer certificate using
      * Endpoint Identification Algorithm if set in SSLParameters.
      *
@@ -348,6 +358,16 @@ public class WolfSSLInternalVerifyCb implements WolfSSLVerifyCallback {
 
         /* Continue handshake, verification succeeded */
         return 1;
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    protected void finalize() throws Throwable {
+        this.callingSocket = null;
+        this.callingEngine = null;
+        this.tm = null;
+        this.params = null;
+        super.finalize();
     }
 }
 


### PR DESCRIPTION
This PR modifies `SSLEngine` so that it explicitly releases the native wolfSSL verify callback when the SSLEngine enters the CLOSED state.  Once CLOSED, an SSLEngine will not be reused.  From the Javadocs for SSLEngine, "Once an engine is closed, it is not reusable: a new SSLEngine must be created."

The native verify callback is stored as a JNI global variable, which can hold up garbage collection if not explicitly released. Prior to this PR it was being released/freed when the native `WOLFSSL` structure was freed, but with the changes in https://github.com/wolfSSL/wolfssljni/pull/159, the circular reference between SSLEngine and WolfSSLInternalVerifyCallback prevented SSLEngine objects from being garbage collected.