### PR TITLE
Delete close method in WolfSSLServerSocket

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLServerSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLServerSocket.java
@@ -374,10 +374,5 @@ public class WolfSSLServerSocket extends SSLServerSocket {
 
         return socket;
     }
-
-    @Override
-    public synchronized void close() throws IOException {
-        super.close();
-    }
 }
 


### PR DESCRIPTION
The close() method currently causes some synchronization issues. The close() method just calls super.close() which is called anyways so deleting will just prevent those synchronization issues.