### PR TITLE
JNI/JSSE: Avoid extraneous Java array allocation in WolfSSLInputStream/OutputStream if offset used

### DIFF
--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -778,6 +778,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_write
         /* get session mutex from SSL app data */
         appData = (SSLAppData*)wolfSSL_get_app_data(ssl);
         if (appData == NULL) {
+            (*jenv)->ReleaseByteArrayElements(jenv, raw, (jbyte*)data,
+                    JNI_ABORT);
             return WOLFSSL_FAILURE;
         }
 
@@ -864,6 +866,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_read(JNIEnv* jenv,
         /* get session mutex from SSL app data */
         appData = (SSLAppData*)wolfSSL_get_app_data(ssl);
         if (appData == NULL) {
+            (*jenv)->ReleaseByteArrayElements(jenv, raw, (jbyte*)data,
+                    JNI_ABORT);
             return WOLFSSL_FAILURE;
         }
 

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -753,10 +753,10 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_connect
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_write
-  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jbyteArray raw, jint length,
-   jint timeout)
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jbyteArray raw, jint offset,
+   jint length, jint timeout)
 {
-    byte* data;
+    byte* data = NULL;
     int ret = SSL_FAILURE, err, sockfd;
     wolfSSL_Mutex* jniSessLock = NULL;
     SSLAppData* appData = NULL;
@@ -767,7 +767,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_write
         return BAD_FUNC_ARG;
     }
 
-    if (length >= 0) {
+    if ((offset >= 0) && (length >= 0)) {
         data = (byte*)(*jenv)->GetByteArrayElements(jenv, raw, NULL);
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
@@ -798,7 +798,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_write
                 break;
             }
 
-            ret = wolfSSL_write(ssl, data, length);
+            ret = wolfSSL_write(ssl, data + offset, length);
             err = wolfSSL_get_error(ssl, ret);
 
             /* unlock mutex around session I/O after write attempt */
@@ -841,10 +841,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_write
     }
 }
 
-JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_read(JNIEnv* jenv,
-    jobject jcl, jlong sslPtr, jbyteArray raw, jint length, int timeout)
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_read
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jbyteArray raw, jint offset,
+   jint length, jint timeout)
 {
-    byte* data;
+    byte* data = NULL;
     int size = 0, ret, err, sockfd;
     wolfSSL_Mutex* jniSessLock = NULL;
     SSLAppData* appData = NULL;
@@ -855,7 +856,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_read(JNIEnv* jenv,
         return BAD_FUNC_ARG;
     }
 
-    if (length >= 0) {
+    if ((offset >= 0) && (length >= 0)) {
         data = (byte*)(*jenv)->GetByteArrayElements(jenv, raw, NULL);
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
@@ -885,7 +886,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_read(JNIEnv* jenv,
                 break;
             }
 
-            size = wolfSSL_read(ssl, data, length);
+            size = wolfSSL_read(ssl, data + offset, length);
             err = wolfSSL_get_error(ssl, size);
 
             /* unlock mutex around session I/O after read attempt */

--- a/native/com_wolfssl_WolfSSLSession.h
+++ b/native/com_wolfssl_WolfSSLSession.h
@@ -90,18 +90,18 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_connect
 /*
  * Class:     com_wolfssl_WolfSSLSession
  * Method:    write
- * Signature: (J[BII)I
+ * Signature: (J[BIII)I
  */
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_write
-  (JNIEnv *, jobject, jlong, jbyteArray, jint, jint);
+  (JNIEnv *, jobject, jlong, jbyteArray, jint, jint, jint);
 
 /*
  * Class:     com_wolfssl_WolfSSLSession
  * Method:    read
- * Signature: (J[BII)I
+ * Signature: (J[BIII)I
  */
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_read
-  (JNIEnv *, jobject, jlong, jbyteArray, jint, jint);
+  (JNIEnv *, jobject, jlong, jbyteArray, jint, jint, jint);
 
 /*
  * Class:     com_wolfssl_WolfSSLSession

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -2375,7 +2375,6 @@ public class WolfSSLSocket extends SSLSocket {
                    IOException {
 
             int ret = 0;
-            byte[] data = null;
 
             if (b == null) {
                 throw new NullPointerException("Input array is null");
@@ -2421,24 +2420,18 @@ public class WolfSSLSocket extends SSLSocket {
                     "Array index out of bounds");
             }
 
-            if (off != 0) {
-                /* create new tmp buffer to read data into */
-                data = new byte[len];
-            } else {
-                data = b;
-            }
-
             try {
                 int err;
 
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                     "ssl.read() socket timeout = " + socket.getSoTimeout());
 
-                ret = ssl.read(data, len, socket.getSoTimeout());
+                ret = ssl.read(b, off, len, socket.getSoTimeout());
                 err = ssl.getError(ret);
 
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "ssl.read() ret = " + ret + ", err = " + err);
+                    "ssl.read(off: " + off + ", len: " + len + ") ret = " +
+                    ret + ", err = " + err);
 
                 /* check for end of stream */
                 if ((err == WolfSSL.SSL_ERROR_ZERO_RETURN) ||
@@ -2466,11 +2459,6 @@ public class WolfSSLSocket extends SSLSocket {
 
             } catch (IllegalStateException e) {
                 throw new IOException(e);
-            }
-
-            if (off != 0) {
-                /* copy data into original array at offset */
-                System.arraycopy(data, 0, b, off, ret);
             }
 
             /* return number of bytes read */
@@ -2517,7 +2505,6 @@ public class WolfSSLSocket extends SSLSocket {
             throws IOException {
 
             int ret;
-            byte[] data = null;
 
             if (b == null) {
                 throw new NullPointerException("Input array is null");
@@ -2553,13 +2540,6 @@ public class WolfSSLSocket extends SSLSocket {
                     "Array index out of bounds");
             }
 
-            if (off != 0) {
-                data = new byte[len];
-                System.arraycopy(b, off, data, 0, len);
-            } else {
-                data = b;
-            }
-
             try {
                 int err;
 
@@ -2567,11 +2547,12 @@ public class WolfSSLSocket extends SSLSocket {
                     "ssl.write() socket timeout = " +
                     socket.getSoTimeout());
 
-                ret = ssl.write(data, len, socket.getSoTimeout());
+                ret = ssl.write(b, off, len, socket.getSoTimeout());
                 err = ssl.getError(ret);
 
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "ssl.write returned ret = " + ret + ", err = " + err);
+                    "ssl.write(off: " + off + ", len: " + len +
+                    ") returned ret = " + ret + ", err = " + err);
 
                 /* check for end of stream */
                 if (err == WolfSSL.SSL_ERROR_ZERO_RETURN) {
@@ -2602,6 +2583,5 @@ public class WolfSSLSocket extends SSLSocket {
             }
         }
     } /* end WolfSSLOutputStream inner class */
-
 }
 


### PR DESCRIPTION
This PR adjusts `WolfSSLInputStream` / `WolfSSLOutputStream` inside `WolfSSLSocket` to avoid creating an extra Java byte array if a buffer offset is used in the respective call to `read/write()`.  In doing so, the offset now gets passed down to native JNI and used as the buffer offset instead.  This should reduce Java heap usage for use cases where `read/write()` are called using offsets.

This also fixes one JNI leak in `WolfSSLSession.read/write()` in the rare case that `wolfSSL_get_app_data()` fails and returns NULL.  I don't think we have hit this case, but found via visual inspection of those functions.