### PR TITLE
SSLEngine fixes around HandshakeStatus, beginHandshake(), and alerts

### DIFF
--- a/native/com_wolfssl_WolfSSL.h
+++ b/native/com_wolfssl_WolfSSL.h
@@ -79,6 +79,8 @@ extern "C" {
 #define com_wolfssl_WolfSSL_SSL_ERROR_ZERO_RETURN 6L
 #undef com_wolfssl_WolfSSL_SSL_ERROR_SSL
 #define com_wolfssl_WolfSSL_SSL_ERROR_SSL 85L
+#undef com_wolfssl_WolfSSL_FATAL_ERROR
+#define com_wolfssl_WolfSSL_FATAL_ERROR -313L
 #undef com_wolfssl_WolfSSL_SSL_ERROR_SOCKET_PEER_CLOSED
 #define com_wolfssl_WolfSSL_SSL_ERROR_SOCKET_PEER_CLOSED -397L
 #undef com_wolfssl_WolfSSL_UNKNOWN_ALPN_PROTOCOL_NAME_E

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -1465,6 +1465,29 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_wolfsslSessionIsSetup
 #endif
 }
 
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_wolfsslSessionIsResumable
+  (JNIEnv* jenv, jclass jcl, jlong sessionPtr)
+{
+#ifdef OPENSSL_EXTRA
+    int ret;
+    WOLFSSL_SESSION* session = (WOLFSSL_SESSION*)(uintptr_t)sessionPtr;
+    (void)jcl;
+
+    if (jenv == NULL) {
+        return 0;
+    }
+
+    ret = wolfSSL_SESSION_is_resumable(session);
+
+    return (jint)ret;
+#else
+    (void)jenv;
+    (void)jcl;
+    (void)sessionPtr;
+    return (jint)NOT_COMPILED_IN;
+#endif
+}
+
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_freeNativeSession
   (JNIEnv* jenv, jclass jcl, jlong sessionPtr)
 {

--- a/native/com_wolfssl_WolfSSLSession.h
+++ b/native/com_wolfssl_WolfSSLSession.h
@@ -169,6 +169,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_wolfsslSessionIsSetup
 
 /*
  * Class:     com_wolfssl_WolfSSLSession
+ * Method:    wolfsslSessionIsResumable
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_wolfsslSessionIsResumable
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_wolfssl_WolfSSLSession
  * Method:    freeNativeSession
  * Signature: (J)V
  */

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -172,6 +172,8 @@ public class WolfSSL {
     public static final int SSL_ERROR_ZERO_RETURN      =  6;
     /** Generatl SSL error */
     public static final int SSL_ERROR_SSL              = 85;
+    /** Received fatal alert error */
+    public static final int FATAL_ERROR                = -313;
     /** Peer closed socket */
     public static final int SSL_ERROR_SOCKET_PEER_CLOSED = -397;
     /** Unrecognized ALPN protocol name */

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -263,6 +263,7 @@ public class WolfSSLSession {
     private native long getSession(long ssl);
     private native long get1Session(long ssl);
     private static native int wolfsslSessionIsSetup(long ssl);
+    private static native int wolfsslSessionIsResumable(long ssl);
     private static native void freeNativeSession(long session);
     private native byte[] getSessionID(long session);
     private native int setServerID(long ssl, byte[] id, int len, int newSess);
@@ -1390,6 +1391,30 @@ public class WolfSSLSession {
         }
 
         return wolfsslSessionIsSetup(session);
+    }
+
+    /**
+     * Check if native WOLFSSL_SESSION is resumable, calling native
+     * wolfSSL_SESSION_is_resumable().
+     *
+     * This method is static and does not check active state since this
+     * takes a native pointer and has no interaction with the rest of this
+     * object.
+     *
+     * @param session pointer to native WOLFSSL_SESSION structure. May be
+     *        obtained from getSession().
+     *
+     * @return 1 if session is resumable, otherwise 0. Returns
+     * WolfSSL.NOT_COMPILED_IN if native wolfSSL does not have
+     * wolfSSL_SESSION_is_resumable() compiled in.
+     */
+    public static int sessionIsResumable(long session) {
+
+        if (session == 0) {
+            return 0;
+        }
+
+        return wolfsslSessionIsResumable(session);
     }
 
     /**

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
@@ -1096,13 +1096,17 @@ public class WolfSSLEngine extends SSLEngine {
             SetHandshakeStatus(ret);
         }
 
-        /* If client side and we have just received a TLS 1.3 session ticket,
-         * we should return FINISHED HandshakeStatus from unwrap() directly
-         * but not from getHandshakeStatus(). Keep track of if we have
-         * received ticket, so we only set/return this once */
+        /* If client side, handshake is done, and we have just received a
+         * TLS 1.3 session ticket, we should return FINISHED HandshakeStatus
+         * from unwrap() directly but not from getHandshakeStatus(). Keep track
+         * of if we have received ticket, so we only set/return this once */
         synchronized (ioLock) {
-            if (this.getUseClientMode() && this.ssl.hasSessionTicket() &&
+            if (this.getUseClientMode() && this.handshakeFinished &&
+                this.ssl.hasSessionTicket() &&
                 this.sessionTicketReceived == false) {
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    "received session ticket, returning " +
+                    "HandshakeStatus FINISHED");
                 hs = SSLEngineResult.HandshakeStatus.FINISHED;
                 this.sessionTicketReceived = true;
             }

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
@@ -341,6 +341,24 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
     }
 
     /**
+     * Check if this session is resumable.
+     *
+     * Calls down to native wolfSSL_SESSION_is_resumable() with
+     * WOLFSSL_SESSION pointer.
+     *
+     * @return true if resumable, otherwise false
+     */
+    protected synchronized boolean isResumable() {
+        synchronized (sesPtrLock) {
+            if (WolfSSLSession.sessionIsResumable(this.sesPtr) == 1) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+    }
+
+    /**
      * Return status of internal session pointer (WOLFSSL_SESSION).
      * @return true if this.sesPtr is set, otherwise false if 0 */
     protected boolean sessionPointerSet() {

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineTest.java
@@ -300,7 +300,8 @@ public class WolfSSLEngineTest {
 
     @Test
     public void testBeginHandshake()
-        throws NoSuchProviderException, NoSuchAlgorithmException {
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               SSLException {
         SSLEngine server;
         SSLEngine client;
         int ret;
@@ -312,6 +313,26 @@ public class WolfSSLEngineTest {
         server = this.ctx.createSSLEngine();
         client = this.ctx.createSSLEngine("wolfSSL begin handshake test", 11111);
 
+        /* Calling beginHandshake() before setUseClientMode() should throw
+         * IllegalStateException */
+        try {
+            server.beginHandshake();
+            error("\t\t... failed");
+            fail("beginHandshake() before setUseClientMode() should throw " +
+                 "IllegalStateException");
+        } catch (IllegalStateException e) {
+            /* expected */
+        }
+        try {
+            client.beginHandshake();
+            error("\t\t... failed");
+            fail("beginHandshake() before setUseClientMode() should throw " +
+                 "IllegalStateException");
+        } catch (IllegalStateException e) {
+            /* expected */
+        }
+
+        /* Set client/server mode, disable auth to simplify tests below */
         server.setUseClientMode(false);
         server.setNeedClientAuth(false);
         client.setUseClientMode(true);
@@ -329,6 +350,24 @@ public class WolfSSLEngineTest {
             error("\t\t... failed");
             fail("failed to create engine");
         }
+
+        /* Calling beginHandshake() again should throw SSLException
+         * since renegotiation is not yet supported in wolfJSSE */
+        try {
+            server.beginHandshake();
+            error("\t\t... failed");
+            fail("beginHandshake() called again should throw SSLException");
+        } catch (SSLException e) {
+            /* expected */
+        }
+        try {
+            client.beginHandshake();
+            error("\t\t... failed");
+            fail("beginHandshake() called again should throw SSLException");
+        } catch (SSLException e) {
+            /* expected */
+        }
+
         pass("\t\t... passed");
     }
 


### PR DESCRIPTION
This PR includes a few various fixes for `SSLEngine` including:

- Only set `HandshakeStatus.FINISHED` for session tickets being received **after** the handshake has completed. Otherwise this may put callers into an odd state when the handshake has not finished yet.
- Calling `beginHandshake()` more than once can be done to instigate renegotiation. Since wolfJSSE SSLEngine implementation does not support renegotiation yet, we throw a `SSLException` to make it clear to callers that is the case. This matches behavior of some other providers that do not support renegotiation.
- Correctly mark inbound and outbound `closed` when we receive fatal alerts on the client or server sides. This fix was made after running the SunJSSE `EngineCloseOnAlert` test against wolfJSSE.

This PR includes one change to the session resumption cache:

- Only store (or return) sessions to/from the Java client cache if the native `WOLFSSL_SESSION` is resumable. This wraps the native API `wolfSSL_SESSION_is_resumable()` in `WolfSSLSession.sessionIsResumable()` and uses that to check. This will ensure we don't try to store or resume a session that native wolfSSL does not consider resumable.