### PR TITLE
JSSE: return end of stream in WolfSSLInputStream.read() on SOCKET_ERROR_E

### DIFF
--- a/native/com_wolfssl_WolfSSL.h
+++ b/native/com_wolfssl_WolfSSL.h
@@ -89,6 +89,8 @@ extern "C" {
 #define com_wolfssl_WolfSSL_SSL_ERROR_ZERO_RETURN 6L
 #undef com_wolfssl_WolfSSL_SSL_ERROR_SSL
 #define com_wolfssl_WolfSSL_SSL_ERROR_SSL 85L
+#undef com_wolfssl_WolfSSL_SOCKET_ERROR_E
+#define com_wolfssl_WolfSSL_SOCKET_ERROR_E -308L
 #undef com_wolfssl_WolfSSL_FATAL_ERROR
 #define com_wolfssl_WolfSSL_FATAL_ERROR -313L
 #undef com_wolfssl_WolfSSL_SSL_ERROR_SOCKET_PEER_CLOSED

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -197,8 +197,10 @@ public class WolfSSL {
     public static final int SSL_ERROR_WANT_X509_LOOKUP = 83;
     /** I/O error, zero return, no more data */
     public static final int SSL_ERROR_ZERO_RETURN      =  6;
-    /** Generatl SSL error */
+    /** General SSL error */
     public static final int SSL_ERROR_SSL              = 85;
+    /** Error state on socket */
+    public static final int SOCKET_ERROR_E             = -308;
     /** Received fatal alert error */
     public static final int FATAL_ERROR                = -313;
     /** Peer closed socket */

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -2514,12 +2514,22 @@ public class WolfSSLSocket extends SSLSocket {
                     /* other errors besides end of stream or WANT_READ
                      * are treated as I/O errors and throw an exception */
                     String errStr = WolfSSL.getErrorString(err);
-                    WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "Native wolfSSL_read() error: " + errStr +
-                        " (error code: " + err + ")");
-                    throw new IOException("Native wolfSSL_read() " +
-                        "error: " + errStr +
-                        " (error code: " + err + ")");
+                    if (err == WolfSSL.SOCKET_ERROR_E) {
+                        /* Socket error, indicate to caller by returning
+                         * end of stream */
+                        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                            "Native wolfSSL_read() error: " + errStr +
+                            " (error code: " + err + "), end of stream");
+                        return -1;
+
+                    } else {
+                        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                            "Native wolfSSL_read() error: " + errStr +
+                            " (error code: " + err + ")");
+                        throw new IOException("Native wolfSSL_read() " +
+                            "error: " + errStr +
+                            " (error code: " + err + ")");
+                    }
                 }
 
             } catch (SocketException e) {


### PR DESCRIPTION
This PR adjusts `WolfSSLInputStream.read()` to return `-1` when native `wolfSSL_read()` returns `SOCKET_ERROR_E / -308`. Returning `-1` indicates end of stream to caller.

Potential fix for customer issue.