### PR TITLE
JNI/JSSE: Add support for poll(), fix for EAGAIN and select()

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,24 @@ $ ./configure --enable-secure-renegotiation
 
 Or by defining `-DHAVE_SECURE_RENEGOTIATION`.
 
+### Native File Descriptor Events
+
+wolfSSL JNI/JSSE internally makes several calls that operate on native
+file descriptors inside Java Socket objects. These native file descriptors
+are watched for read and write events with either `select()` or `poll()`.
+
+By default `poll()` will be used, unless `WOLFJNI_USE_IO_SELECT` is defined
+or added to CFLAGS when compiling the native JNI sources (see `java.sh`).
+Windows builds will also default to using `select()` since `poll()` is not
+available there.
+
+wolfSSL JNI/JSSE does not select/poll on a large number of file descriptors
+(typically just one). Although if used in applications that make lots of
+connections, when using `select()` the `FD_ISSET` and other related macros
+result in undefined behavior when the file descriptor number is larger than
+`FD_SETSIZE` (defaults to 1024 on most systems). For this reason, `poll()` is
+used as the default descriptor monitoring function.
+
 ## Release Notes
 
 Release notes can be found in [ChangeLog.md](./ChangeLog.md).

--- a/native/com_wolfssl_WolfSSL.h
+++ b/native/com_wolfssl_WolfSSL.h
@@ -9,8 +9,18 @@ extern "C" {
 #endif
 #undef com_wolfssl_WolfSSL_JNI_SESSION_UNAVAILABLE
 #define com_wolfssl_WolfSSL_JNI_SESSION_UNAVAILABLE -10001L
-#undef com_wolfssl_WolfSSL_WOLFJNI_TIMEOUT
-#define com_wolfssl_WolfSSL_WOLFJNI_TIMEOUT -11L
+#undef com_wolfssl_WolfSSL_WOLFJNI_IO_EVENT_FAIL
+#define com_wolfssl_WolfSSL_WOLFJNI_IO_EVENT_FAIL -10L
+#undef com_wolfssl_WolfSSL_WOLFJNI_IO_EVENT_TIMEOUT
+#define com_wolfssl_WolfSSL_WOLFJNI_IO_EVENT_TIMEOUT -11L
+#undef com_wolfssl_WolfSSL_WOLFJNI_IO_EVENT_ERROR
+#define com_wolfssl_WolfSSL_WOLFJNI_IO_EVENT_ERROR -14L
+#undef com_wolfssl_WolfSSL_WOLFJNI_IO_EVENT_FD_CLOSED
+#define com_wolfssl_WolfSSL_WOLFJNI_IO_EVENT_FD_CLOSED -15L
+#undef com_wolfssl_WolfSSL_WOLFJNI_IO_EVENT_POLLHUP
+#define com_wolfssl_WolfSSL_WOLFJNI_IO_EVENT_POLLHUP -16L
+#undef com_wolfssl_WolfSSL_WOLFJNI_IO_EVENT_INVALID_TIMEOUT
+#define com_wolfssl_WolfSSL_WOLFJNI_IO_EVENT_INVALID_TIMEOUT -17L
 #undef com_wolfssl_WolfSSL_SSL_ERROR_NONE
 #define com_wolfssl_WolfSSL_SSL_ERROR_NONE 0L
 #undef com_wolfssl_WolfSSL_SSL_FAILURE

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -662,7 +662,7 @@ static int socketSelect(int sockfd, int timeout_ms, int rx)
         }
 
 #ifndef USE_WINDOWS_API
-    } while ((result == -1) && (errno == EINTR));
+    } while ((result == -1) && ((errno == EINTR) || (errno == EAGAIN)));
 #endif
 
     /* Return on error, unless select() was interrupted, try again above */

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -33,6 +33,11 @@
     #include <arpa/inet.h>
     #include <sys/errno.h>
 #endif
+#ifdef WOLFJNI_USE_IO_SELECT
+    #include <sys/select.h>
+#else
+    #include <poll.h>
+#endif
 
 #ifndef WOLFSSL_JNI_DEFAULT_PEEK_TIMEOUT
     /* Default wolfSSL_peek() timeout for wolfSSL_get_session(), ms */
@@ -185,9 +190,6 @@ int NativeSSLVerifyCallback(int preverify_ok, WOLFSSL_X509_STORE_CTX* store)
 
     return retval;
 }
-
-
-/* jni functions */
 
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_newSSL
   (JNIEnv* jenv, jobject jcl, jlong ctx)
@@ -599,22 +601,50 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getFd
     return wolfSSL_get_fd(ssl);
 }
 
-/* enum values used in socketSelect() */
+/* enum values used in socketSelect() and socketPoll(). Some of these
+ * values are also duplicated in WolfSSL.java for access from Java classes.
+ * If updated here, make sure to update in WolfSSL.java too. */
 enum {
-    WOLFJNI_SELECT_FAIL = -10,
-    WOLFJNI_TIMEOUT     = -11,  /* also in WolfSSL.java */
-    WOLFJNI_RECV_READY  = -12,
-    WOLFJNI_SEND_READY  = -13,
-    WOLFJNI_ERROR_READY = -14
+    WOLFJNI_IO_EVENT_FAIL            = -10,
+    WOLFJNI_IO_EVENT_TIMEOUT         = -11,
+    WOLFJNI_IO_EVENT_RECV_READY      = -12,
+    WOLFJNI_IO_EVENT_SEND_READY      = -13,
+    WOLFJNI_IO_EVENT_ERROR           = -14,
+    WOLFJNI_IO_EVENT_FD_CLOSED       = -15,
+    WOLFJNI_IO_EVENT_POLLHUP         = -16,
+    WOLFJNI_IO_EVENT_INVALID_TIMEOUT = -17
 };
 
-/* perform a select() call on underlying socket to wait for socket to be ready
- * to read/write, or timeout. Note that we explicitly set the underlying
- * socket descriptor to non-blocking so we can select() on it.
+#ifdef WOLFJNI_USE_IO_SELECT
+
+/* Perform a select() call on the underlying socket to wait for socket to be
+ * ready for read/write, or timeout. Note that we explicitly set the underlying
+ * socket descriptor to non-blocking.
  *
- * The Java socket timeout value representing no timeout is NULL, not 0 like
- * C. We adjust for this when handling timeout_ms here. timeout_ms is in
- * milliseconds. */
+ * NOTE: the FD_ISSET macro behavior is undefined if the descriptor value is
+ *       less than 0 or greater than or equal to FD_SETSIZE (1024 by default).
+ *
+ * On a Java Socket, a timeout of 0 is an infinite timeout. Greater than zero
+ * is a timeout in milliseconds. Negative timeout is invalid and not supported.
+ * For select(), a non-NULL timeval struct specifies maximum timeout to wait,
+ * a NULL timeval struct is an infinite timeout. A zero-valued timeval struct
+ * will return immediately (no timeout).
+ *
+ * @param sockfd     socket descriptor to select()
+ * @param timeout_ms timeout in milliseconds. 0 indicates infinite timeout, to
+ *                   match Java timeout behavior. Negative timeout not
+ *                   supported, since not supported on Java Socket.
+ * @param rx         set to 1 to monitor readability on socket descriptor,
+ *                   otherwise 0 to monitor writability
+ *
+ * @return possible return values are:
+ *         WOLFJNI_IO_EVENT_FAIL
+ *         WOLFJNI_IO_EVENT_ERROR
+ *         WOLFJNI_IO_EVENT_TIMEOUT
+ *         WOLFJNI_IO_EVENT_RECV_READY
+ *         WOLFJNI_IO_EVENT_SEND_READY
+ *         WOLFJNI_IO_EVENT_INVALID_TIMEOUT
+ */
 static int socketSelect(int sockfd, int timeout_ms, int rx)
 {
     fd_set fds, errfds;
@@ -623,6 +653,11 @@ static int socketSelect(int sockfd, int timeout_ms, int rx)
     int nfds = sockfd + 1;
     int result = 0;
     struct timeval timeout;
+
+    /* Java Socket does not support negative timeouts, sanitize */
+    if (timeout_ms < 0) {
+        return WOLFJNI_IO_EVENT_INVALID_TIMEOUT;
+    }
 
 #ifndef USE_WINDOWS_API
     do {
@@ -648,16 +683,16 @@ static int socketSelect(int sockfd, int timeout_ms, int rx)
         }
 
         if (result == 0) {
-            return WOLFJNI_TIMEOUT;
+            return WOLFJNI_IO_EVENT_TIMEOUT;
         } else if (result > 0) {
             if (FD_ISSET(sockfd, &fds)) {
                 if (rx) {
-                    return WOLFJNI_RECV_READY;
+                    return WOLFJNI_IO_EVENT_RECV_READY;
                 } else {
-                    return WOLFJNI_SEND_READY;
+                    return WOLFJNI_IO_EVENT_SEND_READY;
                 }
             } else if (FD_ISSET(sockfd, &errfds)) {
-                return WOLFJNI_ERROR_READY;
+                return WOLFJNI_IO_EVENT_ERROR;
             }
         }
 
@@ -665,14 +700,101 @@ static int socketSelect(int sockfd, int timeout_ms, int rx)
     } while ((result == -1) && ((errno == EINTR) || (errno == EAGAIN)));
 #endif
 
-    /* Return on error, unless select() was interrupted, try again above */
-    return WOLFJNI_SELECT_FAIL;
+    /* Return on error, unless errno EINTR or EAGAIN, try again above */
+    return WOLFJNI_IO_EVENT_FAIL;
 }
+
+#else /* !WOLFJNI_USE_IO_SELECT */
+
+/* Perform poll() on underlying socket descriptor to wait for socket to be
+ * ready for read/write, or timeout. Note that we are explicitly setting
+ * the underlying descriptor to non-blocking.
+ *
+ * On a Java Socket, a timeout of 0 is an infinite timeout. Greater than zero
+ * is a timeout in milliseconds. Negative timeout is invalid and not supported.
+ * For poll(), timeout greater than 0 specifies max timeout in milliseconds,
+ * zero timeout will return immediately (no timeout), and -1 will block
+ * indefinitely.
+ *
+ * @param sockfd     socket descriptor to poll()
+ * @param timeout_ms timeout in milliseconds. 0 indicates infinite timeout, to
+ *                   match Java timeout behavior. Negative timeout not
+ *                   supported, since not supported on Java Socket.
+ * @param rx         set to 1 to monitor readability on socket descriptor,
+ *                   otherwise 0 to ignore readability events
+ * @param tx         set to 1 to monitor writability on socket descriptor,
+ *                   otherwise 0 to ignore writability events
+ *
+ * @return possible return values are:
+ *         WOLFJNI_IO_EVENT_FAIL
+ *         WOLFJNI_IO_EVENT_ERROR
+ *         WOLFJNI_IO_EVENT_TIMEOUT
+ *         WOLFJNI_IO_EVENT_RECV_READY
+ *         WOLFJNI_IO_EVENT_SEND_READY
+ *         WOLFJNI_IO_EVENT_FD_CLOSED
+ *         WOLFJNI_IO_EVENT_POLLHUP
+ *         WOLFJNI_IO_EVENT_INVALID_TIMEOUT
+ */
+static int socketPoll(int sockfd, int timeout_ms, int rx, int tx)
+{
+    int ret;
+    int timeout;
+    struct pollfd fds[1];
+
+    /* Sanitize timeout and convert from Java to poll() expectations */
+    timeout = timeout_ms;
+    if (timeout < 0) {
+        return WOLFJNI_IO_EVENT_INVALID_TIMEOUT;
+    } else if (timeout == 0) {
+        timeout = -1;
+    }
+
+    fds[0].fd = sockfd;
+    fds[0].events = 0;
+    if (tx) {
+        fds[0].events |= POLLOUT;
+    }
+    if (rx) {
+        fds[0].events |= POLLIN;
+    }
+
+    do {
+        ret = poll(fds, 1, timeout);
+        if (ret == 0) {
+            return WOLFJNI_IO_EVENT_TIMEOUT;
+
+        } else if (ret > 0) {
+            if (fds[0].revents & POLLIN ||
+                fds[0].revents & POLLPRI) {         /* read possible */
+                return WOLFJNI_IO_EVENT_RECV_READY;
+
+            } else if (fds[0].revents & POLLOUT) {  /* write possible */
+                return WOLFJNI_IO_EVENT_SEND_READY;
+
+            } else if (fds[0].revents & POLLNVAL) { /* fd not open */
+                return WOLFJNI_IO_EVENT_FD_CLOSED;
+
+            } else if (fds[0].revents & POLLERR) {  /* exceptional error */
+                return WOLFJNI_IO_EVENT_ERROR;
+
+            } else if (fds[0].revents & POLLHUP) {  /* sock disconnected */
+                return WOLFJNI_IO_EVENT_POLLHUP;
+            }
+        }
+
+    } while ((ret == -1) && ((errno == EINTR) || (errno == EAGAIN)));
+
+    return WOLFJNI_IO_EVENT_FAIL;
+}
+
+#endif /* WOLFJNI_USE_IO_SELECT */
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_connect
   (JNIEnv* jenv, jobject jcl, jlong sslPtr, jint timeout)
 {
     int ret = 0, err = 0, sockfd = 0;
+    int pollRx = 0;
+    int pollTx = 0;
     wolfSSL_Mutex* jniSessLock = NULL;
     SSLAppData* appData = NULL;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
@@ -726,12 +848,28 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_connect
                 break;
             }
 
-            ret = socketSelect(sockfd, (int)timeout, 1);
-            if (ret == WOLFJNI_RECV_READY || ret == WOLFJNI_SEND_READY) {
+            if (err == SSL_ERROR_WANT_READ) {
+                pollRx = 1;
+            }
+            else if (err == SSL_ERROR_WANT_WRITE) {
+                pollTx = 1;
+            }
+
+        #if defined(WOLFJNI_USE_IO_SELECT) || defined(USE_WINDOWS_API)
+            ret = socketSelect(sockfd, (int)timeout, pollRx);
+        #else
+            ret = socketPoll(sockfd, (int)timeout, pollRx, pollTx);
+        #endif
+            if ((ret == WOLFJNI_IO_EVENT_RECV_READY) ||
+                (ret == WOLFJNI_IO_EVENT_SEND_READY)) {
                 /* I/O ready, continue handshake and try again */
                 continue;
-            } else if (ret == WOLFJNI_TIMEOUT) {
-                /* Java will throw SocketTimeoutException */
+            } else if (ret == WOLFJNI_IO_EVENT_TIMEOUT ||
+                       ret == WOLFJNI_IO_EVENT_FD_CLOSED ||
+                       ret == WOLFJNI_IO_EVENT_ERROR ||
+                       ret == WOLFJNI_IO_EVENT_POLLHUP ||
+                       ret == WOLFJNI_IO_EVENT_FAIL) {
+                /* Java will throw SocketTimeoutException or SocketException */
                 break;
             } else {
                 /* error */
@@ -758,6 +896,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_write
 {
     byte* data = NULL;
     int ret = SSL_FAILURE, err, sockfd;
+    int pollRx = 0;
+    int pollTx = 0;
     wolfSSL_Mutex* jniSessLock = NULL;
     SSLAppData* appData = NULL;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
@@ -819,12 +959,32 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_write
                     break;
                 }
 
-                ret = socketSelect(sockfd, (int)timeout, 0);
-                if (ret == WOLFJNI_RECV_READY || ret == WOLFJNI_SEND_READY) {
+                if (err == SSL_ERROR_WANT_READ) {
+                    pollRx = 1;
+                }
+                else if (err == SSL_ERROR_WANT_WRITE) {
+                    pollTx = 1;
+                }
+
+            #if defined(WOLFJNI_USE_IO_SELECT) || defined(USE_WINDOWS_API)
+                ret = socketSelect(sockfd, (int)timeout, pollRx);
+            #else
+                ret = socketPoll(sockfd, (int)timeout, pollRx, pollTx);
+            #endif
+                if ((ret == WOLFJNI_IO_EVENT_RECV_READY) ||
+                    (ret == WOLFJNI_IO_EVENT_SEND_READY)) {
                     /* loop around and try wolfSSL_write() again */
                     continue;
+                } else if (ret == WOLFJNI_IO_EVENT_TIMEOUT ||
+                           ret == WOLFJNI_IO_EVENT_FD_CLOSED ||
+                           ret == WOLFJNI_IO_EVENT_ERROR ||
+                           ret == WOLFJNI_IO_EVENT_POLLHUP ||
+                           ret == WOLFJNI_IO_EVENT_FAIL) {
+                    /* Java will throw SocketTimeoutException or
+                     * SocketException */
+                    break;
                 } else {
-                    /* error or timeout occurred during select */
+                    /* error */
                     ret = WOLFSSL_FAILURE;
                     break;
                 }
@@ -847,6 +1007,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_read
 {
     byte* data = NULL;
     int size = 0, ret, err, sockfd;
+    int pollRx = 0;
+    int pollTx = 0;
     wolfSSL_Mutex* jniSessLock = NULL;
     SSLAppData* appData = NULL;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
@@ -905,12 +1067,32 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_read
                     break;
                 }
 
-                ret = socketSelect(sockfd, timeout, 1);
-                if (ret == WOLFJNI_RECV_READY || ret == WOLFJNI_SEND_READY) {
+                if (err == SSL_ERROR_WANT_READ) {
+                    pollRx = 1;
+                }
+                else if (err == SSL_ERROR_WANT_WRITE) {
+                    pollTx = 1;
+                }
+
+            #if defined(WOLFJNI_USE_IO_SELECT) || defined(USE_WINDOWS_API)
+                ret = socketSelect(sockfd, (int)timeout, pollRx);
+            #else
+                ret = socketPoll(sockfd, (int)timeout, pollRx, pollTx);
+            #endif
+                if ((ret == WOLFJNI_IO_EVENT_RECV_READY) ||
+                    (ret == WOLFJNI_IO_EVENT_SEND_READY)) {
                     /* loop around and try wolfSSL_read() again */
                     continue;
+                } else if (ret == WOLFJNI_IO_EVENT_TIMEOUT ||
+                           ret == WOLFJNI_IO_EVENT_FD_CLOSED ||
+                           ret == WOLFJNI_IO_EVENT_ERROR ||
+                           ret == WOLFJNI_IO_EVENT_POLLHUP ||
+                           ret == WOLFJNI_IO_EVENT_FAIL) {
+                    /* Java will throw SocketTimeoutException or
+                     * SocketException */
+                    break;
                 } else {
-                    /* error or timeout occurred during select */
+                    /* other error occurred */
                     size = ret;
                     break;
                 }
@@ -930,6 +1112,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_accept
   (JNIEnv* jenv, jobject jcl, jlong sslPtr, jint timeout)
 {
     int ret = 0, err, sockfd;
+    int pollRx = 0;
+    int pollTx = 0;
     wolfSSL_Mutex* jniSessLock = NULL;
     SSLAppData* appData = NULL;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
@@ -983,12 +1167,33 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_accept
                 break;
             }
 
-            ret = socketSelect(sockfd, (int)timeout, 1);
-            if (ret == WOLFJNI_RECV_READY || ret == WOLFJNI_SEND_READY) {
-                /* I/O ready, continue handshake and try again */
+            if (err == SSL_ERROR_WANT_READ) {
+                pollRx = 1;
+            }
+            else if (err == SSL_ERROR_WANT_WRITE) {
+                pollTx = 1;
+            }
+
+        #if defined(WOLFJNI_USE_IO_SELECT) || defined(USE_WINDOWS_API)
+            ret = socketSelect(sockfd, (int)timeout, pollRx);
+        #else
+            ret = socketPoll(sockfd, (int)timeout, pollRx, pollTx);
+        #endif
+            if ((ret == WOLFJNI_IO_EVENT_RECV_READY) ||
+                (ret == WOLFJNI_IO_EVENT_SEND_READY)) {
+                /* loop around and try wolfSSL_accept() again */
                 continue;
+            } else if (ret == WOLFJNI_IO_EVENT_TIMEOUT ||
+                       ret == WOLFJNI_IO_EVENT_FD_CLOSED ||
+                       ret == WOLFJNI_IO_EVENT_ERROR ||
+                       ret == WOLFJNI_IO_EVENT_POLLHUP ||
+                       ret == WOLFJNI_IO_EVENT_FAIL) {
+                /* Java will throw SocketTimeoutException or
+                 * SocketException */
+                break;
             } else {
-                /* error or timeout */
+                /* other error occurred */
+                ret = SSL_FAILURE;
                 break;
             }
         }
@@ -1156,6 +1361,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_shutdownSSL
   (JNIEnv* jenv, jobject jcl, jlong sslPtr, jint timeout)
 {
     int ret = 0, err, sockfd;
+    int pollRx = 0;
+    int pollTx = 0;
     wolfSSL_Mutex* jniSessLock;
     SSLAppData* appData = NULL;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
@@ -1209,12 +1416,33 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_shutdownSSL
                 break;
             }
 
-            ret = socketSelect(sockfd, timeout, 1);
-            if (ret == WOLFJNI_RECV_READY || ret == WOLFJNI_SEND_READY) {
-                /* I/O ready, continue handshake and try again */
+            if (err == SSL_ERROR_WANT_READ) {
+                pollRx = 1;
+            }
+            else if (err == SSL_ERROR_WANT_WRITE) {
+                pollTx = 1;
+            }
+
+        #if defined(WOLFJNI_USE_IO_SELECT) || defined(USE_WINDOWS_API)
+            ret = socketSelect(sockfd, (int)timeout, pollRx);
+        #else
+            ret = socketPoll(sockfd, (int)timeout, pollRx, pollTx);
+        #endif
+            if ((ret == WOLFJNI_IO_EVENT_RECV_READY) ||
+                (ret == WOLFJNI_IO_EVENT_SEND_READY)) {
+                /* loop around and try wolfSSL_shutdown() again */
                 continue;
+            } else if (ret == WOLFJNI_IO_EVENT_TIMEOUT ||
+                       ret == WOLFJNI_IO_EVENT_FD_CLOSED ||
+                       ret == WOLFJNI_IO_EVENT_ERROR ||
+                       ret == WOLFJNI_IO_EVENT_POLLHUP ||
+                       ret == WOLFJNI_IO_EVENT_FAIL) {
+                /* Java will throw SocketTimeoutException or
+                 * SocketException */
+                break;
             } else {
-                /* error or timeout */
+                /* other error occurred */
+                ret = SSL_FAILURE;
                 break;
             }
         }
@@ -1401,9 +1629,16 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_get1Session
                     break;
                 }
 
+            #if defined(WOLFJNI_USE_IO_SELECT) || defined(USE_WINDOWS_API)
+                /* Default to select() on Windows or if WOLFJNI_USE_IO_SELECT */
                 ret = socketSelect(sockfd,
                         (int)WOLFSSL_JNI_DEFAULT_PEEK_TIMEOUT, 1);
-                if (ret == WOLFJNI_RECV_READY || ret == WOLFJNI_SEND_READY) {
+            #else
+                ret = socketPoll(sockfd,
+                        (int)WOLFSSL_JNI_DEFAULT_PEEK_TIMEOUT, 1, 0);
+            #endif
+                if ((ret == WOLFJNI_IO_EVENT_RECV_READY) ||
+                    (ret == WOLFJNI_IO_EVENT_SEND_READY)) {
                     /* I/O ready, continue handshake and try again */
                     continue;
                 } else {

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -54,9 +54,36 @@ public class WolfSSL {
     public static final int JNI_SESSION_UNAVAILABLE = -10001;
 
     /**
-     * Socket timed out, matches com_wolfssl_WolfSSLSession.c socketSelect()
-     * return value */
-    public static final int WOLFJNI_TIMEOUT = -11;
+     * Socket select/poll() failed, matches com_wolfssl_WolfSSLSession.c
+     * socketSelect() and socketPoll() return value.
+     */
+    public static final int WOLFJNI_IO_EVENT_FAIL = -10;
+
+    /**
+     * Socket timed out, matches com_wolfssl_WolfSSLSession.c
+     * socketSelect() and socketPoll() return value.
+     */
+    public static final int WOLFJNI_IO_EVENT_TIMEOUT = -11;
+
+    /**
+     * Socket poll() exceptional error, matches com_wolfssl_WolfSSLSession.c
+     * socketPoll() return value */
+    public static final int WOLFJNI_IO_EVENT_ERROR = -14;
+
+    /**
+     * Socket file descriptor closed, matches com_wolfssl_WolfSSLSession.c
+     * socketPoll() return value */
+    public static final int WOLFJNI_IO_EVENT_FD_CLOSED = -15;
+
+    /**
+     * Socket disconnected during poll(), matches
+     * com_wolfssl_WolfSSLSession.c socketPoll() return value */
+    public static final int WOLFJNI_IO_EVENT_POLLHUP = -16;
+
+    /**
+     * Socket invalid timeout during poll/select(), matches
+     * com_wolfssl_WolfSSLSession.c socketPoll/socketSelect() return value */
+    public static final int WOLFJNI_IO_EVENT_INVALID_TIMEOUT = -17;
 
     /* ----------------------- wolfSSL codes ---------------------------- */
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
@@ -1220,7 +1220,7 @@ public class WolfSSLEngineHelper {
                 /* TODO: SunJSSE sends a Handshake Failure alert instead here */
                 try {
                     this.ssl.shutdownSSL();
-                } catch (SocketException e) {
+                } catch (SocketException | SocketTimeoutException e) {
                     throw new SSLException(e);
                 }
 
@@ -1336,7 +1336,8 @@ public class WolfSSLEngineHelper {
 
             } catch (SocketException e) {
                 /* SocketException may be thrown if native socket
-                 * select() fails. Propogate errno back inside exception. */
+                 * select/poll() fails. Propogate errno back inside new
+                 * SSLException. */
                 throw new SSLException(e);
             }
 


### PR DESCRIPTION
**Addition of `poll()` Support:**

This PR adds support for using `poll()` by default instead of `select()` on native file descriptors.  The previous `select()` behavior was left in tact and used as a default for Windows builds still. `select()` can also be used by building the native JNI library with `WOLFJNI_USE_IO_SELECT` defined. See `java.sh` `cflags` section for where that could be added.

We do not monitor lots of file descriptors at once ourselves inside wolfSSL JNI/JSSE, but one disadvantage to using `select()` is that for file descriptor numbers larger than `FD_SETSIZE`, the `FD_ISSET` and related macros result in undefined behavior. `FD_SETSIZE` defaults to `1024` on most systems, so is not very scalable for consumers using wolfSSL JNI/JSSE in processes that are opening and using lots of file descriptors.

---

**Changes to `select()` Support:**

Native JNI `socketSelect()` loops around calling `select()` if it returns `-1` and `errno == EINTR`. According to the `select(2)` man page, some variants of Unix may return `EAGAIN` from `select()`. This PR adjusts our `socketSelect()` to also loop on `EAGAIN`.

```
VERSIONS
       On some other UNIX systems, select() can fail with the error
       EAGAIN if the system fails to allocate kernel-internal resources,
       rather than ENOMEM as Linux does.  POSIX specifies this error for
       poll(2), but not for select().  Portable programs may wish to
       check for EAGAIN and loop, just as with EINTR.
```

Man page for `select()` from OSX also shows a potential return of `EAGAIN` from select():

```
ERRORS
     An error return from select() indicates:

     [EAGAIN]           The kernel was (perhaps temporarily) unable to allocate the requested number of file descriptors.
```

Related to ZD 17962 (and 17385) - customer confirmed fix seems to be working well so far.