### PR TITLE
Always call wolfSSL_get1_session() inside native JNI WolfSSLSession.getSession()

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,6 +101,25 @@ jobs:
       jdk_version: ${{ matrix.jdk_version }}
       wolfssl_configure: ${{ matrix.wolfssl_configure }}
 
+  # -------------------- session cache variant sanity checks -----------------------
+  # Only check one Linux and Mac JDK version as a sanity check.
+  # Using Zulu, but this can be expanded if needed.
+  linux-zulu-sesscache:
+    strategy:
+      matrix:
+        os: [ 'ubuntu-latest', 'macos-latest' ]
+        jdk_version: [ '11' ]
+        wolfssl_configure: [
+            '--enable-jni CFLAGS=-DNO_SESSION_CACHE_REF',
+        ]
+    name: ${{ matrix.os }} (Zulu JDK ${{ matrix.jdk_version }}, ${{ matrix.wolfssl_configure}})
+    uses: ./.github/workflows/linux-common.yml
+    with:
+      os: ${{ matrix.os }}
+      jdk_distro: "zulu"
+      jdk_version: ${{ matrix.jdk_version }}
+      wolfssl_configure: ${{ matrix.wolfssl_configure }}
+
   # ------------------ Facebook Infer static analysis -------------------
   # Run Facebook infer over PR code, only running on Linux with one
   # JDK/version for now.


### PR DESCRIPTION
Java callers of `WolfSSLSession.getSession()` should always expect to free the returned session pointer with `WolfSSLSession.freeSession(long session)`.  Previously `getSession()` called `wolfSSL_SESSION_dup()` but only for connections that were not TLS 1.3 or had a session ticket.  Calling `wolfSSL_get1_session()` should be a more consistent solution since it increases the ref count on the WOLFSSL_SESSION in question.

This should make it more interoperable with various build options - TLS 1.3, without TLS 1.3, with `-DNO_SESSION_CACHE_REF`.

This also adds one GitHub Action test for the wolfSSL configure `--enable-jni CFLAGS=-DNO_SESSION_CACHE_REF`.

Potential fix for ZD 17211.