### PR TITLE
Return cached SNI request from Server side

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,6 +101,25 @@ jobs:
       jdk_version: ${{ matrix.jdk_version }}
       wolfssl_configure: ${{ matrix.wolfssl_configure }}
 
+  # -------------------- session cache variant sanity checks -----------------------
+  # Only check one Linux and Mac JDK version as a sanity check.
+  # Using Zulu, but this can be expanded if needed.
+  linux-zulu-sesscache:
+    strategy:
+      matrix:
+        os: [ 'ubuntu-latest', 'macos-latest' ]
+        jdk_version: [ '11' ]
+        wolfssl_configure: [
+            '--enable-jni CFLAGS=-DNO_SESSION_CACHE_REF',
+        ]
+    name: ${{ matrix.os }} (Zulu JDK ${{ matrix.jdk_version }}, ${{ matrix.wolfssl_configure}})
+    uses: ./.github/workflows/linux-common.yml
+    with:
+      os: ${{ matrix.os }}
+      jdk_distro: "zulu"
+      jdk_version: ${{ matrix.jdk_version }}
+      wolfssl_configure: ${{ matrix.wolfssl_configure }}
+
   # ------------------ Facebook Infer static analysis -------------------
   # Run Facebook infer over PR code, only running on Linux with one
   # JDK/version for now.

--- a/src/java/com/wolfssl/WolfSSLDebug.java
+++ b/src/java/com/wolfssl/WolfSSLDebug.java
@@ -65,7 +65,9 @@ public class WolfSSLDebug {
      * Will be used to determine what string gets put into log messages.
      */
     public enum Component {
+        /** wolfSSL JNI component */
         JNI("wolfJNI"),
+        /** wolfSSL JSSE component */
         JSSE("wolfJSSE");
 
         private final String componentString;

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLAuthStore.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLAuthStore.java
@@ -326,7 +326,7 @@ public class WolfSSLAuthStore {
 
         /* Return new session if in server mode, or if host is null */
         if (!clientMode || host == null) {
-            return this.getSession(ssl, clientMode);
+            return this.getSession(ssl, clientMode, host, port);
         }
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
@@ -527,18 +527,22 @@ public class WolfSSLAuthStore {
     }
 
     /** Returns a new session, does not check/save for resumption
+     *
      * @param ssl WOLFSSL class to reference with new session
      * @param clientMode true if on client side, false if server
+     * @param host hostname of peer, or null if not available
+     * @param port port of peer
+     *
      * @return a new SSLSession on success
      */
     protected synchronized WolfSSLImplementSSLSession getSession(
-        WolfSSLSession ssl, boolean clientMode) {
+        WolfSSLSession ssl, boolean clientMode, String host, int port) {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                 "creating new session");
 
         WolfSSLImplementSSLSession ses =
-            new WolfSSLImplementSSLSession(ssl, this);
+            new WolfSSLImplementSSLSession(ssl, this, host, port);
 
         ses.setValid(true);
         ses.isFromTable = false;

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
@@ -1394,7 +1394,7 @@ public class WolfSSLEngine extends SSLEngine {
     public String[] getSupportedCipherSuites() {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getSupportedCipherSuites()");
-        return this.engineHelper.getAllCiphers();
+        return WolfSSLEngineHelper.getAllCiphers();
     }
 
     @Override
@@ -1415,7 +1415,7 @@ public class WolfSSLEngine extends SSLEngine {
     public String[] getSupportedProtocols() {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getSupportedProtocols()");
-        return this.engineHelper.getAllProtocols();
+        return WolfSSLEngineHelper.getAllProtocols();
     }
 
     @Override

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
@@ -1262,6 +1262,7 @@ public class WolfSSLEngineHelper {
         int ret, err;
         byte[] serverId = null;
         String hostAddress = null;
+        String sessCacheHostname = this.hostname;
 
         if (!modeSet) {
             throw new SSLException("setUseClientMode has not been called");
@@ -1293,7 +1294,13 @@ public class WolfSSLEngineHelper {
 
                 return WolfSSL.SSL_HANDSHAKE_FAILURE;
             }
-            this.session = this.authStore.getSession(ssl, this.clientMode);
+
+            if (sessCacheHostname == null && this.peerAddr != null) {
+                sessCacheHostname = this.peerAddr.getHostAddress();
+            }
+
+            this.session = this.authStore.getSession(ssl, this.clientMode,
+                sessCacheHostname, this.port);
         }
 
         if (this.clientMode) {

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
@@ -454,7 +454,7 @@ public class WolfSSLEngineHelper {
      *
      * @return String array of all supported cipher suites
      */
-    protected synchronized String[] getAllCiphers() {
+    protected static synchronized String[] getAllCiphers() {
         return WolfSSLUtil.sanitizeSuites(WolfSSL.getCiphersIana());
     }
 
@@ -551,7 +551,7 @@ public class WolfSSLEngineHelper {
      *
      * @return String array of supported protocols
      */
-    protected synchronized String[] getAllProtocols() {
+    protected static synchronized String[] getAllProtocols() {
         return WolfSSLUtil.sanitizeProtocols(WolfSSL.getProtocols());
     }
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
@@ -927,7 +927,7 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
      * Return a list of all SNI server names of the requested Server Name
      * Indication (SNI) extension.
      *
-     * @return non-null immutable List of SNIServerNames. List may be emtpy
+     * @return non-null immutable List of SNIServerNames. List may be empty
      *         if no SNI names were requested.
      */
     @Override
@@ -942,7 +942,20 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
         }
 
         try {
-            sniRequestArr = this.ssl.getClientSNIRequest();
+            /* Return SNI name saved by Client 
+             * or return cached request name from Server
+             * Currently WolfSSL.WOLFSSL_SNI_HOST_NAME is the only
+             * supported type */
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                        "calling getRequestedServerNames (" +
+                        this.getSideString() + ")");
+            if (this.ssl.getSide() == WolfSSL.WOLFSSL_CLIENT_END){
+                sniRequestArr = this.ssl.getClientSNIRequest();
+            } else {
+                sniRequestArr = this.ssl.getSNIRequest((byte)WolfSSL.
+                                            WOLFSSL_SNI_HOST_NAME).getBytes();
+            }
+
             if (sniRequestArr != null) {
                 SNIHostName sniName = new SNIHostName(sniRequestArr);
                 sniNames.add(sniName);

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
@@ -147,12 +147,14 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
      *
      * @param in WolfSSLSession to be used with this object
      * @param params WolfSSLAuthStore for this session
+     * @param host hostname of peer, or null if not available
+     * @param port port of peer
      */
     public WolfSSLImplementSSLSession (WolfSSLSession in,
-                                       WolfSSLAuthStore params) {
+                                       WolfSSLAuthStore params,
+                                       String host, int port) {
         this.ssl = in;
-        this.port = -1;
-        this.host = null;
+        this.host = host;
         this.authStore = params;
         this.valid = false; /* flag if joining or resuming session is allowed */
         this.peerCerts = null;
@@ -162,6 +164,12 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
 
         creation = new Date();
         accessed = new Date();
+
+        if (port > 0) {
+            this.port = port;
+        } else {
+            this.port = -1;
+        }
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "created new session (no host/port yet)");
@@ -478,7 +486,9 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
         X509Certificate exportCert;
 
         if (ssl == null) {
-            throw new SSLPeerUnverifiedException("handshake not complete");
+            throw new SSLPeerUnverifiedException(
+                "internal WolfSSLSession null, handshake not complete or " +
+                "SSLSocket/Engine closed");
         }
 
         try {

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -2501,6 +2501,8 @@ public class WolfSSLSocket extends SSLSocket {
 
                 if (closeSocket) {
                     if (this.socket == null || this.isClosed) {
+                        /* Reset "is closing" state to false and return */
+                        isClosing.set(false);
                         return;
                     }
 
@@ -2719,6 +2721,8 @@ public class WolfSSLSocket extends SSLSocket {
 
                 if (closeSocket) {
                     if (this.socket == null || this.isClosed) {
+                        /* Reset "is closing" state to false and return */
+                        isClosing.set(false);
                         return;
                     }
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -2443,7 +2443,6 @@ public class WolfSSLSocket extends SSLSocket {
                 }
 
                 this.socket = null;
-                this.ssl = null;
                 this.isClosed = true;
 
                 /* Reset "is closing" state to false, now closed */
@@ -2663,7 +2662,6 @@ public class WolfSSLSocket extends SSLSocket {
                 }
 
                 this.socket = null;
-                this.ssl = null;
                 this.isClosed = true;
 
                 /* Reset "is closing" state to false, now closed */

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -112,6 +112,9 @@ public class WolfSSLSocket extends SSLSocket {
     /** ALPN selector callback, if set */
     protected BiFunction<SSLSocket, List<String>, String> alpnSelector = null;
 
+    /* true if client, otherwise false */
+    private boolean isClientMode = false;
+
     /**
      * Create new WolfSSLSocket object
      *
@@ -143,6 +146,7 @@ public class WolfSSLSocket extends SSLSocket {
             EngineHelper = new WolfSSLEngineHelper(this.ssl, this.authStore,
                 this.params);
             EngineHelper.setUseClientMode(clientMode);
+            this.isClientMode = clientMode;
 
         } catch (WolfSSLException e) {
             throw new IOException(e);
@@ -183,6 +187,7 @@ public class WolfSSLSocket extends SSLSocket {
             EngineHelper = new WolfSSLEngineHelper(this.ssl, this.authStore,
                 this.params, port, host);
             EngineHelper.setUseClientMode(clientMode);
+            this.isClientMode = clientMode;
 
         } catch (WolfSSLException e) {
             throw new IOException(e);
@@ -226,6 +231,7 @@ public class WolfSSLSocket extends SSLSocket {
             EngineHelper = new WolfSSLEngineHelper(this.ssl, this.authStore,
                 this.params, port, address);
             EngineHelper.setUseClientMode(clientMode);
+            this.isClientMode = clientMode;
 
         } catch (WolfSSLException e) {
             throw new IOException(e);
@@ -266,6 +272,7 @@ public class WolfSSLSocket extends SSLSocket {
             EngineHelper = new WolfSSLEngineHelper(this.ssl, this.authStore,
                 this.params, port, host);
             EngineHelper.setUseClientMode(clientMode);
+            this.isClientMode = clientMode;
 
         } catch (WolfSSLException e) {
             throw new IOException(e);
@@ -309,6 +316,7 @@ public class WolfSSLSocket extends SSLSocket {
             EngineHelper = new WolfSSLEngineHelper(this.ssl, this.authStore,
                 this.params, port, host);
             EngineHelper.setUseClientMode(clientMode);
+            this.isClientMode = clientMode;
 
         } catch (WolfSSLException e) {
             throw new IOException(e);
@@ -366,6 +374,7 @@ public class WolfSSLSocket extends SSLSocket {
             EngineHelper = new WolfSSLEngineHelper(this.ssl, this.authStore,
                 this.params, port, host);
             EngineHelper.setUseClientMode(clientMode);
+            this.isClientMode = clientMode;
 
         } catch (WolfSSLException e) {
             throw new IOException(e);
@@ -411,6 +420,7 @@ public class WolfSSLSocket extends SSLSocket {
             EngineHelper = new WolfSSLEngineHelper(this.ssl, this.authStore,
                 this.params, s.getPort(), s.getInetAddress());
             EngineHelper.setUseClientMode(clientMode);
+            this.isClientMode = clientMode;
 
         } catch (WolfSSLException e) {
             throw new IOException(e);
@@ -460,6 +470,7 @@ public class WolfSSLSocket extends SSLSocket {
             EngineHelper = new WolfSSLEngineHelper(this.ssl, this.authStore,
                 this.params, s.getPort(), s.getInetAddress());
             EngineHelper.setUseClientMode(false);
+            this.isClientMode = false;
 
             /* register custom receive callback to read consumed first */
             if (consumed != null) {
@@ -1030,7 +1041,8 @@ public class WolfSSLSocket extends SSLSocket {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getSupportedCipherSuites()");
 
-        return EngineHelper.getAllCiphers();
+        /* getAllCiphers() is a static method, calling directly on class */
+        return WolfSSLEngineHelper.getAllCiphers();
     }
 
     /**
@@ -1045,6 +1057,10 @@ public class WolfSSLSocket extends SSLSocket {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getEnabledCipherSuites()");
+
+        if (this.isClosed()) {
+            return null;
+        }
 
         return EngineHelper.getCiphers();
     }
@@ -1063,6 +1079,12 @@ public class WolfSSLSocket extends SSLSocket {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered setEnabledCipherSuites()");
+
+        if (this.isClosed()) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                "SSLSocket closed, not setting enabled cipher suites");
+            return;
+        }
 
         /* sets cipher suite(s) to be used for connection */
         EngineHelper.setCiphers(suites);
@@ -1084,6 +1106,11 @@ public class WolfSSLSocket extends SSLSocket {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getApplicationProtocol()");
+
+        /* If socket has been closed, return an empty string */
+        if (this.isClosed()) {
+            return "";
+        }
 
         return EngineHelper.getAlpnSelectedProtocolString();
     }
@@ -1252,8 +1279,9 @@ public class WolfSSLSocket extends SSLSocket {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getSupportedProtocols()");
 
-        /* returns all protocol version supported by native wolfSSL */
-        return EngineHelper.getAllProtocols();
+        /* returns all protocol version supported by native wolfSSL.
+        /* getAllProtocols() is a static method, calling directly on class */
+        return WolfSSLEngineHelper.getAllProtocols();
     }
 
     /**
@@ -1266,6 +1294,10 @@ public class WolfSSLSocket extends SSLSocket {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getEnabledProtocols()");
+
+        if (this.isClosed()) {
+            return null;
+        }
 
         /* returns protocols versions enabled for this session */
         return EngineHelper.getProtocols();
@@ -1285,6 +1317,12 @@ public class WolfSSLSocket extends SSLSocket {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered setEnabledProtocols()");
+
+        if (this.isClosed()) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                "SSLSocket closed, not setting enabled protocols");
+            return;
+        }
 
         /* sets protocol versions to be enabled for use with this session */
         EngineHelper.setProtocols(protocols);
@@ -1337,6 +1375,15 @@ public class WolfSSLSocket extends SSLSocket {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getSession()");
 
+        if (this.isClosed()) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                "SSLSocket has been closed, returning invalid session");
+
+            /* return invalid session object with cipher suite
+             * "SSL_NULL_WITH_NULL_NULL" */
+            return new WolfSSLImplementSSLSession(this.authStore);
+        }
+
         try {
             /* try to do handshake if not completed yet,
              * handles synchronization */
@@ -1380,7 +1427,7 @@ public class WolfSSLSocket extends SSLSocket {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getHandshakeSession()");
 
-        if (this.handshakeStarted == false) {
+        if ((this.handshakeStarted == false) || this.isClosed()) {
             return null;
         }
 
@@ -1587,7 +1634,11 @@ public class WolfSSLSocket extends SSLSocket {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered setUseClientMode()");
 
-        EngineHelper.setUseClientMode(mode);
+        if (!this.isClosed()) {
+            EngineHelper.setUseClientMode(mode);
+        }
+        this.isClientMode = mode;
+
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                 "socket client mode set to: " + mode);
     }
@@ -1603,7 +1654,7 @@ public class WolfSSLSocket extends SSLSocket {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getUseClientMode()");
 
-        return EngineHelper.getUseClientMode();
+        return this.isClientMode;
     }
 
     /**
@@ -1621,7 +1672,9 @@ public class WolfSSLSocket extends SSLSocket {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered setNeedClientAuth(need: " + String.valueOf(need) + ")");
 
-        EngineHelper.setNeedClientAuth(need);
+        if (!this.isClosed()) {
+            EngineHelper.setNeedClientAuth(need);
+        }
     }
 
     /**
@@ -1635,6 +1688,12 @@ public class WolfSSLSocket extends SSLSocket {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getNeedClientAuth()");
+
+        /* When socket is closed, EngineHelper gets set to null. Since we
+         * don't cache needClientAuth value, return false after closure. */
+        if (this.isClosed()) {
+            return false;
+        }
 
         return EngineHelper.getNeedClientAuth();
     }
@@ -1655,7 +1714,9 @@ public class WolfSSLSocket extends SSLSocket {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered setWantClientAuth(want: " + String.valueOf(want) + ")");
 
-        EngineHelper.setWantClientAuth(want);
+        if (!this.isClosed()) {
+            EngineHelper.setWantClientAuth(want);
+        }
     }
 
     /**
@@ -1673,6 +1734,12 @@ public class WolfSSLSocket extends SSLSocket {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getWantClientAuth()");
+
+        /* When socket is closed, EngineHelper gets set to null. Since we
+         * don't cache wantClientAuth value, return false after closure. */
+        if (this.isClosed()) {
+            return false;
+        }
 
         return EngineHelper.getWantClientAuth();
     }
@@ -1692,7 +1759,9 @@ public class WolfSSLSocket extends SSLSocket {
             "entered setEnableSessionCreation(flag: " +
             String.valueOf(flag) + ")");
 
-        EngineHelper.setEnableSessionCreation(flag);
+        if (!this.isClosed()) {
+            EngineHelper.setEnableSessionCreation(flag);
+        }
     }
 
     /**
@@ -1705,6 +1774,10 @@ public class WolfSSLSocket extends SSLSocket {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getEnableSessionCreation()");
+
+        if (this.isClosed()) {
+            return false;
+        }
 
         return EngineHelper.getEnableSessionCreation();
     }

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -2442,7 +2442,6 @@ public class WolfSSLSocket extends SSLSocket {
                     }
                 }
 
-                this.socket = null;
                 this.isClosed = true;
 
                 /* Reset "is closing" state to false, now closed */
@@ -2661,7 +2660,6 @@ public class WolfSSLSocket extends SSLSocket {
                     }
                 }
 
-                this.socket = null;
                 this.isClosed = true;
 
                 /* Reset "is closing" state to false, now closed */

--- a/src/test/com/wolfssl/test/WolfSSLSessionTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLSessionTest.java
@@ -41,6 +41,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CountDownLatch;
 
 import com.wolfssl.WolfSSL;
 import com.wolfssl.WolfSSLDebug;
@@ -991,6 +993,11 @@ public class WolfSSLSessionTest {
         final WolfSSLContext srvCtx;
         WolfSSLContext cliCtx;
 
+        /* Latch used to wait for server to finish handshake before
+         * test shuts down. Otherwise, we will sometimes miss debug
+         * messages from the server side. */
+        final CountDownLatch latch = new CountDownLatch(1);
+
         System.out.print("\tTesting wolfssljni.debug");
 
         /* Save original property value, then enable debug. Make sure
@@ -1063,6 +1070,8 @@ public class WolfSSLSessionTest {
                             if (server != null) {
                                 server.close();
                             }
+
+                            latch.countDown();
                         }
 
                         return null;
@@ -1129,6 +1138,10 @@ public class WolfSSLSessionTest {
             }
 
         } finally {
+
+            /* Wait for server to finish processing */
+            latch.await(10, TimeUnit.SECONDS);
+
             /* Restore original property value */
             if (originalProp == null || originalProp.isEmpty()) {
                 System.setProperty("wolfssljni.debug", "");

--- a/src/test/com/wolfssl/test/WolfSSLSessionTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLSessionTest.java
@@ -1154,11 +1154,13 @@ public class WolfSSLSessionTest {
             }
             if (!debugOutput.contains("connect() ret: 1")) {
                 System.out.println("\t... failed");
-                fail("Debug output did not contain connect() success");
+                fail("Debug output did not contain connect() success:\n" +
+                     debugOutput);
             }
             if (!debugOutput.contains("accept() ret: 1")) {
                 System.out.println("\t... failed");
-                fail("Debug output did not contain accept() success");
+                fail("Debug output did not contain accept() success:\n" +
+                     debugOutput);
             }
         }
 


### PR DESCRIPTION
Adds ability for `getRequestedServerNames()` to return SNI request saved by server side. Previously only returned SNI server name if called on client side.