### PR TITLE
JSSE: add LDAPS endpoint identification to X509ExtendedTrustManager

### DIFF
--- a/native/com_wolfssl_WolfSSLCertificate.c
+++ b/native/com_wolfssl_WolfSSLCertificate.c
@@ -776,7 +776,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1check_1host
 
     hostname = (*jenv)->GetStringUTFChars(jenv, chk, 0);
     if (hostname != NULL) {
-        /* flags and peerNamePtr not used */
+        /* peerNamePtr not used */
         ret = wolfSSL_X509_check_host(x509, hostname,
             XSTRLEN(hostname), (unsigned int)flags, NULL);
     }

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -549,6 +549,11 @@ public class WolfSSL {
      * level with WolfSSLContext.setDevId() and WolfSSLSession.setDevId() */
     public static int devId = WolfSSL.INVALID_DEVID;
 
+    /* ------------------------- Flag Values ---------------------------- */
+    /** WolfSSLCertificate.checkHost() match only wildcards in left-most
+     * position, used for LDAPS hostname verification. */
+    public static int WOLFSSL_LEFT_MOST_WILDCARD_ONLY = 0x40;
+
     /* ---------------------------- locks ------------------------------- */
 
     /* lock for cleanup */

--- a/src/java/com/wolfssl/WolfSSLCertificate.java
+++ b/src/java/com/wolfssl/WolfSSLCertificate.java
@@ -1439,10 +1439,32 @@ public class WolfSSLCertificate implements Serializable {
      */
     public int checkHost(String hostname) throws IllegalStateException {
 
+        return checkHost(hostname, 0);
+    }
+
+    /**
+     * Checks that given hostname matches this certificate SubjectAltName
+     * or CommonName entries, behavior can be controlled via flags.
+     *
+     * @param hostname Hostname to check certificate against
+     * @param flags Flags to control hostname check behavior. Supported options
+     *        include WolfSSL.WOLFSSL_LEFT_MOST_WILDCARD_ONLY to only match
+     *        wildcards on left-most position.
+     *
+     * @return WolfSSL.SSL_SUCCESS on successful hostname match,
+     *         WolfSSL.SSL_FAILURE on invalid match or error, or
+     *         WolfSSL.NOT_COMPILED_IN if native wolfSSL has been compiled
+     *         with NO_ASN defined and native API is not available.
+     *
+     * @throws IllegalStateException if WolfSSLCertificate has been freed.
+     */
+    public int checkHost(String hostname, long flags)
+        throws IllegalStateException {
+
         confirmObjectIsActive();
 
         synchronized (x509Lock) {
-            return X509_check_host(this.x509Ptr, hostname, 0, 0);
+            return X509_check_host(this.x509Ptr, hostname, flags, 0);
         }
     }
 

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineTest.java
@@ -25,11 +25,15 @@ import com.wolfssl.WolfSSL;
 import com.wolfssl.WolfSSLException;
 import com.wolfssl.provider.jsse.WolfSSLProvider;
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.channels.SocketChannel;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.UnrecoverableKeyException;
 import java.security.Provider;
 import java.security.Security;
 import java.security.cert.Certificate;
@@ -122,7 +126,10 @@ public class WolfSSLEngineTest {
 
     @Test
     public void testSSLEngine()
-        throws NoSuchProviderException, NoSuchAlgorithmException {
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               KeyManagementException, KeyStoreException, CertificateException,
+               IOException, UnrecoverableKeyException {
+
         SSLEngine e;
 
         /* create new SSLEngine */
@@ -142,7 +149,10 @@ public class WolfSSLEngineTest {
 
     @Test
     public void testSSLEngineSetCipher()
-        throws NoSuchProviderException, NoSuchAlgorithmException {
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               KeyManagementException, KeyStoreException, CertificateException,
+               IOException, UnrecoverableKeyException {
+
         SSLEngine e;
         String sup[];
         boolean ok = false;
@@ -197,7 +207,10 @@ public class WolfSSLEngineTest {
 
     @Test
     public void testCipherConnection()
-        throws NoSuchProviderException, NoSuchAlgorithmException {
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               KeyManagementException, KeyStoreException, CertificateException,
+               IOException, UnrecoverableKeyException {
+
         SSLEngine server;
         SSLEngine client;
         String    cipher = null;
@@ -305,7 +318,9 @@ public class WolfSSLEngineTest {
     @Test
     public void testBeginHandshake()
         throws NoSuchProviderException, NoSuchAlgorithmException,
-               SSLException {
+               SSLException, KeyManagementException, KeyStoreException,
+               CertificateException, IOException, UnrecoverableKeyException {
+
         SSLEngine server;
         SSLEngine client;
         int ret;
@@ -377,7 +392,10 @@ public class WolfSSLEngineTest {
 
     @Test
     public void testConnectionOutIn()
-        throws NoSuchProviderException, NoSuchAlgorithmException {
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               KeyManagementException, KeyStoreException, CertificateException,
+               IOException, UnrecoverableKeyException {
+
         SSLEngine server;
         SSLEngine client;
         int ret;
@@ -424,7 +442,9 @@ public class WolfSSLEngineTest {
 
     @Test
     public void testSetUseClientMode()
-        throws NoSuchProviderException, NoSuchAlgorithmException {
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               KeyManagementException, KeyStoreException, CertificateException,
+               IOException, UnrecoverableKeyException {
 
         int ret;
         SSLEngine client;
@@ -494,7 +514,10 @@ public class WolfSSLEngineTest {
 
     @Test
     public void testMutualAuth()
-        throws NoSuchProviderException, NoSuchAlgorithmException {
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               KeyManagementException, KeyStoreException, CertificateException,
+               IOException, UnrecoverableKeyException {
+
         SSLEngine server;
         SSLEngine client;
         int ret;
@@ -569,7 +592,9 @@ public class WolfSSLEngineTest {
 
     @Test
     public void testSetWantNeedClientAuth_ClientServerDefaultKeyManager()
-        throws NoSuchProviderException, NoSuchAlgorithmException {
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               KeyManagementException, KeyStoreException, CertificateException,
+               IOException, UnrecoverableKeyException {
 
         int ret = 0;
         SSLContext cCtx = null;
@@ -634,7 +659,9 @@ public class WolfSSLEngineTest {
 
     @Test
     public void testSetWantNeedClientAuth_ClientNoKeyManager()
-        throws NoSuchProviderException, NoSuchAlgorithmException {
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               KeyManagementException, KeyStoreException, CertificateException,
+               IOException, UnrecoverableKeyException {
 
         int ret = 0;
         SSLContext cCtx = null;
@@ -700,7 +727,9 @@ public class WolfSSLEngineTest {
 
     @Test
     public void testSetWantNeedClientAuth_ServerNoKeyManager()
-        throws NoSuchProviderException, NoSuchAlgorithmException {
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               KeyManagementException, KeyStoreException, CertificateException,
+               IOException, UnrecoverableKeyException {
 
         int ret = 0;
         SSLContext cCtx = null;
@@ -768,7 +797,9 @@ public class WolfSSLEngineTest {
 
     @Test
     public void testSetWantNeedClientAuth_ClientServerExternalTrustAllCerts()
-        throws NoSuchProviderException, NoSuchAlgorithmException {
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               KeyStoreException, CertificateException, IOException,
+               UnrecoverableKeyException {
 
         int ret = 0;
         SSLContext cCtx = null;
@@ -864,7 +895,9 @@ public class WolfSSLEngineTest {
 
     @Test
     public void testSetWantNeedClientAuth_ExternalTrustNoClientCerts()
-        throws NoSuchProviderException, NoSuchAlgorithmException {
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               KeyStoreException, CertificateException, IOException,
+               UnrecoverableKeyException {
 
         int ret = 0;
         SSLContext cCtx = null;
@@ -976,7 +1009,10 @@ public class WolfSSLEngineTest {
 
     @Test
     public void testReuseSession()
-        throws NoSuchProviderException, NoSuchAlgorithmException {
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               KeyManagementException, KeyStoreException, CertificateException,
+               IOException, UnrecoverableKeyException {
+
         SSLEngine server;
         SSLEngine client;
         int ret;
@@ -1064,7 +1100,9 @@ public class WolfSSLEngineTest {
     @Test
     public void testExtendedThreadingUse()
         throws NoSuchProviderException, NoSuchAlgorithmException,
-               InterruptedException {
+               InterruptedException, KeyManagementException,
+               KeyStoreException, CertificateException, IOException,
+               UnrecoverableKeyException {
 
         /* Number of SSLEngine client threads to start up */
         int numThreads = 50;

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLKeyX509Test.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLKeyX509Test.java
@@ -24,11 +24,17 @@ package com.wolfssl.provider.jsse.test;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
-import java.security.NoSuchProviderException;
+import java.io.IOException;
 import java.security.Principal;
 import java.security.Provider;
 import java.security.Security;
+import java.security.NoSuchProviderException;
+import java.security.NoSuchAlgorithmException;
+import java.security.KeyStoreException;
+import java.security.KeyManagementException;
+import java.security.UnrecoverableKeyException;
 import java.security.cert.X509Certificate;
+import java.security.cert.CertificateException;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.X509KeyManager;
@@ -67,7 +73,10 @@ public class WolfSSLKeyX509Test {
     }
 
     @Test
-    public void testGetClientAliases() {
+    public void testGetClientAliases()
+        throws NoSuchAlgorithmException, KeyStoreException,
+               KeyManagementException, CertificateException, IOException,
+               NoSuchProviderException, UnrecoverableKeyException {
 
         KeyManager[] list;
         X509KeyManager km;
@@ -137,7 +146,10 @@ public class WolfSSLKeyX509Test {
     }
 
     @Test
-    public void testChooseClientAlias() {
+    public void testChooseClientAlias()
+        throws NoSuchAlgorithmException, KeyStoreException,
+               KeyManagementException, CertificateException, IOException,
+               NoSuchProviderException, UnrecoverableKeyException {
 
         KeyManager[] km = null;
         X509KeyManager x509km = null;
@@ -199,7 +211,10 @@ public class WolfSSLKeyX509Test {
     }
 
     @Test
-    public void testEngineChooseClientAlias() {
+    public void testEngineChooseClientAlias()
+        throws NoSuchAlgorithmException, KeyStoreException,
+               KeyManagementException, CertificateException, IOException,
+               NoSuchProviderException, UnrecoverableKeyException {
 
         KeyManager[] km = null;
         X509ExtendedKeyManager x509km = null;
@@ -264,7 +279,10 @@ public class WolfSSLKeyX509Test {
     }
 
     @Test
-    public void testGetServerAliases() {
+    public void testGetServerAliases()
+        throws NoSuchAlgorithmException, KeyStoreException,
+               KeyManagementException, CertificateException, IOException,
+               NoSuchProviderException, UnrecoverableKeyException {
 
         KeyManager[] list;
         X509KeyManager km;
@@ -311,7 +329,10 @@ public class WolfSSLKeyX509Test {
     }
 
     @Test
-    public void testChooseServerAlias() {
+    public void testChooseServerAlias()
+        throws NoSuchAlgorithmException, KeyStoreException,
+               KeyManagementException, CertificateException, IOException,
+               NoSuchProviderException, UnrecoverableKeyException {
 
         KeyManager[] km = null;
         X509KeyManager x509km = null;
@@ -373,7 +394,10 @@ public class WolfSSLKeyX509Test {
     }
 
     @Test
-    public void testChooseEngineServerAlias() {
+    public void testChooseEngineServerAlias()
+        throws NoSuchAlgorithmException, KeyStoreException,
+               KeyManagementException, CertificateException, IOException,
+               NoSuchProviderException, UnrecoverableKeyException {
 
         KeyManager[] km = null;
         X509ExtendedKeyManager x509km = null;

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSessionContextTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSessionContextTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.*;
 
 import java.util.Arrays;
 import java.util.Enumeration;
+import java.io.IOException;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSessionContext;
 import javax.net.ssl.SSLContext;
@@ -36,8 +37,12 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 import java.security.Security;
 import java.security.Provider;
-import java.security.NoSuchProviderException;
+import java.security.KeyStoreException;
+import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
 
 import com.wolfssl.WolfSSLException;
 import com.wolfssl.provider.jsse.WolfSSLProvider;
@@ -72,7 +77,11 @@ public class WolfSSLSessionContextTest {
 
     @Test
     public void testGetSessionTimeout()
-        throws NoSuchProviderException, NoSuchAlgorithmException {
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               KeyManagementException, KeyStoreException, CertificateException,
+               IOException, UnrecoverableKeyException,
+               NoSuchAlgorithmException {
+
         SSLEngine server;
         SSLEngine client;
         int ret;
@@ -144,7 +153,11 @@ public class WolfSSLSessionContextTest {
 
     @Test
     public void testSetSessionTimeout()
-        throws NoSuchProviderException, NoSuchAlgorithmException {
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               KeyManagementException, KeyStoreException, CertificateException,
+               IOException, UnrecoverableKeyException,
+               NoSuchAlgorithmException {
+
         SSLEngine server;
         SSLEngine client;
         int ret;
@@ -253,7 +266,11 @@ public class WolfSSLSessionContextTest {
 
     @Test
     public void testSessionIDsTLS13()
-        throws NoSuchProviderException, NoSuchAlgorithmException {
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               KeyManagementException, KeyStoreException, CertificateException,
+               IOException, UnrecoverableKeyException,
+               NoSuchAlgorithmException {
+
         SSLEngine server;
         SSLEngine client;
         int ret;
@@ -393,7 +410,11 @@ public class WolfSSLSessionContextTest {
 
     @Test
     public void testSessionIDs()
-        throws NoSuchProviderException, NoSuchAlgorithmException {
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               KeyManagementException, KeyStoreException, CertificateException,
+               IOException, UnrecoverableKeyException,
+               NoSuchAlgorithmException {
+
         SSLEngine server;
         SSLEngine client;
         int ret;

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSessionTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSessionTest.java
@@ -24,12 +24,18 @@ package com.wolfssl.provider.jsse.test;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
+import java.io.IOException;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
-import java.security.NoSuchProviderException;
 import java.security.Principal;
 import java.security.Provider;
 import java.security.Security;
+import java.security.KeyStoreException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
 import java.util.ArrayList;
 
 import javax.net.ssl.SSLContext;
@@ -77,7 +83,11 @@ public class WolfSSLSessionTest {
 
 
     @Test
-    public void testSessionTimeAndCerts() {
+    public void testSessionTimeAndCerts()
+        throws NoSuchAlgorithmException, KeyManagementException,
+               KeyStoreException, CertificateException, IOException,
+               NoSuchProviderException, UnrecoverableKeyException {
+
         int ret;
         SSLSession session;
 
@@ -145,7 +155,11 @@ public class WolfSSLSessionTest {
     }
 
     @Test
-    public void testNullSession() {
+    public void testNullSession()
+        throws NoSuchAlgorithmException, KeyManagementException,
+               KeyStoreException, CertificateException, IOException,
+               NoSuchProviderException, UnrecoverableKeyException {
+
         int ret;
         SSLSession session;
 
@@ -221,7 +235,11 @@ public class WolfSSLSessionTest {
 
 
     @Test
-    public void testBinding() {
+    public void testBinding()
+        throws NoSuchAlgorithmException, KeyManagementException,
+               KeyStoreException, CertificateException, IOException,
+               NoSuchProviderException, UnrecoverableKeyException {
+
         int ret;
         String[] values;
         listner bound  = new listner();
@@ -368,7 +386,11 @@ public class WolfSSLSessionTest {
     }
 
     @Test
-    public void testSessionContext() {
+    public void testSessionContext()
+        throws NoSuchAlgorithmException, KeyManagementException,
+               KeyStoreException, CertificateException, IOException,
+               NoSuchProviderException, UnrecoverableKeyException {
+
         int ret;
         SSLSession session;
         SSLSessionContext context;

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
@@ -958,7 +958,8 @@ public class WolfSSLSocketTest {
     @Test
     public void testExtendedThreadingUse()
         throws NoSuchProviderException, NoSuchAlgorithmException,
-               InterruptedException {
+               InterruptedException, KeyManagementException, KeyStoreException,
+               CertificateException, UnrecoverableKeyException, IOException {
 
         /* Number of SSLSocket client threads to start up */
         int numThreads = 50;
@@ -1697,7 +1698,7 @@ public class WolfSSLSocketTest {
         /* fail case, no root CA loaded to verify client cert */
         this.ctx = tf.createSSLContext("TLSv1.2", ctxProvider,
                 /* using null here for JKS, use system certs only */
-                tf.createTrustManager("SunX509", null, ctxProvider),
+                tf.createTrustManager("SunX509", (String)null, ctxProvider),
                 tf.createKeyManager("SunX509", tf.serverJKS, ctxProvider));
 
         ss = (SSLServerSocket)ctx.getServerSocketFactory()

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLX509Test.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLX509Test.java
@@ -29,13 +29,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.security.InvalidKeyException;
 import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
 import java.security.Provider;
 import java.security.PublicKey;
 import java.security.Security;
 import java.security.SignatureException;
+import java.security.KeyStoreException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateExpiredException;
@@ -410,7 +412,11 @@ public class WolfSSLX509Test {
 
 
     @Test
-    public void testGetters() {
+    public void testGetters()
+        throws NoSuchAlgorithmException, KeyStoreException,
+               KeyManagementException, IOException, CertificateException,
+               NoSuchProviderException, UnrecoverableKeyException {
+
         SSLEngine server;
         SSLEngine client;
         String    cipher = null;


### PR DESCRIPTION
This PR adds Endpoint Identification for hostname verification to wolfJSSE's X509ExtendedTrustManager implementation.

Previously we had only supported HTTPS endpoint identification, but with this now support both HTTPS (RFC 2818) and LDAPS (RFC 2830).

PR also includes ant tests for LDAPS hostname verification.