### PR TITLE
Store protocol after handshake in SSLSession

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
@@ -1258,6 +1258,7 @@ public class WolfSSLEngine extends SSLEngine {
                         if (ssl.handshakeDone() && this.toSend == null) {
                             this.handshakeFinished = true;
                             hs = SSLEngineResult.HandshakeStatus.FINISHED;
+                            this.engineHelper.getSession().updateStoredSessionValues();
 
                             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                                 "SSL/TLS handshake finished");


### PR DESCRIPTION
Update the TLS protocol used in the SSLSession after the handshake is complete. Currently, the TLS protocol is not being updated for SSLEngine and calling getProtocol() returns "NONE" after the handshake.