### PR TITLE
Changed getLocalPrincipal to assume user cert is first in chain

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
@@ -647,7 +647,7 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
 
     @Override
     public Principal getLocalPrincipal() {
-
+    /* Logic needs to be added to check for client auth when wrapper is made TODO */
         X509KeyManager km = authStore.getX509KeyManager();
         java.security.cert.X509Certificate[] certs =
                 km.getCertificateChain(authStore.getCertAlias());
@@ -657,12 +657,9 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
             return null;
         }
 
-        for (int i = 0; i < certs.length; i++) {
-            if (certs[i].getBasicConstraints() < 0) {
-                /* is not a CA treat as end of chain */
-                localPrincipal = certs[i].getSubjectDN();
-                break;
-            }
+        if (certs.length > 0){
+            /* When chain of certificates exceeds one, the user certifcate is the first */
+            localPrincipal = certs[0].getSubjectDN();
         }
 
         /* free native resources earlier than garbage collection if

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
@@ -647,7 +647,7 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
 
     @Override
     public Principal getLocalPrincipal() {
-    /* Logic needs to be added to check for client auth when wrapper is made TODO */
+        /* Logic needs to be added to check for client auth when wrapper is made TODO */
         X509KeyManager km = authStore.getX509KeyManager();
         java.security.cert.X509Certificate[] certs =
                 km.getCertificateChain(authStore.getCertAlias());

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSessionTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSessionTest.java
@@ -120,9 +120,10 @@ public class WolfSSLSessionTest {
         /* test certificates */
         System.out.print("\tTesting session cert");
         session = client.getSession();
-        if (session.getLocalPrincipal() != null) {
+        /* TODO changes back to != null once we can check for client auth */
+        if (session.getLocalPrincipal() == null) {
             error("\t... failed");
-            fail("found unexpected principal");
+            fail("Principal is null when it should not be");
         }
 
         try {


### PR DESCRIPTION
Fixed getLocalPrincipal to changed principal from null, before it would never change with the for loop and we can assume that the user cert is the first in the cert chain.