### PR TITLE
JSSE: pass lower level exception messages up during X509TrustManager peer verification

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLInternalVerifyCb.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLInternalVerifyCb.java
@@ -119,7 +119,8 @@ public class WolfSSLInternalVerifyCb implements WolfSSLVerifyCallback {
             }
         } catch (CertificateException e) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "X509ExtendedTrustManager hostname verification failed");
+                "X509ExtendedTrustManager hostname verification failed: " +
+                e.getMessage());
             return 0;
         }
 
@@ -138,6 +139,17 @@ public class WolfSSLInternalVerifyCb implements WolfSSLVerifyCallback {
      */
     private boolean VerifyCertChainWithTrustManager(X509Certificate[] certs,
         String authType) {
+
+        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+            "Verifying peer with X509TrustManager: " + this.tm);
+        if (this.tm instanceof X509ExtendedTrustManager) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                "X509TrustManager of type X509ExtendedTrustManager");
+        }
+        else {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                "X509TrustManager of type X509TrustManager");
+        }
 
         try {
             /* Call TrustManager to do cert verification, should throw
@@ -211,7 +223,8 @@ public class WolfSSLInternalVerifyCb implements WolfSSLVerifyCallback {
         } catch (Exception e) {
             /* TrustManager rejected certificate, not valid */
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "TrustManager rejected certificates, verification failed");
+                "TrustManager rejected certificates, verification failed: " +
+                e.getMessage());
             return false;
         }
 
@@ -264,7 +277,8 @@ public class WolfSSLInternalVerifyCb implements WolfSSLVerifyCallback {
         } catch (WolfSSLException e) {
             /* failed to get certs from native, give app null array */
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "Failed to get certs from x509StorePtr, certs = null");
+                "Failed to get certs from x509StorePtr, certs = null: " +
+                e.getMessage());
             certs = null;
         }
 
@@ -282,7 +296,7 @@ public class WolfSSLInternalVerifyCb implements WolfSSLVerifyCallback {
                 /* failed to get cert array, give app empty array */
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                     "Failed to get X509Certificate[] array, set to " +
-                    "empty array");
+                    "empty array: " + ce.getMessage());
                 x509certs = new X509Certificate[0];
             }
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLTrustX509.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLTrustX509.java
@@ -421,6 +421,10 @@ public final class WolfSSLTrustX509 extends X509ExtendedTrustManager
                 fullChain.add(rootCA);
             }
         }
+        else {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                "Not returning cert chain from verify, not requested");
+        }
 
         return fullChain;
     }
@@ -695,6 +699,9 @@ public final class WolfSSLTrustX509 extends X509ExtendedTrustManager
 
         /* Verify cert chain, throw CertificateException if not valid */
         certManagerVerify(certs, type, false);
+
+        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+            "leaving checkClientTrusted(), success");
     }
 
     /**
@@ -733,6 +740,9 @@ public final class WolfSSLTrustX509 extends X509ExtendedTrustManager
 
         /* Verify hostname if right criteria matches */
         verifyHostname(certs[0], socket, null, false);
+
+        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+            "leaving checkClientTrusted(Socket), success");
     }
 
     @Override
@@ -755,6 +765,9 @@ public final class WolfSSLTrustX509 extends X509ExtendedTrustManager
 
         /* Verify hostname if right criteria matches */
         verifyHostname(certs[0], null, engine, false);
+
+        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+            "leaving checkClientTrusted(SSLEngine), success");
     }
 
     /**
@@ -787,6 +800,9 @@ public final class WolfSSLTrustX509 extends X509ExtendedTrustManager
 
         /* Verify cert chain, throw CertificateException if not valid */
         certManagerVerify(certs, type, false);
+
+        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+            "leaving checkServerTrusted(certs, type), success");
     }
 
     @Override
@@ -809,6 +825,9 @@ public final class WolfSSLTrustX509 extends X509ExtendedTrustManager
 
         /* Verify hostname if right criteria matches */
         verifyHostname(certs[0], socket, null, true);
+
+        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+            "leaving checkServerTrusted(certs, type, Socket), success");
     }
 
     @Override
@@ -831,6 +850,9 @@ public final class WolfSSLTrustX509 extends X509ExtendedTrustManager
 
         /* Verify hostname if right criteria matches */
         verifyHostname(certs[0], null, engine, true);
+
+        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+            "leaving checkServerTrusted(certs, type, SSLEngine), success");
     }
 
     /**
@@ -851,10 +873,17 @@ public final class WolfSSLTrustX509 extends X509ExtendedTrustManager
     public List<X509Certificate> checkServerTrusted(X509Certificate[] certs,
         String type, String host) throws CertificateException {
 
-        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered checkServerTrusted()");
+        List<X509Certificate> certList = null;
 
-        return certManagerVerify(certs, type, true);
+        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+            "entered checkServerTrusted(cert, type, host)");
+
+        certList = certManagerVerify(certs, type, true);
+
+        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+            "leaving checkServerTrusted(certs, type, host), success");
+
+        return certList;
     }
 
     /**


### PR DESCRIPTION
There were a few places in the internal peer verification logic where if a lower-level exception was thrown, the exception message was disregarded. This PR passes those lower level exception messages up, to help with debugging and log analysis.