### PR TITLE
Add Github Actions PRB test for Android gradle build

### DIFF
--- a/.github/workflows/android_gradle.yml
+++ b/.github/workflows/android_gradle.yml
@@ -1,0 +1,52 @@
+name: Android Gradle Build test logic
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+      jdk_distro:
+        required: true
+        type: string
+      jdk_version:
+        required: true
+        type: string
+
+jobs:
+  build_wolfssljni:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - name: Clone wolfssljni
+        uses: actions/checkout@v4
+
+      # Clone native wolfSSL
+      - name: Clone native wolfSSL
+        uses: actions/checkout@v4
+        with:
+          repository: 'wolfssl/wolfssl'
+          path: IDE/Android/app/src/main/cpp/wolfssl
+
+      # Copy options.h.in to blank options.h
+      - name: Create blank options.h
+        run: cp IDE/Android/app/src/main/cpp/wolfssl/wolfssl/options.h.in IDE/Android/app/src/main/cpp/wolfssl/wolfssl/options.h
+
+      # Setup Java
+      - name: Setup java
+        uses: actions/setup-java@v4
+        with:
+          distribution: ${{ inputs.jdk_distro }}
+          java-version: ${{ inputs.jdk_version }}
+
+      # Gradle assembleDebug
+      - name: Gradle assembleDebug
+        run: cd IDE/Android && ls && ./gradlew assembleDebug
+
+      # Gradle assembleDebugUnitTest
+      - name: Gradle assembleDebugUnitTest
+        run: cd IDE/Android && ls && ./gradlew assembleDebugUnitTest
+
+      # Gradle assembleDebugAndroidTest
+      - name: Gradle assembleDebugAndroidTest
+        run: cd IDE/Android && ls && ./gradlew assembleDebugAndroidTest
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,3 +118,18 @@ jobs:
       jdk_version: ${{ matrix.jdk_version }}
       wolfssl_configure: ${{ matrix.wolfssl_configure }}
 
+  # ----------------------- Android Gradle build ------------------------
+  # Run Android gradle build over PR code, only running on Linux with one
+  # JDK/version for now.
+  android-gradle:
+    strategy:
+      matrix:
+        os: [ 'ubuntu-latest' ]
+        jdk_version: [ '21' ]
+    name: Android Gradle (${{ matrix.os }} Zulu JDK ${{ matrix.jdk_version }})
+    uses: ./.github/workflows/android_gradle.yml
+    with:
+      os: ${{ matrix.os }}
+      jdk_distro: "zulu"
+      jdk_version: ${{ matrix.jdk_version }}
+

--- a/IDE/Android/.idea/misc.xml
+++ b/IDE/Android/.idea/misc.xml
@@ -13,4 +13,11 @@
   <component name="ProjectType">
     <option name="id" value="Android" />
   </component>
+  <component name="VisualizationToolProject">
+    <option name="state">
+      <ProjectState>
+        <option name="scale" value="1.1" />
+      </ProjectState>
+    </option>
+  </component>
 </project>

--- a/IDE/Android/app/build.gradle
+++ b/IDE/Android/app/build.gradle
@@ -1,11 +1,14 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 30
+    compileSdk 33
     defaultConfig {
         applicationId "com.example.wolfssl"
-        minSdkVersion 30
-        targetSdkVersion 30
+        /* Min SDK should stay at 24 to detect if we try to use newer APIs
+         * than were available in that Android SDK. We have users who are still
+         on SDK 24 (ref ZD 18311) */
+        minSdkVersion 24
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -14,6 +17,10 @@ android {
                 cppFlags ""
             }
         }
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
     buildTypes {
         release {
@@ -26,14 +33,18 @@ android {
             path "src/main/cpp/CMakeLists.txt"
         }
     }
+    sourceSets {
+        main.java.srcDirs += '../../src/java'
+        test.java.srcDirs += '../../src/test'
+    }
     namespace 'com.example.wolfssl'
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
-    testImplementation 'junit:junit:4.12'
+    implementation 'com.android.support.constraint:constraint-layout:2.0.4'
+    testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 }

--- a/IDE/Android/app/src/main/AndroidManifest.xml
+++ b/IDE/Android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
@@ -12,7 +11,7 @@
         android:theme="@style/AppTheme"
         android:requestLegacyExternalStorage="true"
         android:preserveLegacyExternalStorage="true">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/IDE/Android/app/src/main/cpp/CMakeLists.txt
+++ b/IDE/Android/app/src/main/cpp/CMakeLists.txt
@@ -11,6 +11,10 @@ project("wolfssljni-gradle" C ASM)
 set(wolfssljni_DIR ${CMAKE_SOURCE_DIR}/../../../../../../)
 set(wolfssl_DIR    ${CMAKE_SOURCE_DIR}/wolfssl/)
 
+# set warnings as errors, used in this example project but may be different
+# in production apps/environments.
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror")
+
 # ------------------------- wolfSSL Normal vs. FIPS Ready Selection --------------------------------
 # Select if wolfSSL is normal ("normal") or FIPS Ready ("fipsready")
 # wolfSSL FIPS Ready is available for download on the wolfssl.com download page. For more
@@ -222,7 +226,10 @@ list(REMOVE_ITEM TLS_SOURCES ${wolfssl_DIR}/src/ssl_bn.c)
 list(REMOVE_ITEM TLS_SOURCES ${wolfssl_DIR}/src/ssl_asn1.c)
 list(REMOVE_ITEM TLS_SOURCES ${wolfssl_DIR}/src/ssl_certman.c)
 list(REMOVE_ITEM TLS_SOURCES ${wolfssl_DIR}/src/ssl_crypto.c)
+list(REMOVE_ITEM TLS_SOURCES ${wolfssl_DIR}/src/ssl_load.c)
 list(REMOVE_ITEM TLS_SOURCES ${wolfssl_DIR}/src/ssl_misc.c)
+list(REMOVE_ITEM TLS_SOURCES ${wolfssl_DIR}/src/ssl_p7p12.c)
+list(REMOVE_ITEM TLS_SOURCES ${wolfssl_DIR}/src/ssl_sess.c)
 list(REMOVE_ITEM TLS_SOURCES ${wolfssl_DIR}/src/x509.c)
 list(REMOVE_ITEM TLS_SOURCES ${wolfssl_DIR}/src/x509_str.c)
 

--- a/IDE/Android/app/src/main/java/com/example/wolfssl/MainActivity.java
+++ b/IDE/Android/app/src/main/java/com/example/wolfssl/MainActivity.java
@@ -22,10 +22,6 @@
 
 package com.example.wolfssl;
 
-import android.content.Intent;
-import android.net.Uri;
-import android.os.Environment;
-import android.provider.Settings;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.view.View;
@@ -35,17 +31,11 @@ import android.widget.TextView;
 import com.wolfssl.WolfSSL;
 import com.wolfssl.WolfSSLException;
 import com.wolfssl.provider.jsse.WolfSSLProvider;
-import com.wolfssl.provider.jsse.WolfSSLX509;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.Provider;
 import java.security.Security;
-import java.security.cert.CertificateException;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -55,7 +45,7 @@ public class MainActivity extends AppCompatActivity {
             TextView tv = (TextView) findViewById(R.id.sample_text);
 
             try {
-                testLoadCert(tv);
+                testFindProvider(tv);
             } catch (Exception e) {
                 e.printStackTrace();
             }
@@ -72,23 +62,11 @@ public class MainActivity extends AppCompatActivity {
 
         TextView tv = (TextView) findViewById(R.id.sample_text);
         tv.setText("wolfSSL JNI Android Studio Example App");
-
-        if (!Environment.isExternalStorageManager()) {
-            Intent intent = new Intent(
-                Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION);
-            Uri uri = Uri.fromParts("package", getPackageName(), null);
-            intent.setData(uri);
-            startActivity(intent);
-        }
     }
 
-    public void testLoadCert(TextView tv)
+    public void testFindProvider(TextView tv)
             throws NoSuchProviderException, NoSuchAlgorithmException,
-                   KeyStoreException, IOException, CertificateException,
                    WolfSSLException {
-        String file = "/sdcard/examples/provider/all.bks";
-        WolfSSLX509 x509;
-        KeyStore ks;
 
         WolfSSL.loadLibrary();
 
@@ -100,11 +78,8 @@ public class MainActivity extends AppCompatActivity {
             System.out.println("Unable to find wolfJSSE provider");
             return;
         }
+        else {
 
-        ks = KeyStore.getInstance("BKS");
-        ks.load(new FileInputStream(file), "wolfSSL test".toCharArray());
-
-        x509 = new WolfSSLX509(ks.getCertificate("server").getEncoded());
-        tv.setText("Server Certificate Found:\n" + x509.toString());
+        }
     }
 }

--- a/IDE/Android/app/src/main/res/layout/activity_main.xml
+++ b/IDE/Android/app/src/main/res/layout/activity_main.xml
@@ -8,9 +8,13 @@
 
     <Button
         android:id="@+id/button"
-        android:layout_width="match_parent"
+        android:layout_width="320dp"
         android:layout_height="wrap_content"
-        android:text="Load Cert File" />
+        android:text="Test Provider Lookup"
+        app:layout_constraintBottom_toTopOf="@+id/sample_text"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
         android:id="@+id/sample_text"
@@ -19,6 +23,7 @@
         android:layout_marginTop="16dp"
         android:paddingVertical="16pt"
         android:text="Hello World!"
+        android:textColor="#000000"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintHorizontal_bias="0.461"
         app:layout_constraintLeft_toLeftOf="parent"

--- a/IDE/Android/build.gradle
+++ b/IDE/Android/build.gradle
@@ -18,7 +18,12 @@ allprojects {
     repositories {
         google()
         jcenter()
-        
+    }
+    gradle.projectsEvaluated {
+        tasks.withType(JavaCompile) {
+            options.compilerArgs << "-Xlint:all" << "-Werror"
+            options.deprecation = false
+        }
     }
 }
 

--- a/IDE/Android/gradle.properties
+++ b/IDE/Android/gradle.properties
@@ -6,7 +6,6 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-android.defaults.buildfeatures.buildconfig=true
 android.nonFinalResIds=false
 android.nonTransitiveRClass=false
 org.gradle.jvmargs=-Xmx1536m

--- a/native/com_wolfssl_WolfSSLCertificate.h
+++ b/native/com_wolfssl_WolfSSLCertificate.h
@@ -7,6 +7,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+#undef com_wolfssl_WolfSSLCertificate_serialVersionUID
+#define com_wolfssl_WolfSSLCertificate_serialVersionUID 1LL
 #undef com_wolfssl_WolfSSLCertificate_EVP_PKEY_RSA
 #define com_wolfssl_WolfSSLCertificate_EVP_PKEY_RSA 16L
 #undef com_wolfssl_WolfSSLCertificate_EVP_PKEY_EC

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -1683,10 +1683,10 @@ public class WolfSSL {
         synchronized(cleanupLock) {
             if (this.active == true) {
                 /* reset logging callback before calling cleanup() */
-                this.setLoggingCb(null);
+                setLoggingCb(null);
 
                 /* free resources, set state */
-                this.cleanup();
+                cleanup();
                 this.active = false;
             }
         }

--- a/src/java/com/wolfssl/WolfSSLException.java
+++ b/src/java/com/wolfssl/WolfSSLException.java
@@ -26,6 +26,9 @@ package com.wolfssl;
  */
 public class WolfSSLException extends Exception {
 
+    /* Exception class is serializable */
+    private static final long serialVersionUID = 1L;
+
     /**
      * Create WolfSSLException with reason String
      *

--- a/src/java/com/wolfssl/WolfSSLJNIException.java
+++ b/src/java/com/wolfssl/WolfSSLJNIException.java
@@ -26,6 +26,9 @@ package com.wolfssl;
  */
 public class WolfSSLJNIException extends Exception {
 
+    /* Exception class is serializable */
+    private static final long serialVersionUID = 1L;
+ 
     /**
      * Create WolfSSLJNIException with reason String
      *

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLAuthStore.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLAuthStore.java
@@ -97,9 +97,9 @@ public class WolfSSLAuthStore {
             store = new SessionStore<>(defaultCacheSize);
         }
         this.serverCtx = new WolfSSLSessionContext(
-                this, defaultCacheSize, WolfSSL.WOLFSSL_SERVER_END);
+            defaultCacheSize, WolfSSL.WOLFSSL_SERVER_END);
         this.clientCtx = new WolfSSLSessionContext(
-                this, defaultCacheSize, WolfSSL.WOLFSSL_CLIENT_END);
+            defaultCacheSize, WolfSSL.WOLFSSL_CLIENT_END);
     }
 
     /**
@@ -251,6 +251,7 @@ public class WolfSSLAuthStore {
      * @return pointer to the context set
      */
     protected WolfSSLSessionContext getServerContext() {
+        this.serverCtx.setWolfSSLAuthStore(this);
         return this.serverCtx;
     }
 
@@ -260,6 +261,7 @@ public class WolfSSLAuthStore {
      * @return pointer to the context set
      */
     protected WolfSSLSessionContext getClientContext() {
+        this.clientCtx.setWolfSSLAuthStore(this);
         return this.clientCtx;
     }
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLDebug.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLDebug.java
@@ -84,7 +84,9 @@ public class WolfSSLDebug {
      * @param tag level of debug message i.e. WolfSSLDebug.INFO
      * @param string message to be printed out
      */
-    public static synchronized void log(Class cl, String tag, String string) {
+    public static synchronized <T> void log(Class<T> cl, String tag,
+        String string) {
+
         if (DEBUG) {
             System.out.println(new Timestamp(new java.util.Date().getTime()) +
                                " [wolfJSSE " + tag + ": TID " +
@@ -102,8 +104,9 @@ public class WolfSSLDebug {
      * @param in byte array to be printed as hex
      * @param sz number of bytes from in array to be printed
      */
-    public static synchronized void logHex(Class cl, String tag, String label,
-                                           byte[] in, int sz) {
+    public static synchronized <T> void logHex(Class<T> cl, String tag,
+        String label, byte[] in, int sz) {
+
         if (DEBUG) {
             int i = 0, j = 0;
             int printSz = 0;

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLParametersHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLParametersHelper.java
@@ -122,7 +122,7 @@ public class WolfSSLParametersHelper
                 /* load WolfSSLJDK8Helper at runtime, not compiled on older JDKs */
                 Class<?> cls = Class.forName("com.wolfssl.provider.jsse.WolfSSLJDK8Helper");
                 Object obj = cls.getConstructor().newInstance();
-                Class[] paramList = new Class[3];
+                Class<?>[] paramList = new Class<?>[3];
                 paramList[0] = javax.net.ssl.SSLParameters.class;
                 paramList[1] = java.lang.reflect.Method.class;
                 paramList[2] = com.wolfssl.provider.jsse.WolfSSLParameters.class;
@@ -200,7 +200,7 @@ public class WolfSSLParametersHelper
                 /* load WolfSSLJDK8Helper at runtime, not compiled on older JDKs */
                 Class<?> cls = Class.forName("com.wolfssl.provider.jsse.WolfSSLJDK8Helper");
                 Object obj = cls.getConstructor().newInstance();
-                Class[] paramList = new Class[2];
+                Class<?>[] paramList = new Class<?>[2];
                 paramList[0] = javax.net.ssl.SSLParameters.class;
                 paramList[1] = com.wolfssl.provider.jsse.WolfSSLParameters.class;
                 Method mth = null;

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java
@@ -32,6 +32,8 @@ import com.wolfssl.WolfSSLFIPSErrorCallback;
  */
 public final class WolfSSLProvider extends Provider {
 
+    private static final long serialVersionUID = 1L;
+
     /* Keep one static reference to native wolfSSL library across
      * all WolfSSLProvider objects. */
     private static WolfSSL sslLib = null;
@@ -164,7 +166,7 @@ public final class WolfSSLProvider extends Provider {
 
         /* Store devId into static WolfSSL variable, used by
          * WolfSSLContext (SSLContext) */
-        sslLib.devId = devId;
+        WolfSSL.devId = devId;
 
     }
 
@@ -190,7 +192,7 @@ public final class WolfSSLProvider extends Provider {
         /* Call native JNI entry point to register native wolfSSL
          * CryptoDevice callback function. See native JNI function in
          * native/com_wolfssl_WolfSSL.c */
-        ret = sslLib.cryptoCbRegisterDevice(devId);
+        ret = WolfSSL.cryptoCbRegisterDevice(devId);
         if (ret != 0) {
             throw new WolfSSLException(
                 "Error registering native wolfSSL crypto callback, " +
@@ -215,7 +217,7 @@ public final class WolfSSLProvider extends Provider {
         /* Call native JNI entry point to unregister native wolfSSL
          * CryptoDevice callback function. See native JNI function in
          * native/com_wolfssl_WolfSSL.c */
-        ret = sslLib.cryptoCbUnRegisterDevice(devId);
+        ret = WolfSSL.cryptoCbUnRegisterDevice(devId);
         if (ret != 0) {
             throw new WolfSSLException(
                 "Error unregistering native wolfSSL crypto callback, " +

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLUtil.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLUtil.java
@@ -64,7 +64,7 @@ public class WolfSSLUtil {
 
         String disabledAlgos =
             Security.getProperty("jdk.tls.disabledAlgorithms");
-        List disabledList = null;
+        List<?> disabledList = null;
 
         /* If system property not set, no filtering needed */
         if (disabledAlgos == null || disabledAlgos.isEmpty()) {
@@ -119,7 +119,7 @@ public class WolfSSLUtil {
 
         String enabledSuites =
             Security.getProperty("wolfjsse.enabledCipherSuites");
-        List enabledList = null;
+        List<?> enabledList = null;
 
         /* If system property not set, no filtering needed */
         if (enabledSuites == null || enabledSuites.isEmpty()) {

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLX509.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLX509.java
@@ -57,8 +57,12 @@ import com.wolfssl.WolfSSLJNIException;
  */
 public class WolfSSLX509 extends X509Certificate {
 
+    /* X509Certificate class is serializable */
+    private static final long serialVersionUID = 1L;
+
     /** Inner WolfSSLCertificate object */
     private WolfSSLCertificate cert = null;
+
     /** Certificate extension OID values */
     private String[] extensionOid = {
         "2.5.29.15", /* key usage */
@@ -521,7 +525,7 @@ public class WolfSSLX509 extends X509Certificate {
 
             if (kf != null) {
                 spec = new X509EncodedKeySpec(der);
-                key = (PublicKey)kf.generatePublic(spec);
+                key = kf.generatePublic(spec);
             }
 
         } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLContextTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLContextTest.java
@@ -412,7 +412,7 @@ public class WolfSSLContextTest {
         ArrayList<String> expected = new ArrayList<String>();
 
         /* already sorted highest to lowest (ie TLSv1.3, ..., TLSv1.1) */
-        List enabledNativeProtocols = Arrays.asList(WolfSSL.getProtocols());
+        List<?> enabledNativeProtocols = Arrays.asList(WolfSSL.getProtocols());
 
         if (ctxProtocol == "TLS") {
             if (enabledNativeProtocols.contains("TLSv1.3")) {
@@ -490,7 +490,7 @@ public class WolfSSLContextTest {
 
         System.out.print("\tjdk.tls.disabledAlgorithms");
 
-        List enabledNativeProtocols = Arrays.asList(WolfSSL.getProtocols());
+        List<?> enabledNativeProtocols = Arrays.asList(WolfSSL.getProtocols());
         if (enabledNativeProtocols == null) {
             System.out.println("\t... failed");
             fail("WolfSSL.getProtocols() returned null");
@@ -714,7 +714,7 @@ public class WolfSSLContextTest {
 
         System.out.print("\twolfjsse.enabledCipherSuites");
 
-        List enabledNativeProtocols = Arrays.asList(WolfSSL.getProtocols());
+        List<?> enabledNativeProtocols = Arrays.asList(WolfSSL.getProtocols());
         if (enabledNativeProtocols == null) {
             System.out.println("\t... failed");
             fail("WolfSSL.getProtocols() returned null");

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineTest.java
@@ -215,7 +215,11 @@ public class WolfSSLEngineTest {
 
         ciphers = client.getSupportedCipherSuites();
         certs = server.getSession().getLocalCertificates();
-        if (certs != null) {
+        if (certs == null) {
+            error("\t... failed");
+            fail("no certs available from server SSLEngine.getSession()");
+        }
+        else {
             certType = ((X509Certificate)certs[0]).getSigAlgName();
             if (certType.contains("RSA")) {
                 /* use a ECDHE-RSA suite if available */

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
@@ -1054,7 +1054,7 @@ public class WolfSSLSocketTest {
         SSLSocket cs = (SSLSocket)ctx.getSocketFactory().createSocket();
         cs.connect(new InetSocketAddress(serverSock.getLocalPort()));
 
-        final Socket server = (Socket)serverSock.accept();
+        final Socket server = serverSock.accept();
 
         ExecutorService es = Executors.newSingleThreadExecutor();
         Future<Void> serverFuture = es.submit(new Callable<Void>() {
@@ -1390,8 +1390,8 @@ public class WolfSSLSocketTest {
 
         /* create new CTX */
         this.ctx = tf.createSSLContext("TLS", ctxProvider);
-        this.clientFlag = false;
-        this.serverFlag = false;
+        clientFlag = false;
+        serverFlag = false;
 
         /* create SSLServerSocket first to get ephemeral port */
         SSLServerSocket ss = (SSLServerSocket)ctx.getServerSocketFactory()
@@ -2398,11 +2398,13 @@ public class WolfSSLSocketTest {
 
         System.setProperty("javax.net.ssl.trustStore", tf.clientJKS);
         System.setProperty("javax.net.ssl.trustStoreType", tf.keyStoreType);
-        System.setProperty("javax.net.ssl.trustStorePassword", tf.jksPassStr);
+        System.setProperty("javax.net.ssl.trustStorePassword",
+            WolfSSLTestFactory.jksPassStr);
 
         System.setProperty("javax.net.ssl.keyStore", tf.clientJKS);
         System.setProperty("javax.net.ssl.keyStoreType", tf.keyStoreType);
-        System.setProperty("javax.net.ssl.keyStorePassword", tf.jksPassStr);
+        System.setProperty("javax.net.ssl.keyStorePassword",
+            WolfSSLTestFactory.jksPassStr);
 
         SSLContext ctx = SSLContext.getInstance("TLS", ctxProvider);
 
@@ -2456,7 +2458,8 @@ public class WolfSSLSocketTest {
 
         System.setProperty("javax.net.ssl.keyStore", tf.clientJKS);
         System.setProperty("javax.net.ssl.keyStoreType", tf.keyStoreType);
-        System.setProperty("javax.net.ssl.keyStorePassword", tf.jksPassStr);
+        System.setProperty("javax.net.ssl.keyStorePassword",
+            WolfSSLTestFactory.jksPassStr);
 
         ctx = SSLContext.getInstance("TLS", ctxProvider);
 
@@ -2475,11 +2478,13 @@ public class WolfSSLSocketTest {
         /* ------------------------------------------------ */
         System.setProperty("javax.net.ssl.trustStore", "badstorepath");
         System.setProperty("javax.net.ssl.trustStoreType", tf.keyStoreType);
-        System.setProperty("javax.net.ssl.trustStorePassword", tf.jksPassStr);
+        System.setProperty("javax.net.ssl.trustStorePassword",
+            WolfSSLTestFactory.jksPassStr);
 
         System.setProperty("javax.net.ssl.keyStore", tf.clientJKS);
         System.setProperty("javax.net.ssl.keyStoreType", tf.keyStoreType);
-        System.setProperty("javax.net.ssl.keyStorePassword", tf.jksPassStr);
+        System.setProperty("javax.net.ssl.keyStorePassword",
+            WolfSSLTestFactory.jksPassStr);
 
         ctx = SSLContext.getInstance("TLS", ctxProvider);
 
@@ -2498,11 +2503,13 @@ public class WolfSSLSocketTest {
         /* ------------------------------------------------ */
         System.setProperty("javax.net.ssl.trustStore", tf.clientJKS);
         System.setProperty("javax.net.ssl.trustStoreType", "badtype");
-        System.setProperty("javax.net.ssl.trustStorePassword", tf.jksPassStr);
+        System.setProperty("javax.net.ssl.trustStorePassword",
+            WolfSSLTestFactory.jksPassStr);
 
         System.setProperty("javax.net.ssl.keyStore", tf.clientJKS);
         System.setProperty("javax.net.ssl.keyStoreType", tf.keyStoreType);
-        System.setProperty("javax.net.ssl.keyStorePassword", tf.jksPassStr);
+        System.setProperty("javax.net.ssl.keyStorePassword",
+            WolfSSLTestFactory.jksPassStr);
 
         ctx = SSLContext.getInstance("TLS", ctxProvider);
 
@@ -2521,7 +2528,8 @@ public class WolfSSLSocketTest {
         /* ------------------------------------------------ */
         System.setProperty("javax.net.ssl.trustStore", tf.clientJKS);
         System.setProperty("javax.net.ssl.trustStoreType", tf.keyStoreType);
-        System.setProperty("javax.net.ssl.trustStorePassword", tf.jksPassStr);
+        System.setProperty("javax.net.ssl.trustStorePassword",
+            WolfSSLTestFactory.jksPassStr);
 
         System.setProperty("javax.net.ssl.keyStore", tf.clientJKS);
         System.setProperty("javax.net.ssl.keyStoreType", tf.keyStoreType);
@@ -2544,11 +2552,13 @@ public class WolfSSLSocketTest {
         /* ------------------------------------------------ */
         System.setProperty("javax.net.ssl.trustStore", tf.clientJKS);
         System.setProperty("javax.net.ssl.trustStoreType", tf.keyStoreType);
-        System.setProperty("javax.net.ssl.trustStorePassword", tf.jksPassStr);
+        System.setProperty("javax.net.ssl.trustStorePassword",
+            WolfSSLTestFactory.jksPassStr);
 
         System.setProperty("javax.net.ssl.keyStore", "badpath");
         System.setProperty("javax.net.ssl.keyStoreType", tf.keyStoreType);
-        System.setProperty("javax.net.ssl.keyStorePassword", tf.jksPassStr);
+        System.setProperty("javax.net.ssl.keyStorePassword",
+            WolfSSLTestFactory.jksPassStr);
 
         ctx = SSLContext.getInstance("TLS", ctxProvider);
 
@@ -2567,11 +2577,13 @@ public class WolfSSLSocketTest {
         /* ------------------------------------------------ */
         System.setProperty("javax.net.ssl.trustStore", tf.clientJKS);
         System.setProperty("javax.net.ssl.trustStoreType", tf.keyStoreType);
-        System.setProperty("javax.net.ssl.trustStorePassword", tf.jksPassStr);
+        System.setProperty("javax.net.ssl.trustStorePassword",
+            WolfSSLTestFactory.jksPassStr);
 
         System.setProperty("javax.net.ssl.keyStore", tf.clientJKS);
         System.setProperty("javax.net.ssl.keyStoreType", "badtype");
-        System.setProperty("javax.net.ssl.keyStorePassword", tf.jksPassStr);
+        System.setProperty("javax.net.ssl.keyStorePassword",
+            WolfSSLTestFactory.jksPassStr);
 
         ctx = SSLContext.getInstance("TLS", ctxProvider);
 

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
@@ -2376,7 +2376,7 @@ public class WolfSSLSocketTest {
 
         try {
             /* connect to invalid host/port, expect java.net.ConnectException.
-             * we do not expecdt anything to be running at localhost:12345 */
+             * we do not expect anything to be running at localhost:12345 */
             SSLSocket cs = (SSLSocket)sf.createSocket("localhost", 12345);
         } catch (ConnectException ce) {
             /* expected */

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLTestFactory.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLTestFactory.java
@@ -68,13 +68,13 @@ class WolfSSLTestFactory {
     protected String clientRSAJKS;
     protected String clientECCJKS;
     protected String clientRSAPSSJKS;
-    protected static String serverJKS;
+    protected String serverJKS;
     protected String serverRSA1024JKS;
     protected String serverRSAJKS;
     protected String serverECCJKS;
     protected String serverRSAPSSJKS;
     protected String caJKS;
-    protected static String caClientJKS;
+    protected String caClientJKS;
     protected String caServerJKS;
 
     protected String googleCACert;
@@ -858,7 +858,7 @@ class WolfSSLTestFactory {
     protected static boolean securityPropContains(String prop, String needle) {
 
         String secProp = null;
-        List propList = null;
+        List<?> propList = null;
 
         if (prop == null || needle == null) {
             return false;

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLX509Test.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLX509Test.java
@@ -303,7 +303,7 @@ public class WolfSSLX509Test {
             store = KeyStore.getInstance(tf.keyStoreType);
             stream = new FileInputStream(tf.allJKS);
 
-            store.load(stream, tf.jksPass);
+            store.load(stream, WolfSSLTestFactory.jksPass);
             stream.close();
             ca = new WolfSSLX509(store.getCertificate("ca").getEncoded());
             cax = new WolfSSLX509X(ca.getEncoded());
@@ -368,7 +368,7 @@ public class WolfSSLX509Test {
 
             store = KeyStore.getInstance(tf.keyStoreType);
             stream = new FileInputStream(tf.allJKS);
-            store.load(stream, tf.jksPass);
+            store.load(stream, WolfSSLTestFactory.jksPass);
             stream.close();
             server = new WolfSSLX509(store.getCertificate("server").getEncoded());
             ca = new WolfSSLX509(store.getCertificate("ca").getEncoded());

--- a/src/test/com/wolfssl/test/WolfSSLCertificateTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLCertificateTest.java
@@ -574,9 +574,9 @@ public class WolfSSLCertificateTest {
             boolean[] kuse;
 
             if (WolfSSL.FileSystemEnabled() == true) {
-                ext = new WolfSSLCertificate(this.external);
+                ext = new WolfSSLCertificate(external);
             } else {
-                ext = new WolfSSLCertificate(fileToByteArray(this.external),
+                ext = new WolfSSLCertificate(fileToByteArray(external),
                                              WolfSSL.SSL_FILETYPE_ASN1);
             }
 

--- a/src/test/com/wolfssl/test/WolfSSLContextTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLContextTest.java
@@ -424,7 +424,7 @@ public class WolfSSLContextTest {
             WolfSSL.WOLFSSL_ECC_SECP256R1
         };
         int[] tooLong = new int[50];
-        int[] badGroups = { (int)0xDEAD, (int)0xBEEF };
+        int[] badGroups = { 0xDEAD, 0xBEEF };
 
         System.out.print("\tsetGroups()");
         try {

--- a/src/test/com/wolfssl/test/WolfSSLSessionTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLSessionTest.java
@@ -1102,14 +1102,14 @@ public class WolfSSLSessionTest {
 
             /* wolfSSL_SessionIsSetup() may not be available, don't treat
              * NOT_COMPILED_IN as an error */
-            ret = cliSes.sessionIsSetup(sessionPtr);
+            ret = WolfSSLSession.sessionIsSetup(sessionPtr);
             if ((ret != 1) && (ret != WolfSSL.NOT_COMPILED_IN)) {
                 throw new Exception(
                     "WolfSSLSession.sessionIsSetup() did not return 1: " + ret);
             }
 
             /* Test duplicateSession(), wraps wolfSSL_SESSION_dup() */
-            sesDup = cliSes.duplicateSession(sessionPtr);
+            sesDup = WolfSSLSession.duplicateSession(sessionPtr);
             if (sesDup == 0) {
                 throw new Exception(
                     "WolfSSLSession.duplicateSession() returned 0");
@@ -1118,7 +1118,7 @@ public class WolfSSLSessionTest {
                 throw new Exception(
                     "WolfSSLSession.duplicateSession() returned same pointer");
             }
-            cliSes.freeSession(sesDup);
+            WolfSSLSession.freeSession(sesDup);
             sesDup = 0;
 
             cliSes.shutdownSSL();
@@ -1160,7 +1160,7 @@ public class WolfSSLSessionTest {
             }
 
             /* Get WOLFSSL_SESSION pointer, free original one first */
-            cliSes.freeSession(sessionPtr);
+            WolfSSLSession.freeSession(sessionPtr);
             sessionPtr = cliSes.getSession();
             if (sessionPtr == 0) {
                 throw new Exception(
@@ -1168,7 +1168,7 @@ public class WolfSSLSessionTest {
             }
 
             /* Free WOLFSSL_SESSION pointer */
-            cliSes.freeSession(sessionPtr);
+            WolfSSLSession.freeSession(sessionPtr);
             sessionPtr = 0;
 
             /* Session should be marked as resumed */
@@ -1190,10 +1190,10 @@ public class WolfSSLSessionTest {
 
         } finally {
             if (sessionPtr != 0) {
-                cliSes.freeSession(sessionPtr);
+                WolfSSLSession.freeSession(sessionPtr);
             }
             if (sesDup != 0) {
-                cliSes.freeSession(sesDup);
+                WolfSSLSession.freeSession(sesDup);
             }
             if (cliSes != null) {
                 cliSes.freeSSL();

--- a/src/test/com/wolfssl/test/WolfSSLTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLTest.java
@@ -85,22 +85,22 @@ public class WolfSSLTest {
     }
 
     public void test_WolfSSL_Method_Allocators(WolfSSL lib) {
-        tstMethod(lib.SSLv3_ServerMethod(), "SSLv3_ServerMethod()");
-        tstMethod(lib.SSLv3_ClientMethod(), "SSLv3_ClientMethod()");
-        tstMethod(lib.TLSv1_ServerMethod(), "TLSv1_ServerMethod()");
-        tstMethod(lib.TLSv1_ClientMethod(), "TLSv1_ClientMethod()");
-        tstMethod(lib.TLSv1_1_ServerMethod(), "TLSv1_1_ServerMethod()");
-        tstMethod(lib.TLSv1_1_ClientMethod(), "TLSv1_1_ClientMethod()");
-        tstMethod(lib.TLSv1_2_ServerMethod(), "TLSv1_2_ServerMethod()");
-        tstMethod(lib.TLSv1_2_ClientMethod(), "TLSv1_2_ClientMethod()");
-        tstMethod(lib.TLSv1_3_ServerMethod(), "TLSv1_3_ServerMethod()");
-        tstMethod(lib.TLSv1_3_ClientMethod(), "TLSv1_3_ClientMethod()");
-        tstMethod(lib.DTLSv1_ServerMethod(), "DTLSv1_ServerMethod()");
-        tstMethod(lib.DTLSv1_ClientMethod(), "DTLSv1_ClientMethod()");
-        tstMethod(lib.DTLSv1_2_ServerMethod(), "DTLSv1_2_ServerMethod()");
-        tstMethod(lib.DTLSv1_2_ClientMethod(), "DTLSv1_2_ClientMethod()");
-        tstMethod(lib.SSLv23_ServerMethod(), "SSLv23_ServerMethod()");
-        tstMethod(lib.SSLv23_ClientMethod(), "SSLv23_ClientMethod()");
+        tstMethod(WolfSSL.SSLv3_ServerMethod(), "SSLv3_ServerMethod()");
+        tstMethod(WolfSSL.SSLv3_ClientMethod(), "SSLv3_ClientMethod()");
+        tstMethod(WolfSSL.TLSv1_ServerMethod(), "TLSv1_ServerMethod()");
+        tstMethod(WolfSSL.TLSv1_ClientMethod(), "TLSv1_ClientMethod()");
+        tstMethod(WolfSSL.TLSv1_1_ServerMethod(), "TLSv1_1_ServerMethod()");
+        tstMethod(WolfSSL.TLSv1_1_ClientMethod(), "TLSv1_1_ClientMethod()");
+        tstMethod(WolfSSL.TLSv1_2_ServerMethod(), "TLSv1_2_ServerMethod()");
+        tstMethod(WolfSSL.TLSv1_2_ClientMethod(), "TLSv1_2_ClientMethod()");
+        tstMethod(WolfSSL.TLSv1_3_ServerMethod(), "TLSv1_3_ServerMethod()");
+        tstMethod(WolfSSL.TLSv1_3_ClientMethod(), "TLSv1_3_ClientMethod()");
+        tstMethod(WolfSSL.DTLSv1_ServerMethod(), "DTLSv1_ServerMethod()");
+        tstMethod(WolfSSL.DTLSv1_ClientMethod(), "DTLSv1_ClientMethod()");
+        tstMethod(WolfSSL.DTLSv1_2_ServerMethod(), "DTLSv1_2_ServerMethod()");
+        tstMethod(WolfSSL.DTLSv1_2_ClientMethod(), "DTLSv1_2_ClientMethod()");
+        tstMethod(WolfSSL.SSLv23_ServerMethod(), "SSLv23_ServerMethod()");
+        tstMethod(WolfSSL.SSLv23_ClientMethod(), "SSLv23_ClientMethod()");
     }
 
     public void tstMethod(long method, String name) {


### PR DESCRIPTION
This PR adds a GitHub Actions PRB test which builds for Android using gradle.  This builds the example Android Studio project under `IDE/Android`, and currently is only a build test (no runtime test).

Adding this test also exposed a bunch of warnings that were found by the Android compiler when `-Wall` and `-Werror` were turned on. This PR fixes those warnings so the PRB test has a clean build. Warnings will continue to be treated as errors in this Actions test going forward to catch things.

One more improvement in this test is that we test against the minimum Android SDK version of 24. We have users running on Android 24 and we need to ensure backwards build compatibility with that SDK version. Setting `minSdkVersion 24` in `IDE/Android/app/build.gradle` means we will see warnings (errors) if we try to use APIs which are not in Android SDK 24.

The Android Studio example has been simplified to only register and check for the wolfSSLProvider. The file/cert loading behavior has been removed to make it easier to support this across older Android SDK versions.  The API's used which were taken out (ex: `Environment.isExternalStorageManager()`) were not supported in Android SDK 24.

The run of this new PRB test on this PR is here: https://github.com/wolfSSL/wolfssljni/actions/runs/10965959952/job/30452876531?pr=222