### PR TITLE
JNI/JSSE: clean up ant build warnings for Corretto 20.0.1

### DIFF
--- a/src/java/com/wolfssl/WolfSSLCertificate.java
+++ b/src/java/com/wolfssl/WolfSSLCertificate.java
@@ -54,20 +54,23 @@ public class WolfSSLCertificate implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    /** Flag if this class is active or not */
     private boolean active = false;
+
+    /** Internal pointer for native WOLFSSL_X509 */
     private long x509Ptr = 0;
 
-    /* Does this WolfSSLCertificate own the internal WOLFSSL_X509 pointer?
+    /** Does this WolfSSLCertificate own the internal WOLFSSL_X509 pointer?
      * If not, don't try to free native memory on free(). */
     private boolean weOwnX509Ptr = false;
 
-    /* lock around active state */
+    /** lock around active state */
     private transient final Object stateLock = new Object();
 
-    /* lock around native WOLFSSL_X509 pointer use */
+    /** lock around native WOLFSSL_X509 pointer use */
     private transient final Object x509Lock = new Object();
 
-    /* cache alt names once retrieved once */
+    /** Cache alt names once retrieved once */
     private ArrayList<List<?>> altNames = null;
 
     /* Public key types used for certificate generation, mirrored from

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLDebug.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLDebug.java
@@ -68,6 +68,12 @@ public class WolfSSLDebug {
     private static WolfSSLNativeLoggingCallback nativeLogCb = null;
 
     /**
+     * Default constructor for wolfJSSE debug class.
+     */
+    public WolfSSLDebug() {
+    }
+
+    /**
      * Check if "wolfjsse.debug" System property is set to "true".
      *
      * @return true if set to "true", otherwise return false
@@ -163,6 +169,7 @@ public class WolfSSLDebug {
      *         "thread_id": "thread_ID"
      *     }
      *
+     * @param <T> class type of cl
      * @param cl class being called from to get debug info
      * @param tag level of debug message i.e. WolfSSLDebug.INFO
      * @param string message to be printed out
@@ -205,6 +212,7 @@ public class WolfSSLDebug {
      *         "thread_id": "thread_ID"
      *     }
      *
+     * @param <T> class type for cl
      * @param cl class this method is being called from
      * @param tag level of debug message i.e. WolfSSLDebug.INFO
      * @param label label string to print with hex

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
@@ -1413,6 +1413,9 @@ public class WolfSSLEngineHelper {
         return WolfSSL.SSL_FAILURE;
     }
 
+    /**
+     * Clear internal state of this WolfSSLEngineHelper.
+     */
     protected synchronized void clearObjectState() {
         this.ssl = null;
         this.session = null;

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
@@ -831,6 +831,9 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
         }
     }
 
+    /**
+     * Update internally-stored session values.
+     */
     protected synchronized void updateStoredSessionValues() {
 
         try {

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSessionContext.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSessionContext.java
@@ -43,7 +43,6 @@ public class WolfSSLSessionContext implements SSLSessionContext {
      * WolfSSLAuthStore not given as parameter in this constructor, caller
      * should explicitly set with WolfSSLSessionContext.setWolfSSLAuthStore().
      *
-     * @param in WolfSSLAuthStore object to use with this context
      * @param defaultCacheSize default session cache size
      * @param side client or server side. Either WolfSSL.WOLFSSL_CLIENT_END or
      *        WolfSSL.WOLFSSL_SERVER_END
@@ -70,6 +69,11 @@ public class WolfSSLSessionContext implements SSLSessionContext {
         this.side      = side;
     }
 
+    /**
+     * Set WolfSSLAuthStore for this object.
+     *
+     * @param store WolfSSLAuthStore to use with this object
+     */
     public void setWolfSSLAuthStore(WolfSSLAuthStore store) {
         this.store = store;
     }

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLUtil.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLUtil.java
@@ -43,6 +43,12 @@ import com.wolfssl.WolfSSLException;
 public class WolfSSLUtil {
 
     /**
+     * Default constructor for WolfSSLUtil class.
+     */
+    public WolfSSLUtil() {
+    }
+
+    /**
      * Sanitize or filter protocol list based on system property limitations.
      *
      * Supported system properties which limit protocol list are:


### PR DESCRIPTION
This PR cleans up `ant` build warnings on Corretto 20.0.1.