### PR TITLE
Prep for 1.14 Release

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,70 @@
+### wolfSSL JNI Release 1.14.0 (11/7/2024)
+
+Release 1.14.0 has bug fixes and new features including:
+
+**New JSSE Functionality:**
+* Add wolfJCE WKS KeyStore type support (PR 178)
+* Add support for native `poll()` and set as default over `select()` (PR 201)
+* Add `getSSLParameters()` to SSLServerSocket implementation (PR 214)
+* Add `rsa_pss` support and tests to wolfJSSE (PR 218)
+* Add LDAPS endpoint identification to X509ExtendedTrustManager (PR 227)
+
+**JSSE System/Security Property Support:**
+* Add option to print debug logs in JSON format (`wolfjsse.debugFormat=JSON`) (PR 187)
+* Add Security property to disable Java client session cache (`wolfjsse.clientSessionCache.disabled=true`) (PR 225)
+
+**JSSE Changes:**
+* Fix for native memory leak when calling `wolfSSL_get_peer_certificate()` (PR 188)
+* Optimization to allow for easier garbage collection (PR 189)
+* Fix for SSLEngine session storage and unwrap() FINISHED state (PR 193)
+* Fix to not close SSLSocket when SSLServerSocket is closed (PR 194)
+* Fix for getting end of stream when calling InputStream.read() (PR 195)
+* Fix for throwing exceptions on KeyManagerFactory/TrustManagerFactory use before init (PR 196)
+* Fix for SSLEngine HandshakeStatus when receiving TLS 1.3 session tickets after handshake (PR 197)
+* Throw SSLException to indicate lack of renegotiation support in `SSLEngine.beginHandshake()` (PR 197)
+* Fix to mark inbound and outbound closed in SSLEngine when fatal alerts are received (PR 197)
+* Return `X509Certificate[]` from `SSLSession.getPeerCertificates()` (PR 199)
+* Remove unneeded `SSLServerSocket.close()` method (PR 200)
+* Fix `SSLSession.getLocalPrincipal()` to assume user cert is first in chain (PR 204)
+* Ensure that socket is closed if implicit handshake in `SSLSocket.getSession()` fails (PR 205)
+* If SSLSocket handshake is unsuccessful, close Socket before throwing an exception (PR 205)
+* Close SSLEngine inbound on ALPN protocol name error (PR 208)
+* Adjust client-side session resumption to check cipher suite and protocol (PR 209)
+* Pass lower level exception messages up during X509TrustManager verification (PR 211)
+* Refactor code calls not available in Android API 24 (PR 216)
+* Fix to return end of stream in `InputStream.read()` on socket error (PR 217)
+* Fix to update the TLS protocol in SSLSession after handshake completes (PR 219)
+* Fix potential deadlock on close() between SSLSocket and Input/OutputStream (PR 220)
+* Fixes for issues found with SpotBugs (PR 221)
+* Clean up ant build warnings on Corretto 20.0.1 (PR 223)
+* Error out on invalid port during creation of SSLEngine (PR 224)
+* Correct SSLSocket exception types and fix setting of native file descriptor (PR 228)
+* Fix deadlock issues between `SSLSocket close()` and `OutputStream.write()` (PR 230)
+
+**New JNI Wrapped APIs and Functionality:**
+* `wolfSSL_SessionIsSetup()` (PR 191)
+* `wolfSSL_SESSION_dup()` (PR 206)
+
+**JNI Changes:**
+* Fix for JNI example use of TLS 1.3 secret callback strings (PR 192)
+
+**Example Changes:**
+* Add Host into HTTP GET in example ClientJSSE when used with `-g` (PR 213)
+* Add example JNI-only threaded client/server applications (PR 212)
+* Add basic RMI example client and server (PR 226)
+
+**Debugging Changes:**
+* Fix typo in SSLEngine debug logs (PR 203)
+
+**Testing Changes:**
+* Run Facebook Infer on all PRs with GitHub Actions (PR 190)
+* Run TLS 1.0 and 1.1 tests if enabled in native wolfSSL even if disabled in `java.security` (PR 198)
+* Add GitHub Actions PRB test for Android gradle build (PR 222)
+
+The wolfSSL JNI Manual is available at:
+https://www.wolfssl.com/documentation/manuals/wolfssljni. For build
+instructions and more detailed comments, please check the manual.
+
 ### wolfSSL JNI Release 1.13.0 (4/9/2024)
 
 Release 1.13.0 has bug fixes and new features including:

--- a/IDE/WIN/README.md
+++ b/IDE/WIN/README.md
@@ -137,6 +137,7 @@ section titled `/* Configuration */`:
 ```
 #define WOLFSSL_JNI
 #define HAVE_EX_DATA
+#define OPENSSL_EXTRA
 #define OPENSSL_ALL
 #define HAVE_CRL
 #define HAVE_OCSP
@@ -146,9 +147,16 @@ section titled `/* Configuration */`:
 #define HAVE_DH
 #define WOLFSSL_CERT_EXT
 #define WOLFSSL_CERT_GEN
+#define WOLFSSL_KEY_GEN
+#define WOLFSSL_CERT_REQ
+#define WOLFSSL_ALT_NAMES
 #define HAVE_TLS_EXTENSIONS
 #define HAVE_SNI
 #define HAVE_ALPN
+#define KEEP_PEER_CERT
+#define SESSION_CERTS
+#define WOLFSSL_ALT_CERT_CHAINS
+#define WOLFSSL_ALWAYS_VERIFY_CB
 ```
 
 After editing and saving the `user_settings.h` file, select one of the following
@@ -171,10 +179,13 @@ When bulding wolfSSL JNI/JSSE, the Visual Studio project file for that library
 will look in the above locations to link against the wolfSSL DLL matching
 the same build configuration.
 
-## wolfSSL FIPS 140-2 (Certificate #3389)
+## wolfSSL FIPS 140-2 (Certificate #3389, Now Historical)
+
+Please consider looking at and migrating to wolfSSL's new FIPS 140-3
+validated version of wolfCrypt. Email fips@wolfssl.com for more information.
 
 To build a wolfSSL FIPS 140-2 variant of wolfSSL for use with FIPS 140-2
-certificate #3389 or later, use the Visual Studio solution file located under
+certificate #3389, use the Visual Studio solution file located under
 the `IDE\WIN10` directory inside the wolfSSL FIPS release package:
 
 ```
@@ -216,6 +227,7 @@ and set the values for `HAVE_FIPS`, `HAVE_FIPS_VERSION`, and
 ```
 #define WOLFSSL_JNI
 #define HAVE_EX_DATA
+#define OPENSSL_EXTRA
 #define OPENSSL_ALL
 #define HAVE_CRL
 #define HAVE_OCSP
@@ -225,9 +237,16 @@ and set the values for `HAVE_FIPS`, `HAVE_FIPS_VERSION`, and
 #define HAVE_DH
 #define WOLFSSL_CERT_EXT
 #define WOLFSSL_CERT_GEN
+#define WOLFSSL_KEY_GEN
+#define WOLFSSL_CERT_REQ
+#define WOLFSSL_ALT_NAMES
 #define HAVE_TLS_EXTENSIONS
 #define HAVE_SNI
 #define HAVE_ALPN
+#define KEEP_PEER_CERT
+#define SESSION_CERTS
+#define WOLFSSL_ALT_CERT_CHAINS
+#define WOLFSSL_ALWAYS_VERIFY_CB
 ```
 
 6. Build the `wolfssl-fips` project, which will create a DLL in one of the
@@ -254,19 +273,20 @@ in the wolfCrypt tests successfully running.
 See the FIPS User Guide for more details on the FIPS verifyCore hash, or
 email support@wolfssl.com.
 
-## wolfSSL FIPS 140-3 (Upcoming)
+## wolfSSL FIPS 140-3 (Certificate #4718)
 
-To build a version of wolfSSL that has been submitted for FIPS 140-3, use
-the Visual Studio solution file under the `IDE\WIN10` directory inside the
-wolfSSL package:
+To build a wolfSSL FIPS 140-3 variant for use with FIPS 140-3 certificate
+#4718, use the Visual Studio solution file located in the `IDE/WIN10`
+directory inside the wolfSSL package:
 
 ```
 <wolfssl>\IDE\WIN10\wolfssl-fips.sln
 ```
 
 Follow instructions in the above section for 140-2 / 3389, except use the
-following values for `HAVE_FIPS`, `HAVE_FIPS_VERSION`, and
-`HAVE_FIPS_VERSION_MINOR` in `user_settings.h`:
+following values for `HAVE_FIPS`, `HAVE_FIPS_VERSION`,
+`HAVE_FIPS_VERSION_MAJOR`, `HAVE_FIPS_VERSION_MINOR`, and
+`HAVE_FIPS_VERSION_PATCH` in `user_settings.h`:
 
 ```
 #if 1
@@ -274,8 +294,12 @@ following values for `HAVE_FIPS`, `HAVE_FIPS_VERSION`, and
 #define HAVE_FIPS
 #undef HAVE_FIPS_VERSION
 #define HAVE_FIPS_VERSION 5
+#undef HAVE_FIPS_VERSION_MAJOR
+#define HAVE_FIPS_VERSION_MAJOR 5
 #undef HAVE_FIPS_VERSION_MINOR
-#define HAVE_FIPS_VERSION_MINOR 1
+#define HAVE_FIPS_VERSION_MINOR 2
+#undef HAVE_FIPS_VERSION_PATCH
+#define HAVE_FIPS_VERSION_PATCH 0
 #endif
 ```
 
@@ -285,6 +309,7 @@ The following additional defines will also need to be added to
 ```
 #define WOLFSSL_JNI
 #define HAVE_EX_DATA
+#define OPENSSL_EXTRA
 #define OPENSSL_ALL
 #define HAVE_CRL
 #define HAVE_OCSP
@@ -294,9 +319,16 @@ The following additional defines will also need to be added to
 #define HAVE_DH
 #define WOLFSSL_CERT_EXT
 #define WOLFSSL_CERT_GEN
+#define WOLFSSL_KEY_GEN
+#define WOLFSSL_CERT_REQ
+#define WOLFSSL_ALT_NAMES
 #define HAVE_TLS_EXTENSIONS
 #define HAVE_SNI
 #define HAVE_ALPN
+#define KEEP_PEER_CERT
+#define SESSION_CERTS
+#define WOLFSSL_ALT_CERT_CHAINS
+#define WOLFSSL_ALWAYS_VERIFY_CB
 ```
 
 For additional help, contact support@wolfssl.com.

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ an application can include this as a dependency in the application's
         <dependency>
             <groupId>com.wolfssl</groupId>
             <artifactId>wolfssl-jsse</artifactId>
-            <version>1.13.0-SNAPSHOT</version>
+            <version>1.14.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
     ...

--- a/build.xml
+++ b/build.xml
@@ -14,7 +14,7 @@
     <!-- versioning/manifest properties -->
     <property name="implementation.vendor"  value="wolfSSL Inc." />
     <property name="implementation.title"   value="wolfSSL JNI/JSSE" />
-    <property name="implementation.version" value="1.13" />
+    <property name="implementation.version" value="1.14" />
 
     <!-- set properties for this build -->
     <property name="src.dir" value="src/java/"/>

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -32,11 +32,11 @@
     #include <sys/time.h>
     #include <arpa/inet.h>
     #include <sys/errno.h>
-#endif
-#ifdef WOLFJNI_USE_IO_SELECT
-    #include <sys/select.h>
-#else
-    #include <poll.h>
+    #if defined(WOLFJNI_USE_IO_SELECT)
+        #include <sys/select.h>
+    #else
+        #include <poll.h>
+    #endif
 #endif
 
 #ifndef WOLFSSL_JNI_DEFAULT_PEEK_TIMEOUT
@@ -615,7 +615,8 @@ enum {
     WOLFJNI_IO_EVENT_INVALID_TIMEOUT = -17
 };
 
-#ifdef WOLFJNI_USE_IO_SELECT
+/* Windows doesn't have poll(), use select() */
+#if defined(WOLFJNI_USE_IO_SELECT) || defined(USE_WINDOWS_API)
 
 /* Perform a select() call on the underlying socket to wait for socket to be
  * ready for read/write, or timeout. Note that we explicitly set the underlying
@@ -787,7 +788,7 @@ static int socketPoll(int sockfd, int timeout_ms, int rx, int tx)
     return WOLFJNI_IO_EVENT_FAIL;
 }
 
-#endif /* WOLFJNI_USE_IO_SELECT */
+#endif /* WOLFJNI_USE_IO_SELECT | USE_WINDOWS_API */
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_connect
   (JNIEnv* jenv, jobject jcl, jlong sslPtr, jint timeout)

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.wolfssl</groupId>
 	<artifactId>wolfssl-jsse</artifactId>
-	<version>1.13.0-SNAPSHOT</version>
+	<version>1.14.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>wolfssl-jsse</name>
     <url>https://www.wolfssl.com</url>

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java
@@ -73,8 +73,8 @@ public final class WolfSSLProvider extends Provider {
      * wolfSSL JSSE Provider class
      */
     public WolfSSLProvider() {
-        super("wolfJSSE", 1.13, "wolfSSL JSSE Provider");
-        //super("wolfJSSE", "1.13", "wolfSSL JSSE Provider");
+        super("wolfJSSE", 1.14, "wolfSSL JSSE Provider");
+        //super("wolfJSSE", "1.14", "wolfSSL JSSE Provider");
 
         /* load native wolfSSLJNI library */
         WolfSSL.loadLibrary();

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLTrustX509Test.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLTrustX509Test.java
@@ -1514,8 +1514,9 @@ public class WolfSSLTrustX509Test {
     @Test
     public void testUsingRsaPssCert()
         throws Exception {
-        /* skip if RSA_PSS is not compiled in at native level */
-        if (WolfSSL.RsaPssEnabled() == false) {
+        /* skip if RSA_PSS or TLS 1.3 are not compiled in at native level */
+        if ((WolfSSL.RsaPssEnabled() == false) ||
+            (WolfSSL.TLSv13Enabled() == false)) {
             return;
         }
 


### PR DESCRIPTION
This PR includes prep work for the wolfSSL JNI/JSSE 1.14 release:

- Fixes use of `select()` on Windows, since `poll()` is not available
- Small fix for `WolfSSLTrustX509Test` to not run RSA-PSS TLS 1.3 test if TLS 1.3 is disabled
- Update README for Windows builds
- Update version to 1.14
- Update ChangeLog with release notes

Tested against release cycle items, including:
- wolfSSL master, 5.7.4, FIPSv2, FIPSv5, FIPS Ready
- Java 8, 11, 17, 20, 22, 23
- Facebook Infer (Mac)
- Android Studio IDE project
- Alongside wolfJCE installed in system
- Windows Visual Studio build