### PR TITLE
fix read() in WolfSSLInputStream to reflect end of stream

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -2380,10 +2380,11 @@ public class WolfSSLSocket extends SSLSocket {
         @Override
         public synchronized int read() throws IOException {
 
+            int ret;
             byte[] data = new byte[1];
 
             try {
-                int ret = this.read(data, 0, 1);
+                ret = this.read(data, 0, 1);
 
                 /* check for end of stream and other errors */
                 if (ret < 0) {

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -2383,7 +2383,12 @@ public class WolfSSLSocket extends SSLSocket {
             byte[] data = new byte[1];
 
             try {
-                this.read(data, 0, 1);
+                int ret = this.read(data, 0, 1);
+
+                /* check for end of stream and other errors */
+                if (ret < 0) {
+                    return ret;
+                }
 
             } catch (NullPointerException ne) {
                 throw new IOException(ne);


### PR DESCRIPTION
Calling the read() method (with no parameters) on a WolfSSLInputStream will now reflect the end of a stream in the return value. If the end of the stream has been reached, -1 should be returned instead of a byte (as noted here: https://docs.oracle.com/javase/8/docs/api/java/io/InputStream.html#read-- ). 