### PR TITLE
JNI/JSSE: optimize out array creation in WolfSSLEngine RecvAppData()

### DIFF
--- a/native/com_wolfssl_WolfSSLSession.h
+++ b/native/com_wolfssl_WolfSSLSession.h
@@ -100,8 +100,16 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_write
  * Method:    read
  * Signature: (J[BIII)I
  */
-JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_read
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_read__J_3BIII
   (JNIEnv *, jobject, jlong, jbyteArray, jint, jint, jint);
+
+/*
+ * Class:     com_wolfssl_WolfSSLSession
+ * Method:    read
+ * Signature: (JLjava/nio/ByteBuffer;II)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_read__JLjava_nio_ByteBuffer_2II
+  (JNIEnv *, jobject, jlong, jobject, jint, jint);
 
 /*
  * Class:     com_wolfssl_WolfSSLSession


### PR DESCRIPTION
This is an optimization PR that removes an extra `byte[]` array creation inside `WolfSSLEngine.RecvAppData()`, which is called from `SSLEngine.unwrap()`.

Prior to this PR, we allocated a new `byte[]` to read ByteBuffer data into and pass down to JNI for `SSL_read()` operations.

This PR changes that behavior so that if there is only one `ByteBuffer` in the output `ByteBuffer[]` passed to `unwrap()`, that ByteBuffer is passed down to JNI directly where the underlying array is retrieved and used without an extra array creation.

This should have positive impacts on reducing the number of objects created, especially in use cases where lots of data is being received (or downloaded) via an `SSLEngine.unwrap()` interface.