### PR TITLE
Fix mistake in SSLEngine debug logs

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
@@ -554,7 +554,7 @@ public class WolfSSLEngine extends SSLEngine {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                     "ByteBuffer in["+i+"].position(): " + in[i].position());
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "ByteBuffer in["+i+"].limit(): " + in[i].position());
+                    "ByteBuffer in["+i+"].limit(): " + in[i].limit());
             }
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                 "ofst: " + ofst + ", len: " + len);
@@ -675,7 +675,7 @@ public class WolfSSLEngine extends SSLEngine {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                     "ByteBuffer in["+i+"].position(): " + in[i].position());
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "ByteBuffer in["+i+"].limit(): " + in[i].position());
+                    "ByteBuffer in["+i+"].limit(): " + in[i].limit());
             }
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                 "ofst: " + ofst + ", len: " + len);


### PR DESCRIPTION
Adjust a small typo in the debugging logs to increase debugging accuracy.