### PR TITLE
JNI: wrap wolfSSL_set_tls13_secret_cb() in WolfSSLSession.setTls13SecretCb()

### DIFF
--- a/examples/MyTls13SecretCallback.java
+++ b/examples/MyTls13SecretCallback.java
@@ -1,0 +1,141 @@
+/* MyTls13SecretCallback.java
+ *
+ * Copyright (C) 2006-2024 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+import java.io.FileWriter;
+import java.io.PrintWriter;
+import java.io.IOException;
+
+import com.wolfssl.WolfSSL;
+import com.wolfssl.WolfSSLSession;
+import com.wolfssl.WolfSSLTls13SecretCallback;
+import com.wolfssl.WolfSSLJNIException;
+
+/**
+ * Example TLS 1.3 secret callback implementation.
+ *
+ * This is provided as an example only, and used with the example JNI
+ * applications provided in this package. Users in production environments
+ * should write their own implementation to conform to desired goals.
+ */
+class MyTls13SecretCallback implements WolfSSLTls13SecretCallback
+{
+    /* SSL keylog file to output secrets to */
+    private String sslKeyLogFile = "sslkeylog.log";
+
+    /**
+     * Create new MyTls13SecretCallback using default "sslkeylog.log" file
+     * path.
+     */
+    public MyTls13SecretCallback() {
+    }
+
+    /**
+     * Create new MyTls13SecretCallback object specifying SSL keylog file
+     * path.
+     *
+     * @param keyLogFile path to output file (ex: sslkeylog.log) to use
+     *        for writing TLS 1.3 secrets into.
+     */
+    public MyTls13SecretCallback(String keyLogFile) {
+        this.sslKeyLogFile = keyLogFile;
+    }
+
+    /**
+     * Callback method for printing/saving TLS 1.3 secrets, for use
+     * with Wireshark. Called by native wolfSSL when each secret is available.
+     *
+     * @param ssl       the current SSL session object from which the
+     *                  callback was initiated.
+     * @param id        Identifier specifying what type of secret this callback
+     *                  is being called with, one of the following:
+     *                      WolfSSL.CLIENT_EARLY_TRAFFIC_SECRET
+     *                      WolfSSL.EARLY_EXPORTER_SECRET
+     *                      WolfSSL.CLIENT_HANDSHAKE_TRAFFIC_SECRET
+     *                      WolfSSL.SERVER_HANDSHAKE_TRAFFIC_SECRET
+     *                      WolfSSL.CLIENT_TRAFFIC_SECRET
+     *                      WolfSSL.SERVER_TRAFFIC_SECRET
+     *                      WolfSSL.EXPORTER_SECRET
+     * @param secret    Current secret as byte array
+     * @param ctx       Optional user context if set
+     *
+     * @return 0 on success, otherwise negative if callback encounters
+     *         an error.
+     */
+    public int tls13SecretCallback(WolfSSLSession ssl, int id, byte[] secret,
+        Object ctx) {
+
+        int i;
+        String str = null;
+        FileWriter fw = null;
+        PrintWriter pw = null;
+        byte[] clientRandom = null;
+       
+        try { 
+            /* Open FileWriter in append mode */
+            fw = new FileWriter(sslKeyLogFile, true);
+            pw = new PrintWriter(fw);
+
+            clientRandom = ssl.getClientRandom();
+            if (clientRandom == null || clientRandom.length == 0) {
+                System.out.println("Error getting client random");
+            }
+
+            /* Set secret label based on ID */
+            if (id == WolfSSL.CLIENT_EARLY_TRAFFIC_SECRET) {
+                str = "CLIENT_EARLY_TRAFFIC_SECRET";
+            } else if (id == WolfSSL.EARLY_EXPORTER_SECRET) {
+                str = "EARLY_EXPORTER_SECRET";
+            } else if (id == WolfSSL.CLIENT_HANDSHAKE_TRAFFIC_SECRET) {
+                str = "CLIENT_HANDSHAKE_TRAFFIC_SECRET";
+            } else if (id == WolfSSL.SERVER_HANDSHAKE_TRAFFIC_SECRET) {
+                str = "SERVER_HANDSHAKE_TRAFFIC_SECRET";
+            } else if (id == WolfSSL.CLIENT_TRAFFIC_SECRET) {
+                str = "CLIENT_TRAFFIC_SECRET";
+            } else if (id == WolfSSL.SERVER_TRAFFIC_SECRET) {
+                str = "SERVER_TRAFFIC_SECRET";
+            } else if (id == WolfSSL.EXPORTER_SECRET) {
+                str = "EXPORTER_SECRET";
+            } else {
+                pw.close();
+                return WolfSSL.TLS13_SECRET_CB_E;
+            }
+
+            pw.printf("%s ", str);
+            for (i = 0; i < clientRandom.length; i++) {
+                pw.printf("%02x", clientRandom[i]);
+            }
+            pw.printf(" ");
+            for (i = 0; i < clientRandom.length; i++) {
+                pw.printf("%02x", secret[i]);
+            }
+            pw.printf("\n");
+
+            pw.close();
+
+            return 0;
+
+        } catch (IOException | WolfSSLJNIException e) {
+            e.printStackTrace();
+            return WolfSSL.TLS13_SECRET_CB_E;
+        }
+    }
+}
+

--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -298,6 +298,97 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumCAMELL
     return wolfssl_camellia;
 }
 
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getTls13SecretEnum_1CLIENT_1EARLY_1TRAFFIC_1SECRET
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+#if defined(HAVE_SECRET_CALLBACK) && defined(WOLFSSL_TLS13)
+    return CLIENT_EARLY_TRAFFIC_SECRET;
+#else
+    return NOT_COMPILED_IN;
+#endif
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getTls13SecretEnum_1CLIENT_1HANDSHAKE_1TRAFFIC_1SECRET
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+#if defined(HAVE_SECRET_CALLBACK) && defined(WOLFSSL_TLS13)
+    return CLIENT_HANDSHAKE_TRAFFIC_SECRET;
+#else
+    return NOT_COMPILED_IN;
+#endif
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getTls13SecretEnum_1SERVER_1HANDSHAKE_1TRAFFIC_1SECRET
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+#if defined(HAVE_SECRET_CALLBACK) && defined(WOLFSSL_TLS13)
+    return SERVER_HANDSHAKE_TRAFFIC_SECRET;
+#else
+    return NOT_COMPILED_IN;
+#endif
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getTls13SecretEnum_1CLIENT_1TRAFFIC_1SECRET
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+#if defined(HAVE_SECRET_CALLBACK) && defined(WOLFSSL_TLS13)
+    return CLIENT_TRAFFIC_SECRET;
+#else
+    return NOT_COMPILED_IN;
+#endif
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getTls13SecretEnum_1SERVER_1TRAFFIC_1SECRET
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+#if defined(HAVE_SECRET_CALLBACK) && defined(WOLFSSL_TLS13)
+    return SERVER_TRAFFIC_SECRET;
+#else
+    return NOT_COMPILED_IN;
+#endif
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getTls13SecretEnum_1EARLY_1EXPORTER_1SECRET
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+#if defined(HAVE_SECRET_CALLBACK) && defined(WOLFSSL_TLS13)
+    return EARLY_EXPORTER_SECRET;
+#else
+    return NOT_COMPILED_IN;
+#endif
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getTls13SecretEnum_1EXPORTER_1SECRET
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+#if defined(HAVE_SECRET_CALLBACK) && defined(WOLFSSL_TLS13)
+    return EXPORTER_SECRET;
+#else
+    return NOT_COMPILED_IN;
+#endif
+}
+
 JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_TLSv1Enabled
   (JNIEnv* jenv, jclass jcl)
 {
@@ -513,6 +604,19 @@ JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_sessionTicketEnabled
     (void)jcl;
 
 #ifdef HAVE_SESSION_TICKET
+    return JNI_TRUE;
+#else
+    return JNI_FALSE;
+#endif
+}
+
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_secretCallbackEnabled
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+#ifdef HAVE_SECRET_CALLBACK
     return JNI_TRUE;
 #else
     return JNI_FALSE;

--- a/native/com_wolfssl_WolfSSL.h
+++ b/native/com_wolfssl_WolfSSL.h
@@ -187,6 +187,8 @@ extern "C" {
 #define com_wolfssl_WolfSSL_NOT_COMPILED_IN -174L
 #undef com_wolfssl_WolfSSL_NO_PASSWORD
 #define com_wolfssl_WolfSSL_NO_PASSWORD -176L
+#undef com_wolfssl_WolfSSL_TLS13_SECRET_CB_E
+#define com_wolfssl_WolfSSL_TLS13_SECRET_CB_E -438L
 #undef com_wolfssl_WolfSSL_MD5
 #define com_wolfssl_WolfSSL_MD5 0L
 #undef com_wolfssl_WolfSSL_SHA
@@ -425,6 +427,62 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumCAMELL
 
 /*
  * Class:     com_wolfssl_WolfSSL
+ * Method:    getTls13SecretEnum_CLIENT_EARLY_TRAFFIC_SECRET
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getTls13SecretEnum_1CLIENT_1EARLY_1TRAFFIC_1SECRET
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getTls13SecretEnum_CLIENT_HANDSHAKE_TRAFFIC_SECRET
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getTls13SecretEnum_1CLIENT_1HANDSHAKE_1TRAFFIC_1SECRET
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getTls13SecretEnum_SERVER_HANDSHAKE_TRAFFIC_SECRET
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getTls13SecretEnum_1SERVER_1HANDSHAKE_1TRAFFIC_1SECRET
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getTls13SecretEnum_CLIENT_TRAFFIC_SECRET
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getTls13SecretEnum_1CLIENT_1TRAFFIC_1SECRET
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getTls13SecretEnum_SERVER_TRAFFIC_SECRET
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getTls13SecretEnum_1SERVER_1TRAFFIC_1SECRET
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getTls13SecretEnum_EARLY_EXPORTER_SECRET
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getTls13SecretEnum_1EARLY_1EXPORTER_1SECRET
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getTls13SecretEnum_EXPORTER_SECRET
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getTls13SecretEnum_1EXPORTER_1SECRET
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
  * Method:    getEnabledCipherSuites
  * Signature: ()Ljava/lang/String;
  */
@@ -597,6 +655,14 @@ JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_trustPeerCertEnabled
  * Signature: ()Z
  */
 JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_sessionTicketEnabled
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    secretCallbackEnabled
+ * Signature: ()Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_secretCallbackEnabled
   (JNIEnv *, jclass);
 
 /*

--- a/native/com_wolfssl_WolfSSLSession.h
+++ b/native/com_wolfssl_WolfSSLSession.h
@@ -777,6 +777,30 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setALPNSelectCb
 
 /*
  * Class:     com_wolfssl_WolfSSLSession
+ * Method:    setTls13SecretCb
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setTls13SecretCb
+  (JNIEnv *, jobject, jlong);
+
+/*
+ * Class:     com_wolfssl_WolfSSLSession
+ * Method:    keepArrays
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_keepArrays
+  (JNIEnv *, jobject, jlong);
+
+/*
+ * Class:     com_wolfssl_WolfSSLSession
+ * Method:    getClientRandom
+ * Signature: (J)[B
+ */
+JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getClientRandom
+  (JNIEnv *, jobject, jlong);
+
+/*
+ * Class:     com_wolfssl_WolfSSLSession
  * Method:    useSecureRenegotiation
  * Signature: (J)I
  */

--- a/scripts/infer.sh
+++ b/scripts/infer.sh
@@ -42,6 +42,7 @@ infer run -- javac \
     src/java/com/wolfssl/WolfSSLRsaSignCallback.java \
     src/java/com/wolfssl/WolfSSLRsaVerifyCallback.java \
     src/java/com/wolfssl/WolfSSLSession.java \
+    src/java/com/wolfssl/WolfSSLTls13SecretCallback.java \
     src/java/com/wolfssl/WolfSSLVerifyCallback.java \
     src/java/com/wolfssl/WolfSSLX509StoreCtx.java \
     src/java/com/wolfssl/wolfcrypt/ECC.java \

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -313,6 +313,28 @@ public class WolfSSL {
     /** ALPN ERR FATAL, ALPN callback no match and fatal */
     public static final int SSL_TLSEXT_ERR_ALERT_FATAL = 2;
 
+    /* ----------------- TLS 1.3 secret callback IDs  -------------------- */
+    /** TLS 1.3 secret ID: client early traffic secret */
+    public static int CLIENT_EARLY_TRAFFIC_SECRET;
+
+    /** TLS 1.3 secret ID: client handshake traffic secret */
+    public static int CLIENT_HANDSHAKE_TRAFFIC_SECRET;
+
+    /** TLS 1.3 secret ID: server handshake traffic secret */
+    public static int SERVER_HANDSHAKE_TRAFFIC_SECRET;
+
+    /** TLS 1.3 secret ID: client traffic secret */
+    public static int CLIENT_TRAFFIC_SECRET;
+
+    /** TLS 1.3 secret ID: server traffic secret */
+    public static int SERVER_TRAFFIC_SECRET;
+
+    /** TLS 1.3 secret ID: early exporter secret */
+    public static int EARLY_EXPORTER_SECRET;
+
+    /** TLS 1.3 secret ID: exporter secret */
+    public static int EXPORTER_SECRET;
+
     /* ---------------------- wolfCrypt codes ---------------------------- */
 
     /** Out of memory error */
@@ -332,6 +354,9 @@ public class WolfSSL {
 
     /** No password provided by user */
     public static final int NO_PASSWORD     = -176;
+
+    /** TLS 1.3 secret callback function failure */
+    public static final int TLS13_SECRET_CB_E = -438;
 
     /* hmac codes, from wolfssl/wolfcrypt/hmac.h */
     /** Md5 HMAC type */
@@ -519,6 +544,22 @@ public class WolfSSL {
         wolfssl_aes_gcm     = getBulkCipherAlgorithmEnumAESGCM();
         wolfssl_aes_ccm     = getBulkCipherAlgorithmEnumAESCCM();
 
+        /* initialize TLS 1.3 secret callback ID enums */
+        CLIENT_EARLY_TRAFFIC_SECRET =
+            getTls13SecretEnum_CLIENT_EARLY_TRAFFIC_SECRET();
+        CLIENT_HANDSHAKE_TRAFFIC_SECRET =
+            getTls13SecretEnum_CLIENT_HANDSHAKE_TRAFFIC_SECRET();
+        SERVER_HANDSHAKE_TRAFFIC_SECRET =
+            getTls13SecretEnum_SERVER_HANDSHAKE_TRAFFIC_SECRET();
+        CLIENT_TRAFFIC_SECRET =
+            getTls13SecretEnum_CLIENT_TRAFFIC_SECRET();
+        SERVER_TRAFFIC_SECRET =
+            getTls13SecretEnum_SERVER_TRAFFIC_SECRET();
+        EARLY_EXPORTER_SECRET =
+            getTls13SecretEnum_EARLY_EXPORTER_SECRET();
+        EXPORTER_SECRET =
+            getTls13SecretEnum_EXPORTER_SECRET();
+
         this.active = true;
     }
 
@@ -543,6 +584,14 @@ public class WolfSSL {
     static native int getBulkCipherAlgorithmEnumAESCCM();
     static native int getBulkCipherAlgorithmEnumCHACHA();
     static native int getBulkCipherAlgorithmEnumCAMELLIA();
+
+    static native int getTls13SecretEnum_CLIENT_EARLY_TRAFFIC_SECRET();
+    static native int getTls13SecretEnum_CLIENT_HANDSHAKE_TRAFFIC_SECRET();
+    static native int getTls13SecretEnum_SERVER_HANDSHAKE_TRAFFIC_SECRET();
+    static native int getTls13SecretEnum_CLIENT_TRAFFIC_SECRET();
+    static native int getTls13SecretEnum_SERVER_TRAFFIC_SECRET();
+    static native int getTls13SecretEnum_EARLY_EXPORTER_SECRET();
+    static native int getTls13SecretEnum_EXPORTER_SECRET();
 
     static native String getEnabledCipherSuites();
     static native String getEnabledCipherSuitesIana();
@@ -758,6 +807,16 @@ public class WolfSSL {
      *         has not been defined.
      */
     public static native boolean sessionTicketEnabled();
+
+    /**
+     * Tests if native wolfSSL has been compiled with HAVE_SECRET_CALLBACK
+     * default. If defined, will compile in APIs to support SSL/TLS secret
+     * callback support.
+     *
+     * @return true if enabled, otherwise false if HAVE_SECRET_CALLBACK
+     *         has not been defind.
+     */
+    public static native boolean secretCallbackEnabled();
 
     /* ---------------- native SSL/TLS version functions ---------------- */
 

--- a/src/java/com/wolfssl/WolfSSLTls13SecretCallback.java
+++ b/src/java/com/wolfssl/WolfSSLTls13SecretCallback.java
@@ -1,0 +1,66 @@
+/* WolfSSLTls13SecretCallback.java
+ *
+ * Copyright (C) 2006-2024 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+package com.wolfssl;
+
+import java.nio.ByteBuffer;
+
+/**
+ * wolfSSL TLS 1.3 Secret Callback Interface.
+ * This interface specifies how applications should implement the TLS 1.3
+ * secret callback class, to be used by wolfSSL when logging TLS 1.3 secrets.
+ * <p>
+ * To use this interface, native wolfSSL must be compiled with
+ * HAVE_SECRET_CALLBACK defined.
+ * <p>
+ * After implementing this interface, it should be passed as a parameter
+ * to the
+ * {@link WolfSSLSession#setTls13SecretCb(WolfSSLTls13SecretCallback, Object)
+ * WolfSSLSession.setTls13SecretCb()} method to be registered with the native
+ * wolfSSL library.
+ */
+public interface WolfSSLTls13SecretCallback {
+
+    /**
+     * Callback method for printing/saving TLS 1.3 secrets, for use
+     * with Wireshark.
+     *
+     * @param ssl       the current SSL session object from which the
+     *                  callback was initiated.
+     * @param id        Identifier specifying what type of secret this callback
+     *                  is being called with, one of the following:
+     *                      WolfSSL.CLIENT_EARLY_TRAFFIC_SECRET
+     *                      WolfSSL.EARLY_EXPORTER_SECRET
+     *                      WolfSSL.CLIENT_HANDSHAKE_TRAFFIC_SECRET
+     *                      WolfSSL.SERVER_HANDSHAKE_TRAFFIC_SECRET
+     *                      WolfSSL.CLIENT_TRAFFIC_SECRET
+     *                      WolfSSL.SERVER_TRAFFIC_SECRET
+     *                      WolfSSL.EXPORTER_SECRET
+     * @param secret    Current secret as byte array
+     * @param ctx       Optional user context if set
+     *
+     * @return 0 on success, otherwise negative if callback encounters
+     *         an error.
+     */
+    public int tls13SecretCallback(WolfSSLSession ssl, int id,
+        byte[] secret, Object ctx);
+}
+

--- a/src/test/com/wolfssl/test/WolfSSLSessionTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLSessionTest.java
@@ -39,6 +39,7 @@ import com.wolfssl.WolfSSLException;
 import com.wolfssl.WolfSSLJNIException;
 import com.wolfssl.WolfSSLPskClientCallback;
 import com.wolfssl.WolfSSLPskServerCallback;
+import com.wolfssl.WolfSSLTls13SecretCallback;
 import com.wolfssl.WolfSSLSession;
 
 public class WolfSSLSessionTest {
@@ -95,6 +96,7 @@ public class WolfSSLSessionTest {
         test_WolfSSLSession_UseAfterFree();
         test_WolfSSLSession_getSessionID();
         test_WolfSSLSession_useSecureRenegotiation();
+        test_WolfSSLSession_setTls13SecretCb();
     }
 
     public void test_WolfSSLSession_new() {
@@ -662,6 +664,55 @@ public class WolfSSLSessionTest {
         }
 
         System.out.println("... passed");
+    }
+
+    class TestTls13SecretCb implements WolfSSLTls13SecretCallback
+    {
+        public int tls13SecretCallback(WolfSSLSession ssl, int id,
+            byte[] secret, Object ctx)
+        {
+            return 0;
+        }
+    }
+
+    public void test_WolfSSLSession_setTls13SecretCb() {
+
+        int ret;
+        WolfSSL sslLib = null;
+        WolfSSLContext sslCtx = null;
+        WolfSSLSession ssl = null;
+        TestTls13SecretCb cb = null;
+
+        System.out.print("\tTesting setTls13SecretCb()");
+
+        if (!WolfSSL.secretCallbackEnabled()) {
+            System.out.println("\t... skipped");
+            return;
+        }
+
+        try {
+
+            /* setup library, context, session, socket */
+            sslLib = new WolfSSL();
+            sslCtx = new WolfSSLContext(WolfSSL.TLSv1_3_ClientMethod());
+            sslCtx.setVerify(WolfSSL.SSL_VERIFY_NONE, null);
+            ssl = new WolfSSLSession(sslCtx);
+
+            /* setting with null should pass */
+            ssl.setTls13SecretCb(null, null);
+
+            /* set with test callback */
+            cb = new TestTls13SecretCb();
+            ssl.setTls13SecretCb(cb, null);
+
+        } catch (Exception e) {
+            System.out.println("\t... failed");
+            e.printStackTrace();
+            fail("failed setTls13SecretCb() test");
+            return;
+        }
+
+        System.out.println("\t... passed");
     }
 }
 


### PR DESCRIPTION
This PR wraps the native wolfSSL API `wolfSSL_set_tls13_secret_cb()` inside the `WolfSSLSession` class. This allows JNI-level users to write and register a TLS 1.3 secret callback for use with Wireshark.

Native wolfSSL needs to be compiled with `-DHAVE_SECRET_CALLBACK`, ie:

```
cd wolfssl-X.X.X
./configure --enable-jni CFLAGS="-DHAVE_SECRET_CALLBACK"
make
sudo make install
```

Java applications need to implement the `com.wolfssl.WolfSSLTls13SecretCallback` interface, for example:

```
class MyTls13SecretCb implements WolfSSLTls13SecretCallback
{
    public int tls13SecretCallback(WolfSSLSession ssl, int id,
        byte[] secret, Object ctx)
    {
        /* Implement callback logic, see examples/MyTls13ClientCallback.java for example */
    }
}
```

Then provide an instance of that to `WolfSSLSession.setTls13SecretCb()`. For example:

```
WolfSSLSession ssl = ...
MyTls13SecretCb cb = new MyTls13SecretCb();

ssl.keepArrays();
ssl.setTls13SecretCb(cb, null);
```

For an example of using the TLS 1.3 secret callback, see the example JNI client (examples/Client.java, examples/MyTls13SecretCallback.java).

The example JNI client and server can be connected against each other with the client using the example TLS 1.3 secret callback using the following.  Note that like mentioned above, native wolfSSL must be compiled with `-DHAVE_SECRET_CALLBACK`.

```
./examples/server.sh -v 4
./examples/client.sh -tls13secretcb sslkeylog.log -v 4
...
(sslkeylog.log should be available under examples/build/sslkeylog.log)
```