### PR TITLE
WolfSSLSession.getPeerCertificates(): provide full cert chain

### DIFF
--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -2858,8 +2858,28 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_sessionReused
     return wolfSSL_session_reused(ssl);
 }
 
-JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_getPeerCertificate
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getPeerCertificateCount
   (JNIEnv* jenv, jobject jcl, jlong sslPtr)
+{
+#ifdef KEEP_PEER_CERT
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
+    (void)jenv;
+    (void)jcl;
+    if (ssl == NULL) {
+        return (jlong)0;
+    }
+    WOLFSSL_X509_CHAIN* chain = wolfSSL_get_peer_chain(ssl);
+    return wolfSSL_get_chain_count(chain);
+#else
+    (void)jenv;
+    (void)jcl;
+    (void)sslPtr;
+    return 0;
+#endif
+}
+
+JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_getPeerCertificate
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr, jint index)
 {
 #ifdef KEEP_PEER_CERT
     WOLFSSL_X509* x509 = NULL;
@@ -2870,8 +2890,8 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_getPeerCertificate
     if (ssl == NULL) {
         return (jlong)0;
     }
-
-    x509 = wolfSSL_get_peer_certificate(ssl);
+    WOLFSSL_X509_CHAIN* chain = wolfSSL_get_peer_chain(ssl);
+    x509 = wolfSSL_get_chain_X509(chain, index);
 
     return (jlong)(uintptr_t)x509;
 #else

--- a/native/com_wolfssl_WolfSSLSession.h
+++ b/native/com_wolfssl_WolfSSLSession.h
@@ -353,11 +353,19 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_sessionReused
 
 /*
  * Class:     com_wolfssl_WolfSSLSession
+ * Method:    getPeerCertificateCount
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getPeerCertificateCount
+  (JNIEnv *, jobject, jlong);
+
+/*
+ * Class:     com_wolfssl_WolfSSLSession
  * Method:    getPeerCertificate
- * Signature: (J)J
+ * Signature: (JI)J
  */
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_getPeerCertificate
-  (JNIEnv *, jobject, jlong);
+  (JNIEnv *, jobject, jlong, jint);
 
 /*
  * Class:     com_wolfssl_WolfSSLSession

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -358,7 +358,8 @@ public class WolfSSLSession {
     private native long getDtlsReplayDropCount(long ssl);
     private native InetSocketAddress dtlsGetPeer(long ssl);
     private native int sessionReused(long ssl);
-    private native long getPeerCertificate(long ssl);
+    private native int getPeerCertificateCount(long ssl);
+    private native long getPeerCertificate(long ssl, int index);
     private native String getPeerX509Issuer(long ssl, long x509);
     private native String getPeerX509Subject(long ssl, long x509);
     private native String getPeerX509AltName(long ssl, long x509);
@@ -2591,6 +2592,27 @@ public class WolfSSLSession {
     }
 
     /**
+     * Returns the number of certificates in the peer's certificate chain.
+     *
+     * @return number of certificates in the peer's certificate chain.
+     * @throws IllegalStateException WolfSSLContext has been freed
+     * @throws WolfSSLJNIException Internal JNI error
+     * @see    WolfSSLSession#getPeerCertificate(int)
+     */
+    public int getPeerCertificateCount()
+        throws IllegalStateException, WolfSSLJNIException {
+
+        confirmObjectIsActive();
+
+        synchronized (sslLock) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.sslPtr, "entered getPeerCertificateCount()");
+
+            return getPeerCertificateCount(this.sslPtr);
+        }
+    }
+
+    /**
      * Gets the native (long) WOLFSSL_X509 pointer to the peer's certificate.
      * This can be used to retrieve further information about the peer's
      * certificate (issuer, subject, alt name, etc.)
@@ -2606,6 +2628,7 @@ public class WolfSSLSession {
      * Pointer should be freed by calling:
      *     WolfSSLCertificate.freeX509(long x509);
      *
+     * @param index index of the certificate in the peer's certificate chain
      * @return (long) WOLFSSL_X509 pointer to the peer's certificate.
      * @throws IllegalStateException WolfSSLContext has been freed
      * @throws WolfSSLJNIException Internal JNI error
@@ -2614,7 +2637,7 @@ public class WolfSSLSession {
      * @see    WolfSSLSession#getVersion()
      * @see    WolfSSLSession#getCurrentCipher()
      */
-    public long getPeerCertificate()
+    public long getPeerCertificate(int index)
         throws IllegalStateException, WolfSSLJNIException {
 
         confirmObjectIsActive();
@@ -2623,7 +2646,7 @@ public class WolfSSLSession {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr, "entered getPeerCertificate()");
 
-            return getPeerCertificate(this.sslPtr);
+            return getPeerCertificate(this.sslPtr, index);
         }
     }
 


### PR DESCRIPTION
This is needed for Certificate Pinning which is a common practice in Android applications.

This patch comes from the Android Translation Layer project, see https://gitlab.com/android_translation_layer/art_standalone/-/merge_requests/30 . Maybe it could be helpful for other people as well.