### PR TITLE
getSNIRequest checks for null value before converting to String

### DIFF
--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -4147,10 +4147,15 @@ public class WolfSSLSession {
      *         active
      */
     public String getSNIRequest(byte type) throws IllegalStateException {
+        byte[] request;
 
         confirmObjectIsActive();
+        request = getSNIRequestBytes(type);
+        if (request != null){
+            return new String(request, StandardCharsets.UTF_8);
+        }
 
-        return new String(getSNIRequestBytes(type), StandardCharsets.UTF_8);
+        return null;
     }
 
     /**


### PR DESCRIPTION
Additional check for null values in getSNIRequest before converting to String.