### PR TITLE
Correct example TLS 1.3 secret callback

### DIFF
--- a/examples/MyTls13SecretCallback.java
+++ b/examples/MyTls13SecretCallback.java
@@ -108,9 +108,9 @@ class MyTls13SecretCallback implements WolfSSLTls13SecretCallback
             } else if (id == WolfSSL.SERVER_HANDSHAKE_TRAFFIC_SECRET) {
                 str = "SERVER_HANDSHAKE_TRAFFIC_SECRET";
             } else if (id == WolfSSL.CLIENT_TRAFFIC_SECRET) {
-                str = "CLIENT_TRAFFIC_SECRET";
+                str = "CLIENT_TRAFFIC_SECRET_0";
             } else if (id == WolfSSL.SERVER_TRAFFIC_SECRET) {
-                str = "SERVER_TRAFFIC_SECRET";
+                str = "SERVER_TRAFFIC_SECRET_0";
             } else if (id == WolfSSL.EXPORTER_SECRET) {
                 str = "EXPORTER_SECRET";
             } else {


### PR DESCRIPTION
This PR corrects the example TLS 1.3 secret callback (`examples/MyTls13SecretCallback.java`) strings for `CLIENT_TRAFFIC_SECRET` and `SERVER_TRAFFIC_SECRET` to include the `_0`.

This example and support were originally added with https://github.com/wolfSSL/wolfssljni/pull/181.

ZD 17211