### PR TITLE
JNI: wrap native wolfSSL_SESSION_dup() in WolfSSLSession.duplicateSession()

### DIFF
--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -1723,6 +1723,20 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_wolfsslSessionIsResumable
 #endif
 }
 
+JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_wolfsslSessionDup
+  (JNIEnv* jenv, jclass jcl, jlong sessionPtr)
+{
+    WOLFSSL_SESSION* session = (WOLFSSL_SESSION*)(uintptr_t)sessionPtr;
+    (void)jcl;
+
+    if (jenv == NULL) {
+        return 0;
+    }
+
+    /* checks session for NULL */
+    return (jlong)(uintptr_t)wolfSSL_SESSION_dup(session);
+}
+
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_freeNativeSession
   (JNIEnv* jenv, jclass jcl, jlong sessionPtr)
 {

--- a/native/com_wolfssl_WolfSSLSession.h
+++ b/native/com_wolfssl_WolfSSLSession.h
@@ -177,6 +177,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_wolfsslSessionIsResumable
 
 /*
  * Class:     com_wolfssl_WolfSSLSession
+ * Method:    wolfsslSessionDup
+ * Signature: (J)J
+ */
+JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_wolfsslSessionDup
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_wolfssl_WolfSSLSession
  * Method:    freeNativeSession
  * Signature: (J)V
  */

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -259,6 +259,7 @@ public class WolfSSLSession {
     private native long get1Session(long ssl);
     private static native int wolfsslSessionIsSetup(long ssl);
     private static native int wolfsslSessionIsResumable(long ssl);
+    private static native long wolfsslSessionDup(long session);
     private static native void freeNativeSession(long session);
     private native byte[] getSessionID(long session);
     private native int setServerID(long ssl, byte[] id, int len, int newSess);
@@ -1362,6 +1363,30 @@ public class WolfSSLSession {
         }
 
         return wolfsslSessionIsResumable(session);
+    }
+
+    /**
+     * Deep copy the contents of the WOLFSSL_SESSION, calling native
+     * wolfSSL_SESSION_dup().
+     *
+     * This session will create a new WOLFSSL_SESSION and deep copy it
+     * from the WOLFSSL_SESSION pointer provided. Note that if a non-zero
+     * value is returned the application is responsible for freeing this
+     * WOLFSSL_SESSION memory when finished by calling freeSession().
+     *
+     * @param session pointer to native WOLFSSL_SESSION structure. May have
+     *        been obtained from getSession().
+     *
+     * @return long representing a native pointer to a new WOLFSSL_SESSION
+     *         structure, or zero on error (equivalent to a NULL pointer).
+     */
+    public static long duplicateSession(long session) {
+
+        if (session == 0) {
+            return 0;
+        }
+
+        return wolfsslSessionDup(session);
     }
 
     /**

--- a/src/test/com/wolfssl/test/WolfSSLSessionTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLSessionTest.java
@@ -938,6 +938,7 @@ public class WolfSSLSessionTest {
         int ret = 0;
         int err = 0;
         long sessionPtr = 0;
+        long sesDup = 0;
         Socket cliSock = null;
         WolfSSLSession cliSes = null;
 
@@ -1107,6 +1108,19 @@ public class WolfSSLSessionTest {
                     "WolfSSLSession.sessionIsSetup() did not return 1: " + ret);
             }
 
+            /* Test duplicateSession(), wraps wolfSSL_SESSION_dup() */
+            sesDup = cliSes.duplicateSession(sessionPtr);
+            if (sesDup == 0) {
+                throw new Exception(
+                    "WolfSSLSession.duplicateSession() returned 0");
+            }
+            if (sesDup == sessionPtr) {
+                throw new Exception(
+                    "WolfSSLSession.duplicateSession() returned same pointer");
+            }
+            cliSes.freeSession(sesDup);
+            sesDup = 0;
+
             cliSes.shutdownSSL();
             cliSes.freeSSL();
             cliSes = null;
@@ -1177,6 +1191,9 @@ public class WolfSSLSessionTest {
         } finally {
             if (sessionPtr != 0) {
                 cliSes.freeSession(sessionPtr);
+            }
+            if (sesDup != 0) {
+                cliSes.freeSession(sesDup);
             }
             if (cliSes != null) {
                 cliSes.freeSSL();


### PR DESCRIPTION
This PR wraps the native `wolfSSL_SESSION_dup()` API in `WolfSSLSession.duplicateSession()`. This can be used to create a duplicate copy of a native `WOLFSSL_SESSION` pointer.