### PR TITLE
Add support for DTLS 1.3 (`DTLSv1.3`) through `SSLContext` / `SSLEngine`

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,11 @@ are enabled in different ways depending on the JDK implementation. For
 Oracle/OpenJDK and variants, this System property enables session tickets and
 was added in Java 13. Should be set to "true" to enable.
 
+**jdk.tls.useExtendedMasterSecret (boolean)** - Can be used to enable or
+disable the use of the Extended Master Secret (EMS) extension. This extension
+is enabled by default, unless explicitly disabled by setting this property to
+false.
+
 **wolfjsse.autoSNI (boolean)** - Controls automatic Server Name Indication (SNI)
 extension setting based on hostname or peer address. When set to "true", enables
 legacy behavior where SNI is automatically configured from hostname/peer information

--- a/README.md
+++ b/README.md
@@ -373,9 +373,12 @@ Additional instructions can be found on the wolfSSL.com website:
 
 ### JSSE Class Implementation Support
 
-wolfJSSE extends or implements the following JSSE classes:
+wolfJSSE extends or implements the following JSSE classes. Note that
+SSLContext `DTLSv1.3` support is only supported through the `SSLEngine`
+interface.
+
 - javax.net.ssl.SSLContextSpi
-    - SSL, TLS, DEFAULT, TLSv1, TLSv1.1, TLSv1.2, TLSv1.3
+    - SSL, TLS, DEFAULT, TLSv1, TLSv1.1, TLSv1.2, TLSv1.3, DTLSv1.3
 - javax.net.ssl.KeyManagerFactorySpi
     - PKIX, X509, SunX509
 - javax.net.ssl.TrustManagerFactorySpi

--- a/examples/Client.java
+++ b/examples/Client.java
@@ -222,10 +222,15 @@ public class Client {
 
             /* sort out DTLS versus TLS versions */
             if (doDTLS == 1) {
-                if (sslVersion == 3)
+                if (sslVersion == 4) {
+                    sslVersion = -3;
+                }
+                else if (sslVersion == 3) {
                     sslVersion = -2;
-                else
+                }
+                else {
                     sslVersion = -1;
+                }
             }
 
             /* init library */
@@ -259,6 +264,9 @@ public class Client {
                     break;
                 case -2:
                     method = WolfSSL.DTLSv1_2_ClientMethod();
+                    break;
+                case -3:
+                    method = WolfSSL.DTLSv1_3_ClientMethod();
                     break;
                 default:
                     System.err.println("Bad SSL version");
@@ -786,7 +794,7 @@ public class Client {
         System.out.println("-d\t\tDisable peer checks");
         if (WolfSSL.isEnabledDTLS() == 1)
             System.out.println("-u\t\tUse UDP DTLS, add -v 2 for DTLSv1 " +
-                    "(default), -v 3 for DTLSv1.2");
+                    "(default), -v 3 for DTLSv1.2, -v 4 for DTLSv1.3");
         System.out.println("-iocb\t\tEnable test I/O callbacks");
         System.out.println("-logtest\tEnable test logging callback");
         if (WolfSSL.isEnabledOCSP() == 1) {

--- a/examples/Server.java
+++ b/examples/Server.java
@@ -209,10 +209,15 @@ public class Server {
 
             /* sort out DTLS versus TLS versions */
             if (doDTLS == 1) {
-                if (sslVersion == 3)
+                if (sslVersion == 4) {
+                    sslVersion = -3;
+                }
+                else if (sslVersion == 3) {
                     sslVersion = -2;
-                else
+                }
+                else {
                     sslVersion = -1;
+                }
             }
 
             /* init library */
@@ -246,6 +251,9 @@ public class Server {
                     break;
                 case -2:
                     method = WolfSSL.DTLSv1_2_ServerMethod();
+                    break;
+                case -3:
+                    method = WolfSSL.DTLSv1_3_ServerMethod();
                     break;
                 default:
                     System.err.println("Bad SSL version");
@@ -683,7 +691,7 @@ public class Server {
             System.out.println("-s\t\tUse pre shared keys");
         if (WolfSSL.isEnabledDTLS() == 1)
             System.out.println("-u\t\tUse UDP DTLS, add -v 2 for DTLSv1 (default)" +
-                ", -v 3 for DTLSv1.2");
+                ", -v 3 for DTLSv1.2, -v 4 for DTLSv1.3");
         System.out.println("-iocb\t\tEnable test I/O callbacks");
         System.out.println("-logtest\tEnable test logging callback");
         if (WolfSSL.isEnabledOCSP() == 1) {

--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -1969,6 +1969,19 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_isEnabledDTLS
 #endif
 }
 
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_isEnabledSendHrrCookie
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+#ifdef WOLFSSL_SEND_HRR_COOKIE
+    return 1;
+#else
+    return 0;
+#endif
+}
+
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_isEnabledAtomicUser
   (JNIEnv* jenv, jclass jcl)
 {

--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -747,7 +747,7 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_SSLv3_1ServerMethod
 #if defined(WOLFSSL_ALLOW_SSLV3) && !defined(NO_OLD_TLS)
     return (jlong)(uintptr_t)wolfSSLv3_server_method();
 #else
-    return NOT_COMPILED_IN;
+    return 0;
 #endif
 }
 
@@ -760,7 +760,7 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_SSLv3_1ClientMethod
 #if defined(WOLFSSL_ALLOW_SSLV3) && !defined(NO_OLD_TLS)
     return (jlong)(uintptr_t)wolfSSLv3_client_method();
 #else
-    return NOT_COMPILED_IN;
+    return 0;
 #endif
 }
 
@@ -773,7 +773,7 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_TLSv1_1Method
 #if !defined(NO_OLD_TLS) && defined(WOLFSSL_ALLOW_TLSV10)
     return (jlong)(uintptr_t)wolfTLSv1_method();
 #else
-    return NOT_COMPILED_IN;
+    return 0;
 #endif
 }
 
@@ -786,7 +786,7 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_TLSv1_1ServerMethod
 #if !defined(NO_OLD_TLS) && defined(WOLFSSL_ALLOW_TLSV10)
     return (jlong)(uintptr_t)wolfTLSv1_server_method();
 #else
-    return NOT_COMPILED_IN;
+    return 0;
 #endif
 }
 
@@ -799,7 +799,7 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_TLSv1_1ClientMethod
 #if !defined(NO_OLD_TLS) && defined(WOLFSSL_ALLOW_TLSV10)
     return (jlong)(uintptr_t)wolfTLSv1_client_method();
 #else
-    return NOT_COMPILED_IN;
+    return 0;
 #endif
 }
 
@@ -812,7 +812,7 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_TLSv1_11_1Method
 #ifndef NO_OLD_TLS
     return (jlong)(uintptr_t)wolfTLSv1_1_method();
 #else
-    return NOT_COMPILED_IN;
+    return 0;
 #endif
 }
 
@@ -825,7 +825,7 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_TLSv1_11_1ServerMethod
 #ifndef NO_OLD_TLS
     return (jlong)(uintptr_t)wolfTLSv1_1_server_method();
 #else
-    return NOT_COMPILED_IN;
+    return 0;
 #endif
 }
 
@@ -838,7 +838,7 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_TLSv1_11_1ClientMethod
 #ifndef NO_OLD_TLS
     return (jlong)(uintptr_t)wolfTLSv1_1_client_method();
 #else
-    return NOT_COMPILED_IN;
+    return 0;
 #endif
 }
 
@@ -878,7 +878,7 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_TLSv1_13_1Method
 #ifdef WOLFSSL_TLS13
     return (jlong)(uintptr_t)wolfTLSv1_3_method();
 #else
-    return NOT_COMPILED_IN;
+    return 0;
 #endif
 }
 
@@ -891,7 +891,7 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_TLSv1_13_1ServerMethod
 #ifdef WOLFSSL_TLS13
     return (jlong)(uintptr_t)wolfTLSv1_3_server_method();
 #else
-    return NOT_COMPILED_IN;
+    return 0;
 #endif
 }
 
@@ -904,7 +904,7 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_TLSv1_13_1ClientMethod
 #ifdef WOLFSSL_TLS13
     return (jlong)(uintptr_t)wolfTLSv1_3_client_method();
 #else
-    return NOT_COMPILED_IN;
+    return 0;
 #endif
 }
 
@@ -917,7 +917,7 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_DTLSv1_1Method
 #if defined(WOLFSSL_DTLS) && !defined(NO_OLD_TLS)
     return (jlong)(uintptr_t)wolfDTLSv1_method();
 #else
-    return NOT_COMPILED_IN;
+    return 0;
 #endif
 }
 
@@ -930,7 +930,7 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_DTLSv1_1ClientMethod
 #if defined(WOLFSSL_DTLS) && !defined(NO_OLD_TLS)
     return (jlong)(uintptr_t)wolfDTLSv1_client_method();
 #else
-    return NOT_COMPILED_IN;
+    return 0;
 #endif
 }
 
@@ -943,7 +943,7 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_DTLSv1_1ServerMethod
 #if defined(WOLFSSL_DTLS) && !defined(NO_OLD_TLS)
     return (jlong)(uintptr_t)wolfDTLSv1_server_method();
 #else
-    return NOT_COMPILED_IN;
+    return 0;
 #endif
 }
 
@@ -956,7 +956,7 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_DTLSv1_12_1Method
 #if defined(WOLFSSL_DTLS) && !defined(WOLFSSL_NO_TLS12)
     return (jlong)(uintptr_t)wolfDTLSv1_2_method();
 #else
-    return NOT_COMPILED_IN;
+    return 0;
 #endif
 }
 
@@ -969,7 +969,7 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_DTLSv1_12_1ClientMethod
 #if defined(WOLFSSL_DTLS) && !defined(WOLFSSL_NO_TLS12)
     return (jlong)(uintptr_t)wolfDTLSv1_2_client_method();
 #else
-    return NOT_COMPILED_IN;
+    return 0;
 #endif
 }
 
@@ -982,7 +982,46 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_DTLSv1_12_1ServerMethod
 #if defined(WOLFSSL_DTLS) && !defined(WOLFSSL_NO_TLS12)
     return (jlong)(uintptr_t)wolfDTLSv1_2_server_method();
 #else
-    return NOT_COMPILED_IN;
+    return 0;
+#endif
+}
+
+JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_DTLSv1_13_1Method
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+#if defined(WOLFSSL_DTLS) && defined(WOLFSSL_DTLS13)
+    return (jlong)(uintptr_t)wolfDTLSv1_3_method();
+#else
+    return 0;
+#endif
+}
+
+JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_DTLSv1_13_1ServerMethod
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+#if defined(WOLFSSL_DTLS) && defined(WOLFSSL_DTLS13)
+    return (jlong)(uintptr_t)wolfDTLSv1_3_server_method();
+#else
+    return 0;
+#endif
+}
+
+JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_DTLSv1_13_1ClientMethod
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+#if defined(WOLFSSL_DTLS) && defined(WOLFSSL_DTLS13)
+    return (jlong)(uintptr_t)wolfDTLSv1_3_client_method();
+#else
+    return 0;
 #endif
 }
 
@@ -1652,7 +1691,7 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSL_getAvailableCipherSuitesIana
         return NULL;
     }
 
-    if (protocolVersion < 0 || protocolVersion > 5) {
+    if (protocolVersion < 0 || protocolVersion > 8) {
         printf("Input protocol version invalid: %d\n", protocolVersion);
         return NULL;
     }
@@ -1683,6 +1722,23 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSL_getAvailableCipherSuitesIana
         case 5:
             method = wolfSSLv23_client_method();
             break;
+#ifdef WOLFSSL_DTLS
+    #ifndef NO_OLD_TLS
+        case 6:
+            method = wolfDTLSv1_client_method();
+            break;
+    #endif
+    #ifndef WOLFSSL_NO_TLS12
+        case 7:
+            method = wolfDTLSv1_2_client_method();
+            break;
+    #endif
+    #ifdef WOLFSSL_DTLS13
+        case 8:
+            method = wolfDTLSv1_3_client_method();
+            break;
+    #endif
+#endif
         default:
             printf("Input protocol version invalid: %d\n", protocolVersion);
             return NULL;
@@ -1961,6 +2017,20 @@ JNIEXPORT jobjectArray JNICALL Java_com_wolfssl_WolfSSL_getProtocolsMask
     if(!(mask & SSL_OP_NO_SSLv3))
         numProtocols += 1;
 #endif
+#ifdef WOLFSSL_DTLS
+    #ifndef NO_OLD_TLS
+        /* DTLS 1.0 */
+        numProtocols += 1;
+    #endif
+    #ifndef WOLFSSL_NO_TLS12
+        /* DTLS 1.2 */
+        numProtocols += 1;
+    #endif
+    #ifdef WOLFSSL_DTLS13
+        /* DTLS 1.3 */
+        numProtocols += 1;
+    #endif
+#endif /* WOLFSSL_DTLS */
 
     ret = (*jenv)->NewObjectArray(jenv, numProtocols,
             (*jenv)->FindClass(jenv, "java/lang/String"), NULL);
@@ -2030,6 +2100,42 @@ JNIEXPORT jobjectArray JNICALL Java_com_wolfssl_WolfSSL_getProtocolsMask
             return NULL;
         }
     }
+#endif
+
+#ifdef WOLFSSL_DTLS
+    #ifndef NO_OLD_TLS
+        /* DTLS 1.0 */
+        (*jenv)->SetObjectArrayElement(jenv, ret, idx++,
+                (*jenv)->NewStringUTF(jenv, "DTLSv1"));
+        if ((*jenv)->ExceptionOccurred(jenv)) {
+            (*jenv)->ExceptionDescribe(jenv);
+            (*jenv)->ExceptionClear(jenv);
+            (*jenv)->ThrowNew(jenv, jcl, "Error setting DTLSv1 string");
+            return NULL;
+        }
+    #endif
+    #ifndef WOLFSSL_NO_TLS12
+        /* DTLS 1.2 */
+        (*jenv)->SetObjectArrayElement(jenv, ret, idx++,
+                (*jenv)->NewStringUTF(jenv, "DTLSv1.2"));
+        if ((*jenv)->ExceptionOccurred(jenv)) {
+            (*jenv)->ExceptionDescribe(jenv);
+            (*jenv)->ExceptionClear(jenv);
+            (*jenv)->ThrowNew(jenv, jcl, "Error setting DTLSv1.2 string");
+            return NULL;
+        }
+    #endif
+    #ifdef WOLFSSL_DTLS13
+        /* DTLS 1.3 */
+        (*jenv)->SetObjectArrayElement(jenv, ret, idx++,
+                (*jenv)->NewStringUTF(jenv, "DTLSv1.3"));
+        if ((*jenv)->ExceptionOccurred(jenv)) {
+            (*jenv)->ExceptionDescribe(jenv);
+            (*jenv)->ExceptionClear(jenv);
+            (*jenv)->ThrowNew(jenv, jcl, "Error setting DTLSv1.3 string");
+            return NULL;
+        }
+    #endif
 #endif
     return ret;
 }

--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -1995,6 +1995,19 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_isEnabledPKCallbacks
 #endif
 }
 
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_isEnabledTLSExtendedMasterSecret
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+#if defined(HAVE_EXTENDED_MASTER) && !defined(NO_WOLFSSL_CLIENT)
+    return 1;
+#else
+    return 0;
+#endif
+}
+
 JNIEXPORT jobjectArray JNICALL Java_com_wolfssl_WolfSSL_getProtocols
   (JNIEnv* jenv, jclass jcl)
 {

--- a/native/com_wolfssl_WolfSSL.h
+++ b/native/com_wolfssl_WolfSSL.h
@@ -887,6 +887,30 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_DTLSv1_12_1ClientMethod
 
 /*
  * Class:     com_wolfssl_WolfSSL
+ * Method:    DTLSv1_3_Method
+ * Signature: ()J
+ */
+JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_DTLSv1_13_1Method
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    DTLSv1_3_ServerMethod
+ * Signature: ()J
+ */
+JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_DTLSv1_13_1ServerMethod
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    DTLSv1_3_ClientMethod
+ * Signature: ()J
+ */
+JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSL_DTLSv1_13_1ClientMethod
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
  * Method:    SSLv23_Method
  * Signature: ()J
  */

--- a/native/com_wolfssl_WolfSSL.h
+++ b/native/com_wolfssl_WolfSSL.h
@@ -1099,6 +1099,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_isEnabledDTLS
 
 /*
  * Class:     com_wolfssl_WolfSSL
+ * Method:    isEnabledSendHrrCookie
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_isEnabledSendHrrCookie
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
  * Method:    isEnabledAtomicUser
  * Signature: ()I
  */

--- a/native/com_wolfssl_WolfSSL.h
+++ b/native/com_wolfssl_WolfSSL.h
@@ -93,10 +93,14 @@ extern "C" {
 #define com_wolfssl_WolfSSL_SOCKET_ERROR_E -308L
 #undef com_wolfssl_WolfSSL_FATAL_ERROR
 #define com_wolfssl_WolfSSL_FATAL_ERROR -313L
+#undef com_wolfssl_WolfSSL_OUT_OF_ORDER_E
+#define com_wolfssl_WolfSSL_OUT_OF_ORDER_E -373L
 #undef com_wolfssl_WolfSSL_SSL_ERROR_SOCKET_PEER_CLOSED
 #define com_wolfssl_WolfSSL_SSL_ERROR_SOCKET_PEER_CLOSED -397L
 #undef com_wolfssl_WolfSSL_UNKNOWN_ALPN_PROTOCOL_NAME_E
 #define com_wolfssl_WolfSSL_UNKNOWN_ALPN_PROTOCOL_NAME_E -405L
+#undef com_wolfssl_WolfSSL_APP_DATA_READY
+#define com_wolfssl_WolfSSL_APP_DATA_READY -441L
 #undef com_wolfssl_WolfSSL_WOLFSSL_CRL_CHECKALL
 #define com_wolfssl_WolfSSL_WOLFSSL_CRL_CHECKALL 1L
 #undef com_wolfssl_WolfSSL_WOLFSSL_OCSP_URL_OVERRIDE
@@ -595,6 +599,14 @@ JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_TLSv12Enabled
  * Signature: ()Z
  */
 JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_TLSv13Enabled
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    DTLSv13Enabled
+ * Signature: ()Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_DTLSv13Enabled
   (JNIEnv *, jclass);
 
 /*

--- a/native/com_wolfssl_WolfSSL.h
+++ b/native/com_wolfssl_WolfSSL.h
@@ -1115,6 +1115,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_isEnabledPKCallbacks
 
 /*
  * Class:     com_wolfssl_WolfSSL
+ * Method:    isEnabledTLSExtendedMasterSecret
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_isEnabledTLSExtendedMasterSecret
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
  * Method:    getProtocols
  * Signature: ()[Ljava/lang/String;
  */

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -63,6 +63,12 @@ int NativeALPNSelectCb(WOLFSSL *ssl, const unsigned char **out,
 int NativeTls13SecretCb(WOLFSSL *ssl, int id, const unsigned char* secret,
     int secretSz, void* ctx);
 
+#if !defined(NO_WOLFSSL_CLIENT) && defined(HAVE_SESSION_TICKET)
+/* Session ticket callback prototype */
+int NativeSessionTicketCb(WOLFSSL *ssl, const unsigned char* ticket,
+    int ticketLen, void* ctx);
+#endif
+
 #ifdef HAVE_CRL
 /* global object refs for CRL callback */
 static jobject g_crlCbIfaceObj;
@@ -5622,6 +5628,30 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setTls13SecretCb
 #endif
 }
 
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setSessionTicketCb
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
+{
+#if !defined(NO_WOLFSSL_CLIENT) && defined(HAVE_SESSION_TICKET)
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
+    int ret = SSL_SUCCESS;
+    (void)jcl;
+
+    if (jenv == NULL || ssl == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    /* Java layer handles setting and giving back user CTX */
+    ret = wolfSSL_set_SessionTicket_cb(ssl, NativeSessionTicketCb, NULL);
+
+    return ret;
+#else
+    (void)jenv;
+    (void)jcl;
+    (void)sslPtr;
+    return NOT_COMPILED_IN;
+#endif
+}
+
 #if defined(WOLFSSL_TLS13) && !defined(WOLFCRYPT_ONLY) && \
     defined(HAVE_SECRET_CALLBACK)
 
@@ -5752,6 +5782,146 @@ int NativeTls13SecretCb(WOLFSSL *ssl, int id, const unsigned char* secret,
 
         /* Delete local refs */
         (*jenv)->DeleteLocalRef(jenv, secretArr);
+    }
+
+    /* Detach JNIEnv from thread */
+    if (needsDetach) {
+        (*g_vm)->DetachCurrentThread(g_vm);
+    }
+
+    return (int)retval;
+}
+
+#endif /* WOLFSSL_TLS13 && !WOLFCRYPT_ONLY && HAVE_SECRET_CALLBACK */
+
+#if !defined(NO_WOLFSSL_CLIENT) && defined(HAVE_SESSION_TICKET)
+
+int NativeSessionTicketCb(WOLFSSL* ssl, const unsigned char* ticket,
+    int ticketLen, void* ctx)
+{
+    JNIEnv* jenv;                   /* JNI environment */
+    jclass  excClass;               /* WolfSSLJNIException class */
+    int     needsDetach = 0;        /* Should we explicitly detach? */
+    jint    retval = 0;
+    jint    vmret = 0;
+
+    jobject*  g_cachedSSLObj;       /* WolfSSLSession cached object */
+    jclass    sslClass;             /* WolfSSLSession class */
+    jmethodID sessTicketCbMethodId; /* internalTls13SecretCallback ID */
+    jbyteArray ticketArr = NULL;
+
+    if (g_vm == NULL || ssl == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    /* get JavaEnv from JavaVM */
+    vmret = (int)((*g_vm)->GetEnv(g_vm, (void**) &jenv, JNI_VERSION_1_6));
+    if (vmret == JNI_EDETACHED) {
+#ifdef __ANDROID__
+        vmret = (*g_vm)->AttachCurrentThread(g_vm, &jenv, NULL);
+#else
+        vmret = (*g_vm)->AttachCurrentThread(g_vm, (void**) &jenv, NULL);
+#endif
+        if (vmret) {
+            return -1;
+        }
+        needsDetach = 1;
+    }
+    else if (vmret != JNI_OK) {
+        return -1;
+    }
+
+    /* Find exception class in case we need it */
+    excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLJNIException");
+    if ((*jenv)->ExceptionOccurred(jenv)) {
+        (*jenv)->ExceptionDescribe(jenv);
+        (*jenv)->ExceptionClear(jenv);
+        if (needsDetach) {
+            (*g_vm)->DetachCurrentThread(g_vm);
+        }
+        return -1;
+    }
+
+    /* Get stored WolfSSLSession object */
+    g_cachedSSLObj = (jobject*) wolfSSL_get_jobject(ssl);
+    if (!g_cachedSSLObj) {
+        (*jenv)->ThrowNew(jenv, excClass,
+            "Can't get native WolfSSLSession object reference in "
+            "NativeSessionTicketCb");
+        if (needsDetach) {
+            (*g_vm)->DetachCurrentThread(g_vm);
+        }
+        return -1;
+    }
+
+    /* Lookup WolfSSLSession class from object */
+    sslClass = (*jenv)->GetObjectClass(jenv, (jobject)(*g_cachedSSLObj));
+    if (sslClass == NULL) {
+        (*jenv)->ThrowNew(jenv, excClass,
+            "Can't get native WolfSSLSession class reference in "
+            "NativeSessionTicketCb");
+        if (needsDetach) {
+            (*g_vm)->DetachCurrentThread(g_vm);
+        }
+        return -1;
+    }
+
+    /* Call internal TLS 1.3 secret callback */
+    sessTicketCbMethodId = (*jenv)->GetMethodID(jenv, sslClass,
+        "internalSessionTicketCallback", "(Lcom/wolfssl/WolfSSLSession;[B)I");
+    if (sessTicketCbMethodId == NULL) {
+        if ((*jenv)->ExceptionOccurred(jenv)) {
+            (*jenv)->ExceptionDescribe(jenv);
+            (*jenv)->ExceptionClear(jenv);
+        }
+        (*jenv)->ThrowNew(jenv, excClass,
+            "Error getting internalSessionTicketCallback method from JNI");
+        if (needsDetach) {
+            (*g_vm)->DetachCurrentThread(g_vm);
+        }
+        return -1;
+    }
+
+    if (ticketLen > 0) {
+        /* Create jbyteArray to hold session ticket */
+        ticketArr = (*jenv)->NewByteArray(jenv, ticketLen);
+        if (ticketArr == NULL) {
+            (*jenv)->ThrowNew(jenv, excClass,
+                "Error creating new jbyteArray in NativeSessionTicketCb");
+            if (needsDetach) {
+                (*g_vm)->DetachCurrentThread(g_vm);
+            }
+            return -1;
+        }
+
+        (*jenv)->SetByteArrayRegion(jenv, ticketArr, 0, ticketLen,
+            (jbyte*)ticket);
+        if ((*jenv)->ExceptionOccurred(jenv)) {
+            (*jenv)->ExceptionDescribe(jenv);
+            (*jenv)->ExceptionClear(jenv);
+            if (needsDetach) {
+                (*g_vm)->DetachCurrentThread(g_vm);
+            }
+            return -1;
+        }
+
+        /* Call Java session ticket callback, ignore native CTX since Java
+         * handles it */
+        retval = (*jenv)->CallIntMethod(jenv, (jobject)(*g_cachedSSLObj),
+            sessTicketCbMethodId, (jobject)(*g_cachedSSLObj), ticketArr);
+        if ((*jenv)->ExceptionOccurred(jenv)) {
+            (*jenv)->ExceptionDescribe(jenv);
+            (*jenv)->ExceptionClear(jenv);
+            (*jenv)->ThrowNew(jenv, excClass,
+                "Exception while calling internalSessionTicketCallback()");
+            if (needsDetach) {
+                (*g_vm)->DetachCurrentThread(g_vm);
+            }
+            return -1;
+        }
+
+        /* Delete local refs */
+        (*jenv)->DeleteLocalRef(jenv, ticketArr);
     }
 
     /* Detach JNIEnv from thread */

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -5765,6 +5765,26 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useSupportedCurve
 #endif
 }
 
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_disableExtendedMasterSecret
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
+{
+#if defined(HAVE_EXTENDED_MASTER) && !defined(NO_WOLFSSL_CLIENT)
+    int ret = 0;
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
+    (void)jcl;
+
+    /* Checks ssl for null internally */
+    ret = wolfSSL_DisableExtendedMasterSecret(ssl);
+
+    return (jint)ret;
+#else
+    (void)jenv;
+    (void)jcl;
+    (void)sslPtr;
+    return (jint)NOT_COMPILED_IN;
+#endif
+}
+
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_hasTicket
   (JNIEnv* jenv, jobject jcl, jlong sessionPtr)
 {

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -2708,6 +2708,43 @@ JNIEXPORT jobject JNICALL Java_com_wolfssl_WolfSSLSession_dtlsGetPeer
     }
 }
 
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_sendHrrCookie
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jbyteArray secret)
+{
+    int ret = SSL_FAILURE;
+#ifdef WOLFSSL_SEND_HRR_COOKIE
+    byte* secretBuf = NULL;
+    word32 secretSz = 0;
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
+    (void)jcl;
+
+    if (jenv == NULL || ssl == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    if (secret != NULL) {
+        secretBuf = (byte*)(*jenv)->GetByteArrayElements(jenv, secret, NULL);
+        secretSz = (*jenv)->GetArrayLength(jenv, secret);
+    }
+
+    ret = wolfSSL_send_hrr_cookie(ssl, secretBuf, secretSz);
+
+    if (secret != NULL) {
+        (*jenv)->ReleaseByteArrayElements(jenv, secret,
+            (jbyte*)secretBuf, JNI_ABORT);
+    }
+
+#else
+    ret = NOT_COMPILED_IN;
+    (void)jenv;
+    (void)jcl;
+    (void)sslPtr;
+    (void)secret;
+#endif /* WOLFSSL_SEND_HRR_COOKIE */
+
+    return (jint)ret;
+}
+
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setMTU
   (JNIEnv* jenv, jobject jcl, jlong sslPtr, jint mtu)
 {

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -2745,6 +2745,46 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_sendHrrCookie
     return (jint)ret;
 }
 
+JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_getDtlsMacDropCount
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
+{
+    word32 dropCount = 0;
+#if defined(WOLFSSL_DTLS) && defined(WOLFSSL_DTLS_DROP_STATS)
+    int ret = 0;
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
+
+    /* checks ssl for NULL internally */
+    ret = wolfSSL_dtls_get_drop_stats(ssl, &dropCount, NULL);
+    if (ret != WOLFSSL_SUCCESS) {
+        return (jlong)ret;
+    }
+#endif
+    (void)jenv;
+    (void)jcl;
+
+    return (jlong)dropCount;
+}
+
+JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_getDtlsReplayDropCount
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
+{
+    word32 dropCount = 0;
+#if defined(WOLFSSL_DTLS) && defined(WOLFSSL_DTLS_DROP_STATS)
+    int ret = 0;
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
+
+    /* checks ssl for NULL internally */
+    ret = wolfSSL_dtls_get_drop_stats(ssl, NULL, &dropCount);
+    if (ret != WOLFSSL_SUCCESS) {
+        return (jlong)ret;
+    }
+#endif
+    (void)jenv;
+    (void)jcl;
+
+    return (jlong)dropCount;
+}
+
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setMTU
   (JNIEnv* jenv, jobject jcl, jlong sslPtr, jint mtu)
 {

--- a/native/com_wolfssl_WolfSSLSession.h
+++ b/native/com_wolfssl_WolfSSLSession.h
@@ -889,6 +889,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useSupportedCurve
 
 /*
  * Class:     com_wolfssl_WolfSSLSession
+ * Method:    disableExtendedMasterSecret
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_disableExtendedMasterSecret
+  (JNIEnv *, jobject, jlong);
+
+/*
+ * Class:     com_wolfssl_WolfSSLSession
  * Method:    hasTicket
  * Signature: (J)I
  */

--- a/native/com_wolfssl_WolfSSLSession.h
+++ b/native/com_wolfssl_WolfSSLSession.h
@@ -113,6 +113,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_read__JLjava_nio_ByteBuff
 
 /*
  * Class:     com_wolfssl_WolfSSLSession
+ * Method:    pending
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_pending
+  (JNIEnv *, jobject, jlong);
+
+/*
+ * Class:     com_wolfssl_WolfSSLSession
  * Method:    accept
  * Signature: (JI)I
  */
@@ -277,6 +285,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_dtlsGetCurrentTimeout
  * Signature: (J)I
  */
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_dtlsGotTimeout
+  (JNIEnv *, jobject, jlong);
+
+/*
+ * Class:     com_wolfssl_WolfSSLSession
+ * Method:    dtlsRetransmit
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_dtlsRetransmit
   (JNIEnv *, jobject, jlong);
 
 /*
@@ -893,6 +909,22 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_interruptBlockedIO
  * Signature: (J)I
  */
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getThreadsBlockedInPoll
+  (JNIEnv *, jobject, jlong);
+
+/*
+ * Class:     com_wolfssl_WolfSSLSession
+ * Method:    setMTU
+ * Signature: (JI)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setMTU
+  (JNIEnv *, jobject, jlong, jint);
+
+/*
+ * Class:     com_wolfssl_WolfSSLSession
+ * Method:    stateStringLong
+ * Signature: (J)Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_stateStringLong
   (JNIEnv *, jobject, jlong);
 
 #ifdef __cplusplus

--- a/native/com_wolfssl_WolfSSLSession.h
+++ b/native/com_wolfssl_WolfSSLSession.h
@@ -865,6 +865,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setTls13SecretCb
 
 /*
  * Class:     com_wolfssl_WolfSSLSession
+ * Method:    setSessionTicketCb
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setSessionTicketCb
+  (JNIEnv *, jobject, jlong);
+
+/*
+ * Class:     com_wolfssl_WolfSSLSession
  * Method:    keepArrays
  * Signature: (J)V
  */

--- a/native/com_wolfssl_WolfSSLSession.h
+++ b/native/com_wolfssl_WolfSSLSession.h
@@ -313,6 +313,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_dtlsSetPeer
 
 /*
  * Class:     com_wolfssl_WolfSSLSession
+ * Method:    sendHrrCookie
+ * Signature: (J[B)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_sendHrrCookie
+  (JNIEnv *, jobject, jlong, jbyteArray);
+
+/*
+ * Class:     com_wolfssl_WolfSSLSession
  * Method:    dtlsGetPeer
  * Signature: (J)Ljava/net/InetSocketAddress;
  */

--- a/native/com_wolfssl_WolfSSLSession.h
+++ b/native/com_wolfssl_WolfSSLSession.h
@@ -321,6 +321,22 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_sendHrrCookie
 
 /*
  * Class:     com_wolfssl_WolfSSLSession
+ * Method:    getDtlsMacDropCount
+ * Signature: (J)J
+ */
+JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_getDtlsMacDropCount
+  (JNIEnv *, jobject, jlong);
+
+/*
+ * Class:     com_wolfssl_WolfSSLSession
+ * Method:    getDtlsReplayDropCount
+ * Signature: (J)J
+ */
+JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_getDtlsReplayDropCount
+  (JNIEnv *, jobject, jlong);
+
+/*
+ * Class:     com_wolfssl_WolfSSLSession
  * Method:    dtlsGetPeer
  * Signature: (J)Ljava/net/InetSocketAddress;
  */

--- a/scripts/infer.sh
+++ b/scripts/infer.sh
@@ -61,6 +61,7 @@ infer --fail-on-issue run -- javac \
     src/java/com/wolfssl/WolfSSLRsaSignCallback.java \
     src/java/com/wolfssl/WolfSSLRsaVerifyCallback.java \
     src/java/com/wolfssl/WolfSSLSession.java \
+    src/java/com/wolfssl/WolfSSLSessionTicketCallback.java \
     src/java/com/wolfssl/WolfSSLTls13SecretCallback.java \
     src/java/com/wolfssl/WolfSSLVerifyCallback.java \
     src/java/com/wolfssl/WolfSSLVerifyDecryptCallback.java \

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -51,7 +51,13 @@ public class WolfSSL {
         /** TLS 1.3 */
         TLSv1_3,
         /** Downgrade starting from highest supported SSL/TLS version */
-        SSLv23
+        SSLv23,
+        /** DTLS 1.0 */
+        DTLSv1,
+        /** DTLS 1.2 */
+        DTLSv1_2,
+        /** DTLS 1.3 */
+        DTLSv1_3
     }
 
     /* ------------------ wolfSSL JNI error codes ----------------------- */
@@ -1233,6 +1239,46 @@ public class WolfSSL {
      * @see     WolfSSLContext#newContext(long)
      */
     public static final native long DTLSv1_2_ClientMethod();
+
+    /**
+     * Indicates that the application will only support the DTLS 1.3 protocol.
+     * Application is side-independent at this time, and client/server side
+     * will be determined at connect/accept stage.
+     * This method allocates memory for and initializes a new native
+     * WOLFSSL_METHOD structure to be used when creating the SSL/TLS
+     * context with newContext().
+     *
+     * @return  A pointer to the created WOLFSSL_METHOD structure if
+     *          successful, null on failure.
+     * @see     WolfSSLContext#newContext(long)
+     */
+    public static final native long DTLSv1_3_Method();
+
+    /**
+     * Indicates that the application is a server and will only support the
+     * DTLS 1.3 protocol.
+     * This method allocates memory for and initializes a new native
+     * WOLFSSL_METHOD structure to be used when creating the SSL/TLS
+     * context with newContext().
+     *
+     * @return  A pointer to the created WOLFSSL_METHOD structure if
+     *          successful, null on failure.
+     * @see     WolfSSLContext#newContext(long)
+     */
+    public static final native long DTLSv1_3_ServerMethod();
+
+    /**
+     * Indicates that the application is a client and will only support the
+     * DTLS 1.3 protocol.
+     * This method allocates memory for and initializes a new native
+     * WOLFSSL_METHOD structure to be used when creating the SSL/TLS
+     * context with newContext().
+     *
+     * @return  A pointer to the created WOLFSSL_METHOD structure if
+     *          successful, null on failure.
+     * @see     WolfSSLContext#newContext(long)
+     */
+    public static final native long DTLSv1_3_ClientMethod();
 
     /**
      * Indicates that the application will use the highest possible SSL/TLS

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -1648,6 +1648,14 @@ public class WolfSSL {
     public static native int isEnabledDTLS();
 
     /**
+     * Checks if (D)TLS 1.3 HRR Cookie is enabled in the native wolfSSL
+     * library. Checks if native WOLFSSL_SEND_HRR_COOKIE is defined.
+     *
+     * @return 1 if enabled, 9 if not compiled in.
+     */
+    public static native int isEnabledSendHrrCookie();
+
+    /**
      * Checks if Atomic User support is enabled in wolfSSL native library.
      *
      * @return 1 if enabled, 0 if not compiled in

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -1663,6 +1663,14 @@ public class WolfSSL {
     public static native int isEnabledPKCallbacks();
 
     /**
+     * Checks if TLS Extended Master Secret support has been compiled into
+     * native wolfSSL library.
+     *
+     * @return 1 if available, 0 if not compiled in.
+     */
+    public static native int isEnabledTLSExtendedMasterSecret();
+
+    /**
      * Checks which protocols where built into wolfSSL
      *
      * @return an array of Strings for supported protocols

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -214,10 +214,14 @@ public class WolfSSL {
     public static final int SOCKET_ERROR_E             = -308;
     /** Received fatal alert error */
     public static final int FATAL_ERROR                = -313;
+    /** Out of order message */
+    public static final int OUT_OF_ORDER_E             = -373;
     /** Peer closed socket */
     public static final int SSL_ERROR_SOCKET_PEER_CLOSED = -397;
     /** Unrecognized ALPN protocol name */
     public static final int UNKNOWN_ALPN_PROTOCOL_NAME_E = -405;
+    /** DTLS application data ready for read */
+    public static final int APP_DATA_READY = -441;
 
     /* extra definitions from ssl.h */
     /** CertManager: check all cert CRLs */
@@ -843,6 +847,13 @@ public class WolfSSL {
      * @return true if enabled, otherwise false if not compiled in.
      */
     public static native boolean TLSv13Enabled();
+
+    /**
+     * Tests if DTLS 1.3 has been compiled into the native wolfSSL library.
+     *
+     * @return true if enabled, otherwise false if not compiled in.
+     */
+    public static native boolean DTLSv13Enabled();
 
     /**
      * Tests if SHA-1 is enabled in the native wolfSSL library.

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -342,6 +342,8 @@ public class WolfSSLSession {
     private native int dtls(long ssl);
     private native int dtlsSetPeer(long ssl, InetSocketAddress peer);
     private native int sendHrrCookie(long ssl, byte[] secret);
+    private native long getDtlsMacDropCount(long ssl);
+    private native long getDtlsReplayDropCount(long ssl);
     private native InetSocketAddress dtlsGetPeer(long ssl);
     private native int sessionReused(long ssl);
     private native long getPeerCertificate(long ssl);
@@ -2422,6 +2424,48 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             return sendHrrCookie(this.sslPtr, secret);
+        }
+    }
+
+    /**
+     * Get the number of DTLS packets that have been dropped due
+     * to verify MAC decrypt errors.
+     *
+     * Native wolfSSL must be compiled with WOLFSSL_DTLS_DROP_STATS
+     * defined for this functionality to be available, otherwise this
+     * method will return 0.
+     *
+     * @return number of dropped packets
+     *
+     * @throws IllegalStateException WolfSSLSession has been freed
+     */
+    public long getDtlsMacDropCount() throws IllegalStateException {
+
+        confirmObjectIsActive();
+
+        synchronized (sslLock) {
+            return getDtlsMacDropCount(this.sslPtr);
+        }
+    }
+
+    /**
+     * Get the number of DTLS packets that have been dropped due to
+     * receiving a replayed / duplicated packet.
+     *
+     * Native wolfSSL must be compiled with WOLFSSL_DTLS_DROP_STATS
+     * defined for this functionality to be available, otherwise this
+     * method will return 0.
+     *
+     * @return number of dropped packets
+     *
+     * @throws IllegalStateException WolfSSLSession has been freed
+     */
+    public long getDtlsReplayDropCount() throws IllegalStateException {
+
+        confirmObjectIsActive();
+
+        synchronized (sslLock) {
+            return getDtlsReplayDropCount(this.sslPtr);
         }
     }
 

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -341,6 +341,7 @@ public class WolfSSLSession {
     private native int dtlsRetransmit(long ssl);
     private native int dtls(long ssl);
     private native int dtlsSetPeer(long ssl, InetSocketAddress peer);
+    private native int sendHrrCookie(long ssl, byte[] secret);
     private native InetSocketAddress dtlsGetPeer(long ssl);
     private native int sessionReused(long ssl);
     private native long getPeerCertificate(long ssl);
@@ -2399,6 +2400,28 @@ public class WolfSSLSession {
                 "entered dtlsSetPeer(" + peer + ")");
 
             return dtlsSetPeer(this.sslPtr, peer);
+        }
+    }
+
+    /**
+     * Send a cookie with the HelloRetryRequest to avoid storing state.
+     *
+     * @param secret Secret to use when generating integrity check for cookie.
+     * A value of null indicates to generate a new random secret.
+     *
+     * @return <code>WolfSSL.SSL_SUCCESS</code> on success,
+     *         <code>WolfSSL.BAD_FUNC_ARG</code> when not using (D)TLS 1.3,
+     *         <code>WolfSSL.SIDE_ERROR</code> when called on a client.
+     *
+     * @throws IllegalStateException WolfSSLContext has been freed
+     */
+    public int sendHrrCookie(byte[] secret)
+        throws IllegalStateException {
+
+        confirmObjectIsActive();
+
+        synchronized (sslLock) {
+            return sendHrrCookie(this.sslPtr, secret);
         }
     }
 

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -2511,8 +2511,8 @@ public class WolfSSLSession {
     /**
      * Returns the SSL/TLS version being used with this session object in
      * String format.
-     * Examples include "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "DTLS", and
-     * "DTLS 1.2".
+     * Examples include "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "DTLS",
+     * "DTLS 1.2", and "DTLS 1.3.
      *
      * @return      SSL/TLS protocol version being used in String format,
      *              or "unknown".

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -418,6 +418,7 @@ public class WolfSSLSession {
     private native int rehandshake(long ssl);
     private native int set1SigAlgsList(long ssl, String list);
     private native int useSupportedCurve(long ssl, int name);
+    private native int disableExtendedMasterSecret(long ssl);
     private native int hasTicket(long session);
     private native int interruptBlockedIO(long ssl);
     private native int getThreadsBlockedInPoll(long ssl);
@@ -2239,6 +2240,23 @@ public class WolfSSLSession {
         }
 
         return ret;
+    }
+
+    /**
+     * Disable TLS Extended Master Secret usage.
+     *
+     * @return <code>WolfSSL.SSL_SUCCESS</code> on success, otherwise
+     *         negative on error.
+     * @throws IllegalStateException WolfSSLSession has been freed
+     */
+    public int disableExtendedMasterSecret()
+        throws IllegalStateException {
+
+        confirmObjectIsActive();
+
+        synchronized (sslLock) {
+            return disableExtendedMasterSecret(this.sslPtr);
+        }
     }
 
     /* ---------------- Nonblocking DTLS helper functions  -------------- */

--- a/src/java/com/wolfssl/WolfSSLSessionTicketCallback.java
+++ b/src/java/com/wolfssl/WolfSSLSessionTicketCallback.java
@@ -1,0 +1,59 @@
+/* WolfSSLSessionTicketCallback.java
+ *
+ * Copyright (C) 2006-2025 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+package com.wolfssl;
+
+/**
+ * wolfSSL session ticket callback interface.
+ * This interface specifies how applications should implement the session
+ * ticket callback class, to be used by wolfSSL when receiving a session
+ * ticket message.
+ * <p>
+ * To use this interface, native wolfSSL must be compiled with
+ * HAVE_SESSION_TICKET defined.
+ * </p>
+ * After implementing this interface, it should be passed as a parameter
+ * to the
+ * {@link WolfSSLSession#setSessionTicketCb(WolfSSLSessionTicketCallback, Object)
+ * WolfSSLSession.setSessionTicketCb()} method to be registered with the native
+ * wolfSSL library.
+ */
+public interface WolfSSLSessionTicketCallback {
+
+    /**
+     * Callback method which is called when native wolfSSL receives a
+     * session ticket message.
+     *
+     * @param ssl     the current SSL session object from which the
+     *                callback was initiated
+     * @param ticket  Session ticket received as a byte array
+     * @param ctx     Optional user context if set when callback was
+     *                registered
+     *
+     * @return 0 on success. wolfSSL does not currently do anything with
+     *         the return value of this method, but is in place for
+     *         future expansion if needed.
+     */
+    public int sessionTicketCallback(WolfSSLSession ssl, byte[] ticket,
+        Object ctx);
+}
+
+

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLContext.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLContext.java
@@ -91,7 +91,8 @@ public class WolfSSLContext extends SSLContextSpi {
            ctxAttr.version == TLS_VERSION.TLSv1_1 ||
            ctxAttr.version == TLS_VERSION.TLSv1_2 ||
            ctxAttr.version == TLS_VERSION.TLSv1_3 ||
-           ctxAttr.version == TLS_VERSION.SSLv23) {
+           ctxAttr.version == TLS_VERSION.SSLv23  ||
+           ctxAttr.version == TLS_VERSION.DTLSv1_3) {
             this.currentVersion = ctxAttr.version;
         } else {
             throw new IllegalArgumentException(
@@ -134,6 +135,11 @@ public class WolfSSLContext extends SSLContextSpi {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                     "creating WolfSSLContext with SSLv23");
                 break;
+            case DTLSv1_3:
+                method = WolfSSL.DTLSv1_3_Method();
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    "creating WolfSSLContext with DTLSv1_3");
+                break;
             default:
                 throw new IllegalArgumentException(
                     "Invalid SSL/TLS protocol version");
@@ -175,7 +181,7 @@ public class WolfSSLContext extends SSLContextSpi {
          * which have been disabled via system property get filtered in
          * WolfSSLEngineHelper.sanitizeProtocols() */
         params.setProtocols(WolfSSLUtil.sanitizeProtocols(
-            this.getProtocolsMask(ctxAttr.noOptions)));
+            this.getProtocolsMask(ctxAttr.noOptions), this.currentVersion));
 
         try {
             LoadTrustedRootCerts();
@@ -677,6 +683,20 @@ public class WolfSSLContext extends SSLContextSpi {
         }
     }
 
+    /**
+     * SSLContext implementation supporting DTLS 1.3
+     */
+    public static final class DTLSV13_Context extends WolfSSLContext {
+        /**
+         * Create new DTLSv13_Context, calls parent WolfSSLContext constructor
+         */
+        public DTLSV13_Context() {
+            super(TLS_VERSION.DTLSv1_3);
+
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                "creating new WolfSSLContext using DTLSV13_Context");
+        }
+    }
 
     /**
      * DEFAULT SSLContext class.

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
@@ -1176,6 +1176,38 @@ public class WolfSSLEngineHelper {
         }
     }
 
+    private void setLocalExtendedMasterSecret() {
+        /* Native wolfSSL enables TLS Extended Master Secret by default.
+         * Check the Java System property (jdk.tls.useExtendedMasterSecret)
+         * to see if the user has explicitly disabled it. */
+        int ret;
+        boolean useEMS = WolfSSLUtil.useExtendedMasterSecret();
+
+        if (!useEMS) {
+            ret = this.ssl.disableExtendedMasterSecret();
+            if (ret == WolfSSL.SSL_SUCCESS) {
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    "TLS Extended Master Secret disabled due to " +
+                    "jdk.tls.useExtendedMasterSecret System property");
+            }
+            else {
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    "Failed to disable TLS Extended Master Secret, " +
+                    "ret = " + ret);
+            }
+        }
+        else {
+            if (WolfSSL.isEnabledTLSExtendedMasterSecret() == 1) {
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    "using TLS Extended Master Secret");
+            }
+            else {
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    "not using TLS Extended Master Secret, not compiled in");
+            }
+        }
+    }
+
     private void setLocalParams(SSLSocket socket, SSLEngine engine)
         throws SSLException {
 
@@ -1192,6 +1224,7 @@ public class WolfSSLEngineHelper {
         this.setLocalSigAlgorithms();
         this.setLocalSupportedCurves();
         this.setLocalMaximumPacketSize();
+        this.setLocalExtendedMasterSecret();
     }
 
     /**

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLParameters.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLParameters.java
@@ -49,6 +49,8 @@ final class WolfSSLParameters {
     String[] applicationProtocols = new String[0];
     private boolean useSessionTickets = false;
     private byte[] alpnProtocols = null;
+    /* Default to 0, means use implicit implementation size */
+    private int maxPacketSize = 0;
 
     /* create duplicate copy of these parameters */
     protected synchronized WolfSSLParameters copy() {
@@ -62,6 +64,7 @@ final class WolfSSLParameters {
         cp.endpointIdAlgorithm = this.endpointIdAlgorithm;
         cp.setApplicationProtocols(this.applicationProtocols);
         cp.useCipherSuiteOrder = this.useCipherSuiteOrder;
+        cp.maxPacketSize = this.maxPacketSize;
 
         if (alpnProtocols != null && alpnProtocols.length != 0) {
             cp.setAlpnProtocols(this.alpnProtocols);
@@ -212,6 +215,14 @@ final class WolfSSLParameters {
         else {
             this.applicationProtocols = protocols.clone();
         }
+    }
+
+    int getMaximumPacketSize() {
+        return this.maxPacketSize;
+    }
+
+    void setMaximumPacketSize(int maximumPacketSize) {
+        this.maxPacketSize = maximumPacketSize;
     }
 }
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLParametersHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLParametersHelper.java
@@ -21,6 +21,7 @@
 package com.wolfssl.provider.jsse;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.InvocationTargetException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import javax.net.ssl.SSLParameters;
@@ -37,6 +38,8 @@ public class WolfSSLParametersHelper
     private static Method setApplicationProtocols = null;
     private static Method getEndpointIdentificationAlgorithm = null;
     private static Method setEndpointIdentificationAlgorithm = null;
+    private static Method getMaximumPacketSize = null;
+    private static Method setMaximumPacketSize = null;
 
     /** Default WolfSSLParametersHelper constructor */
     public WolfSSLParametersHelper() { }
@@ -72,6 +75,12 @@ public class WolfSSLParametersHelper
                                     continue;
                                 case "setEndpointIdentificationAlgorithm":
                                     setEndpointIdentificationAlgorithm = m;
+                                    continue;
+                                case "getMaximumPacketSize":
+                                    getMaximumPacketSize = m;
+                                    continue;
+                                case "setMaximumPacketSize":
+                                    setMaximumPacketSize = m;
                                     continue;
                                 default:
                                     continue;
@@ -112,15 +121,17 @@ public class WolfSSLParametersHelper
             ret.setWantClientAuth(in.getWantClientAuth());
         }
 
-        /* Methods added as of JDK 1.8, older JDKs will not have them. Using
-         * Java reflection to detect availability. */
-
+        /* Methods added as of JDK 1.8 that rely on specific classes that
+         * do not existing in older JDKs. Since older JDKs will not have them,
+         * use Java reflection to detect availability in helper class. */
         if (setServerNames != null || setApplicationProtocols != null ||
             setEndpointIdentificationAlgorithm != null) {
 
             try {
-                /* load WolfSSLJDK8Helper at runtime, not compiled on older JDKs */
-                Class<?> cls = Class.forName("com.wolfssl.provider.jsse.WolfSSLJDK8Helper");
+                /* load WolfSSLJDK8Helper at runtime, not compiled
+                 * on older JDKs */
+                Class<?> cls = Class.forName(
+                    "com.wolfssl.provider.jsse.WolfSSLJDK8Helper");
                 Object obj = cls.getConstructor().newInstance();
                 Class<?>[] paramList = new Class<?>[3];
                 paramList[0] = javax.net.ssl.SSLParameters.class;
@@ -133,17 +144,32 @@ public class WolfSSLParametersHelper
                     mth.invoke(obj, ret, setServerNames, in);
                 }
                 if (setApplicationProtocols != null) {
-                    mth = cls.getDeclaredMethod("setApplicationProtocols", paramList);
+                    mth = cls.getDeclaredMethod(
+                        "setApplicationProtocols", paramList);
                     mth.invoke(obj, ret, setApplicationProtocols, in);
                 }
                 if (setEndpointIdentificationAlgorithm != null) {
-                    mth = cls.getDeclaredMethod("setEndpointIdentificationAlgorithm", paramList);
-                    mth.invoke(obj, ret, setEndpointIdentificationAlgorithm, in);
+                    mth = cls.getDeclaredMethod(
+                        "setEndpointIdentificationAlgorithm", paramList);
+                    mth.invoke(obj, ret,
+                        setEndpointIdentificationAlgorithm, in);
                 }
 
             } catch (Exception e) {
                 /* ignore, class not found */
             }
+        }
+
+        /* Methods added in later versions of SSLParameters which do not
+         * use any additional classes. Since no unique class names, these
+         * are called here directly instead of placed into a separate helper
+         * class. */
+        try {
+            if (setMaximumPacketSize != null) {
+                setMaximumPacketSize.invoke(ret, in.getMaximumPacketSize());
+            }
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            /* Not available, just ignore and continue */
         }
 
         /* The following SSLParameters features are not yet supported
@@ -191,14 +217,15 @@ public class WolfSSLParametersHelper
             out.setWantClientAuth(in.getWantClientAuth());
         }
 
-        /* Methods added as of JDK 1.8, older JDKs will not have them. Using
-         * Java reflection to detect availability. */
-
+        /* Methods added as of JDK 1.8 that rely on specific classes that
+         * do not existing in older JDKs. Since older JDKs will not have them,
+         * use Java reflection to detect availability in helper class. */
         if (getServerNames != null || getApplicationProtocols != null ||
             getEndpointIdentificationAlgorithm != null) {
             try {
                 /* load WolfSSLJDK8Helper at runtime, not compiled on older JDKs */
-                Class<?> cls = Class.forName("com.wolfssl.provider.jsse.WolfSSLJDK8Helper");
+                Class<?> cls = Class.forName(
+                    "com.wolfssl.provider.jsse.WolfSSLJDK8Helper");
                 Object obj = cls.getConstructor().newInstance();
                 Class<?>[] paramList = new Class<?>[2];
                 paramList[0] = javax.net.ssl.SSLParameters.class;
@@ -210,17 +237,32 @@ public class WolfSSLParametersHelper
                     mth.invoke(obj, in, out);
                 }
                 if (getApplicationProtocols != null) {
-                    mth = cls.getDeclaredMethod("getApplicationProtocols", paramList);
+                    mth = cls.getDeclaredMethod(
+                        "getApplicationProtocols", paramList);
                     mth.invoke(obj, in, out);
                 }
                 if (getEndpointIdentificationAlgorithm != null) {
-                    mth = cls.getDeclaredMethod("getEndpointIdentificationAlgorithm", paramList);
+                    mth = cls.getDeclaredMethod(
+                        "getEndpointIdentificationAlgorithm", paramList);
                     mth.invoke(obj, in, out);
                 }
 
             } catch (Exception e) {
                 /* ignore, class not found */
             }
+        }
+
+        /* Methods added in later versions of SSLParameters which do not
+         * use any additional classes. Since no unique class names, these
+         * are called here directly instead of placed into a separate helper
+         * class. */
+        try {
+            if (getMaximumPacketSize != null) {
+                int maxPacketSz = (int)getMaximumPacketSize.invoke(in);
+                out.setMaximumPacketSize(maxPacketSz);
+            }
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            /* Not available, just ignore and continue */
         }
 
         /* The following SSLParameters features are not yet supported

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLParametersHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLParametersHelper.java
@@ -25,6 +25,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import javax.net.ssl.SSLParameters;
+import com.wolfssl.provider.jsse.WolfSSLJDK8Helper;
 
 /**
  * WolfSSLParametersHelper class

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java
@@ -134,6 +134,10 @@ public final class WolfSSLProvider extends Provider {
             put("SSLContext.TLSv1.3",
                     "com.wolfssl.provider.jsse.WolfSSLContext$TLSV13_Context");
         }
+        if (WolfSSL.DTLSv13Enabled()) {
+            put("SSLContext.DTLSv1.3",
+                    "com.wolfssl.provider.jsse.WolfSSLContext$DTLSV13_Context");
+        }
         put("SSLContext.SSL",
                 "com.wolfssl.provider.jsse.WolfSSLContext$TLSV23_Context");
         put("SSLContext.TLS",

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLServerSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLServerSocket.java
@@ -211,7 +211,8 @@ public class WolfSSLServerSocket extends SSLServerSocket {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getSupportedProtocols()");
 
-        return WolfSSLUtil.sanitizeProtocols(params.getProtocols());
+        return WolfSSLUtil.sanitizeProtocols(
+            params.getProtocols(), WolfSSL.TLS_VERSION.INVALID);
     }
 
     @Override
@@ -220,7 +221,8 @@ public class WolfSSLServerSocket extends SSLServerSocket {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
             "entered getEnabledProtocols()");
 
-        return WolfSSLUtil.sanitizeProtocols(params.getProtocols());
+        return WolfSSLUtil.sanitizeProtocols(
+            params.getProtocols(), WolfSSL.TLS_VERSION.INVALID);
     }
 
     @Override
@@ -242,7 +244,8 @@ public class WolfSSLServerSocket extends SSLServerSocket {
         List<String> supported;
 
         supported = Arrays.asList(
-            WolfSSLUtil.sanitizeProtocols(WolfSSL.getProtocols()));
+            WolfSSLUtil.sanitizeProtocols(
+                WolfSSL.getProtocols(), WolfSSL.TLS_VERSION.INVALID));
 
         for (int i = 0; i < protocols.length; i++) {
             if (!supported.contains(protocols[i])) {

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLUtil.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLUtil.java
@@ -287,6 +287,35 @@ public class WolfSSLUtil {
     }
 
     /**
+     * Return if TLS Extended Master Secret support has been enabled or
+     * disabled via the following System property:
+     *
+     * jdk.tls.useExtendedMasterSecret
+     *
+     * If property is not set (null) or an empty string, we default to
+     * leaving TLS Extended Master Secret enabled.
+     *
+     * @return true if enabled, otherwise false
+     */
+    protected static boolean useExtendedMasterSecret() {
+
+        String useEMS =
+            System.getProperty("jdk.tls.useExtendedMasterSecret");
+
+        /* Native wolfSSL defaults to having extended master secret support
+         * enabled. Do the same here if property not set or empty. */
+        if (useEMS == null || useEMS.isEmpty()) {
+            return true;
+        }
+
+        if (useEMS.equalsIgnoreCase("false")) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * Check given KeyStore against any pre-defind requirements for
      * KeyStore use, including the following.
      *

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineTest.java
@@ -24,10 +24,8 @@ package com.wolfssl.provider.jsse.test;
 import com.wolfssl.WolfSSL;
 import com.wolfssl.WolfSSLException;
 import com.wolfssl.provider.jsse.WolfSSLProvider;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.nio.channels.SocketChannel;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
@@ -39,11 +37,8 @@ import java.security.Security;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.security.cert.CertificateException;
-import java.security.KeyStore;
 import java.util.Random;
 import java.util.ArrayList;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.net.Socket;
 import java.net.InetSocketAddress;
 import javax.net.ssl.SSLContext;
@@ -51,10 +46,8 @@ import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLServerSocket;
-import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509ExtendedTrustManager;
-import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.SSLEngineResult;
 import javax.net.ssl.SSLEngineResult.HandshakeStatus;
 import javax.net.ssl.SSLException;
@@ -65,8 +58,15 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicIntegerArray;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
+import org.junit.Rule;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.rules.Timeout;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import java.util.Arrays;
+
+import com.wolfssl.provider.jsse.WolfSSLEngine;
 
 /**
  *
@@ -75,26 +75,31 @@ import org.junit.Test;
 public class WolfSSLEngineTest {
     public final static char[] jksPass = "wolfSSL test".toCharArray();
     public final static String engineProvider = "wolfJSSE";
-    private static boolean extraDebug = false;
     private static WolfSSLTestFactory tf;
 
     private SSLContext ctx = null;
     private static String allProtocols[] = {
+        "TLS",
         "TLSv1",
         "TLSv1.1",
         "TLSv1.2",
         "TLSv1.3",
-        "TLS"
+        "TLS",
+        "DTLSv1.3"
     };
 
     private static ArrayList<String> enabledProtocols =
         new ArrayList<String>();
 
+    /**
+     * Global timeout for all tests in this class.
+     */
+    @Rule
+    public Timeout globalTimeout = new Timeout(60, TimeUnit.SECONDS);
+
     @BeforeClass
     public static void testProviderInstallationAtRuntime()
-        throws NoSuchProviderException {
-
-        SSLContext ctx;
+        throws NoSuchProviderException, WolfSSLException {
 
         System.out.println("WolfSSLEngine Class");
 
@@ -107,7 +112,7 @@ public class WolfSSLEngineTest {
         /* populate enabledProtocols */
         for (int i = 0; i < allProtocols.length; i++) {
             try {
-                ctx = SSLContext.getInstance(allProtocols[i], "wolfJSSE");
+                SSLContext.getInstance(allProtocols[i], "wolfJSSE");
                 enabledProtocols.add(allProtocols[i]);
 
             } catch (NoSuchAlgorithmException e) {
@@ -118,8 +123,8 @@ public class WolfSSLEngineTest {
         try {
             tf = new WolfSSLTestFactory();
         } catch (WolfSSLException e) {
-            // TODO Auto-generated catch block
             e.printStackTrace();
+            throw e;
         }
     }
 
@@ -164,49 +169,88 @@ public class WolfSSLEngineTest {
             return;
         }
 
-        this.ctx = tf.createSSLContext("TLSv1.2", engineProvider);
-        e = this.ctx.createSSLEngine();
-        if (e == null) {
-            error("\t\t... failed");
-            fail("failed to create engine");
-            return;
-        }
+        for (int i = 0; i < enabledProtocols.size(); i++) {
 
-        sup = e.getSupportedProtocols();
-        for (String x : sup) {
-            if (x.equals("TLSv1.2")) {
-                ok = true;
+            /* 'TLS' is not a 'supported' protocol from
+             * SSLEngine.getSupportedProtocols(). That list returns
+             * Strings such as: TLSv1, TLSv1.2, DTLSv1.3, etc. */
+            if (enabledProtocols.get(i).equals("TLS")) {
+                continue;
+            }
+
+            this.ctx = tf.createSSLContext(
+                enabledProtocols.get(i), engineProvider);
+
+            e = this.ctx.createSSLEngine();
+            if (e == null) {
+                error("\t\t... failed");
+                fail("failed to create engine");
+                return;
+            }
+
+            sup = e.getSupportedProtocols();
+            for (String x : sup) {
+                if (x.equals(enabledProtocols.get(i))) {
+                    ok = true;
+                }
+            }
+            if (!ok) {
+                error("\t\t... failed");
+                fail("failed to find " + enabledProtocols.get(i) +
+                     " in supported protocols");
+            }
+
+            sup = e.getEnabledProtocols();
+            for (String x : sup) {
+                if (x.equals(enabledProtocols.get(i))) {
+                    ok = true;
+                }
+            }
+            if (!ok) {
+                error("\t\t... failed");
+                fail("failed to find " + enabledProtocols.get(i) +
+                     " in enabled protocols");
+            }
+
+            /* check supported cipher suites */
+            sup = e.getSupportedCipherSuites();
+            e.setEnabledCipherSuites(new String[] {sup[0]});
+            if (e.getEnabledCipherSuites() == null ||
+                    !sup[0].equals(e.getEnabledCipherSuites()[0])) {
+                error("\t\t... failed");
+                fail("unexpected empty cipher list");
             }
         }
-        if (!ok) {
-            error("\t\t... failed");
-            fail("failed to find TLSv1.2 in supported protocols");
-        }
 
-        sup = e.getEnabledProtocols();
-        for (String x : sup) {
-            if (x.equals("TLSv1.2")) {
-                ok = true;
-            }
-        }
-        if (!ok) {
-            error("\t\t... failed");
-            fail("failed to find TLSv1.2 in enabled protocols");
-        }
-
-        /* check supported cipher suites */
-        sup = e.getSupportedCipherSuites();
-        e.setEnabledCipherSuites(new String[] {sup[0]});
-        if (e.getEnabledCipherSuites() == null ||
-                !sup[0].equals(e.getEnabledCipherSuites()[0])) {
-            error("\t\t... failed");
-            fail("unexpected empty cipher list");
-        }
         pass("\t\t... passed");
     }
 
     @Test
-    public void testCipherConnection()
+    public void testCipherConnectionTLS()
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               KeyManagementException, KeyStoreException, CertificateException,
+               IOException, UnrecoverableKeyException {
+
+        synchronized (WolfSSLTestFactory.jdkTlsDisabledAlgorithmsLock) {
+            for (int i = 0; i < enabledProtocols.size(); i++) {
+                if (enabledProtocols.get(i).equals("TLS")) {
+                    /* 'TLS' is not a 'supported' protocol from
+                     * SSLEngine.getSupportedProtocols(). That list returns
+                     * Strings such as: TLSv1, TLSv1.2, DTLSv1.3, etc. */
+                    continue;
+                }
+
+                testCipherConnectionByProtocol(enabledProtocols.get(i));
+            }
+        }
+    }
+
+    /**
+     * Test the connection using the given protocol.
+     *
+     * Private method, called by testCipherConnectionTLS()
+     */
+    private void testCipherConnectionByProtocol(String protocol)
         throws NoSuchProviderException, NoSuchAlgorithmException,
                KeyManagementException, KeyStoreException, CertificateException,
                IOException, UnrecoverableKeyException {
@@ -214,15 +258,15 @@ public class WolfSSLEngineTest {
         SSLEngine server;
         SSLEngine client;
         String    cipher = null;
-        int ret, i;
+        int ret;
         String[] ciphers;
         String   certType;
         Certificate[] certs;
 
         /* create new SSLEngine */
-        System.out.print("\tBasic ciphersuiet connection");
+        System.out.print("\tBasic connection: " + protocol);
 
-        this.ctx = tf.createSSLContext("TLS", engineProvider);
+        this.ctx = tf.createSSLContext(protocol, engineProvider);
         server = this.ctx.createSSLEngine();
         client = this.ctx.createSSLEngine("wolfSSL client test", 11111);
 
@@ -258,7 +302,7 @@ public class WolfSSLEngineTest {
         server.setNeedClientAuth(false);
         client.setUseClientMode(true);
         ret = tf.testConnection(server, client, new String[] { cipher },
-                new String[] { "TLSv1.2" }, "Test cipher suite");
+                new String[] { protocol }, "Test cipher suite");
         if (ret != 0) {
             error("\t... failed");
             fail("failed to create engine");
@@ -281,26 +325,24 @@ public class WolfSSLEngineTest {
             error("\t... failed");
             fail("invalid client mode");
         }
-        pass("\t... passed");
 
-        System.out.print("\tclose connection");
+        /* Test closing connection */
         try {
-            /* test close connection */
             tf.CloseConnection(server, client, false);
         } catch (SSLException ex) {
-            error("\t\t... failed");
+            error("\t... failed");
             fail("failed to create engine");
         }
 
         /* check if inbound is still open */
         if (!server.isInboundDone() || !client.isInboundDone()) {
-            error("\t\t... failed");
+            error("\t... failed");
             fail("inbound is not done");
         }
 
         /* check if outbound is still open */
         if (!server.isOutboundDone() || !client.isOutboundDone()) {
-            error("\t\t... failed");
+            error("\t... failed");
             fail("outbound is not done");
         }
 
@@ -308,11 +350,11 @@ public class WolfSSLEngineTest {
         try {
             server.closeInbound();
         } catch (SSLException ex) {
-            error("\t\t... failed");
+            error("\t... failed");
             fail("close inbound failure");
         }
 
-        pass("\t\t... passed");
+        pass("\t... passed");
     }
 
     @Test
@@ -328,63 +370,71 @@ public class WolfSSLEngineTest {
         /* create new SSLEngine */
         System.out.print("\tbeginHandshake()");
 
-        this.ctx = tf.createSSLContext("TLS", engineProvider);
-        server = this.ctx.createSSLEngine();
-        client = this.ctx.createSSLEngine("wolfSSL begin handshake test", 11111);
+        for (int i = 0; i < enabledProtocols.size(); i++) {
 
-        /* Calling beginHandshake() before setUseClientMode() should throw
-         * IllegalStateException */
-        try {
-            server.beginHandshake();
-            error("\t\t... failed");
-            fail("beginHandshake() before setUseClientMode() should throw " +
-                 "IllegalStateException");
-        } catch (IllegalStateException e) {
-            /* expected */
-        }
-        try {
-            client.beginHandshake();
-            error("\t\t... failed");
-            fail("beginHandshake() before setUseClientMode() should throw " +
-                 "IllegalStateException");
-        } catch (IllegalStateException e) {
-            /* expected */
-        }
+            this.ctx = tf.createSSLContext(
+                enabledProtocols.get(i), engineProvider);
 
-        /* Set client/server mode, disable auth to simplify tests below */
-        server.setUseClientMode(false);
-        server.setNeedClientAuth(false);
-        client.setUseClientMode(true);
+            server = this.ctx.createSSLEngine();
+            client = this.ctx.createSSLEngine(
+                "wolfSSL begin handshake test", 11111);
 
-        try {
-            server.beginHandshake();
-            client.beginHandshake();
-        } catch (SSLException e) {
-            error("\t\t... failed");
-            fail("failed to begin handshake");
-        }
+            /* Calling beginHandshake() before setUseClientMode() should throw
+             * IllegalStateException */
+            try {
+                server.beginHandshake();
+                error("\t\t... failed");
+                fail("beginHandshake() before setUseClientMode() should " +
+                     "throw IllegalStateException");
+            } catch (IllegalStateException e) {
+                /* expected */
+            }
 
-        ret = tf.testConnection(server, client, null, null, "Test in/out bound");
-        if (ret != 0) {
-            error("\t\t... failed");
-            fail("failed to create engine");
-        }
+            try {
+                client.beginHandshake();
+                error("\t\t... failed");
+                fail("beginHandshake() before setUseClientMode() should " +
+                     "throw IllegalStateException");
+            } catch (IllegalStateException e) {
+                /* expected */
+            }
 
-        /* Calling beginHandshake() again should throw SSLException
-         * since renegotiation is not yet supported in wolfJSSE */
-        try {
-            server.beginHandshake();
-            error("\t\t... failed");
-            fail("beginHandshake() called again should throw SSLException");
-        } catch (SSLException e) {
-            /* expected */
-        }
-        try {
-            client.beginHandshake();
-            error("\t\t... failed");
-            fail("beginHandshake() called again should throw SSLException");
-        } catch (SSLException e) {
-            /* expected */
+            /* Set client/server mode, disable auth to simplify tests below */
+            server.setUseClientMode(false);
+            server.setNeedClientAuth(false);
+            client.setUseClientMode(true);
+
+            try {
+                server.beginHandshake();
+                client.beginHandshake();
+            } catch (SSLException e) {
+                error("\t\t... failed");
+                fail("failed to begin handshake");
+            }
+
+            ret = tf.testConnection(server, client, null, null,
+                "Test in/out bound");
+            if (ret != 0) {
+                error("\t\t... failed");
+                fail("failed to create engine");
+            }
+
+            /* Calling beginHandshake() again should throw SSLException
+             * since renegotiation is not yet supported in wolfJSSE */
+            try {
+                server.beginHandshake();
+                error("\t\t... failed");
+                fail("beginHandshake() called again should throw SSLException");
+            } catch (SSLException e) {
+                /* expected */
+            }
+            try {
+                client.beginHandshake();
+                error("\t\t... failed");
+                fail("beginHandshake() called again should throw SSLException");
+            } catch (SSLException e) {
+                /* expected */
+            }
         }
 
         pass("\t\t... passed");
@@ -403,38 +453,45 @@ public class WolfSSLEngineTest {
         /* create new SSLEngine */
         System.out.print("\tisIn/OutboundDone()");
 
-        this.ctx = tf.createSSLContext("TLS", engineProvider);
-        server = this.ctx.createSSLEngine();
-        client = this.ctx.createSSLEngine("wolfSSL in/out test", 11111);
+        for (int i = 0; i < enabledProtocols.size(); i++) {
 
-        server.setUseClientMode(false);
-        server.setNeedClientAuth(false);
-        client.setUseClientMode(true);
-        ret = tf.testConnection(server, client, null, null, "Test in/out bound");
-        if (ret != 0) {
-            error("\t\t... failed");
-            fail("failed to create engine");
-        }
+            this.ctx = tf.createSSLContext(
+                enabledProtocols.get(i), engineProvider);
 
-        /* check if inbound is still open */
-        if (server.isInboundDone() && client.isInboundDone()) {
-            error("\t\t... failed");
-            fail("inbound done too early");
-        }
+            server = this.ctx.createSSLEngine();
+            client = this.ctx.createSSLEngine("wolfSSL in/out test", 11111);
 
-        /* check if outbound is still open */
-        if (server.isOutboundDone() && client.isOutboundDone()) {
-            error("\t\t... failed");
-            fail("outbound done too early");
-        }
+            server.setUseClientMode(false);
+            server.setNeedClientAuth(false);
+            client.setUseClientMode(true);
 
-        /* close inbound before peer responded to shutdown should fail */
-        try {
-            server.closeInbound();
-            error("\t\t... failed");
-            fail("was able to incorrectly close inbound");
-        } catch (SSLException ex) {
-            /* expected to fail here */
+            ret = tf.testConnection(server, client, null, null,
+                "Test in/out bound");
+            if (ret != 0) {
+                error("\t\t... failed");
+                fail("failed to create engine");
+            }
+
+            /* check if inbound is still open */
+            if (server.isInboundDone() && client.isInboundDone()) {
+                error("\t\t... failed");
+                fail("inbound done too early");
+            }
+
+            /* check if outbound is still open */
+            if (server.isOutboundDone() && client.isOutboundDone()) {
+                error("\t\t... failed");
+                fail("outbound done too early");
+            }
+
+            /* close inbound before peer responded to shutdown should fail */
+            try {
+                server.closeInbound();
+                error("\t\t... failed");
+                fail("was able to incorrectly close inbound");
+            } catch (SSLException ex) {
+                /* expected to fail here */
+            }
         }
 
         pass("\t\t... passed");
@@ -446,67 +503,71 @@ public class WolfSSLEngineTest {
                KeyManagementException, KeyStoreException, CertificateException,
                IOException, UnrecoverableKeyException {
 
-        int ret;
         SSLEngine client;
         SSLEngine server;
 
         System.out.print("\tsetUseClientMode()");
 
-        /* expected to fail, not calling setUseClientMode() */
-        this.ctx = tf.createSSLContext("TLS", engineProvider);
-        server = this.ctx.createSSLEngine();
-        client = this.ctx.createSSLEngine("wolfSSL test", 11111);
-        server.setWantClientAuth(false);
-        server.setNeedClientAuth(false);
-        try {
-            ret = tf.testConnection(server, client, null, null, "Testing");
-            error("\t\t... failed");
-            fail("did not fail without setUseClientMode()");
-        } catch (IllegalStateException e) {
-            /* expected */
-        }
+        for (int i = 0; i < enabledProtocols.size(); i++) {
 
-        /* expected to fail, only calling client.setUseClientMode() */
-        server = this.ctx.createSSLEngine();
-        client = this.ctx.createSSLEngine("wolfSSL test", 11111);
-        server.setWantClientAuth(false);
-        server.setNeedClientAuth(false);
-        client.setUseClientMode(true);
-        try {
-            ret = tf.testConnection(server, client, null, null, "Testing");
-            error("\t\t... failed");
-            fail("did not fail without server.setUseClientMode()");
-        } catch (IllegalStateException e) {
-            /* expected */
-        }
+            /* expected to fail, not calling setUseClientMode() */
+            this.ctx = tf.createSSLContext(
+                enabledProtocols.get(i), engineProvider);
 
-        /* expected to fail, only calling client.setUseClientMode() */
-        server = this.ctx.createSSLEngine();
-        client = this.ctx.createSSLEngine("wolfSSL test", 11111);
-        server.setWantClientAuth(false);
-        server.setNeedClientAuth(false);
-        server.setUseClientMode(false);
-        try {
-            ret = tf.testConnection(server, client, null, null, "Testing");
-            error("\t\t... failed");
-            fail("did not fail without client.setUseClientMode()");
-        } catch (IllegalStateException e) {
-            /* expected */
-        }
+            server = this.ctx.createSSLEngine();
+            client = this.ctx.createSSLEngine("wolfSSL test", 11111);
+            server.setWantClientAuth(false);
+            server.setNeedClientAuth(false);
+            try {
+                tf.testConnection(server, client, null, null, "Testing");
+                error("\t\t... failed");
+                fail("did not fail without setUseClientMode()");
+            } catch (IllegalStateException e) {
+                /* expected */
+            }
 
-        /* expected to succeed, both setUseClientMode() set */
-        server = this.ctx.createSSLEngine();
-        client = this.ctx.createSSLEngine("wolfSSL test", 11111);
-        server.setWantClientAuth(false);
-        server.setNeedClientAuth(false);
-        client.setUseClientMode(true);
-        server.setUseClientMode(false);
-        try {
-            ret = tf.testConnection(server, client, null, null, "Testing");
-        } catch (IllegalStateException e) {
-            e.printStackTrace();
-            error("\t\t... failed");
-            fail("failed with setUseClientMode(), should succeed");
+            /* expected to fail, only calling client.setUseClientMode() */
+            server = this.ctx.createSSLEngine();
+            client = this.ctx.createSSLEngine("wolfSSL test", 11111);
+            server.setWantClientAuth(false);
+            server.setNeedClientAuth(false);
+            client.setUseClientMode(true);
+            try {
+                tf.testConnection(server, client, null, null, "Testing");
+                error("\t\t... failed");
+                fail("did not fail without server.setUseClientMode()");
+            } catch (IllegalStateException e) {
+                /* expected */
+            }
+
+            /* expected to fail, only calling client.setUseClientMode() */
+            server = this.ctx.createSSLEngine();
+            client = this.ctx.createSSLEngine("wolfSSL test", 11111);
+            server.setWantClientAuth(false);
+            server.setNeedClientAuth(false);
+            server.setUseClientMode(false);
+            try {
+                tf.testConnection(server, client, null, null, "Testing");
+                error("\t\t... failed");
+                fail("did not fail without client.setUseClientMode()");
+            } catch (IllegalStateException e) {
+                /* expected */
+            }
+
+            /* expected to succeed, both setUseClientMode() set */
+            server = this.ctx.createSSLEngine();
+            client = this.ctx.createSSLEngine("wolfSSL test", 11111);
+            server.setWantClientAuth(false);
+            server.setNeedClientAuth(false);
+            client.setUseClientMode(true);
+            server.setUseClientMode(false);
+            try {
+                tf.testConnection(server, client, null, null, "Testing");
+            } catch (IllegalStateException e) {
+                e.printStackTrace();
+                error("\t\t... failed");
+                fail("failed with setUseClientMode(), should succeed");
+            }
         }
 
         pass("\t\t... passed");
@@ -525,42 +586,50 @@ public class WolfSSLEngineTest {
         /* create new SSLEngine */
         System.out.print("\tMutual authentication");
 
-        /* success case */
-        this.ctx = tf.createSSLContext("TLS", engineProvider);
-        server = this.ctx.createSSLEngine();
-        client = this.ctx.createSSLEngine("wolfSSL auth test", 11111);
+        for (int i = 0; i < enabledProtocols.size(); i++) {
 
-        server.setWantClientAuth(true);
-        server.setNeedClientAuth(true);
-        client.setUseClientMode(true);
-        server.setUseClientMode(false);
-        ret = tf.testConnection(server, client, null, null, "Test mutual auth");
-        if (ret != 0) {
-            error("\t\t... failed");
-            fail("failed to create connection with engine");
-        }
+            /* success case */
+            this.ctx = tf.createSSLContext(
+                enabledProtocols.get(i), engineProvider);
 
-        /* want client auth should be overwritten by need client auth */
-        if (!server.getNeedClientAuth() || server.getWantClientAuth()) {
-            error("\t\t... failed");
-            fail("failed with mutual auth getter check");
-        }
+            server = this.ctx.createSSLEngine();
+            client = this.ctx.createSSLEngine("wolfSSL auth test", 11111);
 
-        /* fail case */
-        this.ctx = tf.createSSLContext("TLS", engineProvider,
+            server.setWantClientAuth(true);
+            server.setNeedClientAuth(true);
+            client.setUseClientMode(true);
+            server.setUseClientMode(false);
+            ret = tf.testConnection(server, client, null, null,
+                "Test mutual auth");
+            if (ret != 0) {
+                error("\t\t... failed");
+                fail("failed to create connection with engine");
+            }
+
+            /* want client auth should be overwritten by need client auth */
+            if (!server.getNeedClientAuth() || server.getWantClientAuth()) {
+                error("\t\t... failed");
+                fail("failed with mutual auth getter check");
+            }
+
+            /* fail case */
+            this.ctx = tf.createSSLContext(
+                enabledProtocols.get(i), engineProvider,
                 tf.createTrustManager("SunX509", tf.serverJKS, engineProvider),
                 tf.createKeyManager("SunX509", tf.serverJKS, engineProvider));
-        server = this.ctx.createSSLEngine();
-        client = this.ctx.createSSLEngine("wolfSSL auth fail test", 11111);
+            server = this.ctx.createSSLEngine();
+            client = this.ctx.createSSLEngine("wolfSSL auth fail test", 11111);
 
-        server.setWantClientAuth(true);
-        server.setNeedClientAuth(true);
-        client.setUseClientMode(true);
-        server.setUseClientMode(false);
-        ret = tf.testConnection(server, client, null, null, "Test in/out bound");
-        if (ret == 0) {
-            error("\t\t... failed");
-            fail("failed to create engine");
+            server.setWantClientAuth(true);
+            server.setNeedClientAuth(true);
+            client.setUseClientMode(true);
+            server.setUseClientMode(false);
+            ret = tf.testConnection(server, client, null, null,
+                "Test in/out bound");
+            if (ret == 0) {
+                error("\t\t... failed");
+                fail("failed to create engine");
+            }
         }
 
         pass("\t\t... passed");
@@ -626,31 +695,36 @@ public class WolfSSLEngineTest {
 
         System.out.print("\tsetWantClientAuth(default KM)");
 
-        for (PeerAuthConfig c : configsDefaultManagers) {
+        for (int i = 0; i < enabledProtocols.size(); i++) {
+            for (PeerAuthConfig c : configsDefaultManagers) {
 
-            sCtx = tf.createSSLContext("TLS", engineProvider);
-            server = sCtx.createSSLEngine();
-            server.setUseClientMode(false);
-            server.setWantClientAuth(c.serverWantClientAuth);
-            server.setNeedClientAuth(c.serverNeedClientAuth);
+                sCtx = tf.createSSLContext(
+                    enabledProtocols.get(i), engineProvider);
+                server = sCtx.createSSLEngine();
+                server.setUseClientMode(false);
+                server.setWantClientAuth(c.serverWantClientAuth);
+                server.setNeedClientAuth(c.serverNeedClientAuth);
 
-            cCtx = tf.createSSLContext("TLS", engineProvider);
-            client = cCtx.createSSLEngine("wolfSSL test case", 11111);
-            client.setUseClientMode(true);
-            client.setWantClientAuth(c.clientWantClientAuth);
-            client.setNeedClientAuth(c.clientNeedClientAuth);
+                cCtx = tf.createSSLContext(
+                    enabledProtocols.get(i), engineProvider);
+                client = cCtx.createSSLEngine("wolfSSL test case", 11111);
+                client.setUseClientMode(true);
+                client.setWantClientAuth(c.clientWantClientAuth);
+                client.setNeedClientAuth(c.clientNeedClientAuth);
 
-            ret = tf.testConnection(server, client, null, null, "Test");
-            if ((c.expectSuccess && ret != 0) ||
-                (!c.expectSuccess && ret == 0)) {
-                error("\t... failed");
-                fail("SSLEngine want/needClientAuth failed: \n" +
-                     "\n  cWantClientAuth = " + c.clientWantClientAuth +
-                     "\n  cNeedClientAuth = " + c.clientNeedClientAuth +
-                     "\n  sWantClientAuth = " + c.serverWantClientAuth +
-                     "\n  sNeedClientAuth = " + c.serverNeedClientAuth +
-                     "\n  expectSuccess = " + c.expectSuccess +
-                     "\n  got ret = " + ret);
+                ret = tf.testConnection(server, client, null, null, "Test");
+                if ((c.expectSuccess && ret != 0) ||
+                    (!c.expectSuccess && ret == 0)) {
+                    error("\t... failed");
+                    fail("SSLEngine want/needClientAuth failed: \n" +
+                         "\n  cWantClientAuth = " + c.clientWantClientAuth +
+                         "\n  cNeedClientAuth = " + c.clientNeedClientAuth +
+                         "\n  sWantClientAuth = " + c.serverWantClientAuth +
+                         "\n  sNeedClientAuth = " + c.serverNeedClientAuth +
+                         "\n  expectSuccess = " + c.expectSuccess +
+                         "\n  got ret = " + ret +
+                         "\n  protocol = " + enabledProtocols.get(i));
+                }
             }
         }
 
@@ -692,33 +766,39 @@ public class WolfSSLEngineTest {
 
         System.out.print("\tsetWantClientAuth(no client KM)");
 
-        for (PeerAuthConfig c : configs) {
+        for (int i = 0; i < enabledProtocols.size(); i++) {
+            for (PeerAuthConfig c : configs) {
 
-            sCtx = tf.createSSLContext("TLS", engineProvider);
-            server = sCtx.createSSLEngine();
-            server.setUseClientMode(false);
-            server.setWantClientAuth(c.serverWantClientAuth);
-            server.setNeedClientAuth(c.serverNeedClientAuth);
+                sCtx = tf.createSSLContext(
+                    enabledProtocols.get(i), engineProvider);
+                server = sCtx.createSSLEngine();
+                server.setUseClientMode(false);
+                server.setWantClientAuth(c.serverWantClientAuth);
+                server.setNeedClientAuth(c.serverNeedClientAuth);
 
-            cCtx = tf.createSSLContextNoDefaults("TLS", engineProvider,
-                tf.createTrustManager("SunX509", tf.clientJKS, engineProvider),
-                null);
-            client = cCtx.createSSLEngine("wolfSSL test case", 11111);
-            client.setUseClientMode(true);
-            client.setWantClientAuth(c.clientWantClientAuth);
-            client.setNeedClientAuth(c.clientNeedClientAuth);
+                cCtx = tf.createSSLContextNoDefaults(
+                    enabledProtocols.get(i), engineProvider,
+                    tf.createTrustManager("SunX509", tf.clientJKS,
+                        engineProvider),
+                    null);
+                client = cCtx.createSSLEngine("wolfSSL test case", 11111);
+                client.setUseClientMode(true);
+                client.setWantClientAuth(c.clientWantClientAuth);
+                client.setNeedClientAuth(c.clientNeedClientAuth);
 
-            ret = tf.testConnection(server, client, null, null, "Test");
-            if ((c.expectSuccess && ret != 0) ||
-                (!c.expectSuccess && ret == 0)) {
-                error("\t... failed");
-                fail("SSLEngine want/needClientAuth failed: \n" +
-                     "\n  cWantClientAuth = " + c.clientWantClientAuth +
-                     "\n  cNeedClientAuth = " + c.clientNeedClientAuth +
-                     "\n  sWantClientAuth = " + c.serverWantClientAuth +
-                     "\n  sNeedClientAuth = " + c.serverNeedClientAuth +
-                     "\n  expectSuccess = " + c.expectSuccess +
-                     "\n  got ret = " + ret);
+                ret = tf.testConnection(server, client, null, null, "Test");
+                if ((c.expectSuccess && ret != 0) ||
+                    (!c.expectSuccess && ret == 0)) {
+                    error("\t... failed");
+                    fail("SSLEngine want/needClientAuth failed: \n" +
+                         "\n  cWantClientAuth = " + c.clientWantClientAuth +
+                         "\n  cNeedClientAuth = " + c.clientNeedClientAuth +
+                         "\n  sWantClientAuth = " + c.serverWantClientAuth +
+                         "\n  sNeedClientAuth = " + c.serverNeedClientAuth +
+                         "\n  expectSuccess = " + c.expectSuccess +
+                         "\n  got ret = " + ret +
+                         "\n  protocol = " + enabledProtocols.get(i));
+                }
             }
         }
 
@@ -762,33 +842,39 @@ public class WolfSSLEngineTest {
 
         System.out.print("\tsetWantClientAuth(no server KM)");
 
-        for (PeerAuthConfig c : configs) {
+        for (int i = 0; i < enabledProtocols.size(); i++) {
+            for (PeerAuthConfig c : configs) {
 
-            sCtx = tf.createSSLContextNoDefaults("TLS", engineProvider,
-                tf.createTrustManager("SunX509", tf.clientJKS, engineProvider),
-                null);
-            server = sCtx.createSSLEngine();
-            server.setUseClientMode(false);
-            server.setWantClientAuth(c.serverWantClientAuth);
-            server.setNeedClientAuth(c.serverNeedClientAuth);
+                sCtx = tf.createSSLContextNoDefaults(enabledProtocols.get(i),
+                    engineProvider,
+                    tf.createTrustManager("SunX509", tf.clientJKS,
+                        engineProvider),
+                    null);
+                server = sCtx.createSSLEngine();
+                server.setUseClientMode(false);
+                server.setWantClientAuth(c.serverWantClientAuth);
+                server.setNeedClientAuth(c.serverNeedClientAuth);
 
-            cCtx = tf.createSSLContext("TLS", engineProvider);
-            client = cCtx.createSSLEngine("wolfSSL test case", 11111);
-            client.setUseClientMode(true);
-            client.setWantClientAuth(c.clientWantClientAuth);
-            client.setNeedClientAuth(c.clientNeedClientAuth);
+                cCtx = tf.createSSLContext(enabledProtocols.get(i),
+                    engineProvider);
+                client = cCtx.createSSLEngine("wolfSSL test case", 11111);
+                client.setUseClientMode(true);
+                client.setWantClientAuth(c.clientWantClientAuth);
+                client.setNeedClientAuth(c.clientNeedClientAuth);
 
-            ret = tf.testConnection(server, client, null, null, "Test");
-            if ((c.expectSuccess && ret != 0) ||
-                (!c.expectSuccess && ret == 0)) {
-                error("\t... failed");
-                fail("SSLEngine want/needClientAuth failed: \n" +
-                     "\n  cWantClientAuth = " + c.clientWantClientAuth +
-                     "\n  cNeedClientAuth = " + c.clientNeedClientAuth +
-                     "\n  sWantClientAuth = " + c.serverWantClientAuth +
-                     "\n  sNeedClientAuth = " + c.serverNeedClientAuth +
-                     "\n  expectSuccess = " + c.expectSuccess +
-                     "\n  got ret = " + ret);
+                ret = tf.testConnection(server, client, null, null, "Test");
+                if ((c.expectSuccess && ret != 0) ||
+                    (!c.expectSuccess && ret == 0)) {
+                    error("\t... failed");
+                    fail("SSLEngine want/needClientAuth failed: \n" +
+                         "\n  cWantClientAuth = " + c.clientWantClientAuth +
+                         "\n  cNeedClientAuth = " + c.clientNeedClientAuth +
+                         "\n  sWantClientAuth = " + c.serverWantClientAuth +
+                         "\n  sNeedClientAuth = " + c.serverNeedClientAuth +
+                         "\n  expectSuccess = " + c.expectSuccess +
+                         "\n  got ret = " + ret +
+                         "\n  protocol = " + enabledProtocols.get(i));
+                }
             }
         }
 
@@ -858,35 +944,42 @@ public class WolfSSLEngineTest {
 
         System.out.print("\tsetWantClientAuth(ext KM all)");
 
-        for (PeerAuthConfig c : configsDefaultManagers) {
+        for (int i = 0; i < enabledProtocols.size(); i++) {
+            for (PeerAuthConfig c : configsDefaultManagers) {
 
-            sCtx = tf.createSSLContextNoDefaults("TLS", engineProvider,
-                trustAllCerts,
-                tf.createKeyManager("SunX509", tf.clientJKS, engineProvider));
-            server = sCtx.createSSLEngine();
-            server.setUseClientMode(false);
-            server.setWantClientAuth(c.serverWantClientAuth);
-            server.setNeedClientAuth(c.serverNeedClientAuth);
+                sCtx = tf.createSSLContextNoDefaults(enabledProtocols.get(i),
+                    engineProvider,
+                    trustAllCerts,
+                    tf.createKeyManager("SunX509", tf.clientJKS,
+                        engineProvider));
+                server = sCtx.createSSLEngine();
+                server.setUseClientMode(false);
+                server.setWantClientAuth(c.serverWantClientAuth);
+                server.setNeedClientAuth(c.serverNeedClientAuth);
 
-            cCtx = tf.createSSLContextNoDefaults("TLS", engineProvider,
-                trustAllCerts,
-                tf.createKeyManager("SunX509", tf.clientJKS, engineProvider));
-            client = cCtx.createSSLEngine("wolfSSL test case", 11111);
-            client.setUseClientMode(true);
-            client.setWantClientAuth(c.clientWantClientAuth);
-            client.setNeedClientAuth(c.clientNeedClientAuth);
+                cCtx = tf.createSSLContextNoDefaults(enabledProtocols.get(i),
+                    engineProvider,
+                    trustAllCerts,
+                    tf.createKeyManager("SunX509", tf.clientJKS,
+                        engineProvider));
+                client = cCtx.createSSLEngine("wolfSSL test case", 11111);
+                client.setUseClientMode(true);
+                client.setWantClientAuth(c.clientWantClientAuth);
+                client.setNeedClientAuth(c.clientNeedClientAuth);
 
-            ret = tf.testConnection(server, client, null, null, "Test");
-            if ((c.expectSuccess && ret != 0) ||
-                (!c.expectSuccess && ret == 0)) {
-                error("\t... failed");
-                fail("SSLEngine want/needClientAuth failed: \n" +
-                     "\n  cWantClientAuth = " + c.clientWantClientAuth +
-                     "\n  cNeedClientAuth = " + c.clientNeedClientAuth +
-                     "\n  sWantClientAuth = " + c.serverWantClientAuth +
-                     "\n  sNeedClientAuth = " + c.serverNeedClientAuth +
-                     "\n  expectSuccess = " + c.expectSuccess +
-                     "\n  got ret = " + ret);
+                ret = tf.testConnection(server, client, null, null, "Test");
+                if ((c.expectSuccess && ret != 0) ||
+                    (!c.expectSuccess && ret == 0)) {
+                    error("\t... failed");
+                    fail("SSLEngine want/needClientAuth failed: \n" +
+                         "\n  cWantClientAuth = " + c.clientWantClientAuth +
+                         "\n  cNeedClientAuth = " + c.clientNeedClientAuth +
+                         "\n  sWantClientAuth = " + c.serverWantClientAuth +
+                         "\n  sNeedClientAuth = " + c.serverNeedClientAuth +
+                         "\n  expectSuccess = " + c.expectSuccess +
+                         "\n  got ret = " + ret +
+                         "\n  protocol = " + enabledProtocols.get(i));
+                }
             }
         }
 
@@ -971,35 +1064,42 @@ public class WolfSSLEngineTest {
 
         System.out.print("\tsetWantClientAuth(ext KM no)");
 
-        for (PeerAuthConfig c : configsDefaultManagers) {
+        for (int i = 0; i < enabledProtocols.size(); i++) {
+            for (PeerAuthConfig c : configsDefaultManagers) {
 
-            sCtx = tf.createSSLContextNoDefaults("TLS", engineProvider,
-                trustNoClientCerts,
-                tf.createKeyManager("SunX509", tf.clientJKS, engineProvider));
-            server = sCtx.createSSLEngine();
-            server.setUseClientMode(false);
-            server.setWantClientAuth(c.serverWantClientAuth);
-            server.setNeedClientAuth(c.serverNeedClientAuth);
+                sCtx = tf.createSSLContextNoDefaults(enabledProtocols.get(i),
+                    engineProvider,
+                    trustNoClientCerts,
+                    tf.createKeyManager("SunX509", tf.clientJKS,
+                        engineProvider));
+                server = sCtx.createSSLEngine();
+                server.setUseClientMode(false);
+                server.setWantClientAuth(c.serverWantClientAuth);
+                server.setNeedClientAuth(c.serverNeedClientAuth);
 
-            cCtx = tf.createSSLContextNoDefaults("TLS", engineProvider,
-                trustNoClientCerts,
-                tf.createKeyManager("SunX509", tf.clientJKS, engineProvider));
-            client = cCtx.createSSLEngine("wolfSSL test case", 11111);
-            client.setUseClientMode(true);
-            client.setWantClientAuth(c.clientWantClientAuth);
-            client.setNeedClientAuth(c.clientNeedClientAuth);
+                cCtx = tf.createSSLContextNoDefaults(enabledProtocols.get(i),
+                    engineProvider,
+                    trustNoClientCerts,
+                    tf.createKeyManager("SunX509", tf.clientJKS,
+                        engineProvider));
+                client = cCtx.createSSLEngine("wolfSSL test case", 11111);
+                client.setUseClientMode(true);
+                client.setWantClientAuth(c.clientWantClientAuth);
+                client.setNeedClientAuth(c.clientNeedClientAuth);
 
-            ret = tf.testConnection(server, client, null, null, "Test");
-            if ((c.expectSuccess && ret != 0) ||
-                (!c.expectSuccess && ret == 0)) {
-                error("\t... failed");
-                fail("SSLEngine want/needClientAuth failed: \n" +
-                     "\n  cWantClientAuth = " + c.clientWantClientAuth +
-                     "\n  cNeedClientAuth = " + c.clientNeedClientAuth +
-                     "\n  sWantClientAuth = " + c.serverWantClientAuth +
-                     "\n  sNeedClientAuth = " + c.serverNeedClientAuth +
-                     "\n  expectSuccess = " + c.expectSuccess +
-                     "\n  got ret = " + ret);
+                ret = tf.testConnection(server, client, null, null, "Test");
+                if ((c.expectSuccess && ret != 0) ||
+                    (!c.expectSuccess && ret == 0)) {
+                    error("\t... failed");
+                    fail("SSLEngine want/needClientAuth failed: \n" +
+                         "\n  cWantClientAuth = " + c.clientWantClientAuth +
+                         "\n  cNeedClientAuth = " + c.clientNeedClientAuth +
+                         "\n  sWantClientAuth = " + c.serverWantClientAuth +
+                         "\n  sNeedClientAuth = " + c.serverNeedClientAuth +
+                         "\n  expectSuccess = " + c.expectSuccess +
+                         "\n  got ret = " + ret +
+                         "\n  protocol = " + enabledProtocols.get(i));
+                }
             }
         }
 
@@ -1028,51 +1128,56 @@ public class WolfSSLEngineTest {
         Security.setProperty("wolfjsse.clientSessionCache.disabled", "false");
 
         try {
-            /* create new SSLEngine */
-            this.ctx = tf.createSSLContext("TLS", engineProvider);
-            server = this.ctx.createSSLEngine();
-            client = this.ctx.createSSLEngine("wolfSSL client test", 11111);
+            for (int i = 0; i < enabledProtocols.size(); i++) {
+                /* create new SSLEngine */
+                this.ctx = tf.createSSLContext(enabledProtocols.get(i),
+                    engineProvider);
+                server = this.ctx.createSSLEngine();
+                client = this.ctx.createSSLEngine("wolfSSL client test", 11111);
 
-            server.setUseClientMode(false);
-            server.setNeedClientAuth(false);
-            client.setUseClientMode(true);
-            ret = tf.testConnection(server, client, null, null, "Test reuse");
-            if (ret != 0) {
-                error("\t\t\t... failed");
-                fail("failed to create engine");
-            }
+                server.setUseClientMode(false);
+                server.setNeedClientAuth(false);
+                client.setUseClientMode(true);
+                ret = tf.testConnection(server, client, null, null,
+                    "Test reuse");
+                if (ret != 0) {
+                    error("\t\t\t... failed");
+                    fail("failed to create engine");
+                }
 
-            try {
-                /* test close connection */
-                tf.CloseConnection(server, client, false);
-            } catch (SSLException ex) {
-                error("\t\t\t... failed");
-                fail("failed to create engine");
-            }
+                try {
+                    /* test close connection */
+                    tf.CloseConnection(server, client, false);
+                } catch (SSLException ex) {
+                    error("\t\t\t... failed");
+                    fail("failed to create engine");
+                }
 
-            server = this.ctx.createSSLEngine();
-            client = this.ctx.createSSLEngine("wolfSSL client test", 11111);
-            client.setEnableSessionCreation(false);
-            server.setUseClientMode(false);
-            server.setNeedClientAuth(false);
-            client.setUseClientMode(true);
-            ret = tf.testConnection(server, client, null, null, "Test reuse");
-            if (ret != 0) {
-                error("\t\t\t... failed");
-                fail("failed to create engine");
-            }
-            try {
-                /* test close connection */
-                tf.CloseConnection(server, client, false);
-            } catch (SSLException ex) {
-                error("\t\t\t... failed");
-                fail("failed to create engine");
-            }
+                server = this.ctx.createSSLEngine();
+                client = this.ctx.createSSLEngine("wolfSSL client test", 11111);
+                client.setEnableSessionCreation(false);
+                server.setUseClientMode(false);
+                server.setNeedClientAuth(false);
+                client.setUseClientMode(true);
+                ret = tf.testConnection(server, client, null, null,
+                    "Test reuse");
+                if (ret != 0) {
+                    error("\t\t\t... failed");
+                    fail("failed to create engine");
+                }
+                try {
+                    /* test close connection */
+                    tf.CloseConnection(server, client, false);
+                } catch (SSLException ex) {
+                    error("\t\t\t... failed");
+                    fail("failed to create engine");
+                }
 
-            if (client.getEnableSessionCreation() ||
-                !server.getEnableSessionCreation()) {
-                error("\t\t\t... failed");
-                fail("bad enabled session creation");
+                if (client.getEnableSessionCreation() ||
+                    !server.getEnableSessionCreation()) {
+                    error("\t\t\t... failed");
+                    fail("bad enabled session creation");
+                }
             }
 
             pass("\t\t\t... passed");
@@ -1332,7 +1437,7 @@ public class WolfSSLEngineTest {
                     case OK:
                         netData.flip();
                         while (netData.hasRemaining()) {
-                            int sent = sock.write(netData);
+                            sock.write(netData);
                         }
                         break;
                     case CLOSED:
@@ -1512,20 +1617,23 @@ public class WolfSSLEngineTest {
         SSLEngine engine;
         SSLSession session;
 
-        System.out.print("\tTesting getAppBufferSize");
+        System.out.print("\tgetApplicationBufferSize()");
 
         try {
-            /* create SSLContext */
-            this.ctx = tf.createSSLContext("TLS", engineProvider);
+            for (int i = 0; i < enabledProtocols.size(); i++) {
+                this.ctx = tf.createSSLContext(enabledProtocols.get(i),
+                    engineProvider);
 
-            engine = this.ctx.createSSLEngine("test", 11111);
-            session = engine.getSession();
-            appBufSz = session.getApplicationBufferSize();
+                engine = this.ctx.createSSLEngine("test", 11111);
+                session = engine.getSession();
+                appBufSz = session.getApplicationBufferSize();
 
-            /* expected to be 16384 */
-            if (appBufSz != 16384) {
-                error("\t... failed");
-                fail("got incorrect application buffer size");
+                /* expected to be 16384 */
+                if (appBufSz != 16384) {
+                    error("\t... failed");
+                    fail("got incorrect application buffer size (" +
+                        enabledProtocols.get(i) + ")");
+                }
             }
         } catch (Exception e) {
             e.printStackTrace();
@@ -1543,28 +1651,31 @@ public class WolfSSLEngineTest {
         SSLEngine engine;
         SSLSession session;
 
-        System.out.print("\tTesting getPacketBufferSize");
+        System.out.print("\tgetPacketBufferSize()");
 
         try {
-            /* create SSLContext */
-            this.ctx = tf.createSSLContext("TLS", engineProvider);
+            for (int i = 0; i < enabledProtocols.size(); i++) {
+                this.ctx = tf.createSSLContext(enabledProtocols.get(i),
+                    engineProvider);
 
-            engine = this.ctx.createSSLEngine("test", 11111);
-            session = engine.getSession();
-            packetBufSz = session.getPacketBufferSize();
+                engine = this.ctx.createSSLEngine("test", 11111);
+                session = engine.getSession();
+                packetBufSz = session.getPacketBufferSize();
 
-            /* expected to be 18437 */
-            if (packetBufSz != 18437) {
-                error("\t... failed");
-                fail("got incorrect packet buffer size");
+                /* expected to be 18437 */
+                if (packetBufSz != 18437) {
+                    error("\t\t... failed");
+                    fail("got incorrect packet buffer size (" +
+                        enabledProtocols.get(i) + ")");
+                }
             }
         } catch (Exception e) {
             e.printStackTrace();
-            error("\t... failed");
+            error("\t\t... failed");
             fail("unexpected Exception during getPacketBufferSize test");
         }
 
-        pass("\t... passed");
+        pass("\t\t... passed");
     }
 
     @Test
@@ -1581,9 +1692,6 @@ public class WolfSSLEngineTest {
 
         /* big input buffer to test, 16k */
         byte[] bigInput = new byte[16384];
-
-        SSLEngineResult cResult;
-        SSLEngineResult sResult;
 
         System.out.print("\tTesting large data transfer");
 
@@ -1620,14 +1728,14 @@ public class WolfSSLEngineTest {
             while (!(client.isOutboundDone() && client.isInboundDone()) &&
                    !(server.isOutboundDone() && server.isInboundDone())) {
 
-                cResult = client.wrap(cOut, clientToServer);
-                sResult = server.wrap(sOut, serverToClient);
+                client.wrap(cOut, clientToServer);
+                server.wrap(sOut, serverToClient);
 
                 clientToServer.flip();
                 serverToClient.flip();
 
-                cResult = client.unwrap(serverToClient, cIn);
-                sResult = server.unwrap(clientToServer, sIn);
+                client.unwrap(serverToClient, cIn);
+                server.unwrap(clientToServer, sIn);
 
                 clientToServer.compact();
                 serverToClient.compact();
@@ -1691,12 +1799,6 @@ public class WolfSSLEngineTest {
         ByteBuffer clientToServer;
         ByteBuffer serverToClient;
 
-        byte[] input1Buf = "Hello client, ".getBytes();
-        byte[] input2Buf = "from server".getBytes();
-
-        SSLEngineResult cResult;
-        SSLEngineResult sResult;
-
         System.out.print("\tTesting split input data");
 
         try {
@@ -1736,14 +1838,14 @@ public class WolfSSLEngineTest {
             while (!(client.isOutboundDone() && client.isInboundDone()) &&
                    !(server.isOutboundDone() && server.isInboundDone())) {
 
-                cResult = client.wrap(cOutBuffs, clientToServer);
-                sResult = server.wrap(sOutBuffs, serverToClient);
+                client.wrap(cOutBuffs, clientToServer);
+                server.wrap(sOutBuffs, serverToClient);
 
                 clientToServer.flip();
                 serverToClient.flip();
 
-                cResult = client.unwrap(serverToClient, cIn);
-                sResult = server.unwrap(clientToServer, sIn);
+                client.unwrap(serverToClient, cIn);
+                server.unwrap(clientToServer, sIn);
 
                 clientToServer.compact();
                 serverToClient.compact();
@@ -1783,6 +1885,141 @@ public class WolfSSLEngineTest {
             fail("failed split input test with Exception");
         }
         pass("\t... passed");
+    }
+
+    @Test
+    public void testDTLSv13Engine()
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               KeyManagementException, KeyStoreException, IOException,
+               CertificateException, UnrecoverableKeyException {
+
+        System.out.print("\tDTLSv1.3 basic connection");
+
+        /* Skip if DTLSv1.3 not enabled */
+        if (!enabledProtocols.contains("DTLSv1.3")) {
+            System.out.println("\t... skipped");
+            return;
+        }
+
+        SSLEngine client = null;
+        SSLEngine server = null;
+
+        try {
+            /* Create SSLContext */
+            this.ctx = tf.createSSLContext("DTLSv1.3", engineProvider);
+
+            /* Create client engine */
+            client = this.ctx.createSSLEngine("wolfSSL client", 11111);
+            client.setUseClientMode(true);
+
+            /* Create server engine */
+            server = this.ctx.createSSLEngine();
+            server.setUseClientMode(false);
+            server.setNeedClientAuth(true);
+
+            /* Test buffer sizes */
+            SSLSession session = client.getSession();
+            assertTrue(session.getApplicationBufferSize() > 0);
+            assertTrue(session.getPacketBufferSize() > 0);
+
+            /* Test handshake with small app data */
+            tf.testConnection(client, server, null, null, "Test Message");
+
+            /* Test handshake with large app data */
+            byte[] largeData = new byte[16384];
+            new Random().nextBytes(largeData);
+            tf.testConnection(client, server, null, null, new String(largeData));
+
+            pass("\t... passed");
+
+        } catch (Exception e) {
+            error("\t... failed");
+            e.printStackTrace();
+            fail("Failed DTLSv1.3 test with exception: " + e);
+        }
+    }
+
+    /**
+     * Internal helper method for testDTLSv13EngineResumeSession.
+     */
+    private void dtls13ResumeTest(String con1Host, String con2Host,
+        boolean expectResume) throws Exception {
+
+        SSLEngine client1 = null;
+        SSLEngine client2 = null;
+        SSLEngine server1 = null;
+        SSLEngine server2 = null;
+        boolean resumed = false;
+
+        /* Create SSLContext */
+        SSLContext dtlsCtx = tf.createSSLContext("DTLSv1.3", engineProvider);
+
+        /* First connection */
+        client1 = dtlsCtx.createSSLEngine(con1Host, 11111);
+        client1.setUseClientMode(true);
+        server1 = dtlsCtx.createSSLEngine();
+        server1.setUseClientMode(false);
+        server1.setNeedClientAuth(true);
+
+        /* First handshake */
+        tf.testConnection(client1, server1, null, null, "First Connection");
+
+        /* Second connection */
+        client2 = dtlsCtx.createSSLEngine(con2Host, 11111);
+        client2.setUseClientMode(true);
+        server2 = dtlsCtx.createSSLEngine();
+        server2.setUseClientMode(false);
+        server2.setNeedClientAuth(true);
+
+        /* Second handshake */
+        tf.testConnection(client2, server2, null, null, "Second Connection");
+
+        /* Verify session was resumed */
+        WolfSSLEngine we = (WolfSSLEngine)client2;
+        resumed = we.sessionResumed();
+
+        if (expectResume && !resumed) {
+            throw new Exception(
+                "Session was not resumed, but should have been");
+        }
+        else if (!expectResume && resumed) {
+            throw new Exception(
+                "Session was resumed, but should not have been");
+        }
+    }
+
+    /**
+     * Test that SSLEngine with DTLSv1.3 resumes (and not) as expected.
+     */
+    @Test
+    public void testDTLSv13EngineResumeSession()
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               KeyManagementException, KeyStoreException, IOException,
+               CertificateException, UnrecoverableKeyException {
+
+        System.out.print("\tDTLSv1.3 session resumption");
+
+        /* Skip if DTLSv1.3 not enabled */
+        if (!enabledProtocols.contains("DTLSv1.3")) {
+            System.out.println("\t... skipped");
+            return;
+        }
+
+        try {
+
+            /* Test expected resumption case */
+            dtls13ResumeTest("wolfSSL client", "wolfSSL client", true);
+            /* Test expected not resumption case */
+            dtls13ResumeTest("wolfSSL client", "wolfSSL client 2", false);
+
+            pass("\t... passed");
+
+        } catch (Exception e) {
+            error("\t... failed");
+            e.printStackTrace();
+            fail("Failed DTLSv1.3 session resumption test " +
+                 "with exception: " + e);
+        }
     }
 }
 

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
@@ -414,47 +414,54 @@ public class WolfSSLSocketTest {
 
             /* test that removing protocols with jdk.tls.disabledAlgorithms
              * behaves as expected */
-            String originalProperty =
-                Security.getProperty("jdk.tls.disabledAlgorithms");
+            synchronized (WolfSSLTestFactory.jdkTlsDisabledAlgorithmsLock) {
+                String originalProperty =
+                    Security.getProperty("jdk.tls.disabledAlgorithms");
 
-            try {
-                Security.setProperty("jdk.tls.disabledAlgorithms", "TLSv1");
-                s.setEnabledProtocols(new String[] {"TLSv1"});
-                System.out.println("\t\t... failed");
-                fail("SSLSocket.setEnabledProtocols() failed");
-            } catch (IllegalArgumentException e) {
-                /* expected */
+                try {
+                    Security.setProperty(
+                        "jdk.tls.disabledAlgorithms", "TLSv1");
+                    s.setEnabledProtocols(new String[] {"TLSv1"});
+                    System.out.println("\t\t... failed");
+                    fail("SSLSocket.setEnabledProtocols() failed");
+                } catch (IllegalArgumentException e) {
+                    /* expected */
+                }
+
+                try {
+                    Security.setProperty(
+                        "jdk.tls.disabledAlgorithms", "TLSv1.1");
+                    s.setEnabledProtocols(new String[] {"TLSv1.1"});
+                    System.out.println("\t\t... failed");
+                    fail("SSLSocket.setEnabledProtocols() failed");
+                } catch (IllegalArgumentException e) {
+                    /* expected */
+                }
+
+                try {
+                    Security.setProperty(
+                        "jdk.tls.disabledAlgorithms", "TLSv1.2");
+                    s.setEnabledProtocols(new String[] {"TLSv1.2"});
+                    System.out.println("\t\t... failed");
+                    fail("SSLSocket.setEnabledProtocols() failed");
+                } catch (IllegalArgumentException e) {
+                    /* expected */
+                }
+
+                try {
+                    Security.setProperty(
+                        "jdk.tls.disabledAlgorithms", "TLSv1.3");
+                    s.setEnabledProtocols(new String[] {"TLSv1.3"});
+                    System.out.println("\t\t... failed");
+                    fail("SSLSocket.setEnabledProtocols() failed");
+                } catch (IllegalArgumentException e) {
+                    /* expected */
+                }
+
+                /* restore original property value */
+                Security.setProperty("jdk.tls.disabledAlgorithms",
+                    originalProperty);
             }
-
-            try {
-                Security.setProperty("jdk.tls.disabledAlgorithms", "TLSv1.1");
-                s.setEnabledProtocols(new String[] {"TLSv1.1"});
-                System.out.println("\t\t... failed");
-                fail("SSLSocket.setEnabledProtocols() failed");
-            } catch (IllegalArgumentException e) {
-                /* expected */
-            }
-
-            try {
-                Security.setProperty("jdk.tls.disabledAlgorithms", "TLSv1.2");
-                s.setEnabledProtocols(new String[] {"TLSv1.2"});
-                System.out.println("\t\t... failed");
-                fail("SSLSocket.setEnabledProtocols() failed");
-            } catch (IllegalArgumentException e) {
-                /* expected */
-            }
-
-            try {
-                Security.setProperty("jdk.tls.disabledAlgorithms", "TLSv1.3");
-                s.setEnabledProtocols(new String[] {"TLSv1.3"});
-                System.out.println("\t\t... failed");
-                fail("SSLSocket.setEnabledProtocols() failed");
-            } catch (IllegalArgumentException e) {
-                /* expected */
-            }
-
-            /* restore original property value */
-            System.setProperty("jdk.tls.disabledAlgorithms", originalProperty);
         }
 
         System.out.println("\t... passed");
@@ -1857,17 +1864,20 @@ public class WolfSSLSocketTest {
 
         /* reset disabledAlgorithms property to test TLS 1.0 which is
          * disabled by default */
-        String originalProperty =
-            Security.getProperty("jdk.tls.disabledAlgorithms");
-        Security.setProperty("jdk.tls.disabledAlgorithms", "");
+        synchronized (WolfSSLTestFactory.jdkTlsDisabledAlgorithmsLock) {
+            String originalProperty =
+                Security.getProperty("jdk.tls.disabledAlgorithms");
+            Security.setProperty("jdk.tls.disabledAlgorithms", "");
 
-        protocolConnectionTest("TLSv1");
+            protocolConnectionTest("TLSv1");
 
-        System.out.print("\tTLS 1.0 extended Socket test");
-        protocolConnectionTestExtendedSocket("TLSv1");
+            System.out.print("\tTLS 1.0 extended Socket test");
+            protocolConnectionTestExtendedSocket("TLSv1");
 
-        /* restore system property */
-        Security.setProperty("jdk.tls.disabledAlgorithms", originalProperty);
+            /* restore system property */
+            Security.setProperty(
+                "jdk.tls.disabledAlgorithms", originalProperty);
+        }
     }
 
     @Test
@@ -1883,17 +1893,20 @@ public class WolfSSLSocketTest {
 
         /* reset disabledAlgorithms property to test TLS 1.1 which is
          * disabled by default */
-        String originalProperty =
-            Security.getProperty("jdk.tls.disabledAlgorithms");
-        Security.setProperty("jdk.tls.disabledAlgorithms", "");
+        synchronized (WolfSSLTestFactory.jdkTlsDisabledAlgorithmsLock) {
+            String originalProperty =
+                Security.getProperty("jdk.tls.disabledAlgorithms");
+            Security.setProperty("jdk.tls.disabledAlgorithms", "");
 
-        protocolConnectionTest("TLSv1.1");
+            protocolConnectionTest("TLSv1.1");
 
-        System.out.print("\tTLS 1.1 extended Socket test");
-        protocolConnectionTestExtendedSocket("TLSv1.1");
+            System.out.print("\tTLS 1.1 extended Socket test");
+            protocolConnectionTestExtendedSocket("TLSv1.1");
 
-        /* restore system property */
-        Security.setProperty("jdk.tls.disabledAlgorithms", originalProperty);
+            /* restore system property */
+            Security.setProperty(
+                "jdk.tls.disabledAlgorithms", originalProperty);
+        }
     }
 
     @Test
@@ -1902,17 +1915,19 @@ public class WolfSSLSocketTest {
         System.out.print("\tTLS 1.2 connection test");
 
         /* skip if TLS 1.2 is not compiled in at native level */
-        if (WolfSSL.TLSv12Enabled() == false ||
-            WolfSSLTestFactory.securityPropContains(
-                "jdk.tls.disabledAlgorithms", "TLSv1.2")) {
-            System.out.println("\t\t... skipped");
-            return;
+        synchronized (WolfSSLTestFactory.jdkTlsDisabledAlgorithmsLock) {
+            if (WolfSSL.TLSv12Enabled() == false ||
+                WolfSSLTestFactory.securityPropContains(
+                    "jdk.tls.disabledAlgorithms", "TLSv1.2")) {
+                System.out.println("\t\t... skipped");
+                return;
+            }
+
+            protocolConnectionTest("TLSv1.2");
+
+            System.out.print("\tTLS 1.2 extended Socket test");
+            protocolConnectionTestExtendedSocket("TLSv1.2");
         }
-
-        protocolConnectionTest("TLSv1.2");
-
-        System.out.print("\tTLS 1.2 extended Socket test");
-        protocolConnectionTestExtendedSocket("TLSv1.2");
     }
 
     @Test
@@ -1921,17 +1936,19 @@ public class WolfSSLSocketTest {
         System.out.print("\tTLS 1.3 connection test");
 
         /* skip if TLS 1.3 is not compiled in at native level */
-        if (WolfSSL.TLSv13Enabled() == false ||
-            WolfSSLTestFactory.securityPropContains(
-                "jdk.tls.disabledAlgorithms", "TLSv1.3")) {
-            System.out.println("\t\t... skipped");
-            return;
+        synchronized (WolfSSLTestFactory.jdkTlsDisabledAlgorithmsLock) {
+            if (WolfSSL.TLSv13Enabled() == false ||
+                WolfSSLTestFactory.securityPropContains(
+                    "jdk.tls.disabledAlgorithms", "TLSv1.3")) {
+                System.out.println("\t\t... skipped");
+                return;
+            }
+
+            protocolConnectionTest("TLSv1.3");
+
+            System.out.print("\tTLS 1.3 extended Socket test");
+            protocolConnectionTestExtendedSocket("TLSv1.3");
         }
-
-        protocolConnectionTest("TLSv1.3");
-
-        System.out.print("\tTLS 1.3 extended Socket test");
-        protocolConnectionTestExtendedSocket("TLSv1.3");
     }
 
     private void protocolConnectionTest(String protocol) throws Exception {
@@ -2119,47 +2136,51 @@ public class WolfSSLSocketTest {
         this.ctx = tf.createSSLContext("TLS", ctxProvider);
 
         /* save current system property value */
-        String originalProperty =
-            Security.getProperty("jdk.tls.disabledAlgorithms");
+        synchronized (WolfSSLTestFactory.jdkTlsDisabledAlgorithmsLock) {
+            String originalProperty =
+                Security.getProperty("jdk.tls.disabledAlgorithms");
 
-        for (int i = 0; i < enabledProtocols.size(); i++) {
+            for (int i = 0; i < enabledProtocols.size(); i++) {
 
-            /* skip generic "TLS" */
-            if (enabledProtocols.get(i).equals("TLS")) {
-                continue;
+                /* skip generic "TLS" */
+                if (enabledProtocols.get(i).equals("TLS")) {
+                    continue;
+                }
+
+                /* create SSLServerSocket first to get ephemeral port */
+                SSLServerSocket ss =
+                    (SSLServerSocket)ctx.getServerSocketFactory()
+                    .createServerSocket(0);
+
+                SSLSocket cs = (SSLSocket)ctx.getSocketFactory().createSocket();
+                /* restrict to single protocol that is being disabled */
+                cs.setEnabledProtocols(new String[] {enabledProtocols.get(i)});
+
+                /* disable protocol after socket setup, should fail conn */
+                Security.setProperty("jdk.tls.disabledAlgorithms",
+                        enabledProtocols.get(i));
+
+                /* don't need server since should throw exception before */
+                cs.connect(new InetSocketAddress(ss.getLocalPort()));
+
+                try {
+                    cs.startHandshake();
+                    System.out.println("\t... failed");
+                    fail();
+
+                } catch (SSLException e) {
+                    /* expected, should fail with
+                     * "No protocols enabled or available" */
+                }
+
+                cs.close();
+                ss.close();
             }
 
-            /* create SSLServerSocket first to get ephemeral port */
-            SSLServerSocket ss = (SSLServerSocket)ctx.getServerSocketFactory()
-                .createServerSocket(0);
-
-            SSLSocket cs = (SSLSocket)ctx.getSocketFactory().createSocket();
-            /* restrict to single protocol that is being disabled */
-            cs.setEnabledProtocols(new String[] {enabledProtocols.get(i)});
-
-            /* disable protocol after socket setup, should fail connection */
-            Security.setProperty("jdk.tls.disabledAlgorithms",
-                    enabledProtocols.get(i));
-
-            /* don't need server since should throw exception before */
-            cs.connect(new InetSocketAddress(ss.getLocalPort()));
-
-            try {
-                cs.startHandshake();
-                System.out.println("\t... failed");
-                fail();
-
-            } catch (SSLException e) {
-                /* expected, should fail with
-                 * "No protocols enabled or available" */
-            }
-
-            cs.close();
-            ss.close();
+            /* restore system property */
+            Security.setProperty(
+                "jdk.tls.disabledAlgorithms", originalProperty);
         }
-
-        /* restore system property */
-        Security.setProperty("jdk.tls.disabledAlgorithms", originalProperty);
 
         System.out.println("\t... passed");
     }

--- a/src/test/com/wolfssl/test/WolfSSLTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLTest.java
@@ -27,6 +27,9 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import static org.junit.Assert.*;
 
+import java.util.Arrays;
+import java.util.List;
+
 import com.wolfssl.WolfSSL;
 import com.wolfssl.WolfSSLException;
 
@@ -85,20 +88,45 @@ public class WolfSSLTest {
     }
 
     public void test_WolfSSL_Method_Allocators(WolfSSL lib) {
-        tstMethod(WolfSSL.SSLv3_ServerMethod(), "SSLv3_ServerMethod()");
-        tstMethod(WolfSSL.SSLv3_ClientMethod(), "SSLv3_ClientMethod()");
-        tstMethod(WolfSSL.TLSv1_ServerMethod(), "TLSv1_ServerMethod()");
-        tstMethod(WolfSSL.TLSv1_ClientMethod(), "TLSv1_ClientMethod()");
-        tstMethod(WolfSSL.TLSv1_1_ServerMethod(), "TLSv1_1_ServerMethod()");
-        tstMethod(WolfSSL.TLSv1_1_ClientMethod(), "TLSv1_1_ClientMethod()");
-        tstMethod(WolfSSL.TLSv1_2_ServerMethod(), "TLSv1_2_ServerMethod()");
-        tstMethod(WolfSSL.TLSv1_2_ClientMethod(), "TLSv1_2_ClientMethod()");
-        tstMethod(WolfSSL.TLSv1_3_ServerMethod(), "TLSv1_3_ServerMethod()");
-        tstMethod(WolfSSL.TLSv1_3_ClientMethod(), "TLSv1_3_ClientMethod()");
-        tstMethod(WolfSSL.DTLSv1_ServerMethod(), "DTLSv1_ServerMethod()");
-        tstMethod(WolfSSL.DTLSv1_ClientMethod(), "DTLSv1_ClientMethod()");
-        tstMethod(WolfSSL.DTLSv1_2_ServerMethod(), "DTLSv1_2_ServerMethod()");
-        tstMethod(WolfSSL.DTLSv1_2_ClientMethod(), "DTLSv1_2_ClientMethod()");
+        /* Get protocols compiled into native wolfSSL */
+        List<String> enabledProtocols = Arrays.asList(WolfSSL.getProtocols());
+
+        if (enabledProtocols.contains("SSLv3")) {
+            tstMethod(WolfSSL.SSLv3_ServerMethod(), "SSLv3_ServerMethod()");
+            tstMethod(WolfSSL.SSLv3_ClientMethod(), "SSLv3_ClientMethod()");
+        }
+        if (enabledProtocols.contains("TLSv1")) {
+            tstMethod(WolfSSL.TLSv1_ServerMethod(), "TLSv1_ServerMethod()");
+            tstMethod(WolfSSL.TLSv1_ClientMethod(), "TLSv1_ClientMethod()");
+        }
+        if (enabledProtocols.contains("TLSv1.1")) {
+            tstMethod(WolfSSL.TLSv1_1_ServerMethod(), "TLSv1_1_ServerMethod()");
+            tstMethod(WolfSSL.TLSv1_1_ClientMethod(), "TLSv1_1_ClientMethod()");
+        }
+        if (enabledProtocols.contains("TLSv1.2")) {
+            tstMethod(WolfSSL.TLSv1_2_ServerMethod(), "TLSv1_2_ServerMethod()");
+            tstMethod(WolfSSL.TLSv1_2_ClientMethod(), "TLSv1_2_ClientMethod()");
+        }
+        if (enabledProtocols.contains("TLSv1.3")) {
+            tstMethod(WolfSSL.TLSv1_3_ServerMethod(), "TLSv1_3_ServerMethod()");
+            tstMethod(WolfSSL.TLSv1_3_ClientMethod(), "TLSv1_3_ClientMethod()");
+        }
+        if (enabledProtocols.contains("DTLSv1")) {
+            tstMethod(WolfSSL.DTLSv1_ServerMethod(), "DTLSv1_ServerMethod()");
+            tstMethod(WolfSSL.DTLSv1_ClientMethod(), "DTLSv1_ClientMethod()");
+        }
+        if (enabledProtocols.contains("DTLSv1.2")) {
+            tstMethod(WolfSSL.DTLSv1_2_ServerMethod(),
+                "DTLSv1_2_ServerMethod()");
+            tstMethod(WolfSSL.DTLSv1_2_ClientMethod(),
+                "DTLSv1_2_ClientMethod()");
+        }
+        if (enabledProtocols.contains("DTLSv1.3")) {
+            tstMethod(WolfSSL.DTLSv1_3_ServerMethod(),
+                "DTLSv1_3_ServerMethod()");
+            tstMethod(WolfSSL.DTLSv1_3_ClientMethod(),
+                "DTLSv1_3_ClientMethod()");
+        }
         tstMethod(WolfSSL.SSLv23_ServerMethod(), "SSLv23_ServerMethod()");
         tstMethod(WolfSSL.SSLv23_ClientMethod(), "SSLv23_ClientMethod()");
     }


### PR DESCRIPTION
This PR adds DTLS 1.3 support to the wolfJSSE `SSLContext` class, for use through the `SSLEngine` interface. SunJSSE supports up to DTLS 1.2 through the SSLEngine interface, so we are matching similar behavior here for DTLS 1.3.

To support this addition, this PR also makes the following changes:
- Adds DTLS 1.3 to the thin JNI-only layer
- Wraps `wolfSSL_DisableExtendedMasterSecret()`
- Adds support for the Java system property: `jdk.tls.useExtendedMasterSecret` for enabling or disabling the TLS Extended Master Secret (EMS) extension. Enabled by default unless explicitly disabled.
- Wraps `wolfSSL_send_hrr_cookie()` in `WolfSSLSession.sendHrrCookie()` for enabling HelloRetryRequest use in SSLEngine DTLS support.
- Wraps `wolfSSL_dtls_get_drop_stats()` for use in SSLEngine DTLS detection of dropped packets to properly set `BUFFER_UNDERFLOW` status.
- Wrap `wolfSSL_set_SessionTicket_cb()` and add session ticket callback support to SSLEngine for detection of ticket being received.

**wolfSSL Configuration**

When testing this work, wolfSSL was configured using:

```
./configure --enable-jni --enable-dtls --enable-dtls13 --enable-dtls-mtu --enable-hrrcookie --enable-debug CFLAGS="-DWOLFSSL_DTLS_DROP_STATS"
```

Native wolfSSL's build option for `--enable-jni` will be updated to include these definitions by default, with https://github.com/wolfSSL/wolfssl/pull/8481.

**Testing**

Simple JUnit tests for SSLEngine DTLSv1.3 have been added with this PR.  This has also been tested against modified versions of the SunJSSE DTLS tests, specifically:

```
Passed: javax/net/ssl/DTLS/CipherSuite.java
Passed: javax/net/ssl/DTLS/ClientAuth.java
Passed: javax/net/ssl/DTLS/DTLSBufferOverflowUnderflowTest.java
Passed: javax/net/ssl/DTLS/DTLSDataExchangeTest.java
Passed: javax/net/ssl/DTLS/DTLSEnginesClosureTest.java
Passed: javax/net/ssl/DTLS/DTLSHandshakeTest.java
Passed: javax/net/ssl/DTLS/DTLSHandshakeWithReplicatedPacketsTest.java
Passed: javax/net/ssl/DTLS/DTLSIncorrectAppDataTest.java
Passed: javax/net/ssl/DTLS/DTLSNotEnabledRC4Test.java
Passed: javax/net/ssl/DTLS/DTLSOverDatagram.java
Passed: javax/net/ssl/DTLS/DTLSUnsupportedCiphersTest.java
Passed: javax/net/ssl/DTLS/InvalidCookie.java
Passed: javax/net/ssl/DTLS/PacketLossRetransmission.java
Passed: javax/net/ssl/DTLS/Reordered.java
Passed: javax/net/ssl/DTLS/RespondToRetransmit.java
Passed: javax/net/ssl/DTLS/Retransmission.java
```

A PR to the testing repo has been opened here: https://github.com/wolfSSL/testing/pull/844.  A nightly Jenkins test will be created based on the test script in that PR.

**Examples**

JNI-level example client and server can be run with DTLS 1.3 support using:

```
$ ant examples
$ ./examples/server.sh -u -v 4
$ ./examples/client.sh -u -v 4
```

**Future Work**

- Add JSSE level example client/server that supports DTLS 1.3
- Add `SSLContext('DTLS')` general mapping
- Add `SSLContext('DTLSv1.2')` for DTLS 1.2 support
- Add support for "special" features of DTLS 1.3, this PR brings in basic functionality