### PR TITLE
Return X509Certificate[] from SSLSession.getPeerCertificates()

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
@@ -75,7 +75,7 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
      * SSLSocket.getSession().getPeerCertificates() will return the peer
      * certificate even on a resumed connection where the cert has not been
      * sent during the handshake. */
-    private Certificate[] peerCerts = null;
+    private X509Certificate[] peerCerts = null;
 
     /**
      * Is this object currently inside the WolfSSLAuthStore session cache table?
@@ -456,7 +456,8 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
      * ssl.getPeerCertificate() fails, then we return the cached cert if
      * we have it.
      *
-     * @return Certificate array of peer certs for session
+     * @return Certificate array of peer certs for session. Actual subclass
+     *         type returned is X509Certificate[] to match SunJSSE behavior
      *
      * @throws SSLPeerUnverifiedException if handshake is not complete,
      *         or error getting certificates
@@ -546,7 +547,7 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
         cert.free();
 
         /* cache peer cert for use by app in resumed session */
-        this.peerCerts = new Certificate[] { exportCert };
+        this.peerCerts = new X509Certificate[] { exportCert };
 
         return this.peerCerts.clone();
     }

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSessionTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSessionTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
 import java.security.NoSuchProviderException;
 import java.security.Principal;
 import java.security.Provider;
@@ -275,6 +276,18 @@ public class WolfSSLSessionTest {
                 if (!certs[0].getType().equals("X.509")) {
                     error("\t\t... failed");
                     fail("unexpected cert type found");
+                }
+
+                /* Check that Certificate[] returned from getPeerCertificates()
+                 * is actually of subclass type X509Certificate[]. If not and
+                 * we try to cast back to it, we should get a
+                 * ClassCastException */
+                try {
+                    X509Certificate[] xCerts = (X509Certificate[])certs;
+                } catch (ClassCastException e) {
+                    error("\t\t... failed");
+                    fail("getPeerCertificates() did not return array of type " +
+                         "X509Certificate[]");
                 }
             }
         } catch (SSLPeerUnverifiedException e) {


### PR DESCRIPTION
This PR adjusts `SSLSession.getPeerCertificates()` to return an array of type`X509Certificate` rather than `Certificate`. Previously wolfJSSE created individual array elements as `java.security.cert.X509Certificate` objects, but returned them as a `java.security.cert.Certificate[]` to conform to the Javadoc specification for `SSLSession.getPeerCertificates()`:

```
Certificate[] getPeerCertificates() throws SSLPeerUnverifiedException
```

Some callers of this API (for example Postgres) tries to cast this return back to an array of `X509Certificate[]`, such as:

```
SSLSession session;
X509Certificate[] peerCerts;
...
peerCerts = (X509Certificate[]) session.getPeerCertificates();
```

This cast will throw an Exception similar to:

```
java.lang.ClassCastException: class [Ljava.security.cert.Certificate; cannot be cast to class [Ljava.security.cert.X509Certificate;
```

This PR adjusts `WolfSSLImplementSSLSession.getPeerCertificates()` to return a `X509Certificate[]` from the body of the method, to match SunJSSE behavior.  Since `X509Certificate` is a subclass of `Certificate`, this should not break calling applications.  Method signature is left intact as returning a `Certificate[]`, so we still conform to SSLSession definition in general.