### PR TITLE
Added check for legacy DHE keys (for cipher suites using keys less than 1024 bits)

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
@@ -1552,7 +1552,13 @@ public class WolfSSLEngine extends SSLEngine {
         try {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                 "calling engineHelper.doHandshake()");
-            int ret = this.engineHelper.doHandshake(1, 0);
+
+            int ret;
+            try {
+                ret = this.engineHelper.doHandshake(1, 0);
+            } catch (WolfSSLException e) {
+                throw new SSLException("Handshake failed: " + e.getMessage(), e);
+            }
             SetHandshakeStatus(ret);
 
             /* Mark that the user has explicitly started the handshake

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
@@ -1377,18 +1377,22 @@ public class WolfSSLEngineHelper {
     private void checkKeySize(WolfSSLSession ssl, boolean clientMode) throws SSLException, WolfSSLException {
         int keySize = this.ssl.getKeySize();
 
-        // Before we update the cached values, and return from the handshake, we
-        // check if we are running a legacy cipher suite, if so, we make sure
-        // that the actual key size is at least 1024 bits.
+        /*
+         * Before we update the cached values, and return from the handshake,
+         * we check if we are running a legacy cipher suite, if so, we make sure
+         * that the actual key size is at least 1024 bits.
+        */
         String[] cipherSuites = getCiphers();
 
         if (containsDHECiphers(cipherSuites)) {
-            // Get the minimum DH key size from security settings
+            /* Get the minimum DH key size from security settings. */
             int minDHEKeySize;
             try {
                 minDHEKeySize = WolfSSLUtil.getDisabledAlgorithmsKeySizeLimit("DH");
 
-                // If we're trying to use DHE with insufficient key size, throw early
+                /*
+                 * If we're trying to use DHE with
+                 * insufficient key size, throw early. */
                 if (isLegacyDHEnabled() && keySize < minDHEKeySize) {
                     if (clientMode) {
                         throw new SSLHandshakeException(
@@ -1414,7 +1418,7 @@ public class WolfSSLEngineHelper {
     }
 
     private boolean isLegacyDHEnabled() {
-        // Check if legacy DH is enabled through system properties
+        /* Check if legacy DH is enabled through system properties. */
         String dhKeySize = System.getProperty("jdk.tls.ephemeralDHKeySize");
         return "legacy".equals(dhKeySize);
     }

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
@@ -1255,9 +1255,11 @@ public class WolfSSLEngineHelper {
      * @throws SSLException if setUseClientMode() has not been called or
      *                      on native socket error
      * @throws SocketTimeoutException if socket timed out
+     *
+     * @throws WolfSSLException if it fails to check the DH key size after the handshake.
      */
     protected synchronized int doHandshake(int isSSLEngine, int timeout)
-        throws SSLException, SocketTimeoutException {
+        throws SSLException, SocketTimeoutException, WolfSSLException {
 
         int ret, err;
         byte[] serverId = null;
@@ -1343,10 +1345,13 @@ public class WolfSSLEngineHelper {
                     /* may throw SocketTimeoutException on socket timeout */
                     ret = this.ssl.connect(timeout);
 
+                    checkKeySize(ssl, this.clientMode);
                 } else {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                                 "calling native wolfSSL_accept()");
                     ret = this.ssl.accept(timeout);
+
+                    checkKeySize(ssl, this.clientMode);
                 }
                 err = ssl.getError(ret);
 
@@ -1367,6 +1372,51 @@ public class WolfSSLEngineHelper {
         this.session.updateStoredSessionValues();
 
         return ret;
+    }
+
+    private void checkKeySize(WolfSSLSession ssl, boolean clientMode) throws SSLException, WolfSSLException {
+        int keySize = this.ssl.getKeySize();
+
+        // Before we update the cached values, and return from the handshake, we
+        // check if we are running a legacy cipher suite, if so, we make sure
+        // that the actual key size is at least 1024 bits.
+        String[] cipherSuites = getCiphers();
+
+        if (containsDHECiphers(cipherSuites)) {
+            // Get the minimum DH key size from security settings
+            int minDHEKeySize;
+            try {
+                minDHEKeySize = WolfSSLUtil.getDisabledAlgorithmsKeySizeLimit("DH");
+
+                // If we're trying to use DHE with insufficient key size, throw early
+                if (isLegacyDHEnabled() && keySize < minDHEKeySize) {
+                    if (clientMode) {
+                        throw new SSLHandshakeException(
+                                "DH ServerKeyExchange does not comply to algorithm constraints");
+                    } else {
+                        throw new SSLHandshakeException(
+                                "Received fatal alert: insufficient_security");
+                    }
+                }
+            } catch (WolfSSLException e) {
+                throw new WolfSSLException("Failed to check DH key size constraints: ", e);
+            }
+        }
+    }
+
+    private boolean containsDHECiphers(String[] cipherSuites) {
+        for (String suite : cipherSuites) {
+            if (suite.contains("_DHE_")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isLegacyDHEnabled() {
+        // Check if legacy DH is enabled through system properties
+        String dhKeySize = System.getProperty("jdk.tls.ephemeralDHKeySize");
+        return "legacy".equals(dhKeySize);
     }
 
     /**

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLServerSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLServerSocket.java
@@ -240,6 +240,7 @@ public class WolfSSLServerSocket extends SSLServerSocket {
 
         /* sanitize protocol array for unsupported strings */
         List<String> supported;
+
         supported = Arrays.asList(
             WolfSSLUtil.sanitizeProtocols(WolfSSL.getProtocols()));
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -1573,10 +1573,10 @@ public class WolfSSLSocket extends SSLSocket {
                 close();
                 throw e;
             } catch (WolfSSLException e) {
-		/* close socket if the handshake is unsuccessful */
+                /* close socket if the handshake is unsuccessful */
                 close();
                 throw new SSLException("Handshake failed: " + e.getMessage(), e);
-	    }
+            }
 
             if (ret != WolfSSL.SSL_SUCCESS) {
                 close();

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -1572,7 +1572,11 @@ public class WolfSSLSocket extends SSLSocket {
                     err + ", TID " + Thread.currentThread().getId() + ")");
                 close();
                 throw e;
-            }
+            } catch (WolfSSLException e) {
+		/* close socket if the handshake is unsuccessful */
+                close();
+                throw new SSLException("Handshake failed: " + e.getMessage(), e);
+	    }
 
             if (ret != WolfSSL.SSL_SUCCESS) {
                 close();


### PR DESCRIPTION
Added exception handling for `WolfSSLException`, implementing key size checks for Diffie-Hellman (DH) key exchanges, and updating method signatures to reflect the new exception types.

Tested running the testOSX.sh to make sure there were no tests regression after the changes.