### PR TITLE
Optimization pass for better garbage collection

### DIFF
--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -1165,6 +1165,8 @@ public class WolfSSLSession {
                 /* free Java resources */
                 this.active = false;
                 this.sslPtr = 0;
+                this.clientSNIRequested = null;
+                this.ctx = null;
             }
         }
     }

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
@@ -1390,6 +1390,13 @@ public class WolfSSLEngineHelper {
         return WolfSSL.SSL_FAILURE;
     }
 
+    protected synchronized void clearObjectState() {
+        this.ssl = null;
+        this.session = null;
+        this.params = null;
+        this.authStore = null;
+    }
+
     @SuppressWarnings("deprecation")
     @Override
     protected synchronized void finalize() throws Throwable {

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLInternalVerifyCb.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLInternalVerifyCb.java
@@ -359,15 +359,5 @@ public class WolfSSLInternalVerifyCb implements WolfSSLVerifyCallback {
         /* Continue handshake, verification succeeded */
         return 1;
     }
-
-    @SuppressWarnings("deprecation")
-    @Override
-    protected void finalize() throws Throwable {
-        this.callingSocket = null;
-        this.callingEngine = null;
-        this.tm = null;
-        this.params = null;
-        super.finalize();
-    }
 }
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLServerSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLServerSocket.java
@@ -375,5 +375,13 @@ public class WolfSSLServerSocket extends SSLServerSocket {
 
         return socket;
     }
+
+    @Override
+    public synchronized void close() throws IOException {
+        if (this.socket != null) {
+            this.socket.close();
+        }
+        super.close();
+    }
 }
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -1909,6 +1909,10 @@ public class WolfSSLSocket extends SSLSocket {
                             this.ssl.freeSSL();
                             this.ssl = null;
 
+                            /* Reset internal WolfSSLEngineHelper to null */
+                            this.EngineHelper.clearObjectState();
+                            this.EngineHelper = null;
+
                             /* Release Input/OutputStream objects */
                             if (this.inStream != null) {
                                 this.inStream.close();
@@ -2080,6 +2084,8 @@ public class WolfSSLSocket extends SSLSocket {
             }
             this.ssl.freeSSL();
             this.ssl = null;
+            this.EngineHelper = null;
+            this.params = null;
         }
         super.finalize();
     }

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -1890,6 +1890,9 @@ public class WolfSSLSocket extends SSLSocket {
 
                             this.connectionClosed = true;
 
+                            /* Release native verify callback (JNI global) */
+                            this.EngineHelper.unsetVerifyCallback();
+
                             /* Connection is closed, free native WOLFSSL session
                              * to release native memory earlier than garbage
                              * collector might with finalize(). */
@@ -1905,6 +1908,17 @@ public class WolfSSLSocket extends SSLSocket {
                                 "calling this.ssl.freeSSL()");
                             this.ssl.freeSSL();
                             this.ssl = null;
+
+                            /* Release Input/OutputStream objects */
+                            if (this.inStream != null) {
+                                this.inStream.close();
+                                this.inStream = null;
+                            }
+                            if (this.outStream != null) {
+                                this.outStream.close();
+                                this.outStream = null;
+                            }
+
                         } /* handshakeLock */
 
                         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
@@ -2326,13 +2340,20 @@ public class WolfSSLSocket extends SSLSocket {
 
         private WolfSSLSession ssl;
         private WolfSSLSocket  socket;
+        private boolean isClosed = true;
 
         public WolfSSLInputStream(WolfSSLSession ssl, WolfSSLSocket socket) {
             this.ssl = ssl;
             this.socket = socket; /* parent socket */
+            this.isClosed = false;
         }
 
         public synchronized void close() throws IOException {
+
+            if (this.socket == null || this.isClosed) {
+                return;
+            }
+
             if (this.socket.isClosed()) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                     "socket (input) already closed");
@@ -2342,6 +2363,10 @@ public class WolfSSLSocket extends SSLSocket {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                             "socket (input) closed: " + this.socket);
             }
+
+            this.socket = null;
+            this.ssl = null;
+            this.isClosed = true;
 
             return;
         }
@@ -2381,7 +2406,7 @@ public class WolfSSLSocket extends SSLSocket {
             }
 
             /* check if socket is closed */
-            if (socket.isClosed()) {
+            if (this.isClosed || socket == null || socket.isClosed()) {
                 throw new SocketException("Socket is closed");
             }
 
@@ -2470,13 +2495,20 @@ public class WolfSSLSocket extends SSLSocket {
 
         private WolfSSLSession ssl;
         private WolfSSLSocket  socket;
+        private boolean isClosed = true;
 
         public WolfSSLOutputStream(WolfSSLSession ssl, WolfSSLSocket socket) {
             this.ssl = ssl;
             this.socket = socket; /* parent socket */
+            this.isClosed = false;
         }
 
         public synchronized void close() throws IOException {
+
+            if (this.socket == null || this.isClosed) {
+                return;
+            }
+
             if (this.socket.isClosed()) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                     "socket (output) already closed");
@@ -2486,6 +2518,10 @@ public class WolfSSLSocket extends SSLSocket {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                             "socket (output) closed: " + this.socket);
             }
+
+            this.socket = null;
+            this.ssl = null;
+            this.isClosed = true;
 
             return;
         }
@@ -2508,6 +2544,10 @@ public class WolfSSLSocket extends SSLSocket {
 
             if (b == null) {
                 throw new NullPointerException("Input array is null");
+            }
+
+            if (this.socket == null || this.isClosed) {
+                throw new SocketException("Socket is closed");
             }
 
             /* check if connection has already been closed/shutdown */


### PR DESCRIPTION
This PR tries to do some optimization for better garbage collection, based on testing with VisuaVM.

- Close `WolfSSLInputStream/WolfSSLOutputStream` when `SSLSocket.close()` is called. This releases the internal references to `WolfSSLSession` and `WolfSSLSocket` to allow easier garbage collection of these Input/OutputStream objects.
- Release/reset `WolfSSLEngineHelper` state when `WolfSSLSocket.close()` is called, removing internal object references and allowing easier garbage collection.
- Set `clientSNIRequested` and `ctx` to null inside `WolfSSLSession` when `freeSSL()` is called, potentially reducing the size of `WolfSSLSession` objects in memory until they are garbage collected.
- Remove finalizer method from `WolfSSLInternalVerifyCb` class. This is not needed and slows down garbage collection, since objects with finalizers are put in a different queue.
- Add `close()` to `WolfSSLServerSocket` which will close the underlying `WolfSSLSocket` if called and free up resources earlier than at garbage collection time.

This PR also refactors `WolfSSLSession.useALPN()` at the JNI level to better guarantee ALPN list is null terminated.