### PR TITLE
SSLEngine fixes for session cache, getError(), and unwrap() HandshakeStatus

### DIFF
--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -4945,6 +4945,27 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useSupportedCurve
 #endif
 }
 
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_hasTicket
+  (JNIEnv* jenv, jobject jcl, jlong sessionPtr)
+{
+#if !defined(NO_SESSION_CACHE) && \
+    (defined(OPENSSL_EXTRA) || defined(HAVE_EXT_CACHE))
+    WOLFSSL_SESSION* session = (WOLFSSL_SESSION*)(uintptr_t)sessionPtr;
+    (void)jcl;
+
+    if (jenv == NULL || session == NULL) {
+        return WOLFSSL_FAILURE;
+    }
+
+    return (jint)wolfSSL_SESSION_has_ticket((const WOLFSSL_SESSION*)session);
+#else
+    (void)jenv;
+    (void)jcl;
+    (void)sessionPtr;
+    return (jint)WolfSSL.SSL_FAILURE;
+#endif
+}
+
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setSSLIORecv
     (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {

--- a/native/com_wolfssl_WolfSSLSession.h
+++ b/native/com_wolfssl_WolfSSLSession.h
@@ -839,6 +839,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_set1SigAlgsList
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useSupportedCurve
   (JNIEnv *, jobject, jlong, jint);
 
+/*
+ * Class:     com_wolfssl_WolfSSLSession
+ * Method:    hasTicket
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_hasTicket
+  (JNIEnv *, jobject, jlong);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -352,6 +352,7 @@ public class WolfSSLSession {
     private native int rehandshake(long ssl);
     private native int set1SigAlgsList(long ssl, String list);
     private native int useSupportedCurve(long ssl, int name);
+    private native int hasTicket(long session);
 
     /* ------------------- session-specific methods --------------------- */
 
@@ -1426,6 +1427,31 @@ public class WolfSSLSession {
             } else {
                 return new byte[0];
             }
+        }
+    }
+
+    /**
+     * Check if there is a session ticket associated with this
+     * WolfSSLSession (WOLFSSL_SESSION).
+     *
+     * @return true if internal session has session ticket, otherwise false
+     * @throws IllegalStateException WolfSSLContext has been freed
+     */
+    public boolean hasSessionTicket() throws IllegalStateException {
+
+        boolean hasTicket = false;
+
+        confirmObjectIsActive();
+
+        synchronized (sslLock) {
+            long sess = getSession(this.sslPtr);
+            if (sess != 0) {
+                if (hasTicket(sess) == WolfSSL.SSL_SUCCESS) {
+                    hasTicket = true;
+                }
+            }
+
+            return hasTicket;
         }
     }
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
@@ -965,7 +965,7 @@ public class WolfSSLEngine extends SSLEngine {
             hs = SSLEngineResult.HandshakeStatus.NEED_WRAP;
         }
         else if (hs == SSLEngineResult.HandshakeStatus.NEED_WRAP &&
-                 this.toSend.length > 0) {
+                 (this.toSend != null) && (this.toSend.length > 0)) {
             /* Already have data buffered to send and in NEED_WRAP state,
              * just return so wrap() can be called */
             hs = SSLEngineResult.HandshakeStatus.NEED_WRAP;

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
@@ -345,6 +345,7 @@ public class WolfSSLEngine extends SSLEngine {
     /**
      * Handles logic during shutdown
      *
+     * @return WolfSSL.SSL_SUCCESS on success, zero or negative on error
      * @throws SocketException if ssl.shutdownSSL() encounters a socket error
      */
     private synchronized int ClosingConnection() throws SocketException {
@@ -374,11 +375,11 @@ public class WolfSSLEngine extends SSLEngine {
         synchronized (ioLock) {
             ret = ssl.shutdownSSL();
             if (ssl.getError(ret) == WolfSSL.SSL_ERROR_ZERO_RETURN) {
-                /* got close_notify alert, reset ret to 0 to continue
+                /* got close_notify alert, reset ret to SSL_SUCCESS to continue
                  * and let corresponding close_notify to be sent */
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                     "ClosingConnection(), ssl.getError() is ZERO_RETURN");
-                ret = 0;
+                ret = WolfSSL.SSL_SUCCESS;
             }
         }
         UpdateCloseNotifyStatus();

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
@@ -316,6 +316,9 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
      * Invalidate this session
      */
     public synchronized void invalidate() {
+        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+            "SSLSession.invalidate() called, invalidating session");
+
         this.valid = false;
     }
 

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
@@ -1813,7 +1813,7 @@ public class WolfSSLSocketTest {
         protocolConnectionTest("TLSv1");
 
         System.out.print("\tTLS 1.0 extended Socket test");
-        protocolConnectionTestExtendedSocket("TLSv1.0");
+        protocolConnectionTestExtendedSocket("TLSv1");
     }
 
     @Test


### PR DESCRIPTION
This PR includes the following fixes to `SSLEngine`:

- Only save the client session (`WOLFSSL_SESSION`) to the cache if the handshake has finished successfully and there is no outstanding error from `wolfSSL_get_error() / getError()`.  This may prevent subsequent session resumption attempts trying to load/use a session that was in an error state.
- Synchronize calls to `wolfSSL_get_error() / getError()` with `ioLock` in case `WOLFSSL` state is changing. We want to prevent getting an error until activity is done/paused on the session.

This PR also fixes some issues found while testing wolfJSSE against the SunJSSE `SSLEngine` tests, including:

- Correctly return `SSL_SUCCESS` from `WolfSSLEngine.ClosingConnection()` when `ZERO_RETURN` is received
- Correctly return `HandshakeStatus.FINISHED` from `SSLEngine.unwrap()` when a client has received a TLS 1.3 session ticket from the peer.  This necessitated also wrapping the native wolfSSL API `wolfSSL_SESSION_has_ticket()`.

ZD 17962