### PR TITLE
JSSE: calling SSLSocket.close() should interrupt threads blocked in select()/poll()

### DIFF
--- a/.github/workflows/linux-common.yml
+++ b/.github/workflows/linux-common.yml
@@ -15,6 +15,9 @@ on:
       wolfssl_configure:
         required: true
         type: string
+      javash_cflags:
+        required: false
+        type: string
 
 jobs:
   build_wolfssljni:
@@ -51,7 +54,7 @@ jobs:
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/build-dir/lib" >> "$GITHUB_ENV"
 
       - name: Build JNI library
-        run: ./java.sh $GITHUB_WORKSPACE/build-dir
+        run: CFLAGS=${{ inputs.javah_cflags }} ./java.sh $GITHUB_WORKSPACE/build-dir
       - name: Build JAR (ant)
         run: ant
       - name: Run Java tests (ant test)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,6 +120,27 @@ jobs:
       jdk_version: ${{ matrix.jdk_version }}
       wolfssl_configure: ${{ matrix.wolfssl_configure }}
 
+  # -------------------- WOLFJNI_USE_IO_SELECT sanity check --------------------
+  # Only check one Linux and Mac JDK version as a sanity check.
+  # Using Zulu, but this can be expanded if needed.
+  linux-zulu-ioselect:
+    strategy:
+      matrix:
+        os: [ 'ubuntu-latest', 'macos-latest' ]
+        jdk_version: [ '11' ]
+        wolfssl_configure: [
+            '--enable-jni',
+        ]
+        javash_cflags: [ '-DWOLFJNI_USE_IO_SELECT' ]
+    name: ${{ matrix.os }} (Zulu JDK ${{ matrix.jdk_version }}, ${{ matrix.wolfssl_configure}}, ${{ matrix.javash_cflags }})
+    uses: ./.github/workflows/linux-common.yml
+    with:
+      os: ${{ matrix.os }}
+      jdk_distro: "zulu"
+      jdk_version: ${{ matrix.jdk_version }}
+      wolfssl_configure: ${{ matrix.wolfssl_configure }}
+      javash_cflags: ${{ matrix.javash_cflags }}
+
   # ------------------ Facebook Infer static analysis -------------------
   # Run Facebook infer over PR code, only running on Linux with one
   # JDK/version for now.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,44 @@ $ ./examples/provider/ServerJSSE.sh
 $ ./examples/provider/ClientJSSE.sh
 ```
 
+### java.sh Script Options
+
+The `java.sh` script compiles the native JNI sources into a shared library named
+either `libwolfssljni.so` (Linux/Unix) or `libwolfssljni.dylib` (MacOS).
+Compiling on Linux/Unix and Mac OSX are currently supported.
+
+This script will attempt to auto-detect the `JAVA_HOME` location if not set.
+To explicitly use a Java home location, set the `JAVA_HOME` environment variable
+prior to running this script.
+
+This script will try to link against a wolfSSL library installed to the
+default location of `/usr/local`. This script accepts two arguments on the
+command line. The first argument can point to a custom wolfSSL installation
+location. A custom install location would match the directory set at wolfSSL
+`./configure --prefix=<DIR>`.
+
+The second argument represents the wolfSSL library name that should be
+linked against. This is helpful if a non-standard library name has been
+used with wolfSSL, for example the `./configure --with-libsuffix` option
+has been used to add a suffix to the wolfSSL library name. Note that to
+use this argument, an installation location must be specified via the
+first argument.
+
+For example, if wolfSSL was configured with `--with-libsuffix=jsse`, then
+this script could be called like so using the default installation
+path of `/usr/local`:
+
+```
+java.sh /usr/local wolfssljsse
+```
+
+`java.sh` can use preset `CFLAGS` defines, if set in the environment variable
+prior to running the script, for example:
+
+```
+CFLAGS=-DWOLFJNI_USE_IO_SELECT java.sh
+```
+
 ## Building with Maven
 
 wolfJSSE supports building and packaging with Maven, for those projects that

--- a/java.sh
+++ b/java.sh
@@ -75,7 +75,6 @@ if [ "$OS" == "Darwin" ] ; then
     javaIncludes="-I$javaHome/include -I$javaHome/include/darwin -I$WOLFSSL_INSTALL_DIR/include"
     javaLibs="-dynamiclib"
     jniLibName="libwolfssljni.dylib"
-    cflags=""
 elif [ "$OS" == "Linux" ] ; then
     echo "    Detected Linux host OS"
     if [ -z $javaHome ]; then
@@ -88,7 +87,6 @@ elif [ "$OS" == "Linux" ] ; then
     javaIncludes="-I$javaHome/include -I$javaHome/include/linux -I$WOLFSSL_INSTALL_DIR/include"
     javaLibs="-shared"
     jniLibName="libwolfssljni.so"
-    cflags=""
     if [ "$ARCH" == "x86_64" ] ; then
         fpic="-fPIC"
     else
@@ -108,18 +106,18 @@ then
     mkdir ./lib
 fi
 
-gcc -Wall -c $fpic $cflags ./native/com_wolfssl_WolfSSL.c -o ./native/com_wolfssl_WolfSSL.o $javaIncludes
-gcc -Wall -c $fpic $cflags ./native/com_wolfssl_WolfSSLSession.c -o ./native/com_wolfssl_WolfSSLSession.o $javaIncludes
-gcc -Wall -c $fpic $cflags ./native/com_wolfssl_WolfSSLContext.c -o ./native/com_wolfssl_WolfSSLContext.o $javaIncludes
-gcc -Wall -c $fpic $cflags ./native/com_wolfssl_wolfcrypt_RSA.c -o ./native/com_wolfssl_wolfcrypt_RSA.o $javaIncludes
-gcc -Wall -c $fpic $cflags ./native/com_wolfssl_wolfcrypt_ECC.c -o ./native/com_wolfssl_wolfcrypt_ECC.o $javaIncludes
-gcc -Wall -c $fpic $cflags ./native/com_wolfssl_wolfcrypt_EccKey.c -o ./native/com_wolfssl_wolfcrypt_EccKey.o $javaIncludes
-gcc -Wall -c $fpic $cflags ./native/com_wolfssl_WolfSSLCertManager.c -o ./native/com_wolfssl_WolfSSLCertManager.o $javaIncludes
-gcc -Wall -c $fpic $cflags ./native/com_wolfssl_WolfSSLCertRequest.c -o ./native/com_wolfssl_WolfSSLCertRequest.o $javaIncludes
-gcc -Wall -c $fpic $cflags ./native/com_wolfssl_WolfSSLCertificate.c -o ./native/com_wolfssl_WolfSSLCertificate.o $javaIncludes
-gcc -Wall -c $fpic $cflags ./native/com_wolfssl_WolfSSLX509Name.c -o ./native/com_wolfssl_WolfSSLX509Name.o $javaIncludes
-gcc -Wall -c $fpic $cflags ./native/com_wolfssl_WolfSSLX509StoreCtx.c -o ./native/com_wolfssl_WolfSSLX509StoreCtx.o $javaIncludes
-gcc -Wall $javaLibs $cflags -o ./lib/$jniLibName ./native/com_wolfssl_WolfSSL.o ./native/com_wolfssl_WolfSSLSession.o ./native/com_wolfssl_WolfSSLContext.o ./native/com_wolfssl_wolfcrypt_RSA.o ./native/com_wolfssl_wolfcrypt_ECC.o ./native/com_wolfssl_wolfcrypt_EccKey.o ./native/com_wolfssl_WolfSSLCertManager.o ./native/com_wolfssl_WolfSSLCertRequest.o ./native/com_wolfssl_WolfSSLCertificate.o ./native/com_wolfssl_WolfSSLX509Name.o ./native/com_wolfssl_WolfSSLX509StoreCtx.o -L$WOLFSSL_INSTALL_DIR/lib -L$WOLFSSL_INSTALL_DIR/lib64 -l$WOLFSSL_LIBNAME
+gcc -Wall -c $fpic $CFLAGS ./native/com_wolfssl_WolfSSL.c -o ./native/com_wolfssl_WolfSSL.o $javaIncludes
+gcc -Wall -c $fpic $CFLAGS ./native/com_wolfssl_WolfSSLSession.c -o ./native/com_wolfssl_WolfSSLSession.o $javaIncludes
+gcc -Wall -c $fpic $CFLAGS ./native/com_wolfssl_WolfSSLContext.c -o ./native/com_wolfssl_WolfSSLContext.o $javaIncludes
+gcc -Wall -c $fpic $CFLAGS ./native/com_wolfssl_wolfcrypt_RSA.c -o ./native/com_wolfssl_wolfcrypt_RSA.o $javaIncludes
+gcc -Wall -c $fpic $CFLAGS ./native/com_wolfssl_wolfcrypt_ECC.c -o ./native/com_wolfssl_wolfcrypt_ECC.o $javaIncludes
+gcc -Wall -c $fpic $CFLAGS ./native/com_wolfssl_wolfcrypt_EccKey.c -o ./native/com_wolfssl_wolfcrypt_EccKey.o $javaIncludes
+gcc -Wall -c $fpic $CFLAGS ./native/com_wolfssl_WolfSSLCertManager.c -o ./native/com_wolfssl_WolfSSLCertManager.o $javaIncludes
+gcc -Wall -c $fpic $CFLAGS ./native/com_wolfssl_WolfSSLCertRequest.c -o ./native/com_wolfssl_WolfSSLCertRequest.o $javaIncludes
+gcc -Wall -c $fpic $CFLAGS ./native/com_wolfssl_WolfSSLCertificate.c -o ./native/com_wolfssl_WolfSSLCertificate.o $javaIncludes
+gcc -Wall -c $fpic $CFLAGS ./native/com_wolfssl_WolfSSLX509Name.c -o ./native/com_wolfssl_WolfSSLX509Name.o $javaIncludes
+gcc -Wall -c $fpic $CFLAGS ./native/com_wolfssl_WolfSSLX509StoreCtx.c -o ./native/com_wolfssl_WolfSSLX509StoreCtx.o $javaIncludes
+gcc -Wall $javaLibs $CFLAGS -o ./lib/$jniLibName ./native/com_wolfssl_WolfSSL.o ./native/com_wolfssl_WolfSSLSession.o ./native/com_wolfssl_WolfSSLContext.o ./native/com_wolfssl_wolfcrypt_RSA.o ./native/com_wolfssl_wolfcrypt_ECC.o ./native/com_wolfssl_wolfcrypt_EccKey.o ./native/com_wolfssl_WolfSSLCertManager.o ./native/com_wolfssl_WolfSSLCertRequest.o ./native/com_wolfssl_WolfSSLCertificate.o ./native/com_wolfssl_WolfSSLX509Name.o ./native/com_wolfssl_WolfSSLX509StoreCtx.o -L$WOLFSSL_INSTALL_DIR/lib -L$WOLFSSL_INSTALL_DIR/lib64 -l$WOLFSSL_LIBNAME
 if [ $? != 0 ]; then
     echo "Error creating native JNI library"
     exit 1

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -1421,7 +1421,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_read__JLjava_nio_ByteBuff
     jint position;
     jint limit;
     jboolean hasArray;
-    jbyteArray bufArr;
+    jbyteArray bufArr = NULL;
 
     (void)jcl;
 

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -3845,12 +3845,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getSide
     (void)jenv;
     (void)jcl;
 
-#ifdef ATOMIC_USER
     /* wolfSSL checks ssl for NULL */
     return wolfSSL_GetSide((WOLFSSL*)(uintptr_t)ssl);
-#else
-    return NOT_COMPILED_IN;
-#endif
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_isTLSv1_11

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -72,8 +72,17 @@ static jobject g_crlCbIfaceObj;
  * function calls. Stored inside WOLFSSL app data, set with
  * wolfSSL_set_app_data(), retrieved with wolfSSL_get_app_data().
  * Global callback objects are created with NewGlobalRef(), then freed
- * inside freeSSL() with DeleteGlobalRef(). */
+ * inside freeSSL() with DeleteGlobalRef().
+ *
+ * interruptFds[2] is a pipe() used for non-Windows platforms. This pipe is
+ * used to interrupt threads blocked inside select()/poll() when a separate
+ * Java thread calls close() on the SSLSocket. */
 typedef struct SSLAppData {
+    int threadsInPoll;               /* number of threads in poll/select() */
+#ifndef USE_WINDOWS_API
+    int interruptFds[2];             /* pipe for interrupting socketSelect() */
+    wolfSSL_Mutex* pollCountLock;    /* lock around threadsInPoll */
+#endif
     wolfSSL_Mutex* jniSessLock;      /* WOLFSSL session lock */
     jobject* g_verifySSLCbIfaceObj;  /* Java verify callback [global ref] */
 } SSLAppData;
@@ -191,13 +200,116 @@ int NativeSSLVerifyCallback(int preverify_ok, WOLFSSL_X509_STORE_CTX* store)
     return retval;
 }
 
+#ifndef USE_WINDOWS_API
+
+/* Close interrupt pipe() descriptors and reset back to -1. */
+static void closeInterruptPipe(SSLAppData* appData)
+{
+    if (appData != NULL) {
+        if (appData->interruptFds[0] != -1) {
+            close(appData->interruptFds[0]);
+            appData->interruptFds[0] = -1;
+        }
+        if (appData->interruptFds[1] != -1) {
+            close(appData->interruptFds[1]);
+            appData->interruptFds[1] = -1;
+        }
+    }
+}
+
+/* Signal to threads blocked in select() or poll() to wake up, by writing
+ * one byte to the appData.interruptFds[1] pipe. */
+static void writeToInterruptPipe(SSLAppData* appData)
+{
+    if (appData != NULL) {
+        if (appData->interruptFds[1] != -1) {
+            write(appData->interruptFds[1], "1", 1);
+        }
+    }
+}
+
+#endif /* !USE_WINDOWS_API */
+
+/* Return number of threads waiting in poll()/select() */
+static int threadsWaitingInPollSelect(SSLAppData* appData)
+{
+    int ret = 0;
+#ifndef USE_WINDOWS_API
+    wolfSSL_Mutex* pollCountLock = NULL;
+
+    if (appData != NULL) {
+        pollCountLock = appData->pollCountLock;
+        if (pollCountLock != NULL) {
+            if (wc_LockMutex(pollCountLock) == 0) {
+                ret = appData->threadsInPoll;
+                wc_UnLockMutex(pollCountLock);
+            }
+        }
+    }
+#endif
+    return ret;
+}
+
+static void incrementThreadPollCount(SSLAppData* appData)
+{
+#ifndef USE_WINDOWS_API
+    wolfSSL_Mutex* pollCountLock = NULL;
+
+    if (appData == NULL) {
+        return;
+    }
+
+    pollCountLock = appData->pollCountLock;
+    if (pollCountLock == NULL) {
+        return;
+    }
+
+    if (wc_LockMutex(pollCountLock) != 0) {
+        return;
+    }
+
+    appData->threadsInPoll++;
+
+    wc_UnLockMutex(pollCountLock);
+#endif
+}
+
+static void decrementThreadPollCount(SSLAppData* appData)
+{
+#ifndef USE_WINDOWS_API
+    wolfSSL_Mutex* pollCountLock = NULL;
+
+    if (appData == NULL) {
+        return;
+    }
+
+    pollCountLock = appData->pollCountLock;
+    if (pollCountLock == NULL) {
+        return;
+    }
+
+    if (wc_LockMutex(pollCountLock) != 0) {
+        return;
+    }
+
+    if (appData->threadsInPoll > 0) {
+        appData->threadsInPoll--;
+    }
+
+    wc_UnLockMutex(pollCountLock);
+#endif
+}
+
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_newSSL
-  (JNIEnv* jenv, jobject jcl, jlong ctx)
+  (JNIEnv* jenv, jobject jcl, jlong ctx, jboolean withIOPipe)
 {
     int ret;
     jlong sslPtr = 0;
     jobject* g_cachedSSLObj = NULL;
     wolfSSL_Mutex* jniSessLock = NULL;
+#ifndef USE_WINDOWS_API
+    wolfSSL_Mutex* pollCountLock = NULL;
+#endif
     SSLAppData* appData = NULL;
 
     if (jenv == NULL) {
@@ -251,11 +363,71 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_newSSL
         wc_InitMutex(jniSessLock);
         appData->jniSessLock = jniSessLock;
 
+        /* set up interrupt pipe for SSLSocket.close() to use if/when needed.
+         * currently only non-Windows platforms supported due to Windows not
+         * supporting direct/same pipe() operation. Make read pipe non
+         * blocking since byte read from it could have already been taken
+         * out by either reader/writer thread before the other has a chance
+         * to read it. But, we only use it for waking us up and don't care
+         * much about actually reading the byte passed over the pipe. */
+        appData->threadsInPoll = 0;
+#ifndef USE_WINDOWS_API
+        pollCountLock = (wolfSSL_Mutex*)XMALLOC(sizeof(wolfSSL_Mutex), NULL,
+                                                DYNAMIC_TYPE_TMP_BUFFER);
+        if (pollCountLock == NULL) {
+            printf("error mallocing pollCountLock in newSSL for SSLAppData\n");
+            (*jenv)->DeleteGlobalRef(jenv, *g_cachedSSLObj);
+            XFREE(jniSessLock, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(appData, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(g_cachedSSLObj, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            wolfSSL_free((WOLFSSL*)(uintptr_t)sslPtr);
+            return SSL_FAILURE;
+        }
+        wc_InitMutex(pollCountLock);
+        appData->pollCountLock = pollCountLock;
+
+        appData->interruptFds[0] = -1;
+        appData->interruptFds[1] = -1;
+
+        if (withIOPipe == JNI_TRUE) {
+            ret = pipe(appData->interruptFds);
+            if (ret == -1) {
+                printf("error setting up pipe() for interruptFds[] in newSSL\n");
+                (*jenv)->DeleteGlobalRef(jenv, *g_cachedSSLObj);
+                XFREE(pollCountLock, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+                XFREE(jniSessLock, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+                XFREE(appData, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+                XFREE(g_cachedSSLObj, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+                wolfSSL_free((WOLFSSL*)(uintptr_t)sslPtr);
+                return SSL_FAILURE;
+            }
+
+            ret = fcntl(appData->interruptFds[0], F_SETFL,
+                    fcntl(appData->interruptFds[0], F_GETFL, 0) | O_NONBLOCK);
+            if (ret < 0) {
+                printf("error setting interruptFds[0] non-blocking in newSSL\n");
+                closeInterruptPipe(appData);
+                (*jenv)->DeleteGlobalRef(jenv, *g_cachedSSLObj);
+                XFREE(pollCountLock, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+                XFREE(jniSessLock, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+                XFREE(appData, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+                XFREE(g_cachedSSLObj, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+                wolfSSL_free((WOLFSSL*)(uintptr_t)sslPtr);
+                return SSL_FAILURE;
+            }
+        }
+#endif /* !USE_WINDOWS_API */
+
         /* cache associated WolfSSLSession jobject in native WOLFSSL */
         ret = wolfSSL_set_jobject((WOLFSSL*)(uintptr_t)sslPtr, g_cachedSSLObj);
         if (ret != SSL_SUCCESS) {
             printf("error storing jobject in wolfSSL native session\n");
             (*jenv)->DeleteGlobalRef(jenv, *g_cachedSSLObj);
+        #ifndef USE_WINDOWS_API
+            closeInterruptPipe(appData);
+            XFREE(pollCountLock, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        #endif
+            XFREE(jniSessLock, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(appData, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(g_cachedSSLObj, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             wolfSSL_free((WOLFSSL*)(uintptr_t)sslPtr);
@@ -267,6 +439,10 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_newSSL
                 (WOLFSSL*)(uintptr_t)sslPtr, appData) != SSL_SUCCESS) {
             printf("error setting WOLFSSL app data in newSSL\n");
             (*jenv)->DeleteGlobalRef(jenv, *g_cachedSSLObj);
+        #ifndef USE_WINDOWS_API
+            closeInterruptPipe(appData);
+            XFREE(pollCountLock, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        #endif
             XFREE(jniSessLock, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(appData, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(g_cachedSSLObj, NULL, DYNAMIC_TYPE_TMP_BUFFER);
@@ -637,16 +813,21 @@ enum {
  *                   supported, since not supported on Java Socket.
  * @param rx         set to 1 to monitor readability on socket descriptor,
  *                   otherwise 0 to monitor writability
+ * @param shutdown   Is this being called from shutdownSSL()? Don't select
+ *                   on interruptFds in that case, since we already know
+ *                   we are closing in that case.
  *
  * @return possible return values are:
  *         WOLFJNI_IO_EVENT_FAIL
  *         WOLFJNI_IO_EVENT_ERROR
+ *         WOLFJNI_IO_EVENT_FD_CLOSED
  *         WOLFJNI_IO_EVENT_TIMEOUT
  *         WOLFJNI_IO_EVENT_RECV_READY
  *         WOLFJNI_IO_EVENT_SEND_READY
  *         WOLFJNI_IO_EVENT_INVALID_TIMEOUT
  */
-static int socketSelect(int sockfd, int timeout_ms, int rx)
+static int socketSelect(SSLAppData* appData, int sockfd, int timeout_ms, int rx,
+    int shutdown)
 {
     fd_set fds, errfds;
     fd_set* recvfds = NULL;
@@ -654,10 +835,17 @@ static int socketSelect(int sockfd, int timeout_ms, int rx)
     int nfds = sockfd + 1;
     int result = 0;
     struct timeval timeout;
+#ifndef USE_WINDOWS_API
+    char tmpBuf[1];
+#endif
 
     /* Java Socket does not support negative timeouts, sanitize */
     if (timeout_ms < 0) {
         return WOLFJNI_IO_EVENT_INVALID_TIMEOUT;
+    }
+
+    if (appData == NULL) {
+        return WOLFJNI_IO_EVENT_ERROR;
     }
 
 #ifndef USE_WINDOWS_API
@@ -666,8 +854,20 @@ static int socketSelect(int sockfd, int timeout_ms, int rx)
         timeout.tv_sec = timeout_ms / 1000;
         timeout.tv_usec = (timeout_ms % 1000) * 1000;
 
+        /* file/socket descriptors */
         FD_ZERO(&fds);
         FD_SET(sockfd, &fds);
+#ifndef USE_WINDOWS_API
+        if ((shutdown == 0) && (appData->interruptFds[0] != -1)) {
+            FD_SET(appData->interruptFds[0], &fds);
+            /* nfds should be set to the highest number descriptor plus 1 */
+            if (appData->interruptFds[0] > sockfd) {
+                nfds = appData->interruptFds[0] + 1;
+            }
+        }
+#endif /* !USE_WINDOWS_API */
+
+        /* error descriptors */
         FD_ZERO(&errfds);
         FD_SET(sockfd, &errfds);
 
@@ -677,11 +877,13 @@ static int socketSelect(int sockfd, int timeout_ms, int rx)
             sendfds = &fds;
         }
 
+        incrementThreadPollCount(appData);
         if (timeout_ms == 0) {
             result = select(nfds, recvfds, sendfds, &errfds, NULL);
         } else {
             result = select(nfds, recvfds, sendfds, &errfds, &timeout);
         }
+        decrementThreadPollCount(appData);
 
         if (result == 0) {
             return WOLFJNI_IO_EVENT_TIMEOUT;
@@ -692,9 +894,26 @@ static int socketSelect(int sockfd, int timeout_ms, int rx)
                 } else {
                     return WOLFJNI_IO_EVENT_SEND_READY;
                 }
-            } else if (FD_ISSET(sockfd, &errfds)) {
+            }
+            else if (FD_ISSET(sockfd, &errfds)) {
                 return WOLFJNI_IO_EVENT_ERROR;
             }
+#ifndef USE_WINDOWS_API
+            else if ((shutdown == 0) && (appData->interruptFds[0] != -1) &&
+                     (FD_ISSET(appData->interruptFds[0], &fds))) {
+                /* We got interrupted by our interrupt fd, due to a Java
+                 * thread calling SSLSocket.close(). Try to read byte that
+                 * was placed on our interruptFds[0] descriptor, but not
+                 * an error if not there. Another read/write() may have
+                 * already read it off. We just want to be interrupted,
+                 * byte value does not matter. */
+                do {
+                    read(appData->interruptFds[0], tmpBuf, 1);
+                } while (errno == EINTR);
+
+                return WOLFJNI_IO_EVENT_FD_CLOSED;
+            }
+#endif /* !USE_WINDOWS_API */
         }
 
 #ifndef USE_WINDOWS_API
@@ -725,6 +944,9 @@ static int socketSelect(int sockfd, int timeout_ms, int rx)
  *                   otherwise 0 to ignore readability events
  * @param tx         set to 1 to monitor writability on socket descriptor,
  *                   otherwise 0 to ignore writability events
+ * @param shutdown   Is this being called from shutdownSSL()? Don't poll
+ *                   on interruptFds in that case, since we already know
+ *                   we are closing in that case.
  *
  * @return possible return values are:
  *         WOLFJNI_IO_EVENT_FAIL
@@ -736,11 +958,18 @@ static int socketSelect(int sockfd, int timeout_ms, int rx)
  *         WOLFJNI_IO_EVENT_POLLHUP
  *         WOLFJNI_IO_EVENT_INVALID_TIMEOUT
  */
-static int socketPoll(int sockfd, int timeout_ms, int rx, int tx)
+static int socketPoll(SSLAppData* appData, int sockfd, int timeout_ms,
+    int rx, int tx, int shutdown)
 {
     int ret;
+    int nfds = 2;
     int timeout;
-    struct pollfd fds[1];
+    struct pollfd fds[2];
+    char tmpBuf[1];
+
+    if (appData == NULL) {
+        return WOLFJNI_IO_EVENT_ERROR;
+    }
 
     /* Sanitize timeout and convert from Java to poll() expectations */
     timeout = timeout_ms;
@@ -750,35 +979,62 @@ static int socketPoll(int sockfd, int timeout_ms, int rx, int tx)
         timeout = -1;
     }
 
+    /* fd for socket I/O */
     fds[0].fd = sockfd;
     fds[0].events = 0;
     if (tx) {
-        fds[0].events |= POLLOUT;
+        fds[0].events |= POLLOUT | POLLPRI;
     }
     if (rx) {
-        fds[0].events |= POLLIN;
+        fds[0].events |= POLLIN | POLLPRI;
+    }
+
+    if ((shutdown == 0) && (appData->interruptFds[0] != -1)) {
+        /* fd for interrupt / signaling SSLSocket.close() */
+        fds[1].fd = appData->interruptFds[0];
+        fds[1].events = POLLIN | POLLPRI;
+    }
+    else {
+        nfds--;
     }
 
     do {
-        ret = poll(fds, 1, timeout);
+        incrementThreadPollCount(appData);
+        ret = poll(fds, nfds, timeout);
+        decrementThreadPollCount(appData);
         if (ret == 0) {
             return WOLFJNI_IO_EVENT_TIMEOUT;
 
-        } else if (ret > 0) {
-            if (fds[0].revents & POLLIN ||
+        }
+        else if (ret > 0) {
+            if ((shutdown == 0) && (appData->interruptFds[0] != -1) &&
+                (fds[1].revents & POLLIN)) {
+                /* received data on interrupt pipe, read and return
+                 * that descriptor is closed (closing) */
+                do {
+                    read(appData->interruptFds[0], tmpBuf, 1);
+                } while (errno == EINTR);
+
+                return WOLFJNI_IO_EVENT_FD_CLOSED;
+            }
+            else if (fds[0].revents & POLLIN ||
                 fds[0].revents & POLLPRI) {         /* read possible */
                 return WOLFJNI_IO_EVENT_RECV_READY;
 
-            } else if (fds[0].revents & POLLOUT) {  /* write possible */
+            }
+            else if (fds[0].revents & POLLOUT) {  /* write possible */
                 return WOLFJNI_IO_EVENT_SEND_READY;
 
-            } else if (fds[0].revents & POLLNVAL) { /* fd not open */
+            }
+            else if (fds[0].revents & POLLNVAL) { /* fd not open */
                 return WOLFJNI_IO_EVENT_FD_CLOSED;
 
-            } else if (fds[0].revents & POLLERR) {  /* exceptional error */
+            }
+            else if (fds[0].revents & POLLERR) {  /* exceptional error */
                 return WOLFJNI_IO_EVENT_ERROR;
 
-            } else if (fds[0].revents & POLLHUP) {  /* sock disconnected */
+            }
+            else if (fds[0].revents & POLLHUP) {  /* sock disconnected */
                 return WOLFJNI_IO_EVENT_POLLHUP;
             }
         }
@@ -795,7 +1051,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_connect
 {
     int ret = 0, err = 0, sockfd = 0;
     int pollRx = 0;
+#if !defined(WOLFJNI_USE_IO_SELECT) && !defined(USE_WINDOWS_API)
     int pollTx = 0;
+#endif
     wolfSSL_Mutex* jniSessLock = NULL;
     SSLAppData* appData = NULL;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
@@ -852,14 +1110,16 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_connect
             if (err == SSL_ERROR_WANT_READ) {
                 pollRx = 1;
             }
+        #if !defined(WOLFJNI_USE_IO_SELECT) && !defined(USE_WINDOWS_API)
             else if (err == SSL_ERROR_WANT_WRITE) {
                 pollTx = 1;
             }
+        #endif
 
         #if defined(WOLFJNI_USE_IO_SELECT) || defined(USE_WINDOWS_API)
-            ret = socketSelect(sockfd, (int)timeout, pollRx);
+            ret = socketSelect(appData, sockfd, (int)timeout, pollRx, 0);
         #else
-            ret = socketPoll(sockfd, (int)timeout, pollRx, pollTx);
+            ret = socketPoll(appData, sockfd, (int)timeout, pollRx, pollTx, 0);
         #endif
             if ((ret == WOLFJNI_IO_EVENT_RECV_READY) ||
                 (ret == WOLFJNI_IO_EVENT_SEND_READY)) {
@@ -898,7 +1158,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_write
     byte* data = NULL;
     int ret = SSL_FAILURE, err, sockfd;
     int pollRx = 0;
+#if !defined(WOLFJNI_USE_IO_SELECT) && !defined(USE_WINDOWS_API)
     int pollTx = 0;
+#endif
     wolfSSL_Mutex* jniSessLock = NULL;
     SSLAppData* appData = NULL;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
@@ -963,14 +1225,17 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_write
                 if (err == SSL_ERROR_WANT_READ) {
                     pollRx = 1;
                 }
+            #if !defined(WOLFJNI_USE_IO_SELECT) && !defined(USE_WINDOWS_API)
                 else if (err == SSL_ERROR_WANT_WRITE) {
                     pollTx = 1;
                 }
+            #endif
 
             #if defined(WOLFJNI_USE_IO_SELECT) || defined(USE_WINDOWS_API)
-                ret = socketSelect(sockfd, (int)timeout, pollRx);
+                ret = socketSelect(appData, sockfd, (int)timeout, pollRx, 0);
             #else
-                ret = socketPoll(sockfd, (int)timeout, pollRx, pollTx);
+                ret = socketPoll(appData, sockfd, (int)timeout, pollRx,
+                    pollTx, 0);
             #endif
                 if ((ret == WOLFJNI_IO_EVENT_RECV_READY) ||
                     (ret == WOLFJNI_IO_EVENT_SEND_READY)) {
@@ -1017,7 +1282,9 @@ static int SSLReadNonblockingWithSelectPoll(WOLFSSL* ssl, byte* out,
 {
     int size, ret, err, sockfd;
     int pollRx = 0;
+#if !defined(WOLFJNI_USE_IO_SELECT) && !defined(USE_WINDOWS_API)
     int pollTx = 0;
+#endif
     wolfSSL_Mutex* jniSessLock = NULL;
     SSLAppData* appData = NULL;
 
@@ -1065,14 +1332,16 @@ static int SSLReadNonblockingWithSelectPoll(WOLFSSL* ssl, byte* out,
             if (err == SSL_ERROR_WANT_READ) {
                 pollRx = 1;
             }
+        #if !defined(WOLFJNI_USE_IO_SELECT) && !defined(USE_WINDOWS_API)
             else if (err == SSL_ERROR_WANT_WRITE) {
                 pollTx = 1;
             }
+        #endif
 
         #if defined(WOLFJNI_USE_IO_SELECT) || defined(USE_WINDOWS_API)
-            ret = socketSelect(sockfd, timeout, pollRx);
+            ret = socketSelect(appData, sockfd, timeout, pollRx, 0);
         #else
-            ret = socketPoll(sockfd, timeout, pollRx, pollTx);
+            ret = socketPoll(appData, sockfd, timeout, pollRx, pollTx, 0);
         #endif
             if ((ret == WOLFJNI_IO_EVENT_RECV_READY) ||
                 (ret == WOLFJNI_IO_EVENT_SEND_READY)) {
@@ -1304,7 +1573,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_accept
 {
     int ret = 0, err, sockfd;
     int pollRx = 0;
+#if !defined(WOLFJNI_USE_IO_SELECT) && !defined(USE_WINDOWS_API)
     int pollTx = 0;
+#endif
     wolfSSL_Mutex* jniSessLock = NULL;
     SSLAppData* appData = NULL;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
@@ -1361,14 +1632,16 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_accept
             if (err == SSL_ERROR_WANT_READ) {
                 pollRx = 1;
             }
+        #if !defined(WOLFJNI_USE_IO_SELECT) && !defined(USE_WINDOWS_API)
             else if (err == SSL_ERROR_WANT_WRITE) {
                 pollTx = 1;
             }
+        #endif
 
         #if defined(WOLFJNI_USE_IO_SELECT) || defined(USE_WINDOWS_API)
-            ret = socketSelect(sockfd, (int)timeout, pollRx);
+            ret = socketSelect(appData, sockfd, (int)timeout, pollRx, 0);
         #else
-            ret = socketPoll(sockfd, (int)timeout, pollRx, pollTx);
+            ret = socketPoll(appData, sockfd, (int)timeout, pollRx, pollTx, 0);
         #endif
             if ((ret == WOLFJNI_IO_EVENT_RECV_READY) ||
                 (ret == WOLFJNI_IO_EVENT_SEND_READY)) {
@@ -1441,6 +1714,16 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_freeSSL
             XFREE(g_cachedVerifyCb, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             g_cachedVerifyCb = NULL;
         }
+#ifndef USE_WINDOWS_API
+        if (appData->pollCountLock != NULL) {
+            wc_FreeMutex(appData->pollCountLock);
+            XFREE(appData->pollCountLock, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            appData->pollCountLock = NULL;
+        }
+
+        /* close pipe() descriptors */
+        closeInterruptPipe(appData);
+#endif
         /* free appData */
         XFREE(appData, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         appData = NULL;
@@ -1553,7 +1836,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_shutdownSSL
 {
     int ret = 0, err, sockfd;
     int pollRx = 0;
+#if !defined(WOLFJNI_USE_IO_SELECT) && !defined(USE_WINDOWS_API)
     int pollTx = 0;
+#endif
     wolfSSL_Mutex* jniSessLock;
     SSLAppData* appData = NULL;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
@@ -1610,14 +1895,16 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_shutdownSSL
             if (err == SSL_ERROR_WANT_READ) {
                 pollRx = 1;
             }
+        #if !defined(WOLFJNI_USE_IO_SELECT) && !defined(USE_WINDOWS_API)
             else if (err == SSL_ERROR_WANT_WRITE) {
                 pollTx = 1;
             }
+        #endif
 
         #if defined(WOLFJNI_USE_IO_SELECT) || defined(USE_WINDOWS_API)
-            ret = socketSelect(sockfd, (int)timeout, pollRx);
+            ret = socketSelect(appData, sockfd, (int)timeout, pollRx, 1);
         #else
-            ret = socketPoll(sockfd, (int)timeout, pollRx, pollTx);
+            ret = socketPoll(appData, sockfd, (int)timeout, pollRx, pollTx, 1);
         #endif
             if ((ret == WOLFJNI_IO_EVENT_RECV_READY) ||
                 (ret == WOLFJNI_IO_EVENT_SEND_READY)) {
@@ -1822,11 +2109,11 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_get1Session
 
             #if defined(WOLFJNI_USE_IO_SELECT) || defined(USE_WINDOWS_API)
                 /* Default to select() on Windows or if WOLFJNI_USE_IO_SELECT */
-                ret = socketSelect(sockfd,
-                        (int)WOLFSSL_JNI_DEFAULT_PEEK_TIMEOUT, 1);
-            #else
-                ret = socketPoll(sockfd,
+                ret = socketSelect(appData, sockfd,
                         (int)WOLFSSL_JNI_DEFAULT_PEEK_TIMEOUT, 1, 0);
+            #else
+                ret = socketPoll(appData, sockfd,
+                        (int)WOLFSSL_JNI_DEFAULT_PEEK_TIMEOUT, 1, 0, 0);
             #endif
                 if ((ret == WOLFJNI_IO_EVENT_RECV_READY) ||
                     (ret == WOLFJNI_IO_EVENT_SEND_READY)) {
@@ -5443,6 +5730,51 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_hasTicket
     (void)sessionPtr;
     return (jint)WolfSSL.SSL_FAILURE;
 #endif
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_interruptBlockedIO
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
+{
+#ifndef USE_WINDOWS_API
+    SSLAppData* appData = NULL;
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
+#endif
+    (void)jenv;
+    (void)jcl;
+
+#ifndef USE_WINDOWS_API
+    /* get session mutex from SSL app data */
+    appData = (SSLAppData*)wolfSSL_get_app_data(ssl);
+    if (appData == NULL) {
+        return WOLFSSL_FAILURE;
+    }
+
+    /* signal any blocked threads in select()/poll() to wake up, so we
+     * don't have a deadlock when trying to lock jniSessLock next */
+    writeToInterruptPipe(appData);
+    writeToInterruptPipe(appData);
+
+#endif /* USE_WINDOWS_API */
+
+    return SSL_SUCCESS;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getThreadsBlockedInPoll
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
+{
+    SSLAppData* appData = NULL;
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
+
+    (void)jenv;
+    (void)jcl;
+
+    /* get session mutex from SSL app data */
+    appData = (SSLAppData*)wolfSSL_get_app_data(ssl);
+    if (appData == NULL) {
+        return 0;
+    }
+
+    return (jint)threadsWaitingInPollSelect(appData);
 }
 
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setSSLIORecv

--- a/native/com_wolfssl_WolfSSLSession.h
+++ b/native/com_wolfssl_WolfSSLSession.h
@@ -10,10 +10,10 @@ extern "C" {
 /*
  * Class:     com_wolfssl_WolfSSLSession
  * Method:    newSSL
- * Signature: (J)J
+ * Signature: (JZ)J
  */
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_newSSL
-  (JNIEnv *, jobject, jlong);
+  (JNIEnv *, jobject, jlong, jboolean);
 
 /*
  * Class:     com_wolfssl_WolfSSLSession
@@ -877,6 +877,22 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useSupportedCurve
  * Signature: (J)I
  */
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_hasTicket
+  (JNIEnv *, jobject, jlong);
+
+/*
+ * Class:     com_wolfssl_WolfSSLSession
+ * Method:    interruptBlockedIO
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_interruptBlockedIO
+  (JNIEnv *, jobject, jlong);
+
+/*
+ * Class:     com_wolfssl_WolfSSLSession
+ * Method:    getThreadsBlockedInPoll
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getThreadsBlockedInPoll
   (JNIEnv *, jobject, jlong);
 
 #ifdef __cplusplus

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
@@ -313,7 +313,7 @@ public class WolfSSLEngine extends SSLEngine {
         }
 
         /* will throw WolfSSLException if issue creating WOLFSSL */
-        ssl = new WolfSSLSession(ctx);
+        ssl = new WolfSSLSession(ctx, false);
 
         enableExtraDebug();
         enableIODebug();

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLTestFactory.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLTestFactory.java
@@ -1052,8 +1052,19 @@ class WolfSSLTestFactory {
      * Test if the env is Android
      * @return true if is Android system
      */
-    protected boolean isAndroid() {
+    protected static boolean isAndroid() {
         if (System.getProperty("java.runtime.name").contains("Android")) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Test if the env is Windows.
+     * @return true if Windows, otherwise false
+     */
+    protected static boolean isWindows() {
+        if (System.getProperty("os.name").startsWith("Windows")) {
             return true;
         }
         return false;

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLTrustX509Test.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLTrustX509Test.java
@@ -121,7 +121,7 @@ public class WolfSSLTrustX509Test {
 
         System.out.print("\tTesting parse all.jks");
 
-        if (tf.isAndroid()) {
+        if (WolfSSLTestFactory.isAndroid()) {
             /* @TODO finding that BKS has different order of certs */
             pass("\t... skipped");
             return;
@@ -186,7 +186,7 @@ public class WolfSSLTrustX509Test {
 
         System.out.print("\tTesting use before init()");
 
-        if (tf.isAndroid()) {
+        if (WolfSSLTestFactory.isAndroid()) {
             /* @TODO finding that BKS has different order of certs */
             pass("\t... skipped");
             return;
@@ -242,7 +242,7 @@ public class WolfSSLTrustX509Test {
 
         System.out.print("\tTesting parsing server.jks");
 
-        if (tf.isAndroid()) {
+        if (WolfSSLTestFactory.isAndroid()) {
             /* @TODO finding that BKS has different order of certs */
             pass("\t... skipped");
             return;
@@ -312,7 +312,7 @@ public class WolfSSLTrustX509Test {
 
         System.out.print("\tTesting parse all_mixed.jks");
 
-        if (tf.isAndroid()) {
+        if (WolfSSLTestFactory.isAndroid()) {
             /* @TODO finding that BKS has different order of certs */
             pass("\t... skipped");
             return;
@@ -570,7 +570,7 @@ public class WolfSSLTrustX509Test {
         String eccInt1Cert = "examples/certs/intermediate/ca-int-ecc-cert.pem";
         String eccInt2Cert = "examples/certs/intermediate/ca-int2-ecc-cert.pem";
 
-        if (tf.isAndroid()) {
+        if (WolfSSLTestFactory.isAndroid()) {
             rsaServerCert = "/sdcard/" + rsaServerCert;
             rsaInt1Cert = "/sdcard/" + rsaInt1Cert;
             rsaInt2Cert = "/sdcard/" + rsaInt2Cert;
@@ -697,7 +697,7 @@ public class WolfSSLTrustX509Test {
             "examples/certs/intermediate/ca-int-cert.pem";
         String eccInt2Cert = "examples/certs/intermediate/ca-int2-ecc-cert.pem";
 
-        if (tf.isAndroid()) {
+        if (WolfSSLTestFactory.isAndroid()) {
             rsaServerCert = "/sdcard/" + rsaServerCert;
             rsaInt1CertWrong = "/sdcard/" + rsaInt1CertWrong;
             rsaInt2Cert = "/sdcard/" + rsaInt2Cert;
@@ -825,7 +825,7 @@ public class WolfSSLTrustX509Test {
         String eccInt1Cert = "examples/certs/intermediate/ca-int-ecc-cert.pem";
         String eccInt2Cert = "examples/certs/intermediate/ca-int2-ecc-cert.pem";
 
-        if (tf.isAndroid()) {
+        if (WolfSSLTestFactory.isAndroid()) {
             rsaServerCert = "/sdcard/" + rsaServerCert;
             rsaInt1Cert = "/sdcard/" + rsaInt1Cert;
             rsaInt2Cert = "/sdcard/" + rsaInt2Cert;
@@ -948,7 +948,7 @@ public class WolfSSLTrustX509Test {
             "examples/certs/intermediate/server-int-ecc-cert.pem";
         String eccInt2Cert = "examples/certs/intermediate/ca-int2-ecc-cert.pem";
 
-        if (tf.isAndroid()) {
+        if (WolfSSLTestFactory.isAndroid()) {
             rsaServerCert = "/sdcard/" + rsaServerCert;
             rsaInt2Cert = "/sdcard/" + rsaInt2Cert;
 
@@ -1054,7 +1054,7 @@ public class WolfSSLTrustX509Test {
         String eccInt1Cert = "examples/certs/intermediate/ca-int-ecc-cert.pem";
         String eccInt2Cert = "examples/certs/intermediate/ca-int2-ecc-cert.pem";
 
-        if (tf.isAndroid()) {
+        if (WolfSSLTestFactory.isAndroid()) {
             rsaServerCert = "/sdcard/" + rsaServerCert;
             rsaInt1Cert = "/sdcard/" + rsaInt1Cert;
             rsaInt2Cert = "/sdcard/" + rsaInt2Cert;
@@ -1180,7 +1180,7 @@ public class WolfSSLTrustX509Test {
         String eccInt1Cert = "examples/certs/intermediate/ca-int-ecc-cert.pem";
         String eccInt2Cert = "examples/certs/intermediate/ca-int2-ecc-cert.pem";
 
-        if (tf.isAndroid()) {
+        if (WolfSSLTestFactory.isAndroid()) {
             rsaServerCert = "/sdcard/" + rsaServerCert;
             rsaInt1Cert = "/sdcard/" + rsaInt1Cert;
             rsaInt2Cert = "/sdcard/" + rsaInt2Cert;
@@ -1340,7 +1340,7 @@ public class WolfSSLTrustX509Test {
         String eccInt1Cert = "examples/certs/intermediate/ca-int-ecc-cert.pem";
         String eccRootCert = "examples/certs/ca-ecc-cert.pem";
 
-        if (tf.isAndroid()) {
+        if (WolfSSLTestFactory.isAndroid()) {
             rsaServerCert = "/sdcard/" + rsaServerCert;
             rsaInt1Cert = "/sdcard/" + rsaInt1Cert;
             rsaInt2Cert = "/sdcard/" + rsaInt2Cert;

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLX509Test.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLX509Test.java
@@ -363,7 +363,7 @@ public class WolfSSLX509Test {
                     break;
                 }
             }
-            if (sigProvider == null || tf.isAndroid()) {
+            if (sigProvider == null || WolfSSLTestFactory.isAndroid()) {
                 pass("\t\t\t... skipped");
                 return;
             }
@@ -511,7 +511,7 @@ public class WolfSSLX509Test {
            }
 
            /* Android KeyStore formats x509 getName() differently than peer getName() */
-           if (!tf.isAndroid()) {
+           if (!WolfSSLTestFactory.isAndroid()) {
                if (!x509.getSubjectDN().getName().equals(
                        peer.getSubjectDN().getName())) {
                    error("\t\t... failed");


### PR DESCRIPTION
This PR adjusts JSSE and lower-level JNI behavior around `SSLSocket.close()`. When `close()` is called, it should interrupt any other threads blocked in `select()/poll()` from `read()/write()` operations.

This adds a `pipe()` descriptor which is watched by `select()/poll()`. That pipe is written to by a thread calling `SSLSocket.close()` to wake those blocked threads up - preventing a possible deadlock in this scenario.

This `pipe()` solution is currently only implemented for **non-Windows platforms** in this PR.

Should fix SunJSSE test: `SSLSocketImpl/BlockedAsyncClose.java`.

Minor fixes also included in this PR:
- Add ability to pass `CFLAGS` to `java.sh`, ie: `CFLAGS="-DTEST_DEFINE" ./java.sh`
- Add GitHub Action test for testing with `-DWOLFJNI_USE_IO_SELECT` defined (uses `select()` instead of `poll()`)
- Update `WolfSSLSocketTest` `TestServer/Client` with `CountDownLatch` for proper Exception detection
- Fix Visual Studio warning about possible uninitialized pointer variable
- Remove incorrect `ATOMIC_USER` define gate around native `wolfSSL_GetSide()`