### PR TITLE
Fix TLS 1.3 session resumption to preserve SNI extension

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
@@ -2073,6 +2073,17 @@ public class WolfSSLEngine extends SSLEngine {
             "entered setSSLParameters()");
         if (params != null) {
             WolfSSLParametersHelper.importParams(params, this.params);
+
+            /* Store SNI server names in the session for potential resumption */
+            if (params.getServerNames() != null && !params.getServerNames().isEmpty()) {
+                WolfSSLImplementSSLSession session =
+                    (WolfSSLImplementSSLSession)this.getSession();
+                if (session != null) {
+                    session.setSNIServerNames(params.getServerNames());
+                    WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                            "Captured SNI server names for session caching");
+                }
+            }
         }
     }
 


### PR DESCRIPTION
- Fixes the test SSLSession/ResumeTLS13WithSNI.java (SunJSSE);
- Adds SNI storing (and restoring) at the wolfJSSE level on session resumption for TLS 1.3;

Note: Requires `-DWOLFSSL_TLS13_MIDDLEBOX_COMPAT` to be enabled.