### PR TITLE
Fix potential deadlock on close() between SSLSocket and Input/OutputStream

### DIFF
--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -725,6 +725,9 @@ public class WolfSSL {
      * @param file File to read into byte array
      *
      * @return byte array representing input File, or null if file is null
+     *
+     * @throws FileNotFoundException if file is not found
+     * @throws IOException if unable to read entire file
      */
     protected static byte[] fileToBytes(File file)
         throws FileNotFoundException, IOException {


### PR DESCRIPTION
This PR fixes a potential deadlock that could occur when `WolfSSLSocket.close()` and `WolfSSLInput/OutputStream.close()` are called simultaneously by different threads.