### PR TITLE
Close socket if handshake fails

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -1297,6 +1297,20 @@ public class WolfSSLSocket extends SSLSocket {
             /* Log error, but continue. Session returned will be empty */
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                 "Handshake attempt failed in SSLSocket.getSession()");
+
+            /* close SSLSocket */
+            if (this.socket != null && !this.socket.isClosed()) {
+                try {
+                    close();
+                } catch (Exception ex) {
+                    WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                        "close attempt failed in SSLSocket.getSession(): " +
+                        ex);
+                }
+            }
+            /* return invalid session object with cipher suite
+             * "SSL_NULL_WITH_NULL_NULL" */
+            return new WolfSSLImplementSSLSession(this.authStore);
         }
 
         return EngineHelper.getSession();
@@ -1446,6 +1460,8 @@ public class WolfSSLSocket extends SSLSocket {
             } catch (SocketTimeoutException e) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                     "got socket timeout in doHandshake()");
+                /* close socket if the handshake is unsuccessful */
+                close();
                 throw e;
             }
 
@@ -1453,6 +1469,8 @@ public class WolfSSLSocket extends SSLSocket {
                 int err = ssl.getError(ret);
                 String errStr = WolfSSL.getErrorString(err);
 
+                /* close socket if the handshake is unsuccessful */
+                close();
                 throw new SSLHandshakeException(errStr + " (error code: " +
                     err + ", TID " + Thread.currentThread().getId() + ")");
             }

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -1299,15 +1299,13 @@ public class WolfSSLSocket extends SSLSocket {
                 "Handshake attempt failed in SSLSocket.getSession()");
 
             /* close SSLSocket */
-            if (this.socket != null && !this.socket.isClosed()) {
-                try {
-                    close();
-                } catch (Exception ex) {
-                    WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "close attempt failed in SSLSocket.getSession(): " +
-                        ex);
-                }
+            try {
+                close();
+            } catch (Exception ex) {
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    "close attempt failed in SSLSocket.getSession(): " + ex);
             }
+
             /* return invalid session object with cipher suite
              * "SSL_NULL_WITH_NULL_NULL" */
             return new WolfSSLImplementSSLSession(this.authStore);


### PR DESCRIPTION
The following changes help wolfJSSE align more closely with standards outlined in the javadocs:
- Ensure that if the implicit handshake in SSLSocket.getSession() fails, the socket is closed
- If the handshake fails in getSession(), return an invalid SSLSession object with the invalid cipher suite "SSL_NULL_WITH_NULL_NULL"
- If any handshake is unsuccessful, close the socket before throwing an exception

https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLSocket.html