### PR TITLE
Fixes from Infer scan over JNI/JSSE classes

### DIFF
--- a/scripts/infer.sh
+++ b/scripts/infer.sh
@@ -17,10 +17,12 @@
 #
 
 infer run -- javac \
-    src/java/com/wolfssl/WolfSSLCertificate.java \
+    src/java/com/wolfssl/WolfSSL.java \
+    src/java/com/wolfssl/WolfSSLALPNSelectCallback.java \
     src/java/com/wolfssl/WolfSSLCertManager.java \
+    src/java/com/wolfssl/WolfSSLCertRequest.java \
+    src/java/com/wolfssl/WolfSSLCertificate.java \
     src/java/com/wolfssl/WolfSSLContext.java \
-    src/java/com/wolfssl/WolfSSLCustomUser.java \
     src/java/com/wolfssl/WolfSSLDecryptVerifyCallback.java \
     src/java/com/wolfssl/WolfSSLEccSharedSecretCallback.java \
     src/java/com/wolfssl/WolfSSLEccSignCallback.java \
@@ -30,7 +32,6 @@ infer run -- javac \
     src/java/com/wolfssl/WolfSSLGenCookieCallback.java \
     src/java/com/wolfssl/WolfSSLIORecvCallback.java \
     src/java/com/wolfssl/WolfSSLIOSendCallback.java \
-    src/java/com/wolfssl/WolfSSL.java \
     src/java/com/wolfssl/WolfSSLJNIException.java \
     src/java/com/wolfssl/WolfSSLLoggingCallback.java \
     src/java/com/wolfssl/WolfSSLMacEncryptCallback.java \
@@ -44,15 +45,17 @@ infer run -- javac \
     src/java/com/wolfssl/WolfSSLSession.java \
     src/java/com/wolfssl/WolfSSLTls13SecretCallback.java \
     src/java/com/wolfssl/WolfSSLVerifyCallback.java \
+    src/java/com/wolfssl/WolfSSLX509Name.java \
     src/java/com/wolfssl/WolfSSLX509StoreCtx.java \
     src/java/com/wolfssl/wolfcrypt/ECC.java \
     src/java/com/wolfssl/wolfcrypt/EccKey.java \
     src/java/com/wolfssl/wolfcrypt/RSA.java \
     src/java/com/wolfssl/provider/jsse/WolfSSLAuthStore.java \
     src/java/com/wolfssl/provider/jsse/WolfSSLContext.java \
+    src/java/com/wolfssl/provider/jsse/WolfSSLCustomUser.java \
     src/java/com/wolfssl/provider/jsse/WolfSSLDebug.java \
-    src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java \
     src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java \
+    src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java \
     src/java/com/wolfssl/provider/jsse/WolfSSLGenericHostName.java \
     src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java \
     src/java/com/wolfssl/provider/jsse/WolfSSLInternalVerifyCb.java \
@@ -62,14 +65,15 @@ infer run -- javac \
     src/java/com/wolfssl/provider/jsse/WolfSSLParametersHelper.java \
     src/java/com/wolfssl/provider/jsse/WolfSSLParameters.java \
     src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java \
-    src/java/com/wolfssl/provider/jsse/WolfSSLServerSocketFactory.java \
-    src/java/com/wolfssl/provider/jsse/WolfSSLServerSocket.java \
-    src/java/com/wolfssl/provider/jsse/WolfSSLSessionContext.java \
     src/java/com/wolfssl/provider/jsse/WolfSSLSNIServerName.java \
+    src/java/com/wolfssl/provider/jsse/WolfSSLServerSocket.java \
+    src/java/com/wolfssl/provider/jsse/WolfSSLServerSocketFactory.java \
+    src/java/com/wolfssl/provider/jsse/WolfSSLSessionContext.java \
     src/java/com/wolfssl/provider/jsse/WolfSSLSocketFactory.java \
     src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java \
     src/java/com/wolfssl/provider/jsse/WolfSSLTrustManager.java \
     src/java/com/wolfssl/provider/jsse/WolfSSLTrustX509.java \
+    src/java/com/wolfssl/provider/jsse/WolfSSLUtil.java \
     src/java/com/wolfssl/provider/jsse/WolfSSLX509.java \
     src/java/com/wolfssl/provider/jsse/WolfSSLX509X.java \
     src/java/com/wolfssl/provider/jsse/adapter/WolfSSLJDK8Helper.java

--- a/src/java/com/wolfssl/WolfSSLCertificate.java
+++ b/src/java/com/wolfssl/WolfSSLCertificate.java
@@ -323,7 +323,9 @@ public class WolfSSLCertificate {
 
         confirmObjectIsActive();
 
-        return this.x509Ptr;
+        synchronized (x509Lock) {
+            return this.x509Ptr;
+        }
     }
 
     /**
@@ -1435,14 +1437,14 @@ public class WolfSSLCertificate {
 
         confirmObjectIsActive();
 
-        if (this.altNames != null) {
-            /* already gathered, return cached version */
-            return this.altNames;
-        }
-
-        Collection<List<?>> names = new ArrayList<List<?>>();
-
         synchronized (x509Lock) {
+            if (this.altNames != null) {
+                /* already gathered, return cached version */
+                return this.altNames;
+            }
+
+            Collection<List<?>> names = new ArrayList<List<?>>();
+
             String nextAltName = X509_get_next_altname(this.x509Ptr);
             while (nextAltName != null) {
                 Object[] entry = new Object[2];
@@ -1453,12 +1455,12 @@ public class WolfSSLCertificate {
                 names.add(Collections.unmodifiableList(entryList));
                 nextAltName = X509_get_next_altname(this.x509Ptr);
             }
+
+            /* cache altNames collection for later use */
+            this.altNames = Collections.unmodifiableCollection(names);
+
+            return this.altNames;
         }
-
-        /* cache altNames collection for later use */
-        this.altNames = Collections.unmodifiableCollection(names);
-
-        return this.altNames;
     }
 
     /**

--- a/src/java/com/wolfssl/WolfSSLContext.java
+++ b/src/java/com/wolfssl/WolfSSLContext.java
@@ -104,32 +104,34 @@ public class WolfSSLContext {
      *
      * @return pointer to native WOLFSSL_CTX structure for this object
      */
-    protected synchronized long getContextPtr() {
-        return sslCtxPtr;
+    protected long getContextPtr() {
+        synchronized (this.ctxLock) {
+            return sslCtxPtr;
+        }
     }
 
     /* used by JNI native recv Cb */
-    WolfSSLIORecvCallback getInternRecvCb() {
+    synchronized WolfSSLIORecvCallback getInternRecvCb() {
         return internRecvCb;
     }
 
     /* used by JNI native send Cb */
-    WolfSSLIOSendCallback getInternSendCb() {
+    synchronized WolfSSLIOSendCallback getInternSendCb() {
         return internSendCb;
     }
 
     /* used by JNI native cookie Cb */
-    WolfSSLGenCookieCallback getInternCookieCb() {
+    synchronized WolfSSLGenCookieCallback getInternCookieCb() {
         return internCookieCb;
     }
 
     /* used by JNI native MAC/encrypt Cb */
-    WolfSSLMacEncryptCallback getInternMacEncryptCb() {
+    synchronized WolfSSLMacEncryptCallback getInternMacEncryptCb() {
         return internMacEncryptCb;
     }
 
     /* used by JNI native decrypt/verify Cb */
-    WolfSSLDecryptVerifyCallback getInternDecryptVerifyCb() {
+    synchronized WolfSSLDecryptVerifyCallback getInternDecryptVerifyCb() {
         return internDecryptVerifyCb;
     }
 
@@ -1127,7 +1129,7 @@ public class WolfSSLContext {
      * @throws WolfSSLJNIException Internal JNI error
      * @see    #setIOSend(WolfSSLIOSendCallback)
      */
-    public void setIORecv(WolfSSLIORecvCallback callback)
+    public synchronized void setIORecv(WolfSSLIORecvCallback callback)
         throws IllegalStateException, WolfSSLJNIException {
 
         confirmObjectIsActive();
@@ -1161,7 +1163,7 @@ public class WolfSSLContext {
      * @throws WolfSSLJNIException Internal JNI error
      * @see    #setIORecv(WolfSSLIORecvCallback)
      */
-    public void setIOSend(WolfSSLIOSendCallback callback)
+    public synchronized void setIOSend(WolfSSLIOSendCallback callback)
         throws IllegalStateException, WolfSSLJNIException {
 
         confirmObjectIsActive();
@@ -1195,7 +1197,7 @@ public class WolfSSLContext {
      * @throws IllegalStateException WolfSSLContext has been freed
      * @throws WolfSSLJNIException Internal JNI error
      */
-    public void setGenCookie(WolfSSLGenCookieCallback callback)
+    public synchronized void setGenCookie(WolfSSLGenCookieCallback callback)
         throws IllegalStateException, WolfSSLJNIException {
 
         confirmObjectIsActive();
@@ -1444,7 +1446,7 @@ public class WolfSSLContext {
      * @throws WolfSSLJNIException Internal JNI error
      * @see    #setDecryptVerifyCb(WolfSSLDecryptVerifyCallback)
      */
-    public void setMacEncryptCb(WolfSSLMacEncryptCallback callback)
+    public synchronized void setMacEncryptCb(WolfSSLMacEncryptCallback callback)
         throws IllegalStateException, WolfSSLJNIException {
 
         confirmObjectIsActive();
@@ -1483,7 +1485,8 @@ public class WolfSSLContext {
      * @throws WolfSSLJNIException Internal JNI error
      * @see    #setMacEncryptCb(WolfSSLMacEncryptCallback)
      */
-    public void setDecryptVerifyCb(WolfSSLDecryptVerifyCallback callback)
+    public synchronized void setDecryptVerifyCb(
+        WolfSSLDecryptVerifyCallback callback)
         throws IllegalStateException, WolfSSLJNIException {
 
         confirmObjectIsActive();
@@ -1519,7 +1522,7 @@ public class WolfSSLContext {
      * @throws WolfSSLJNIException Internal JNI error
      * @see    WolfSSLSession#setEccSignCtx(Object)
      */
-    public void setEccSignCb(WolfSSLEccSignCallback callback)
+    public synchronized void setEccSignCb(WolfSSLEccSignCallback callback)
         throws IllegalStateException, WolfSSLJNIException {
 
         confirmObjectIsActive();
@@ -1555,7 +1558,7 @@ public class WolfSSLContext {
      * @throws WolfSSLJNIException Internal JNI error
      * @see    WolfSSLSession#setEccVerifyCtx(Object)
      */
-    public void setEccVerifyCb(WolfSSLEccVerifyCallback callback)
+    public synchronized void setEccVerifyCb(WolfSSLEccVerifyCallback callback)
         throws IllegalStateException, WolfSSLJNIException {
 
         confirmObjectIsActive();
@@ -1606,7 +1609,8 @@ public class WolfSSLContext {
      * @see    WolfSSLSession#setEccSignCtx(Object)
      * @see    WolfSSLSession#setEccVerifyCtx(Object)
      */
-    public void setEccSharedSecretCb(WolfSSLEccSharedSecretCallback callback)
+    public synchronized void setEccSharedSecretCb(
+        WolfSSLEccSharedSecretCallback callback)
         throws IllegalStateException, WolfSSLJNIException {
 
         confirmObjectIsActive();
@@ -1642,7 +1646,7 @@ public class WolfSSLContext {
      * @throws WolfSSLJNIException Internal JNI error
      * @see    WolfSSLSession#setRsaSignCtx(Object)
      */
-    public void setRsaSignCb(WolfSSLRsaSignCallback callback)
+    public synchronized void setRsaSignCb(WolfSSLRsaSignCallback callback)
         throws IllegalStateException, WolfSSLJNIException {
 
         confirmObjectIsActive();
@@ -1678,7 +1682,7 @@ public class WolfSSLContext {
      * @throws WolfSSLJNIException Internal JNI error
      * @see    WolfSSLSession#setRsaVerifyCtx(Object)
      */
-    public void setRsaVerifyCb(WolfSSLRsaVerifyCallback callback)
+    public synchronized void setRsaVerifyCb(WolfSSLRsaVerifyCallback callback)
         throws IllegalStateException, WolfSSLJNIException {
 
         confirmObjectIsActive();
@@ -1714,7 +1718,7 @@ public class WolfSSLContext {
      * @throws WolfSSLJNIException Internal JNI exception
      * @see    WolfSSLSession#setRsaEncCtx(Object)
      */
-    public void setRsaEncCb(WolfSSLRsaEncCallback callback)
+    public synchronized void setRsaEncCb(WolfSSLRsaEncCallback callback)
         throws IllegalStateException, WolfSSLJNIException {
 
         confirmObjectIsActive();
@@ -1749,7 +1753,7 @@ public class WolfSSLContext {
      * @throws WolfSSLJNIException Internal JNI error
      * @see    WolfSSLSession#setRsaDecCtx(Object)
      */
-    public void setRsaDecCb(WolfSSLRsaDecCallback callback)
+    public synchronized void setRsaDecCb(WolfSSLRsaDecCallback callback)
         throws IllegalStateException, WolfSSLJNIException {
 
         confirmObjectIsActive();
@@ -1788,7 +1792,7 @@ public class WolfSSLContext {
      * @see    WolfSSLSession#getPskIdentityHint()
      * @see    WolfSSLSession#usePskIdentityHint(String)
      */
-    public void setPskClientCb(WolfSSLPskClientCallback callback)
+    public synchronized void setPskClientCb(WolfSSLPskClientCallback callback)
         throws IllegalStateException, WolfSSLJNIException {
 
         confirmObjectIsActive();
@@ -1826,7 +1830,7 @@ public class WolfSSLContext {
      * @see    WolfSSLSession#getPskIdentityHint()
      * @see    WolfSSLSession#usePskIdentityHint(String)
      */
-    public void setPskServerCb(WolfSSLPskServerCallback callback)
+    public synchronized void setPskServerCb(WolfSSLPskServerCallback callback)
         throws IllegalStateException, WolfSSLJNIException {
 
         confirmObjectIsActive();

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
@@ -66,7 +66,7 @@ import java.net.SocketTimeoutException;
  */
 public class WolfSSLEngine extends SSLEngine {
 
-    private WolfSSLEngineHelper EngineHelper = null;
+    private WolfSSLEngineHelper engineHelper = null;
     private WolfSSLSession ssl = null;
     private com.wolfssl.WolfSSLContext ctx = null;
     private WolfSSLAuthStore authStore = null;
@@ -164,11 +164,11 @@ public class WolfSSLEngine extends SSLEngine {
                              null, ex);
             throw new WolfSSLException("Error with init");
         }
-        EngineHelper = new WolfSSLEngineHelper(this.ssl, this.authStore,
-                this.params);
+        this.engineHelper = new WolfSSLEngineHelper(this.ssl, this.authStore,
+            this.params);
 
         try {
-            EngineHelper.LoadKeyAndCertChain(null, this);
+            this.engineHelper.LoadKeyAndCertChain(null, this);
         } catch (CertificateEncodingException | IOException e) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                 "failed to load private key and/or cert chain");
@@ -200,11 +200,11 @@ public class WolfSSLEngine extends SSLEngine {
                              null, ex);
             throw new WolfSSLException("Error with init");
         }
-        EngineHelper = new WolfSSLEngineHelper(this.ssl, this.authStore,
+        this.engineHelper = new WolfSSLEngineHelper(this.ssl, this.authStore,
                 this.params, port, host);
 
         try {
-            EngineHelper.LoadKeyAndCertChain(null, this);
+            this.engineHelper.LoadKeyAndCertChain(null, this);
         } catch (CertificateEncodingException | IOException e) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                 "failed to load private key and/or cert chain");
@@ -355,7 +355,7 @@ public class WolfSSLEngine extends SSLEngine {
          * since underlying get1Session can use I/O with peek. */
         if (!this.sessionStored) {
             synchronized (ioLock) {
-                EngineHelper.saveSession();
+                this.engineHelper.saveSession();
             }
         }
 
@@ -444,7 +444,7 @@ public class WolfSSLEngine extends SSLEngine {
 
         /* only send up to maximum app data size chunk */
         sendSz = Math.min(totalIn,
-                          EngineHelper.getSession().getApplicationBufferSize());
+            this.engineHelper.getSession().getApplicationBufferSize());
         dataBuf = ByteBuffer.allocate(sendSz);
 
         /* gather byte array of sendSz bytes from input buffers */
@@ -533,7 +533,7 @@ public class WolfSSLEngine extends SSLEngine {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                 "==== [ entering wrap() ] ===================================");
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "setUseClientMode: " + EngineHelper.getUseClientMode());
+                "setUseClientMode: " + this.engineHelper.getUseClientMode());
             for (i = 0; i < len; i++) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                     "ByteBuffer in["+i+"].remaining(): " + in[i].remaining());
@@ -583,7 +583,7 @@ public class WolfSSLEngine extends SSLEngine {
         }
 
         if (needInit) {
-            EngineHelper.initHandshake(this);
+            this.engineHelper.initHandshake(this);
             needInit = false;
             closed = false; /* opened a connection */
         }
@@ -593,7 +593,8 @@ public class WolfSSLEngine extends SSLEngine {
         }
 
         /* Force out buffer to be large enough to hold max packet size */
-        if (out.remaining() < EngineHelper.getSession().getPacketBufferSize()) {
+        if (out.remaining() <
+            this.engineHelper.getSession().getPacketBufferSize()) {
             return new SSLEngineResult(Status.BUFFER_OVERFLOW, hs, 0, 0);
         }
 
@@ -610,7 +611,7 @@ public class WolfSSLEngine extends SSLEngine {
             status = SSLEngineResult.Status.CLOSED;
             /* Handshake has finished and SSLEngine is closed, release
              * global JNI verify callback pointer */
-            this.EngineHelper.unsetVerifyCallback();
+            this.engineHelper.unsetVerifyCallback();
 
             try {
                 ClosingConnection();
@@ -645,7 +646,7 @@ public class WolfSSLEngine extends SSLEngine {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                 "==== [ exiting wrap() ] ===================================");
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "setUseClientMode: " + EngineHelper.getUseClientMode());
+                "setUseClientMode: " + this.engineHelper.getUseClientMode());
             for (i = 0; i < len; i++) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                     "ByteBuffer in["+i+"].remaining(): " + in[i].remaining());
@@ -896,7 +897,7 @@ public class WolfSSLEngine extends SSLEngine {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                 "==== [ entering unwrap() ] =================================");
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "setUseClientMode: " + EngineHelper.getUseClientMode());
+                "setUseClientMode: " + this.engineHelper.getUseClientMode());
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                 "in.remaining(): " + in.remaining());
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
@@ -959,7 +960,7 @@ public class WolfSSLEngine extends SSLEngine {
         else {
 
             if (needInit) {
-                EngineHelper.initHandshake(this);
+                this.engineHelper.initHandshake(this);
                 needInit = false;
                 closed = false;
             }
@@ -971,7 +972,7 @@ public class WolfSSLEngine extends SSLEngine {
                         status = SSLEngineResult.Status.CLOSED;
                         /* Handshake has finished and SSLEngine is closed,
                          * release, global JNI verify callback pointer */
-                        this.EngineHelper.unsetVerifyCallback();
+                        this.engineHelper.unsetVerifyCallback();
                     }
                 } catch (SocketException e) {
                     throw new SSLException(e);
@@ -1027,8 +1028,8 @@ public class WolfSSLEngine extends SSLEngine {
                     if (!this.sessionStored) {
                         synchronized (ioLock) {
                             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                                "calling EngineHelper.saveSession()");
-                            int ret2 = EngineHelper.saveSession();
+                                "calling engineHelper.saveSession()");
+                            int ret2 = this.engineHelper.saveSession();
                             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                                 "return from saveSession(), ret = " + ret2);
                             if (ret2 == WolfSSL.SSL_SUCCESS) {
@@ -1043,7 +1044,7 @@ public class WolfSSLEngine extends SSLEngine {
                     status = SSLEngineResult.Status.CLOSED;
                     /* Handshake has finished and SSLEngine is closed,
                      * release, global JNI verify callback pointer */
-                    this.EngineHelper.unsetVerifyCallback();
+                    this.engineHelper.unsetVerifyCallback();
                 }
 
                 int err = ssl.getError(ret);
@@ -1083,7 +1084,7 @@ public class WolfSSLEngine extends SSLEngine {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                 "==== [ exiting unwrap() ] ==================================");
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "setUseClientMode: " + EngineHelper.getUseClientMode());
+                "setUseClientMode: " + this.engineHelper.getUseClientMode());
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                 "in.remaining(): " + in.remaining());
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
@@ -1188,10 +1189,10 @@ public class WolfSSLEngine extends SSLEngine {
                                 "SSL/TLS handshake finished");
                             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                                 "SSL/TLS protocol: " +
-                                EngineHelper.getSession().getProtocol());
+                                this.engineHelper.getSession().getProtocol());
                             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                                 "SSL/TLS cipher suite: " +
-                                EngineHelper.getSession().getCipherSuite());
+                                this.engineHelper.getSession().getCipherSuite());
                         }
                         /* give priority of WRAP/UNWRAP to state of our internal
                          * I/O data buffers first, then wolfSSL err status */
@@ -1279,49 +1280,49 @@ public class WolfSSLEngine extends SSLEngine {
     public String[] getSupportedCipherSuites() {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getSupportedCipherSuites()");
-        return EngineHelper.getAllCiphers();
+        return this.engineHelper.getAllCiphers();
     }
 
     @Override
     public String[] getEnabledCipherSuites() {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getEnabledCipherSuites()");
-        return EngineHelper.getCiphers();
+        return this.engineHelper.getCiphers();
     }
 
     @Override
     public void setEnabledCipherSuites(String[] suites) {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered setEnabledCipherSuites()");
-        EngineHelper.setCiphers(suites);
+        this.engineHelper.setCiphers(suites);
     }
 
     @Override
     public String[] getSupportedProtocols() {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getSupportedProtocols()");
-        return EngineHelper.getAllProtocols();
+        return this.engineHelper.getAllProtocols();
     }
 
     @Override
     public synchronized String[] getEnabledProtocols() {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getEnabledProtocols()");
-        return EngineHelper.getProtocols();
+        return this.engineHelper.getProtocols();
     }
 
     @Override
     public synchronized void setEnabledProtocols(String[] protocols) {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered setEnabledProtocols()");
-        EngineHelper.setProtocols(protocols);
+        this.engineHelper.setProtocols(protocols);
     }
 
     @Override
     public synchronized SSLSession getSession() {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getSession()");
-        return EngineHelper.getSession();
+        return this.engineHelper.getSession();
     }
 
     /**
@@ -1335,7 +1336,7 @@ public class WolfSSLEngine extends SSLEngine {
      * @throws SSLException if native JNI call fails or underlying
      *         WolfSSLSession has been freed
      */
-    public boolean sessionResumed() throws SSLException {
+    public synchronized boolean sessionResumed() throws SSLException {
         if (this.ssl != null) {
             try {
                 int resume = this.ssl.sessionReused();
@@ -1353,7 +1354,7 @@ public class WolfSSLEngine extends SSLEngine {
     public synchronized SSLSession getHandshakeSession() {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getHandshakeSession()");
-        return EngineHelper.getSession();
+        return this.engineHelper.getSession();
     }
 
     @Override
@@ -1379,14 +1380,14 @@ public class WolfSSLEngine extends SSLEngine {
         if (needInit == true) {
             /* will throw SSLHandshakeException if session creation is
                not allowed */
-            EngineHelper.initHandshake(this);
+            this.engineHelper.initHandshake(this);
             needInit = false;
         }
 
         try {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "calling EngineHelper.doHandshake()");
-            int ret = EngineHelper.doHandshake(1, 0);
+                "calling engineHelper.doHandshake()");
+            int ret = this.engineHelper.doHandshake(1, 0);
             SetHandshakeStatus(ret);
 
         } catch (SocketTimeoutException e) {
@@ -1422,7 +1423,7 @@ public class WolfSSLEngine extends SSLEngine {
     public synchronized void setUseClientMode(boolean mode) {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered setUseClientMode(" + mode + ")");
-        EngineHelper.setUseClientMode(mode);
+        this.engineHelper.setUseClientMode(mode);
         this.clientModeSet = true;
     }
 
@@ -1430,55 +1431,55 @@ public class WolfSSLEngine extends SSLEngine {
     public synchronized boolean getUseClientMode() {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getUseClientMode()");
-        return EngineHelper.getUseClientMode();
+        return this.engineHelper.getUseClientMode();
     }
 
     @Override
     public synchronized void setNeedClientAuth(boolean need) {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered setNeedClientAuth(" + need + ")");
-        EngineHelper.setNeedClientAuth(need);
+        this.engineHelper.setNeedClientAuth(need);
     }
 
     @Override
     public synchronized boolean getNeedClientAuth() {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getNeedClientAuth()");
-        return EngineHelper.getNeedClientAuth();
+        return this.engineHelper.getNeedClientAuth();
     }
 
     @Override
     public synchronized void setWantClientAuth(boolean want) {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered setWantClientAuth(" + want + ")");
-        EngineHelper.setWantClientAuth(want);
+        this.engineHelper.setWantClientAuth(want);
     }
 
     @Override
     public synchronized boolean getWantClientAuth() {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getWantClientAuth()");
-        return EngineHelper.getWantClientAuth();
+        return this.engineHelper.getWantClientAuth();
     }
 
     @Override
     public synchronized void setEnableSessionCreation(boolean flag) {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered setEnableSessionCreation(" + flag + ")");
-        EngineHelper.setEnableSessionCreation(flag);
+        this.engineHelper.setEnableSessionCreation(flag);
     }
 
     @Override
     public synchronized boolean getEnableSessionCreation() {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getEnableSessionCreation()");
-        return EngineHelper.getEnableSessionCreation();
+        return this.engineHelper.getEnableSessionCreation();
     }
 
     public synchronized String getApplicationProtocol() {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getApplicationProtocol()");
-        return EngineHelper.getAlpnSelectedProtocolString();
+        return this.engineHelper.getAlpnSelectedProtocolString();
     }
 
     /**
@@ -1501,7 +1502,7 @@ public class WolfSSLEngine extends SSLEngine {
             "entered getHandshakeApplicationProtocol()");
 
         if (!this.needInit && !this.handshakeFinished) {
-            return EngineHelper.getAlpnSelectedProtocolString();
+            return this.engineHelper.getAlpnSelectedProtocolString();
         }
 
         return null;
@@ -1786,7 +1787,6 @@ public class WolfSSLEngine extends SSLEngine {
             this.ssl.freeSSL();
             this.ssl = null;
         }
-        this.EngineHelper = null;
         super.finalize();
     }
 }

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
@@ -284,7 +284,8 @@ public class WolfSSLEngineHelper {
      * @throws IOException on error concatenating certificate chain into
      *         single byte array
      */
-    protected void LoadKeyAndCertChain(Socket sock, SSLEngine engine)
+    protected synchronized void LoadKeyAndCertChain(
+        Socket sock, SSLEngine engine)
         throws WolfSSLException, CertificateEncodingException, IOException {
 
         int ret;
@@ -388,7 +389,7 @@ public class WolfSSLEngineHelper {
      * @param hostname peer hostname String
      * @param port peer port number
      */
-    protected void setHostAndPort(String hostname, int port) {
+    protected synchronized void setHostAndPort(String hostname, int port) {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered setHostAndPort()");
@@ -403,7 +404,7 @@ public class WolfSSLEngineHelper {
      *
      * @param peerAddr InetAddress of peer
      */
-    protected void setPeerAddress(InetAddress peerAddr) {
+    protected synchronized void setPeerAddress(InetAddress peerAddr) {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered setPeerAddress()");
@@ -416,7 +417,7 @@ public class WolfSSLEngineHelper {
      *
      * @return com.wolfssl.WolfSSLSession for this object
      */
-    protected WolfSSLSession getWolfSSLSession() {
+    protected synchronized WolfSSLSession getWolfSSLSession() {
         return ssl;
     }
 
@@ -425,7 +426,7 @@ public class WolfSSLEngineHelper {
      *
      * @return WolfSSLImplementSession for this object
      */
-    protected WolfSSLImplementSSLSession getSession() {
+    protected synchronized WolfSSLImplementSSLSession getSession() {
 
         if (this.session == null) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
@@ -444,7 +445,7 @@ public class WolfSSLEngineHelper {
      *
      * @return String array of all supported cipher suites
      */
-    protected String[] getAllCiphers() {
+    protected synchronized String[] getAllCiphers() {
         return WolfSSLUtil.sanitizeSuites(WolfSSL.getCiphersIana());
     }
 
@@ -454,7 +455,7 @@ public class WolfSSLEngineHelper {
      *
      * @return String array of all enabled cipher suites
      */
-    protected String[] getCiphers() {
+    protected synchronized String[] getCiphers() {
         return WolfSSLUtil.sanitizeSuites(this.params.getCipherSuites());
     }
 
@@ -469,7 +470,8 @@ public class WolfSSLEngineHelper {
      *         cipher suites, input array is null, or input array has length
      *         zero
      */
-    protected void setCiphers(String[] suites) throws IllegalArgumentException {
+    protected synchronized void setCiphers(String[] suites)
+        throws IllegalArgumentException {
 
         if (suites == null) {
             throw new IllegalArgumentException("input array is null");
@@ -501,7 +503,8 @@ public class WolfSSLEngineHelper {
      * @throws IllegalArgumentException if input array is null,
      *         has length zero, or contains invalid/unsupported protocols
      */
-    protected void setProtocols(String[] p) throws IllegalArgumentException {
+    protected synchronized void setProtocols(String[] p)
+        throws IllegalArgumentException {
 
         if (p == null) {
             throw new IllegalArgumentException("input array is null");
@@ -528,7 +531,7 @@ public class WolfSSLEngineHelper {
      *
      * @return String array of enabled SSL/TLS protocols
      */
-    protected String[] getProtocols() {
+    protected synchronized String[] getProtocols() {
         return WolfSSLUtil.sanitizeProtocols(this.params.getProtocols());
     }
 
@@ -539,7 +542,7 @@ public class WolfSSLEngineHelper {
      *
      * @return String array of supported protocols
      */
-    protected String[] getAllProtocols() {
+    protected synchronized String[] getAllProtocols() {
         return WolfSSLUtil.sanitizeProtocols(WolfSSL.getProtocols());
     }
 
@@ -551,7 +554,7 @@ public class WolfSSLEngineHelper {
      * @throws IllegalArgumentException if called after SSL/TLS handshake
      *         has been completed. Only allowed before.
      */
-    protected void setUseClientMode(boolean mode)
+    protected synchronized void setUseClientMode(boolean mode)
         throws IllegalArgumentException {
 
         if (this.ssl.handshakeDone()) {
@@ -574,7 +577,7 @@ public class WolfSSLEngineHelper {
      *
      * @return boolean value of clientMode set for this session
      */
-    protected boolean getUseClientMode() {
+    protected synchronized boolean getUseClientMode() {
         return this.clientMode;
     }
 
@@ -583,7 +586,7 @@ public class WolfSSLEngineHelper {
      *
      * @param need boolean if session needs client authentication
      */
-    protected void setNeedClientAuth(boolean need) {
+    protected synchronized void setNeedClientAuth(boolean need) {
         this.params.setNeedClientAuth(need);
     }
 
@@ -592,7 +595,7 @@ public class WolfSSLEngineHelper {
      *
      * @return boolean value for needClientAuth
      */
-    protected boolean getNeedClientAuth() {
+    protected synchronized boolean getNeedClientAuth() {
         return this.params.getNeedClientAuth();
     }
 
@@ -601,7 +604,7 @@ public class WolfSSLEngineHelper {
      *
      * @param want boolean value of wantClientAuth for this session
      */
-    protected void setWantClientAuth(boolean want) {
+    protected synchronized void setWantClientAuth(boolean want) {
         this.params.setWantClientAuth(want);
     }
 
@@ -610,7 +613,7 @@ public class WolfSSLEngineHelper {
      *
      * @return boolean value for wantClientAuth
      */
-    protected boolean getWantClientAuth() {
+    protected synchronized boolean getWantClientAuth() {
         return this.params.getWantClientAuth();
     }
 
@@ -619,7 +622,7 @@ public class WolfSSLEngineHelper {
      *
      * @param flag boolean to set enable session creation
      */
-    protected void setEnableSessionCreation(boolean flag) {
+    protected synchronized void setEnableSessionCreation(boolean flag) {
         this.sessionCreation = flag;
     }
 
@@ -628,7 +631,7 @@ public class WolfSSLEngineHelper {
      *
      * @return boolean value for enableSessionCreation
      */
-    protected boolean getEnableSessionCreation() {
+    protected synchronized boolean getEnableSessionCreation() {
         return this.sessionCreation;
     }
 
@@ -637,7 +640,7 @@ public class WolfSSLEngineHelper {
      *
      * @param flag boolean to enable/disable session tickets
      */
-    protected void setUseSessionTickets(boolean flag) {
+    protected synchronized void setUseSessionTickets(boolean flag) {
         this.params.setUseSessionTickets(flag);
     }
 
@@ -646,7 +649,7 @@ public class WolfSSLEngineHelper {
      *
      * @param alpnProtos encoded byte array of ALPN protocols
      */
-    protected void setAlpnProtocols(byte[] alpnProtos) {
+    protected synchronized void setAlpnProtocols(byte[] alpnProtos) {
         this.params.setAlpnProtocols(alpnProtos);
     }
 
@@ -658,7 +661,7 @@ public class WolfSSLEngineHelper {
      * @return encoded byte array for selected ALPN protocol or null if
      *         handshake has not finished
      */
-    protected byte[] getAlpnSelectedProtocol() {
+    protected synchronized byte[] getAlpnSelectedProtocol() {
         if (this.ssl.handshakeDone()) {
             return ssl.getAlpnSelected();
         }
@@ -672,7 +675,7 @@ public class WolfSSLEngineHelper {
      *         if protocol is not available yet, or empty String if
      *         ALPN will not be used for this connection.
      */
-    protected String getAlpnSelectedProtocolString() {
+    protected synchronized String getAlpnSelectedProtocolString() {
         String proto = ssl.getAlpnSelectedString();
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
@@ -1133,7 +1136,9 @@ public class WolfSSLEngineHelper {
      * @throws SSLHandshakeException session creation is not allowed
      *
      */
-    protected void initHandshake(SSLSocket socket) throws SSLException {
+    protected synchronized void initHandshake(SSLSocket socket)
+        throws SSLException {
+
         initHandshakeInternal(socket, null);
     }
 
@@ -1152,7 +1157,9 @@ public class WolfSSLEngineHelper {
      * @throws SSLHandshakeException session creation is not allowed
      *
      */
-    protected void initHandshake(SSLEngine engine) throws SSLException {
+    protected synchronized void initHandshake(SSLEngine engine)
+        throws SSLException {
+
         initHandshakeInternal(null, engine);
     }
 
@@ -1235,7 +1242,7 @@ public class WolfSSLEngineHelper {
      *                      on native socket error
      * @throws SocketTimeoutException if socket timed out
      */
-    protected int doHandshake(int isSSLEngine, int timeout)
+    protected synchronized int doHandshake(int isSSLEngine, int timeout)
         throws SSLException, SocketTimeoutException {
 
         int ret, err;

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
@@ -315,7 +315,7 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
     /**
      * Invalidate this session
      */
-    public void invalidate() {
+    public synchronized void invalidate() {
         this.valid = false;
     }
 
@@ -324,7 +324,7 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
      *
      * @return boolean if this session is valid
      */
-    public boolean isValid() {
+    public synchronized boolean isValid() {
         return this.valid;
     }
 
@@ -333,7 +333,7 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
      * session is then valid and can be joined or resumed
      * @param in true/false valid boolean
      */
-    protected void setValid(boolean in) {
+    protected synchronized void setValid(boolean in) {
         this.valid = in;
     }
 
@@ -836,7 +836,7 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
      *         if no SNI names were requested.
      */
     @Override
-    public List<SNIServerName> getRequestedServerNames()
+    public synchronized List<SNIServerName> getRequestedServerNames()
         throws UnsupportedOperationException {
 
         byte[] sniRequestArr = null;
@@ -863,7 +863,7 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
 
     @SuppressWarnings("deprecation")
     @Override
-    protected void finalize() throws Throwable
+    protected synchronized void finalize() throws Throwable
     {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered finalize(): this.sesPtr = " + this.sesPtr);

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -1781,7 +1781,7 @@ public class WolfSSLSocket extends SSLSocket {
      * @throws SSLException if native JNI call fails or underlying
      *         WolfSSLSession has been freed
      */
-    public boolean sessionResumed() throws SSLException {
+    public synchronized boolean sessionResumed() throws SSLException {
         if (this.ssl != null) {
             try {
                 int resume = this.ssl.sessionReused();


### PR DESCRIPTION
This PR includes fixes for potential issues reported by Facebook Infer.  After these changes, Infer returns a clean report:

```
cd wolfssljni
./scripts/infer.sh
Capturing in javac mode...
Found 60 source files to analyze in wolfssljni/infer-out
947/947 [############################################################################] 100% 7.91s

  No issues found
```