### PR TITLE
KeyManagerFactory and TrustManagerFactory throw exceptions if used when uninitialized

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLKeyManager.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLKeyManager.java
@@ -42,6 +42,7 @@ import javax.net.ssl.ManagerFactoryParameters;
 public class WolfSSLKeyManager extends KeyManagerFactorySpi {
     private char[] pswd;
     private KeyStore store;
+    private boolean initialized = false;
 
     /** Default WolfSSLKeyManager constructor */
     public WolfSSLKeyManager() { }
@@ -136,6 +137,7 @@ public class WolfSSLKeyManager extends KeyManagerFactorySpi {
             }
         }
         this.store = certs;
+        this.initialized = true;
     }
 
     @Override
@@ -151,10 +153,16 @@ public class WolfSSLKeyManager extends KeyManagerFactorySpi {
     }
 
     @Override
-    protected KeyManager[] engineGetKeyManagers() {
+    protected KeyManager[] engineGetKeyManagers()
+        throws IllegalStateException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered engineGetKeyManagers()");
+
+        if (!this.initialized) {
+            throw new IllegalStateException("KeyManagerFactory must be " +
+                    "initialized before use, please call init()");
+        }
 
         KeyManager[] km = {new WolfSSLKeyX509(this.store, this.pswd)};
         return km;

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLTrustManager.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLTrustManager.java
@@ -49,6 +49,7 @@ import com.wolfssl.WolfSSLJNIException;
  */
 public class WolfSSLTrustManager extends TrustManagerFactorySpi {
     private KeyStore store;
+    private boolean initialized = false;
 
     /** Default WolfSSLTrustManager constructor */
     public WolfSSLTrustManager() { }
@@ -352,6 +353,7 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
             }
         }
         this.store = certs;
+        this.initialized = true;
     }
 
     @Override
@@ -367,10 +369,17 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
     }
 
     @Override
-    protected TrustManager[] engineGetTrustManagers() {
+    protected TrustManager[] engineGetTrustManagers()
+        throws IllegalStateException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered engineGetTrustManagers()");
+
+        if (!this.initialized) {
+            throw new IllegalStateException("TrustManagerFactory must be " +
+                    "initialized before use, please call init()");
+        }
+
 
         /* array of WolfSSLX509Trust objects to use */
         TrustManager[] tm = {new WolfSSLTrustX509(this.store)};

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLTrustX509Test.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLTrustX509Test.java
@@ -178,8 +178,8 @@ public class WolfSSLTrustX509Test {
         throws NoSuchProviderException, NoSuchAlgorithmException {
         TrustManagerFactory tmf;
         TrustManager[] tm;
-        X509TrustManager x509tm;
-        X509Certificate cas[];
+        KeyManagerFactory kmf;
+        KeyManager[] km;
 
         System.out.print("\tTesting use before init()");
 
@@ -196,24 +196,27 @@ public class WolfSSLTrustX509Test {
             return;
         }
 
-        tm = tmf.getTrustManagers();
-        if (tm == null) {
+        try {
+            tm = tmf.getTrustManagers();
             error("\t... failed");
-            fail("failed to get instance of trustmanager");
+            fail("getTrustManagers() before init() did not throw an error");
+        } catch (IllegalStateException e) {
+            /* Expected, TrustManagerFactory not yet initialized */
+        }
+
+        kmf = KeyManagerFactory.getInstance("SunX509", provider);
+        if (kmf == null) {
+            error("\t... failed");
+            fail("failed to get instance of keymanager factory");
             return;
         }
 
-        x509tm = (X509TrustManager) tm[0];
-        cas = x509tm.getAcceptedIssuers();
-        if (cas == null) {
+        try {
+            km = kmf.getKeyManagers();
             error("\t... failed");
-            fail("get accepted issuers returned null");
-            return;
-        }
-
-        if (cas.length != 0) {
-            error("\t... failed");
-            fail("cas should be empty");
+            fail("getKeyManagers() before init() did not throw an error");
+        } catch (IllegalStateException e) {
+            /* Expected, KeyManagerFactory not yet initialized */
         }
 
         pass("\t... passed");


### PR DESCRIPTION
Both KeyManagerFactory and TrustManagerFactory will throw IllegalStateExceptions if they are used without being initialized. This includes calling getKeyManagers() on an uninitialized KeyManagerFactory and calling getTrustManagers() on an uninitialized TrustManagerFactory. The updated behavior aligns with what is described in the javadocs:
https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/TrustManagerFactory.html#getTrustManagers--
https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/KeyManagerFactory.html#getKeyManagers--