### PR TITLE
Fixes to SSLParameters and WolfSSLServerSocket

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLParameters.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLParameters.java
@@ -60,6 +60,12 @@ final class WolfSSLParameters {
         cp.setServerNames(this.getServerNames());
         cp.useSessionTickets = this.useSessionTickets;
         cp.endpointIdAlgorithm = this.endpointIdAlgorithm;
+        cp.setApplicationProtocols(this.applicationProtocols);
+        cp.useCipherSuiteOrder = this.useCipherSuiteOrder;
+
+        if (alpnProtocols != null && alpnProtocols.length != 0) {
+            cp.setAlpnProtocols(this.alpnProtocols);
+        }
 
         /* TODO: duplicate other properties here when WolfSSLParameters
          * can handle them */

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLServerSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLServerSocket.java
@@ -338,7 +338,7 @@ public class WolfSSLServerSocket extends SSLServerSocket {
     /**
      * Set the SSLParameters for this SSLServerSocket.
      *
-     * @param params SSLParameters to set for this SSLSocket object
+     * @param params SSLParameters to set for this SSLServerSocket object
      */
     synchronized public void setSSLParameters(SSLParameters params) {
 
@@ -350,6 +350,19 @@ public class WolfSSLServerSocket extends SSLServerSocket {
         }
     }
 
+    /**
+     * Gets the SSLParameters for this SSLServerSocket.
+     *
+     * @return SSLParameters for this SSLServerSocket object.
+     */
+    @Override
+    synchronized public SSLParameters getSSLParameters() {
+
+        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+            "entered getSSLParameters()");
+
+        return WolfSSLParametersHelper.decoupleParams(this.params);
+    }
 
     @Override
     synchronized public Socket accept() throws IOException {


### PR DESCRIPTION
- Add `getSSLParameters()` method to WolfSSLServerSocket class, this way SSLParameters returned will be accurate to the SSLServerSocket (method is exactly the same as the corresponding WolfSSLSocket method)
- Add unit test for `getSSLParameters()` to WolfSSLServerSocketTest (very similar to the unit test for getSSLParameters in WolfSSLSocketTest)
- Update `copy()` method in WolfSSLParameters to include all variables. This way, Sockets created with a ServerSocket will have matching SSLParameters