### PR TITLE
Prep for 1.15 Release

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,38 @@
+### wolfSSL JNI Release 1.15.0 (01/24/2025)
+
+Release 1.15.0 has bug fixes and new features including:
+
+**JSSE System/Security Property Support:**
+* Addition of JNI-level debug system property (`wolfssljni.debug=true`) (PR 235)
+
+**JSSE Changes:**
+* Fix to close Socket when SSLSocket startHandshake() fails (PR 234)
+* Fixes for potential NullPointerException in SSLSocket Input/OutputStream (PR 233)
+* Add ability for `SSLSession.getRequestedServerNames()` to return SNI request on server side (PR 240)
+* Add check for legacy DHE keys, for cipher suites using keys less than 1024 bits (PR 243)
+* Optimize `byte[]` creation in `SSLEngine` when receiving app data (PR 244, 250)
+* Add ability for `SSLSocket.close()` to interrupt `read()/write()` operations waiting in `select()/poll()` (PR 246)
+
+**JNI Changes:**
+* Always call `wolfSSL_get1_session()` inside `WolfSSLSession.getSession()` (PR 236)
+* Call `wc_RunAllCast_fips()` with wolfCrypt FIPS builds if available (PR 247)
+* Add ability to pass `CFLAGS` to `java.sh` (ie: `CFLAGS="-DTEST_DEFINE" ./java.sh`) (PR 248)
+* Remove incorrect `ATOMIC_USER` preprocessor gate around native `wolfSSL_GetSide()` (PR 246)
+
+**Example Changes:**
+* Updated Android Studio example project, define `WOLFSSL_CERT_REQ` (PR 234)
+* Update Android Studio CMakeLists.txt with `WOLFSSL_CUSTOM_CONFIG` definition (PR 239)
+
+**Testing Changes:**
+* Add GitHub Actions PRB test for Maven (Linux, macOS) builds (PR 232)
+* Add tests of `SSLSession` state at various points throughout the handshake (PR 233)
+* Add GitHub Actions PRB test for `--enable-jni CFLAGS="-DNO_SESSION_CACHE_REF"` build (PR 236)
+* Add GitHub Actions PRB test for `-DWOLFJNI_USE_IO_SELECT` (PR 246)
+
+The wolfSSL JNI Manual is available at:
+https://www.wolfssl.com/documentation/manuals/wolfssljni. For build
+instructions and more detailed comments, please check the manual.
+
 ### wolfSSL JNI Release 1.14.0 (11/7/2024)
 
 Release 1.14.0 has bug fixes and new features including:

--- a/IDE/Android/.idea/misc.xml
+++ b/IDE/Android/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DesignSurface">
     <option name="filePathToZoomLevelMap">

--- a/IDE/Android/README.md
+++ b/IDE/Android/README.md
@@ -40,6 +40,8 @@ $ mv wolfssl-X.X.X wolfssljni/IDE/Android/app/src/main/cpp/wolfssl
 ```
 $ cd /IDE/Android/app/src/main/cpp/
 $ git clone https://github.com/wolfssl/wolfssl
+$ cd wolfssl
+$ ./autogen.sh
 $ cp wolfssl/options.h.in wolfssl/options.h
 ```
 

--- a/IDE/Android/app/src/main/cpp/CMakeLists.txt
+++ b/IDE/Android/app/src/main/cpp/CMakeLists.txt
@@ -125,44 +125,64 @@ elseif("${WOLFSSL_PKG_TYPE}" MATCHES "fipsready")
         endif()
 
         # Add preprocessor defines to CFLAGS, these match those placed into
-        # wolfssl/options.h by configure if using: "./configure" on a Unix/Linux
-        # platform. The options below have been chosen to match a FIPS Ready build,
-        # and are based on the example user_settings.h file located here:
-        # https://github.com/wolfSSL/wolfssl/blob/master/examples/configs/user_settings_fipsv5.h
+        # wolfssl/options.h by configure if using the following configure on a Unix/Linux
+        # platform with a wolfSSL FIPS Ready GPLv3 bundle:
+        #
+        # ./configure --enable-fips=ready --enable-jni
+        #
         # This list may be configurable depending on use case and desired
         # optimizations, being careful not to break FIPS compatibility if targeting
-        # FIPS proper in the future.
-        add_definitions(-DHAVE_FIPS -DHAVE_FIPS_VERSION=5 -DHAVE_FIPS_VERSION_MINOR=3
-                -DHAVE_HASHDRBG -DHAVE_THREAD_LS -DHAVE_REPRODUCIBLE_BUILD
-                -DFP_MAX_BITS=16384 -DSP_INT_BITS=8192 -DWOLFSSL_PUBLIC_MP
-                -DTFM_TIMING_RESISTANT -DECC_TIMING_RESISTANT -DWC_RSA_BLINDING
-                -DWC_RNG_SEED_CB -DWOLFSSL_VALIDATE_ECC_IMPORT -DWOLFSSL_VALIDATE_ECC_KEYGEN
-                -DWOLFSSL_VALIDATE_FFC_IMPORT
-                -DWOLFSSL_TLS13 -DHAVE_TLS_EXTENSIONS -DHAVE_ENCRYPT_THEN_MAC
-                -DHAVE_SUPPORTED_CURVES -DHAVE_EXTENDED_MASTER -DHAVE_ONE_TIME_AUTH
-                -DHAVE_SECURE_RENEGOTIATION -DHAVE_SERVER_RENEGOTIATION_INFO -DHAVE_SESSION_TICKET
-                -DWOLFSSL_USE_ALIGN -DWOLFSSL_BASE64_ENCODE -DHAVE_CRL
-                -DHAVE_EXT_CACHE -DWOLFSSL_VERIFY_CB_ALL_CERTS -DWOLFSSL_ALWAYS_VERIFY_CB
-                -DWOLFSSL_DH_EXTRA -DWOLFSSL_WOLFSSH -DOPENSSL_EXTRA -DOPENSSL_ALL
-                -DHAVE_FFDHE_Q -DHAVE_FFDHE_2048 -DHAVE_FFDHE_3072 -DHAVE_FFDHE_4096
-                -DHAVE_FFDHE_6144 -DHAVE_FFDHE_8192 -DHAVE_DH_DEFAULT_PARAMS  -DHAVE_PUBLIC_FFDHE
-                -DHAVE_ECC -DTFM_ECC256 -DECC_SHAMIR -DHAVE_ECC_CDH -DECC_USER_CURVES
-                -DHAVE_ECC256 -DHAVE_ECC384 -DHAVE_ECC521 -DWOLFSSL_ECDSA_SET_K
-                -DWC_RSA_PSS -DWOLFSSL_KEY_GEN -DWC_RSA_NO_PADDING
-                -DWOLFSSL_AES_COUNTER -DHAVE_AESCCM -DHAVE_AES_ECB -DWOLFSSL_AES_DIRECT
-                -DWOLFSSL_AES_OFB -DHAVE_AESGCM -DGCM_TABLE_4BIT -DWOLFSSL_CMAC
-                -DWOLFSSL_SHA224 -DWOLFSSL_SHA512 -DWOLFSSL_SHA384 -DWOLFSSL_NO_SHAKE256
-                -DWOLFSSL_NOSHA512_224 -DWOLFSSL_NOSHA512_256 -DWOLFSSL_SHA3 -DHAVE_HKDF
-                -DNO_OLD_TLS -DNO_PSK -DNO_DO178
-                -DNO_RC4 -DNO_MD4 -DNO_MD5 -DNO_DES3 -DNO_DSA -DNO_RABBIT
+        # FIPS proper in the future. Please contact support@wolfssl.com for assistance
+        # properly compiling for use with wolfCrypt FIPS variants.
+        add_definitions(
+                -DWOLFSSL_FIPS_READY -DHAVE_FIPS -DHAVE_FIPS_VERSION=7
+                -DHAVE_FIPS_VERSION_MAJOR=7 -DHAVE_FIPS_VERSION_MINOR=0
+                -DHAVE_FIPS_VERSION_PATCH=0 -DWC_RNG_SEED_CB -DHAVE_THREAD_LS
 
-                -DWOLFSSL_JNI -DHAVE_EX_DATA -DHAVE_OCSP -DHAVE_CRL_MONITOR
-                -DWOLFSSL_CERT_EXT -DWOLFSSL_CERT_GEN -DWOLFSSL_CERT_REQ
-                -DHAVE_SNI -DHAVE_ALPN -DWOLFSSL_ENCRYPTED_KEYS -DNO_ERROR_QUEUE
-                -DWOLFSSL_EITHER_SIDE -DWOLFSSL_PSS_LONG_SALT
-                -DWOLFSSL_TICKET_HAVE_ID -DWOLFSSL_ERROR_CODE_OPENSSL
-                -DWOLFSSL_EXTRA_ALERTS -DWOLFSSL_FORCE_CACHE_ON_TICKET
-                -DWOLFSSL_AKID_NAME -DHAVE_CTS -DKEEP_PEER_CERT -DSESSION_CERTS
+                -DWOLFSSL_WOLFSSH -DNO_DO178 -DHAVE_REPRODUCIBLE_BUILD -DWC_NO_ASYNC_THREADING
+                -DNO_OLD_TLS -DWOLFSSL_TLS13 -DHAVE_TLS_EXTENSIONS -DHAVE_SNI
+                -DHAVE_KEYING_MATERIAL -DHAVE_TLS_EXTENSIONS -DHAVE_SUPPORTED_CURVES
+                -DHAVE_EXTENDED_MASTER -DHAVE_ENCRYPT_THEN_MAC -DWOLFSSL_JNI -DHAVE_EX_DATA
+                -DKEEP_PEER_CERT -DWOLFSSL_ALWAYS_VERIFY_CB -DWOLFSSL_DTLS -DOPENSSL_EXTRA
+                -DOPENSSL_ALL -DWOLFSSL_ERROR_CODE_OPENSSL -DHAVE_CRL -DHAVE_CRL_MONITOR
+                -DHAVE_OCSP -DPERSIST_SESSION_CACHE -DPERSIST_CERT_CACHE -DATOMIC_USER
+                -DWOLFSSL_CERT_EXT -DWOLFSSL_CERT_GEN -DWOLFSSL_CERT_REQ -DWOLFSSL_KEY_GEN
+                -DHAVE_ALPN -DWOLFSSL_ALT_CERT_CHAINS -DSESSION_CERTS -DWOLFSSL_ENCRYPTED_KEYS
+                -DWOLFSSL_SYS_CA_CERTS -DWOLFSSL_ALT_NAMES -DWOLFSSL_EITHER_SIDE
+                -DWOLFSSL_TICKET_HAVE_ID -DWOLFSSL_CERT_NAME_ALL
+                -DHAVE_SERVER_RENEGOTIATION_INFO -DWOLFSSL_ASN_TEMPLATE -DWOLFSSL_ASN_PRINT
+                -DWOLFSSL_BASE64_ENCODE -DERROR_QUEUE_PER_THREAD -DNO_ERROR_QUEUE
+                -DTFM_TIMING_RESISTANT -DECC_TIMING_RESISTANT -DWOLFSSL_USE_ALIGN
+                -DWOLFSSL_PUBLIC_MP
+
+                -DWC_RSA_BLINDING -DWC_RSA_PSS -DWOLFSSL_PSS_LONG_SALT -DWC_RSA_NO_PADDING
+
+                -DHAVE_ECC -DTFM_ECC256 -DECC_SHAMIR -DECC_MIN_KEY_SZ=192 -DHAVE_ECC_CDH
+                -DECC_USER_CURVES -DHAVE_ECC192 -DHAVE_ECC224 -DHAVE_ECC256 -DHAVE_ECC384
+                -DHAVE_ECC521 -DWOLFSSL_ECDSA_SET_K -DWOLFSSL_VALIDATE_ECC_IMPORT
+                -DWOLFSSL_VALIDATE_ECC_KEYGEN
+
+                -DWOLFSSL_VALIDATE_FFC_IMPORT -DHAVE_FFDHE_Q -DHAVE_FFDHE_2048
+                -DHAVE_FFDHE_3072 -DHAVE_FFDHE_4096 -DHAVE_FFDHE_6144 -DHAVE_FFDHE_8192
+                -DHAVE_DH_DEFAULT_PARAMS
+
+                -DHAVE_HKDF -DHAVE_PBKDF2 -DHAVE_HASHDRBG -DWC_SRTP_KDF -DWOLFSSL_SRTP
+
+                -DHAVE_AESGCM -DGCM_TABLE_4BIT -DWOLFSSL_AESGCM_STREAM -DHAVE_AESCCM
+                -DWOLFSSL_AES_COUNTER -DWOLFSSL_CMAC -DWOLFSSL_AES_OFB -DWOLFSSL_AES_CFB
+                -DWOLFSSL_AES_XTS -DWOLFSSL_AESXTS_STREAM -DWOLFSSL_AES_DIRECT
+                -DHAVE_AES_ECB -DHAVE_AES_KEYWRAP -DWOLFSSL_AES_XTS -DHAVE_AES_KEYWRAP
+
+                -DHAVE_ED25519 -DHAVE_ED25519_KEY_IMPORT -DHAVE_ED448 -DHAVE_ED448_KEY_IMPORT
+                -DWOLFSSL_ED448_STREAMING_VERIFY
+
+                -DHAVE_CURVE25519 -DHAVE_CURVE448
+
+                -DWOLFSSL_SHA224 -DWOLFSSL_SHA384 -DWOLFSSL_SHA512 -DWOLFSSL_NOSHA512_224
+                -DWOLFSSL_NOSHA512_256 -DWOLFSSL_SHA3 -DWOLFSSL_SHAKE128 -DWOLFSSL_SHAKE256
+
+                -DNO_DSA -DNO_RC4 -DNO_MD4 -DNO_DES3 -DNO_DES3_TLS_SUITES
+
                 -DSIZEOF_LONG=4 -DSIZEOF_LONG_LONG=8 -DWOLFSSL_CUSTOM_CONFIG
 
                 # For gethostbyname()
@@ -191,7 +211,8 @@ elseif("${WOLFSSL_MATH_LIB}" MATCHES "spmath")
                 -DWOLFSSL_HAVE_SP_RSA -DWOLFSSL_SP_4096
                 -DWOLFSSL_HAVE_SP_DH
                 -DWOLFSSL_HAVE_SP_ECC -DWOLFSSL_SP_384 -DWOLFSSL_SP_521
-                -DWOLFSSL_SP_LARGE_CODE)
+                -DWOLFSSL_SP_LARGE_CODE
+                -DFP_MAX_BITS=16384 -DSP_INT_BITS=8192)
 
         # SP Math architecture-specific settings (ex: assembly optimizations)
         if("${ANDROID_ABI}" MATCHES "arm64-v8a")
@@ -203,8 +224,7 @@ elseif("${WOLFSSL_MATH_LIB}" MATCHES "spmath")
                 # Not using ASM, need to use WOLFSSL_SP_MATH_ALL for SW-only implementation
                 add_definitions(-DWOLFSSL_SP_MATH_ALL)
         elseif("${ANDROID_ABI}" MATCHES "x86_64")
-                # Using ASM for SP, need to use WOLFSSL_SP_MATH instead of WOLFSSL_SP_MATH_ALL
-                add_definitions(-DWOLFSSL_SP_MATH)
+                add_definitions(-DWOLFSSL_SP_MATH_ALL)
                 add_definitions(-DWOLFSSL_SP_ASM -DWOLFSSL_SP_X86_64 -DWOLFSSL_SP_X86_64_ASM -DHAVE___UINT128_T)
                 list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/sp_x86_64_asm.S)
         elseif("${ANDROID_ABI}" MATCHES "x86")
@@ -245,16 +265,21 @@ elseif("${WOLFSSL_PKG_TYPE}" MATCHES "fipsready")
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/wolfcrypt_first.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/hmac.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/random.c)
-        list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/sha256.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/kdf.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/rsa.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/ecc.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/aes.c)
+        list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/sha256.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/sha.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/sha512.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/sha3.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/dh.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/cmac.c)
+        list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/curve448.c)
+        list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/ed448.c)
+        list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/curve25519.c)
+        list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/ed25519.c)
+        list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/pwdbased.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/fips.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/fips_test.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/wolfcrypt_last.c)
@@ -278,9 +303,18 @@ elseif("${WOLFSSL_PKG_TYPE}" MATCHES "fipsready")
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/memory.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/asn.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/coding.c)
+        list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/md5.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/pwdbased.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/pkcs12.c)
         list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/tfm.c)
+        list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/wc_lms.c)
+        list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/wc_lms_impl.c)
+        list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/wc_xmss.c)
+        list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/wc_xmss_impl.c)
+        list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/fe_operations.c)
+        list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/ge_operations.c)
+        list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/fe_448.c)
+        list(APPEND CRYPTO_SOURCES ${wolfssl_DIR}/wolfcrypt/src/ge_448.c)
 endif()
 
 # wolfSSL will be compiled as a SHARED library

--- a/IDE/Android/app/src/main/java/com/example/wolfssl/MainActivity.java
+++ b/IDE/Android/app/src/main/java/com/example/wolfssl/MainActivity.java
@@ -52,6 +52,22 @@ public class MainActivity extends AppCompatActivity {
         }
     };
 
+    private void setDisplayText(String s)
+    {
+        runOnUiThread(() -> {
+            TextView tv = (TextView) findViewById(R.id.sample_text);
+            tv.setText(s);
+        });
+    }
+
+    private void appendDisplayText(String s)
+    {
+        runOnUiThread(() -> {
+            TextView tv = (TextView) findViewById(R.id.sample_text);
+            tv.append(s);
+        });
+    }
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -60,8 +76,7 @@ public class MainActivity extends AppCompatActivity {
         Button button = (Button) findViewById(R.id.button);
         button.setOnClickListener(buttonListener);
 
-        TextView tv = (TextView) findViewById(R.id.sample_text);
-        tv.setText("wolfSSL JNI Android Studio Example App");
+        setDisplayText("wolfSSL JNI Android Studio Example App\n");
     }
 
     public void testFindProvider(TextView tv)
@@ -71,15 +86,18 @@ public class MainActivity extends AppCompatActivity {
         WolfSSL.loadLibrary();
 
         /* create new SSLEngine */
-        Security.addProvider(new WolfSSLProvider());
+        Security.insertProviderAt(new WolfSSLProvider(), 1);
 
         Provider p = Security.getProvider("wolfJSSE");
         if (p == null) {
-            System.out.println("Unable to find wolfJSSE provider");
-            return;
+            appendDisplayText("Unable to find wolfJSSE provider\n");
         }
         else {
-
+            appendDisplayText("Successfully found wolfJSSE provider\n");
         }
+
+        appendDisplayText("\n");
+        appendDisplayText("For more detailed example, see:\n");
+        appendDisplayText("github.com/wolfssl/wolfssl-examples\n");
     }
 }

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ an application can include this as a dependency in the application's
         <dependency>
             <groupId>com.wolfssl</groupId>
             <artifactId>wolfssl-jsse</artifactId>
-            <version>1.14.0-SNAPSHOT</version>
+            <version>1.15.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
     ...

--- a/build.xml
+++ b/build.xml
@@ -14,7 +14,7 @@
     <!-- versioning/manifest properties -->
     <property name="implementation.vendor"  value="wolfSSL Inc." />
     <property name="implementation.title"   value="wolfSSL JNI/JSSE" />
-    <property name="implementation.version" value="1.14" />
+    <property name="implementation.version" value="1.15" />
 
     <!-- set properties for this build -->
     <property name="src.dir" value="src/java/"/>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.wolfssl</groupId>
 	<artifactId>wolfssl-jsse</artifactId>
-	<version>1.14.0-SNAPSHOT</version>
+	<version>1.15.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>wolfssl-jsse</name>
     <url>https://www.wolfssl.com</url>

--- a/scripts/infer.sh
+++ b/scripts/infer.sh
@@ -39,6 +39,7 @@ infer --fail-on-issue run -- javac \
     src/java/com/wolfssl/WolfSSLCertRequest.java \
     src/java/com/wolfssl/WolfSSLCertificate.java \
     src/java/com/wolfssl/WolfSSLContext.java \
+    src/java/com/wolfssl/WolfSSLDebug.java \
     src/java/com/wolfssl/WolfSSLDecryptVerifyCallback.java \
     src/java/com/wolfssl/WolfSSLEccSharedSecretCallback.java \
     src/java/com/wolfssl/WolfSSLEccSignCallback.java \
@@ -52,6 +53,7 @@ infer --fail-on-issue run -- javac \
     src/java/com/wolfssl/WolfSSLLoggingCallback.java \
     src/java/com/wolfssl/WolfSSLMacEncryptCallback.java \
     src/java/com/wolfssl/WolfSSLMissingCRLCallback.java \
+    src/java/com/wolfssl/WolfSSLNativeLoggingCallback.java \
     src/java/com/wolfssl/WolfSSLPskClientCallback.java \
     src/java/com/wolfssl/WolfSSLPskServerCallback.java \
     src/java/com/wolfssl/WolfSSLRsaDecCallback.java \
@@ -69,7 +71,6 @@ infer --fail-on-issue run -- javac \
     src/java/com/wolfssl/provider/jsse/WolfSSLAuthStore.java \
     src/java/com/wolfssl/provider/jsse/WolfSSLContext.java \
     src/java/com/wolfssl/provider/jsse/WolfSSLCustomUser.java \
-    src/java/com/wolfssl/provider/jsse/WolfSSLDebug.java \
     src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java \
     src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java \
     src/java/com/wolfssl/provider/jsse/WolfSSLGenericHostName.java \
@@ -77,7 +78,6 @@ infer --fail-on-issue run -- javac \
     src/java/com/wolfssl/provider/jsse/WolfSSLInternalVerifyCb.java \
     src/java/com/wolfssl/provider/jsse/WolfSSLKeyManager.java \
     src/java/com/wolfssl/provider/jsse/WolfSSLKeyX509.java \
-    src/java/com/wolfssl/provider/jsse/WolfSSLNativeLoggingCallback.java \
     src/java/com/wolfssl/provider/jsse/WolfSSLParametersHelper.java \
     src/java/com/wolfssl/provider/jsse/WolfSSLParameters.java \
     src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java \
@@ -104,8 +104,10 @@ if [ "$RETVAL" == '0' ] && [ "$KEEP" == 'no' ]; then
     rm -r ./infer-out
 fi
 
-if [ "$RETVAL" == '2' ]; then
+if [ "$RETVAL" == '1' ] || [ "$RETVAL" == '2' ]; then
     # GitHub Actions expects return of 1 to mark step as failure
     exit 1
 fi
+
+exit 0
 

--- a/src/java/com/wolfssl/WolfSSLCertRequest.java
+++ b/src/java/com/wolfssl/WolfSSLCertRequest.java
@@ -172,9 +172,11 @@ public class WolfSSLCertRequest {
 
         confirmObjectIsActive();
 
-        WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, this.x509ReqPtr,
-            "entered addAttribute(nid: " + nid + ", byte[])");
+        synchronized (x509ReqLock) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.x509ReqPtr,
+                "entered addAttribute(nid: " + nid + ", byte[])");
+        }
 
         if (nid != WolfSSL.NID_pkcs9_challengePassword &&
             nid != WolfSSL.NID_serialNumber &&
@@ -262,9 +264,11 @@ public class WolfSSLCertRequest {
 
         confirmObjectIsActive();
 
-        WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, this.x509ReqPtr, "entered setPublicKey(" +
-            filePath + ", type: " + keyType + ", format: " + format + ")");
+        synchronized (x509ReqLock) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.x509ReqPtr, "entered setPublicKey(" +
+                filePath + ", type: " + keyType + ", format: " + format + ")");
+        }
 
         if (filePath == null || filePath.isEmpty()) {
             throw new WolfSSLException("File path is null or empty");
@@ -309,10 +313,12 @@ public class WolfSSLCertRequest {
 
         confirmObjectIsActive();
 
-        WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, this.x509ReqPtr,
-            "entered setPublicKey(byte[], type: " + keyType + ", format: " +
-            format + ")");
+        synchronized (x509ReqLock) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.x509ReqPtr,
+                "entered setPublicKey(byte[], type: " + keyType + ", format: " +
+                format + ")");
+        }
 
         if (key == null || key.length == 0) {
             throw new WolfSSLException("Key array is null or empty");
@@ -366,9 +372,11 @@ public class WolfSSLCertRequest {
 
         confirmObjectIsActive();
 
-        WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, this.x509ReqPtr,
-            "entered setPublicKey(" + key + ")");
+        synchronized (x509ReqLock) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.x509ReqPtr,
+                "entered setPublicKey(" + key + ")");
+        }
 
         if (key instanceof RSAPublicKey) {
             keyType = WolfSSL.RSAk;
@@ -442,9 +450,12 @@ public class WolfSSLCertRequest {
 
         confirmObjectIsActive();
 
-        WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, this.x509ReqPtr, "entered addExtension(nid: " +
-            nid + ", value: " + value + ", isCritical: " + isCritical + ")");
+        synchronized (x509ReqLock) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.x509ReqPtr,
+                "entered addExtension(nid: " + nid + ", value: " + value +
+                ", isCritical: " + isCritical + ")");
+        }
 
         if (nid != WolfSSL.NID_key_usage &&
             nid != WolfSSL.NID_subject_alt_name &&
@@ -502,9 +513,12 @@ public class WolfSSLCertRequest {
 
         confirmObjectIsActive();
 
-        WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, this.x509ReqPtr, "entered addExtension(nid: " +
-            nid + ", value: " + value + ", isCritical: " + isCritical + ")");
+        synchronized (x509ReqLock) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.x509ReqPtr,
+                "entered addExtension(nid: " + nid + ", value: " + value +
+                ", isCritical: " + isCritical + ")");
+        }
 
         if (nid != WolfSSL.NID_basic_constraints) {
             throw new WolfSSLException(
@@ -553,10 +567,12 @@ public class WolfSSLCertRequest {
 
         confirmObjectIsActive();
 
-        WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, this.x509ReqPtr, "entered signRequest(" +
-            filePath + ", keyType: " + keyType + ", format: " + format +
-            ", digestAlg: " + digestAlg + ")");
+        synchronized (x509ReqLock) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.x509ReqPtr, "entered signRequest(" +
+                filePath + ", keyType: " + keyType + ", format: " + format +
+                ", digestAlg: " + digestAlg + ")");
+        }
 
         if (filePath == null || filePath.isEmpty()) {
             throw new WolfSSLException("File path is null or empty");
@@ -604,10 +620,12 @@ public class WolfSSLCertRequest {
 
         confirmObjectIsActive();
 
-        WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, this.x509ReqPtr,
-            "entered signRequest(byte[], keyType: " + keyType + ", format: " +
-            format + ", digestAlg: " + digestAlg + ")");
+        synchronized (x509ReqLock) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.x509ReqPtr,
+                "entered signRequest(byte[], keyType: " + keyType +
+                ", format: " + format + ", digestAlg: " + digestAlg + ")");
+        }
 
         if (key == null || key.length == 0) {
             throw new WolfSSLException("Key array is null or empty");
@@ -665,9 +683,12 @@ public class WolfSSLCertRequest {
 
         confirmObjectIsActive();
 
-        WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, this.x509ReqPtr, "entered signRequest(key: " +
-            key + ", digestAlg: " + digestAlg + ")");
+        synchronized (x509ReqLock) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.x509ReqPtr,
+                "entered signRequest(key: " + key + ", digestAlg: " +
+                digestAlg + ")");
+        }
 
         if (key == null) {
             throw new WolfSSLException("Key object is null");

--- a/src/java/com/wolfssl/WolfSSLCertificate.java
+++ b/src/java/com/wolfssl/WolfSSLCertificate.java
@@ -462,9 +462,11 @@ public class WolfSSLCertificate implements Serializable {
 
         confirmObjectIsActive();
 
-        WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, this.x509Ptr, "entering setIssuerName(" +
-            cert + ")");
+        synchronized (x509Lock) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.x509Ptr, "entering setIssuerName(" +
+                cert + ")");
+        }
 
         x509NamePtr = X509_get_issuer_name_ptr(cert.getX509Ptr());
         if (x509NamePtr == 0) {
@@ -505,9 +507,11 @@ public class WolfSSLCertificate implements Serializable {
 
         confirmObjectIsActive();
 
-        WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, this.x509Ptr, "entering setIssuerName(" +
-            cert + ")");
+        synchronized (x509Lock) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.x509Ptr, "entering setIssuerName(" +
+                cert + ")");
+        }
 
         /* Get DER encoding of certificate */
         certDer = cert.getEncoded();
@@ -547,9 +551,12 @@ public class WolfSSLCertificate implements Serializable {
 
         confirmObjectIsActive();
 
-        WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, this.x509Ptr, "entering setPublicKey(" +
-            filePath + ", keyType: " + keyType + ", format: " + format + ")");
+        synchronized (x509Lock) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.x509Ptr, "entering setPublicKey(" +
+                filePath + ", keyType: " + keyType + ", format: " +
+                format + ")");
+        }
 
         if (filePath == null || filePath.isEmpty()) {
             throw new WolfSSLException("File path is null or empty");
@@ -594,10 +601,12 @@ public class WolfSSLCertificate implements Serializable {
 
         confirmObjectIsActive();
 
-        WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, this.x509Ptr,
-            "entering setPublicKey(byte[], keyType: " +
-            keyType + ", format: " + format + ")");
+        synchronized (x509Lock) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.x509Ptr,
+                "entering setPublicKey(byte[], keyType: " +
+                keyType + ", format: " + format + ")");
+        }
 
         if (key == null || key.length == 0) {
             throw new WolfSSLException("Key array is null or empty");
@@ -651,9 +660,11 @@ public class WolfSSLCertificate implements Serializable {
 
         confirmObjectIsActive();
 
-        WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, this.x509Ptr, "entering setPublicKey(" +
-            key + ")");
+        synchronized (x509Lock) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.x509Ptr, "entering setPublicKey(" +
+                key + ")");
+        }
 
         if (key instanceof RSAPublicKey) {
             keyType = WolfSSL.RSAk;
@@ -693,9 +704,11 @@ public class WolfSSLCertificate implements Serializable {
 
         confirmObjectIsActive();
 
-        WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, this.x509Ptr, "entering setSerialNumber(" +
-            serial + ")");
+        synchronized (x509Lock) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.x509Ptr, "entering setSerialNumber(" +
+                serial + ")");
+        }
 
         if (serial == null) {
             throw new WolfSSLException("Input BigInteger is null");
@@ -734,11 +747,11 @@ public class WolfSSLCertificate implements Serializable {
 
         confirmObjectIsActive();
 
-        WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, this.x509Ptr, "entering setNotBefore(" +
-            notBefore + ")");
-
         synchronized (x509Lock) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.x509Ptr, "entering setNotBefore(" +
+                notBefore + ")");
+
             ret = X509_set_notBefore(this.x509Ptr, notBefore.getTime() / 1000);
         }
 
@@ -765,11 +778,11 @@ public class WolfSSLCertificate implements Serializable {
 
         confirmObjectIsActive();
 
-        WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, this.x509Ptr, "entering setNotAfter(" +
-            notAfter + ")");
-
         synchronized (x509Lock) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.x509Ptr, "entering setNotAfter(" +
+                notAfter + ")");
+
             ret = X509_set_notAfter(this.x509Ptr, notAfter.getTime() / 1000);
         }
 
@@ -866,9 +879,12 @@ public class WolfSSLCertificate implements Serializable {
 
         confirmObjectIsActive();
 
-        WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, this.x509Ptr, "entering addExtension(nid: " +
-            nid + ", value: " + value + ", isCritical: " + isCritical + ")");
+        synchronized (x509Lock) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.x509Ptr,
+                "entering addExtension(nid: " + nid + ", value: " + value +
+                ", isCritical: " + isCritical + ")");
+        }
 
         if (nid != WolfSSL.NID_key_usage &&
             nid != WolfSSL.NID_subject_alt_name &&
@@ -926,9 +942,12 @@ public class WolfSSLCertificate implements Serializable {
 
         confirmObjectIsActive();
 
-        WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, this.x509Ptr, "entering addExtension(nid: " +
-            nid + ", value: " + value + ", isCritical: " + isCritical + ")");
+        synchronized (x509Lock) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.x509Ptr,
+                "entering addExtension(nid: " + nid + ", value: " + value +
+                ", isCritical: " + isCritical + ")");
+        }
 
         if (nid != WolfSSL.NID_basic_constraints) {
             throw new WolfSSLException(
@@ -977,10 +996,12 @@ public class WolfSSLCertificate implements Serializable {
 
         confirmObjectIsActive();
 
-        WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, this.x509Ptr, "entering signCert(" + filePath +
-            ", keyType: " + keyType + ", format: " + format + ", digestAlg: " +
-            digestAlg + ")");
+        synchronized (x509Lock) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.x509Ptr, "entering signCert(" +
+                filePath + ", keyType: " + keyType + ", format: " + format +
+                ", digestAlg: " + digestAlg + ")");
+        }
 
         if (filePath == null || filePath.isEmpty()) {
             throw new WolfSSLException("File path is null or empty");
@@ -1028,10 +1049,12 @@ public class WolfSSLCertificate implements Serializable {
 
         confirmObjectIsActive();
 
-        WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, this.x509Ptr,
-            "entering signCert(byte[], keyType: " + keyType + ", format: " +
-            format + ", digestAlg: " + digestAlg + ")");
+        synchronized (x509Lock) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.x509Ptr,
+                "entering signCert(byte[], keyType: " + keyType + ", format: " +
+                format + ", digestAlg: " + digestAlg + ")");
+        }
 
         if (key == null || key.length == 0) {
             throw new WolfSSLException("Key array is null or empty");
@@ -1088,9 +1111,11 @@ public class WolfSSLCertificate implements Serializable {
 
         confirmObjectIsActive();
 
-        WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, this.x509Ptr, "entering signCert(" + key +
-            ", digestAlg: " + digestAlg + ")");
+        synchronized (x509Lock) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.x509Ptr, "entering signCert(" + key +
+                ", digestAlg: " + digestAlg + ")");
+        }
 
         if (key == null) {
             throw new WolfSSLException("Key object is null");
@@ -1697,8 +1722,11 @@ public class WolfSSLCertificate implements Serializable {
 
         confirmObjectIsActive();
 
-        WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, this.x509Ptr, "entering getX509Certificate()");
+        synchronized (x509Lock) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.x509Ptr,
+                "entering getX509Certificate()");
+        }
 
         try {
             in = new ByteArrayInputStream(this.getDer());

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -1349,18 +1349,18 @@ public class WolfSSLSession {
      * @see    WolfSSLContext#newContext(long)
      * @see    WolfSSLContext#free()
      */
-    public synchronized void freeSSL()
+    public void freeSSL()
         throws IllegalStateException, WolfSSLJNIException {
 
-        synchronized (stateLock) {
-            if (this.active == false) {
-                WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                    WolfSSLDebug.INFO, "entered freeSSL(), already freed");
-                /* already freed, just return */
-                return;
-            }
+        synchronized (sslLock) {
+            synchronized (stateLock) {
+                if (this.active == false) {
+                    WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                        WolfSSLDebug.INFO, "entered freeSSL(), already freed");
+                    /* already freed, just return */
+                    return;
+                }
 
-            synchronized (sslLock) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                     WolfSSLDebug.INFO, this.sslPtr, "entered freeSSL()");
 
@@ -2867,7 +2867,7 @@ public class WolfSSLSession {
      * @see    WolfSSLContext#setIORecv(WolfSSLIORecvCallback)
      * @see    WolfSSLContext#setIOSend(WolfSSLIOSendCallback)
      */
-    public synchronized void setIOReadCtx(Object ctx)
+    public void setIOReadCtx(Object ctx)
         throws IllegalStateException, WolfSSLJNIException {
 
         confirmObjectIsActive();
@@ -2886,7 +2886,7 @@ public class WolfSSLSession {
      * @return Object that was set with setIOReadCtx().
      * @throws IllegalStateException WolfSSLContext has been freed
      */
-    public synchronized Object getIOReadCtx()
+    public Object getIOReadCtx()
         throws IllegalStateException {
 
         confirmObjectIsActive();
@@ -2918,7 +2918,7 @@ public class WolfSSLSession {
      * @see    WolfSSLContext#setIOSend(WolfSSLIOSendCallback)
      * @see    WolfSSLContext#setIORecv(WolfSSLIORecvCallback)
      */
-    public synchronized void setIOWriteCtx(Object ctx)
+    public void setIOWriteCtx(Object ctx)
         throws IllegalStateException, WolfSSLJNIException {
 
         confirmObjectIsActive();
@@ -2937,7 +2937,7 @@ public class WolfSSLSession {
      * @return Object that was set with setIOWriteCtx().
      * @throws IllegalStateException WolfSSLContext has been freed
      */
-    public synchronized Object getIOWriteCtx()
+    public Object getIOWriteCtx()
         throws IllegalStateException {
 
         confirmObjectIsActive();
@@ -2964,7 +2964,7 @@ public class WolfSSLSession {
      * @throws WolfSSLJNIException Internal JNI error
      * @see    WolfSSLContext#setGenCookie(WolfSSLGenCookieCallback)
      */
-    public synchronized void setGenCookieCtx(Object ctx)
+    public void setGenCookieCtx(Object ctx)
         throws IllegalStateException, WolfSSLJNIException {
 
         confirmObjectIsActive();
@@ -3541,7 +3541,7 @@ public class WolfSSLSession {
      * @throws WolfSSLJNIException Internal JNI error
      * @see    WolfSSLContext#setMacEncryptCb(WolfSSLMacEncryptCallback)
      */
-    public synchronized void setMacEncryptCtx(Object ctx)
+    public void setMacEncryptCtx(Object ctx)
         throws IllegalStateException, WolfSSLJNIException {
 
         confirmObjectIsActive();
@@ -3565,7 +3565,7 @@ public class WolfSSLSession {
      * @throws WolfSSLJNIException Internal JNI error
      * @see    WolfSSLContext#setDecryptVerifyCb(WolfSSLDecryptVerifyCallback)
      */
-    public synchronized void setDecryptVerifyCtx(Object ctx)
+    public void setDecryptVerifyCtx(Object ctx)
         throws IllegalStateException, WolfSSLJNIException {
 
         confirmObjectIsActive();
@@ -3588,7 +3588,7 @@ public class WolfSSLSession {
      * @throws WolfSSLJNIException Internal JNI error
      * @see    WolfSSLContext#setEccSignCb(WolfSSLEccSignCallback)
      */
-    public synchronized void setEccSignCtx(Object ctx)
+    public void setEccSignCtx(Object ctx)
         throws IllegalStateException, WolfSSLJNIException {
 
         confirmObjectIsActive();
@@ -3612,7 +3612,7 @@ public class WolfSSLSession {
      * @throws WolfSSLJNIException Internal JNI error
      * @see    WolfSSLContext#setEccVerifyCb(WolfSSLEccVerifyCallback)
      */
-    public synchronized void setEccVerifyCtx(Object ctx)
+    public void setEccVerifyCtx(Object ctx)
         throws IllegalStateException, WolfSSLJNIException {
 
         confirmObjectIsActive();
@@ -3637,7 +3637,7 @@ public class WolfSSLSession {
      * @see    WolfSSLContext#setEccSignCb(WolfSSLEccSignCallback)
      * @see    WolfSSLContext#setEccVerifyCb(WolfSSLEccVerifyCallback)
      */
-    public synchronized void setEccSharedSecretCtx(Object ctx)
+    public void setEccSharedSecretCtx(Object ctx)
         throws IllegalStateException, WolfSSLJNIException {
 
         confirmObjectIsActive();
@@ -3661,7 +3661,7 @@ public class WolfSSLSession {
      * @throws WolfSSLJNIException Internal JNI error
      * @see    WolfSSLContext#setRsaSignCb(WolfSSLRsaSignCallback)
      */
-    public synchronized void setRsaSignCtx(Object ctx)
+    public void setRsaSignCtx(Object ctx)
         throws IllegalStateException, WolfSSLJNIException {
 
         confirmObjectIsActive();
@@ -3686,7 +3686,7 @@ public class WolfSSLSession {
      * @throws WolfSSLJNIException Internal JNI error
      * @see    WolfSSLContext#setRsaVerifyCb(WolfSSLRsaVerifyCallback)
      */
-    public synchronized void setRsaVerifyCtx(Object ctx)
+    public void setRsaVerifyCtx(Object ctx)
         throws IllegalStateException, WolfSSLJNIException {
 
         confirmObjectIsActive();
@@ -3711,7 +3711,7 @@ public class WolfSSLSession {
      * @throws WolfSSLJNIException Internal JNI error
      * @see    WolfSSLContext#setRsaEncCb(WolfSSLRsaEncCallback)
      */
-    public synchronized void setRsaEncCtx(Object ctx)
+    public void setRsaEncCtx(Object ctx)
         throws IllegalStateException, WolfSSLJNIException {
 
         confirmObjectIsActive();
@@ -3736,7 +3736,7 @@ public class WolfSSLSession {
      * @throws WolfSSLJNIException Internal JNI error
      * @see    WolfSSLContext#setRsaDecCb(WolfSSLRsaDecCallback)
      */
-    public synchronized void setRsaDecCtx(Object ctx)
+    public void setRsaDecCtx(Object ctx)
         throws IllegalStateException, WolfSSLJNIException {
 
         confirmObjectIsActive();
@@ -3782,7 +3782,7 @@ public class WolfSSLSession {
      * @see    WolfSSLSession#getPskIdentity()
      * @see    WolfSSLSession#getPskIdentityHint()
      */
-    public synchronized void setPskClientCb(WolfSSLPskClientCallback callback)
+    public void setPskClientCb(WolfSSLPskClientCallback callback)
         throws IllegalStateException, WolfSSLJNIException {
 
         confirmObjectIsActive();
@@ -3827,7 +3827,7 @@ public class WolfSSLSession {
      * @see    WolfSSLSession#getPskIdentity()
      * @see    WolfSSLSession#getPskIdentityHint()
      */
-    public synchronized void setPskServerCb(WolfSSLPskServerCallback callback)
+    public void setPskServerCb(WolfSSLPskServerCallback callback)
         throws IllegalStateException, WolfSSLJNIException {
 
         confirmObjectIsActive();
@@ -4126,7 +4126,7 @@ public class WolfSSLSession {
      * @throws WolfSSLJNIException Internal JNI error
      * @see    #setIOSend(WolfSSLIOSendCallback)
      */
-    public synchronized void setIORecv(WolfSSLIORecvCallback callback)
+    public void setIORecv(WolfSSLIORecvCallback callback)
         throws IllegalStateException, WolfSSLJNIException {
 
         confirmObjectIsActive();
@@ -4164,7 +4164,7 @@ public class WolfSSLSession {
      * @throws WolfSSLJNIException Internal JNI error
      * @see    #setIORecv(WolfSSLIORecvCallback)
      */
-    public synchronized void setIOSend(WolfSSLIOSendCallback callback)
+    public void setIOSend(WolfSSLIOSendCallback callback)
         throws IllegalStateException, WolfSSLJNIException {
 
         confirmObjectIsActive();
@@ -4237,7 +4237,7 @@ public class WolfSSLSession {
      * @throws IllegalStateException if called when WolfSSLSession is not
      *         active
      */
-    public synchronized int useSNI(byte type, byte[] data)
+    public int useSNI(byte type, byte[] data)
         throws IllegalStateException {
 
         int ret;
@@ -4268,7 +4268,7 @@ public class WolfSSLSession {
      * @throws IllegalStateException if called when WolfSSLSession is not
      *         active
      */
-    public synchronized byte[] getClientSNIRequest()
+    public byte[] getClientSNIRequest()
         throws IllegalStateException {
 
         confirmObjectIsActive();
@@ -4347,7 +4347,7 @@ public class WolfSSLSession {
      * @return WolfSSL.SSL_SUCCESS on success, otherwise negative.
      * @throws IllegalStateException WolfSSLSession has been freed
      */
-    public synchronized int useSessionTicket()
+    public int useSessionTicket()
         throws IllegalStateException {
 
         int ret;
@@ -4441,8 +4441,11 @@ public class WolfSSLSession {
 
         confirmObjectIsActive();
 
-        WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, this.sslPtr, "entered useALPN(String[], int)");
+        synchronized (sslLock) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.sslPtr,
+                "entered useALPN(String[], int)");
+        }
 
         if (protocols == null) {
             return WolfSSL.BAD_FUNC_ARG;
@@ -4493,8 +4496,11 @@ public class WolfSSLSession {
 
         confirmObjectIsActive();
 
-        WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, this.sslPtr, "entered getAlpnSelectedString()");
+        synchronized (sslLock) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.sslPtr,
+                "entered getAlpnSelectedString()");
+        }
 
         alpnSelectedBytes = getAlpnSelected();
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java
@@ -74,8 +74,8 @@ public final class WolfSSLProvider extends Provider {
      * wolfSSL JSSE Provider class
      */
     public WolfSSLProvider() {
-        super("wolfJSSE", 1.14, "wolfSSL JSSE Provider");
-        //super("wolfJSSE", "1.14", "wolfSSL JSSE Provider");
+        super("wolfJSSE", 1.15, "wolfSSL JSSE Provider");
+        //super("wolfJSSE", "1.15", "wolfSSL JSSE Provider");
 
         /* load native wolfSSLJNI library */
         WolfSSL.loadLibrary();


### PR DESCRIPTION
This PR includes prep work for the wolfSSL JNI/JSSE 1.15 release:

- Update version to 1.15
- Fix Facebook Infer script exit code (was not running properly)
- Fix Facebook Infer reports for thread safety / potential deadlock issues
- Update example Android app CMakeLists.txt for latest FIPS Ready compatibility
- Update ChangeLog with release notes

Tested against release cycle items, including:

- wolfSSL master, 5.7.6, FIPSv2, FIPSv5, FIPSv6, FIPS Ready
- Java 8, 11, 17, 21, 23
- Facebook Infer (Mac)
- Android Studio IDE project (normal and FIPS Ready)
- Windows Visual Studio build