### PR TITLE
Add SSLException when hostname is null

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
@@ -871,7 +871,7 @@ public class WolfSSLEngineHelper {
      * name depending on what createSocket() API the user has called and with
      * what String.
      */
-    private void setLocalServerNames() {
+    private void setLocalServerNames() throws SSLException {
 
         /* Do not add SNI if system property has been set to false */
         boolean enableSNI =
@@ -931,7 +931,9 @@ public class WolfSSLEngineHelper {
                 else {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                         "hostname and peerAddr are null, not setting SNI");
-                }
+                    //throw an SSLException if the hostname is null
+		    throw new SSLException("Hostname is null");
+		}
             }
         }
     }


### PR DESCRIPTION
Throw an SSLException in the setLocalServerNames() method as this is where the hostname is checked. Currently, no exception is being thrown when the hostname is null and the SunJSSETest/Misc/NullHostnameCheck test checks for this case.