### PR TITLE
Free WOLFSSL_X509 from wolfSSL_get_peer_certificate() with wolfSSL >= 5.3.0

### DIFF
--- a/examples/Client.java
+++ b/examples/Client.java
@@ -29,6 +29,7 @@ import java.nio.charset.CharacterCodingException;
 import com.wolfssl.WolfSSL;
 import com.wolfssl.WolfSSLSession;
 import com.wolfssl.WolfSSLContext;
+import com.wolfssl.WolfSSLCertificate;
 import com.wolfssl.WolfSSLException;
 import com.wolfssl.WolfSSLJNIException;
 import com.wolfssl.WolfSSLIOSendCallback;
@@ -722,11 +723,11 @@ public class Client {
 
     void showPeer(WolfSSLSession ssl) {
 
+        long peerCrtPtr = 0;
         String altname;
 
         try {
-
-            long peerCrtPtr = ssl.getPeerCertificate();
+            peerCrtPtr = ssl.getPeerCertificate();
 
             if (peerCrtPtr != 0) {
                 System.out.println("issuer : " +
@@ -743,6 +744,13 @@ public class Client {
 
         } catch (WolfSSLJNIException e) {
             e.printStackTrace();
+
+        } finally {
+            if (WolfSSL.getLibVersionHex() >= 0x05003000) {
+                if (peerCrtPtr != 0) {
+                    WolfSSLCertificate.freeX509(peerCrtPtr);
+                }
+            }
         }
     }
 

--- a/examples/Server.java
+++ b/examples/Server.java
@@ -29,6 +29,7 @@ import java.nio.charset.CharacterCodingException;
 import com.wolfssl.WolfSSL;
 import com.wolfssl.WolfSSLSession;
 import com.wolfssl.WolfSSLContext;
+import com.wolfssl.WolfSSLCertificate;
 import com.wolfssl.WolfSSLException;
 import com.wolfssl.WolfSSLJNIException;
 import com.wolfssl.WolfSSLIOSendCallback;
@@ -618,7 +619,7 @@ public class Server {
     void showPeer(WolfSSLSession ssl) {
 
         String altname;
-        long peerCrtPtr;
+        long peerCrtPtr = 0;
 
         try {
 
@@ -643,6 +644,13 @@ public class Server {
 
         } catch (WolfSSLJNIException e) {
             e.printStackTrace();
+
+        } finally {
+            if (WolfSSL.getLibVersionHex() >= 0x05003000) {
+                if (peerCrtPtr != 0) {
+                    WolfSSLCertificate.freeX509(peerCrtPtr);
+                }
+            }
         }
     }
 

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -1796,6 +1796,17 @@ public class WolfSSLSession {
      * This can be used to retrieve further information about the peer's
      * certificate (issuer, subject, alt name, etc.)
      *
+     * wolfSSL versions 5.3.0 or later return a newly-allocated
+     * WOLFSSL_X509 structure poiner from the native
+     * wolfSSL_get_peer_certificate() API called by this wrapper. If using
+     * wolfSSL greater than or equal to 5.3.0, the pointer (long) returned
+     * from this method must be freed by the caller. Versions of wolfSSL
+     * less than 5.3.0 should not free the pointer returned since it points
+     * to internal memory that is freed by native wolfSSL.
+     *
+     * Pointer should be freed by calling:
+     *     WolfSSLCertificate.freeX509(long x509);
+     *
      * @return (long) WOLFSSL_X509 pointer to the peer's certificate.
      * @throws IllegalStateException WolfSSLContext has been freed
      * @throws WolfSSLJNIException Internal JNI error

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLX509.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLX509.java
@@ -103,15 +103,19 @@ public class WolfSSLX509 extends X509Certificate {
      * Create new WolfSSLX509 object
      *
      * @param x509 initialized pointer to native WOLFSSL_X509 struct
+     * @param doFree should this WOLFSSL_X509 structure be freed when free()
+     *        is called? true to free memory, false to skip free. Free
+     *        should be skipped if caller is controlling memory for this
+     *        WOLFSSL_X509 struct pointer.
      *
      * @throws WolfSSLException if certificate parsing fails
      */
-    public WolfSSLX509(long x509) throws WolfSSLException {
+    public WolfSSLX509(long x509, boolean doFree) throws WolfSSLException {
         super();
-        this.cert = new WolfSSLCertificate(x509);
+        this.cert = new WolfSSLCertificate(x509, doFree);
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "created new WolfSSLX509(long x509)");
+            "created new WolfSSLX509(long x509, boolean doFree)");
     }
 
     @Override

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLX509X.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLX509X.java
@@ -77,15 +77,19 @@ public class WolfSSLX509X extends X509Certificate {
      * Create new WolfSSLX509X object
      *
      * @param x509 initialized pointer to native WOLFSSL_X509 struct
+     * @param doFree should this WOLFSSL_X509 structure be freed when free()
+     *        is called? true to free memory, false to skip free. Free
+     *        should be skipped if caller is controlling memory for this
+     *        WOLFSSL_X509 struct pointer.
      *
      * @throws WolfSSLException if certificate parsing fails
      */
-    public WolfSSLX509X(long x509) throws WolfSSLException {
+    public WolfSSLX509X(long x509, boolean doFree) throws WolfSSLException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "created new WolfSSLX509X(long x509)");
+            "created new WolfSSLX509X(long x509, boolean doFree)");
 
-        this.cert = new WolfSSLX509(x509);
+        this.cert = new WolfSSLX509(x509, doFree);
     }
 
     @Override


### PR DESCRIPTION
Starting with wolfSSL 5.3.0 (https://github.com/wolfSSL/wolfssl/commit/afca455cda81f1b03998b24a369373f2d6531c69), the `wolfSSL_get_peer_certificate()` API returns a new/duplicate `WOLFSSL_X509` structure that needs to be explicitly freed with `wolfSSL_X509_free()`.

Prior to wolfSSL 5.3.0, `wolfSSL_get_peer_certificate()` returned a pointer to internal memory that was freed automatically by normal native wolfSSL cleanup routines.

This shows up through some exploration with `-fsanitize=address`:

```
Indirect leak of 10 byte(s) in 1 object(s) allocated from:
    #0 0x7f5b9d305808 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cc:144
    #1 0x7f5a404785af in wolfSSL_Malloc wolfcrypt/src/memory.c:352
    #2 0x7f5a405296b0 in CopyDecodedToX509 src/internal.c:12942
    #3 0x7f5a4066f818 in d2i_X509orX509REQ src/x509.c:3618
    #4 0x7f5a4066f9f5 in wolfSSL_X509_d2i_ex src/x509.c:3653
    #5 0x7f5a40690c0b in wolfSSL_X509_dup src/x509.c:13671
    #6 0x7f5a4063ccff in wolfSSL_get_peer_certificate src/ssl.c:13255
    #7 0x7f5a4085f20f in Java_com_wolfssl_WolfSSLSession_getPeerCertificate (wolfssljni/lib/libwolfssljni.so+0x2620f)
    #8 0x7f5b8972ffa6  (<unknown module>)
```