### PR TITLE
JSSE: Session resumption check for enabled cipher suite and protocol

### DIFF
--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -1733,6 +1733,27 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_wolfsslSessionDup
     return (jlong)(uintptr_t)wolfSSL_SESSION_dup(session);
 }
 
+JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_wolfsslSessionCipherGetName
+  (JNIEnv* jenv, jclass jcl, jlong sessionPtr)
+{
+    WOLFSSL_SESSION* session = (WOLFSSL_SESSION*)(uintptr_t)sessionPtr;
+    const char* cipherName;
+    jstring cipherStr = NULL;
+    (void)jcl;
+
+    if (jenv == NULL || session == NULL) {
+        return NULL;
+    }
+
+    cipherName = wolfSSL_SESSION_CIPHER_get_name(session);
+
+    if (cipherName != NULL) {
+        cipherStr = (*jenv)->NewStringUTF(jenv, cipherName);
+    }
+
+    return cipherStr;
+}
+
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_freeNativeSession
   (JNIEnv* jenv, jclass jcl, jlong sessionPtr)
 {

--- a/native/com_wolfssl_WolfSSLSession.h
+++ b/native/com_wolfssl_WolfSSLSession.h
@@ -185,6 +185,14 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_wolfsslSessionDup
 
 /*
  * Class:     com_wolfssl_WolfSSLSession
+ * Method:    wolfsslSessionCipherGetName
+ * Signature: (J)Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_wolfsslSessionCipherGetName
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_wolfssl_WolfSSLSession
  * Method:    freeNativeSession
  * Signature: (J)V
  */

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -260,6 +260,7 @@ public class WolfSSLSession {
     private static native int wolfsslSessionIsSetup(long ssl);
     private static native int wolfsslSessionIsResumable(long ssl);
     private static native long wolfsslSessionDup(long session);
+    private static native String wolfsslSessionCipherGetName(long ssl);
     private static native void freeNativeSession(long session);
     private native byte[] getSessionID(long session);
     private native int setServerID(long ssl, byte[] id, int len, int newSess);
@@ -1387,6 +1388,29 @@ public class WolfSSLSession {
         }
 
         return wolfsslSessionDup(session);
+    }
+
+    /**
+     * Get cipher suite name from WOLFSSL_SESSION, calling native
+     * wolfSSL_SESSION_CIPHER_get_name().
+     *
+     * This method is static and does not check active state since this
+     * takes a native pointer and has no interaction with the rest of this
+     * object.
+     *
+     * @param session pointer to native WOLFSSL_SESSION structure. May have
+     *        been obtained from getSession().
+     * @return String representation of the cipher suite used in native
+     *         WOLFSSL_SESSION structure, or NULL if not able to find the
+     *         session.
+     */
+    public static String sessionGetCipherName(long session) {
+
+        if (session == 0) {
+            return null;
+        }
+
+        return wolfsslSessionCipherGetName(session);
     }
 
     /**

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
@@ -1199,7 +1199,7 @@ public class WolfSSLEngineHelper {
 
         /* create non null session */
         this.session = this.authStore.getSession(ssl, this.port,
-            sessCacheHostname, this.clientMode);
+            sessCacheHostname, this.clientMode, getCiphers(), getProtocols());
 
         if (this.session != null) {
             if (this.clientMode) {
@@ -1345,6 +1345,11 @@ public class WolfSSLEngineHelper {
                  (err == WolfSSL.SSL_ERROR_WANT_READ ||
                   err == WolfSSL.SSL_ERROR_WANT_WRITE));
 
+        /* Update cached values in WolfSSLImplementSSLSession from
+         * WolfSSLSession, in case that goes out of scope and is garbage
+         * collected (ex: protocol version). */
+        this.session.updateStoredSessionValues();
+
         return ret;
     }
 
@@ -1385,6 +1390,10 @@ public class WolfSSLEngineHelper {
      */
     protected synchronized int saveSession() {
         if (this.session != null && this.session.isValid()) {
+            /* Update values from WOLFSSL which are stored in
+             * WolfSSLImplementSSLSession (ex: protocol) */
+            this.session.updateStoredSessionValues();
+
             if (this.clientMode) {
                 /* Only need to set resume on client side, server-side
                  * maintains session cache at native level. */


### PR DESCRIPTION
This PR adjusts client-side session resumption to verify the original cipher suite and protocol used for the original session are enabled.

If an initial connection to a server is established and saved into the session cache, but the application then adjusts or removes cipher suites with `SSLSocket/SSLEngine.setEnabledCipherSuites()` or `SSLSocket/SSLEngine.setEnabledProtocols()`, if the cipher suite or protocol used in the first connection is no longer enabled we should fall back to full handshake for the second connection.