### PR TITLE
SSLEngine Performance Optimizations

### DIFF
--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -181,6 +181,32 @@ JNIEXPORT void JNICALL JNI_OnUnload(JavaVM* vm, void* reserved)
     g_verifyCallbackMethodId = NULL;
 }
 
+/**
+ * Throw WolfSSLJNIException
+ */
+void throwWolfSSLJNIException(JNIEnv* jenv, const char* msg)
+{
+    jclass excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLJNIException");
+    if (excClass == NULL) {
+        /* Unable to find exception class, give up trying to throw */
+        return;
+    }
+    (*jenv)->ThrowNew(jenv, excClass, msg);
+}
+
+/**
+ * Throw WolfSSLException
+ */
+void throwWolfSSLException(JNIEnv* jenv, const char* msg)
+{
+    jclass excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
+    if (excClass == NULL) {
+        /* Unable to find exception class, give up trying to throw */
+        return;
+    }
+    (*jenv)->ThrowNew(jenv, excClass, msg);
+}
+
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_init
   (JNIEnv* jenv, jobject jcl)
 {

--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -55,7 +55,13 @@ static jobject g_loggingCbIfaceObj;
 
 /* global method IDs we can cache for performance */
 jmethodID g_sslIORecvMethodId = NULL;
+jmethodID g_sslIORecvMethodId_BB = NULL;
 jmethodID g_sslIOSendMethodId = NULL;
+jmethodID g_sslIOSendMethodId_BB = NULL;
+jmethodID g_isArrayIORecvCallbackSet = NULL;
+jmethodID g_isArrayIOSendCallbackSet = NULL;
+jmethodID g_isByteBufferIORecvCallbackSet = NULL;
+jmethodID g_isByteBufferIOSendCallbackSet = NULL;
 jmethodID g_bufferPositionMethodId = NULL;
 jmethodID g_bufferLimitMethodId = NULL;
 jmethodID g_bufferHasArrayMethodId = NULL;
@@ -99,10 +105,54 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved)
     g_sslIORecvMethodId = (*env)->GetMethodID(env, sslClass,
         "internalIOSSLRecvCallback",
         "(Lcom/wolfssl/WolfSSLSession;[BI)I");
+    if (g_sslIORecvMethodId == NULL) {
+        return JNI_ERR;
+    }
+
+    g_sslIORecvMethodId_BB = (*env)->GetMethodID(env, sslClass,
+        "internalIOSSLRecvCallback",
+        "(Lcom/wolfssl/WolfSSLSession;Ljava/nio/ByteBuffer;I)I");
+    if (g_sslIORecvMethodId_BB == NULL) {
+        return JNI_ERR;
+    }
 
     g_sslIOSendMethodId = (*env)->GetMethodID(env, sslClass,
         "internalIOSSLSendCallback",
         "(Lcom/wolfssl/WolfSSLSession;[BI)I");
+    if (g_sslIOSendMethodId == NULL) {
+        return JNI_ERR;
+    }
+
+    g_sslIOSendMethodId_BB = (*env)->GetMethodID(env, sslClass,
+        "internalIOSSLSendCallback",
+        "(Lcom/wolfssl/WolfSSLSession;Ljava/nio/ByteBuffer;I)I");
+    if (g_sslIOSendMethodId_BB == NULL) {
+        return JNI_ERR;
+    }
+
+    g_isArrayIORecvCallbackSet = (*env)->GetMethodID(env, sslClass,
+        "isArrayIORecvCallbackSet", "()Z");
+    if (g_isArrayIORecvCallbackSet == NULL) {
+        return JNI_ERR;
+    }
+
+    g_isArrayIOSendCallbackSet = (*env)->GetMethodID(env, sslClass,
+        "isArrayIOSendCallbackSet", "()Z");
+    if (g_isArrayIOSendCallbackSet == NULL) {
+        return JNI_ERR;
+    }
+
+    g_isByteBufferIORecvCallbackSet = (*env)->GetMethodID(env, sslClass,
+        "isByteBufferIORecvCallbackSet", "()Z");
+    if (g_isByteBufferIORecvCallbackSet == NULL) {
+        return JNI_ERR;
+    }
+
+    g_isByteBufferIOSendCallbackSet = (*env)->GetMethodID(env, sslClass,
+        "isByteBufferIOSendCallbackSet", "()Z");
+    if (g_isByteBufferIOSendCallbackSet == NULL) {
+        return JNI_ERR;
+    }
 
     /* Cache ByteBuffer method IDs */
     byteBufferClass = (*env)->FindClass(env, "java/nio/ByteBuffer");
@@ -172,7 +222,13 @@ JNIEXPORT void JNICALL JNI_OnUnload(JavaVM* vm, void* reserved)
 
     /* Clear cached method ID */
     g_sslIORecvMethodId = NULL;
+    g_sslIORecvMethodId_BB = NULL;
     g_sslIOSendMethodId = NULL;
+    g_sslIOSendMethodId_BB = NULL;
+    g_isArrayIORecvCallbackSet = NULL;
+    g_isArrayIOSendCallbackSet = NULL;
+    g_isByteBufferIORecvCallbackSet = NULL;
+    g_isByteBufferIOSendCallbackSet = NULL;
     g_bufferPositionMethodId = NULL;
     g_bufferLimitMethodId = NULL;
     g_bufferHasArrayMethodId = NULL;

--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -53,6 +53,16 @@ JavaVM*  g_vm;
 /* global object refs for logging callbacks */
 static jobject g_loggingCbIfaceObj;
 
+/* global method IDs we can cache for performance */
+jmethodID g_sslIORecvMethodId = NULL;
+jmethodID g_sslIOSendMethodId = NULL;
+jmethodID g_bufferPositionMethodId = NULL;
+jmethodID g_bufferLimitMethodId = NULL;
+jmethodID g_bufferHasArrayMethodId = NULL;
+jmethodID g_bufferArrayMethodId = NULL;
+jmethodID g_bufferSetPositionMethodId = NULL;
+jmethodID g_verifyCallbackMethodId = NULL;
+
 #ifdef HAVE_FIPS
 /* global object ref for FIPS error callback */
 static jobject g_fipsCbIfaceObj;
@@ -61,14 +71,114 @@ static jobject g_fipsCbIfaceObj;
 /* custom native fn prototypes */
 void NativeLoggingCallback(const int logLevel, const char *const logMessage);
 
-/* called when native library is loaded */
+/* Called when native library is loaded.
+ * We also cache global jmethodIDs here for performance. */
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved)
 {
+    JNIEnv* env = NULL;
+    jclass sslClass = NULL;
+    jclass byteBufferClass = NULL;
+    jclass verifyClass = NULL;
     (void)reserved;
 
     /* store JavaVM */
     g_vm = vm;
+
+    /* get JNIEnv from JavaVM */
+    if ((*vm)->GetEnv(vm, (void**)&env, JNI_VERSION_1_6) != JNI_OK) {
+        printf("Unable to get JNIEnv from JavaVM in JNI_OnLoad()\n");
+        return JNI_ERR;
+    }
+
+    /* Cache the method ID for IO send and recv callbacks */
+    sslClass = (*env)->FindClass(env, "com/wolfssl/WolfSSLSession");
+    if (sslClass == NULL) {
+        return JNI_ERR;
+    }
+
+    g_sslIORecvMethodId = (*env)->GetMethodID(env, sslClass,
+        "internalIOSSLRecvCallback",
+        "(Lcom/wolfssl/WolfSSLSession;[BI)I");
+
+    g_sslIOSendMethodId = (*env)->GetMethodID(env, sslClass,
+        "internalIOSSLSendCallback",
+        "(Lcom/wolfssl/WolfSSLSession;[BI)I");
+
+    /* Cache ByteBuffer method IDs */
+    byteBufferClass = (*env)->FindClass(env, "java/nio/ByteBuffer");
+    if (byteBufferClass == NULL) {
+        return JNI_ERR;
+    }
+
+    g_bufferPositionMethodId = (*env)->GetMethodID(env, byteBufferClass,
+        "position", "()I");
+    if (g_bufferPositionMethodId == NULL) {
+        return JNI_ERR;
+    }
+
+    g_bufferLimitMethodId = (*env)->GetMethodID(env, byteBufferClass,
+        "limit", "()I");
+    if (g_bufferLimitMethodId == NULL) {
+        return JNI_ERR;
+    }
+
+    g_bufferHasArrayMethodId = (*env)->GetMethodID(env, byteBufferClass,
+        "hasArray", "()Z");
+    if (g_bufferHasArrayMethodId == NULL) {
+        return JNI_ERR;
+    }
+
+    g_bufferArrayMethodId = (*env)->GetMethodID(env, byteBufferClass,
+        "array", "()[B");
+    if (g_bufferArrayMethodId == NULL) {
+        return JNI_ERR;
+    }
+
+    g_bufferSetPositionMethodId = (*env)->GetMethodID(env, byteBufferClass,
+        "position", "(I)Ljava/nio/Buffer;");
+    if (g_bufferSetPositionMethodId == NULL) {
+        return JNI_ERR;
+    }
+
+    /* Cache verify callback method ID */
+    verifyClass = (*env)->FindClass(env, "com/wolfssl/WolfSSLVerifyCallback");
+    if (verifyClass == NULL) {
+        return JNI_ERR;
+    }
+
+    g_verifyCallbackMethodId = (*env)->GetMethodID(env, verifyClass,
+        "verifyCallback", "(IJ)I");
+    if (g_verifyCallbackMethodId == NULL) {
+        return JNI_ERR;
+    }
+
+    /* Clean up local reference to class, not needed */
+    (*env)->DeleteLocalRef(env, sslClass);
+    (*env)->DeleteLocalRef(env, byteBufferClass);
+    (*env)->DeleteLocalRef(env, verifyClass);
+
     return JNI_VERSION_1_6;
+}
+
+/* Called when native library is unloaded.
+ * We clear cached method IDs here. */
+JNIEXPORT void JNICALL JNI_OnUnload(JavaVM* vm, void* reserved)
+{
+    JNIEnv* env;
+
+    if ((*vm)->GetEnv(vm, (void**)&env, JNI_VERSION_1_6) != JNI_OK) {
+        return;
+    }
+
+    /* Clear cached method ID */
+    g_sslIORecvMethodId = NULL;
+    g_sslIOSendMethodId = NULL;
+    g_bufferPositionMethodId = NULL;
+    g_bufferLimitMethodId = NULL;
+    g_bufferHasArrayMethodId = NULL;
+    g_bufferArrayMethodId = NULL;
+    g_bufferSetPositionMethodId = NULL;
+    g_verifyCallbackMethodId = NULL;
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_init

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -102,7 +102,6 @@ int NativeSSLVerifyCallback(int preverify_ok, WOLFSSL_X509_STORE_CTX* store)
     JNIEnv*   jenv;
     jint      vmret  = 0;
     jint      retval = -1;
-    jclass    excClass;
     jobjectRefType refcheck;
     SSLAppData* appData;            /* WOLFSSL app data, stored verify cb obj */
     jobject* g_verifySSLCbIfaceObj;  /* Global jobject, stored in app data */
@@ -125,14 +124,6 @@ int NativeSSLVerifyCallback(int preverify_ok, WOLFSSL_X509_STORE_CTX* store)
         }
     } else if (vmret != JNI_OK) {
         return -102;        /* unable to get JNIEnv from JavaVM */
-    }
-
-    /* find exception class */
-    excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-    if( (*jenv)->ExceptionOccurred(jenv)) {
-        (*jenv)->ExceptionDescribe(jenv);
-        (*jenv)->ExceptionClear(jenv);
-        return -103;
     }
 
     /* get app data to retrieve stored Java jobject callback object */
@@ -160,7 +151,7 @@ int NativeSSLVerifyCallback(int preverify_ok, WOLFSSL_X509_STORE_CTX* store)
                 (*jenv)->ExceptionClear(jenv);
             }
 
-            (*jenv)->ThrowNew(jenv, excClass,
+            throwWolfSSLJNIException(jenv,
                 "verifyCallback method ID is null in NativeSSLVerifyCallback");
             return -107;
         }
@@ -182,7 +173,7 @@ int NativeSSLVerifyCallback(int preverify_ok, WOLFSSL_X509_STORE_CTX* store)
             (*jenv)->ExceptionClear(jenv);
         }
 
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLJNIException(jenv,
                 "Object reference invalid in NativeSSLVerifyCallback");
         return -1;
     }
@@ -694,7 +685,6 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useCertificateChainFile
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setUsingNonblock
   (JNIEnv* jenv, jobject jcl, jlong sslPtr, jint nonblock)
 {
-    jclass excClass;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
@@ -703,13 +693,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setUsingNonblock
     }
 
     if (ssl == NULL) {
-        excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-        if ((*jenv)->ExceptionOccurred(jenv)) {
-            (*jenv)->ExceptionDescribe(jenv);
-            (*jenv)->ExceptionClear(jenv);
-            return;
-        }
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLJNIException(jenv,
                 "Input WolfSSLSession object was null in setUsingNonblock");
     }
 
@@ -719,7 +703,6 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setUsingNonblock
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getUsingNonblock
   (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
-    jclass excClass;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
@@ -728,13 +711,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getUsingNonblock
     }
 
     if (ssl == NULL) {
-        excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-        if ((*jenv)->ExceptionOccurred(jenv)) {
-            (*jenv)->ExceptionDescribe(jenv);
-            (*jenv)->ExceptionClear(jenv);
-            return 0;
-        }
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLJNIException(jenv,
                 "Input WolfSSLSession object was null in getUsingNonblock");
     }
 
@@ -744,7 +721,6 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getUsingNonblock
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getFd
   (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
-    jclass excClass;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
@@ -753,13 +729,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getFd
     }
 
     if (ssl == NULL) {
-        excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-        if ((*jenv)->ExceptionOccurred(jenv)) {
-            (*jenv)->ExceptionDescribe(jenv);
-            (*jenv)->ExceptionClear(jenv);
-            return 0;
-        }
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLJNIException(jenv,
                 "Input WolfSSLSession object was null in getFd");
         return 0;
     }
@@ -1399,7 +1369,6 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_read__JLjava_nio_ByteBuff
     int outSz = length;
     byte* data = NULL;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
-    jclass excClass;
 
     jint position;
     jint limit;
@@ -1413,14 +1382,6 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_read__JLjava_nio_ByteBuff
     }
 
     if (length > 0) {
-        /* Get WolfSSLException class */
-        excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-        if ((*jenv)->ExceptionOccurred(jenv)) {
-            (*jenv)->ExceptionDescribe(jenv);
-            (*jenv)->ExceptionClear(jenv);
-            return -1;
-        }
-
         /* Get ByteBuffer position */
         position = (*jenv)->CallIntMethod(jenv, buf, g_bufferPositionMethodId);
 
@@ -1447,7 +1408,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_read__JLjava_nio_ByteBuff
             if ((*jenv)->ExceptionOccurred(jenv)) {
                 (*jenv)->ExceptionDescribe(jenv);
                 (*jenv)->ExceptionClear(jenv);
-                (*jenv)->ThrowNew(jenv, excClass,
+                throwWolfSSLJNIException(jenv,
                     "Exception when calling ByteBuffer.array() in native read()");
                 return -1;
             }
@@ -1455,7 +1416,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_read__JLjava_nio_ByteBuff
         else {
             data = (byte *)(*jenv)->GetDirectBufferAddress(jenv, buf);
             if (data == NULL) {
-                (*jenv)->ThrowNew(jenv, excClass,
+                throwWolfSSLJNIException(jenv,
                     "Failed to get DirectBuffer address in native read()");
                 return BAD_FUNC_ARG;
             }
@@ -1611,7 +1572,6 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_freeSSL
 {
     jobject* g_cachedSSLObj;
     jobject* g_cachedVerifyCb;
-    jclass excClass;
     SSLAppData* appData;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
@@ -1619,16 +1579,9 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_freeSSL
     internCtx* pkCtx = NULL;
 #endif
 
-    excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-
     if (ssl == NULL) {
-        if ((*jenv)->ExceptionOccurred(jenv)) {
-            (*jenv)->ExceptionDescribe(jenv);
-            (*jenv)->ExceptionClear(jenv);
-            return;
-        }
-        (*jenv)->ThrowNew(jenv, excClass,
-                "Input WolfSSLSession object was null in freeSSL");
+        throwWolfSSLException(jenv,
+            "Input WolfSSLSession object was null in freeSSL");
         return;
     }
 
@@ -1676,8 +1629,8 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_freeSSL
             (*jenv)->ExceptionClear(jenv);
             return;
         }
-        (*jenv)->ThrowNew(jenv, excClass,
-                "Error reseting internal wolfSSL JNI pointer to NULL, freeSSL");
+        throwWolfSSLException(jenv,
+            "Error reseting internal wolfSSL JNI pointer to NULL, freeSSL");
         return;
     }
 
@@ -2316,20 +2269,13 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_dtlsGetCurrentTimeout
   (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
 #if !defined(WOLFSSL_LEANPSK) && defined(WOLFSSL_DTLS)
-    jclass excClass;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
     if (ssl == NULL) {
-        excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-        if ((*jenv)->ExceptionOccurred(jenv)) {
-            (*jenv)->ExceptionDescribe(jenv);
-            (*jenv)->ExceptionClear(jenv);
-            return 0;
-        }
-        (*jenv)->ThrowNew(jenv, excClass,
-                "Input WolfSSLSession object was null in "
-                "dtlsGetCurrentTimeout()");
+        throwWolfSSLException(jenv,
+            "Input WolfSSLSession object was null in "
+            "dtlsGetCurrentTimeout()");
         return 0;
     }
 
@@ -2406,7 +2352,6 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_dtlsSetPeer
     struct sockaddr_in sa;
     const char* ipAddress = NULL;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
-    jclass excClass = NULL;
     jclass inetsockaddr = NULL;
     jclass inetaddr = NULL;
     jmethodID portID = NULL;
@@ -2423,7 +2368,6 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_dtlsSetPeer
     }
 
     /* get class references */
-    excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
     inetsockaddr = (*jenv)->FindClass(jenv, "java/net/InetSocketAddress");
     inetaddr = (*jenv)->FindClass(jenv, "java/net/InetAddress");
 
@@ -2433,7 +2377,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_dtlsSetPeer
         if ((*jenv)->ExceptionOccurred(jenv))
             (*jenv)->ExceptionClear(jenv);
 
-        (*jenv)->ThrowNew(jenv, excClass, "Can't get getPort() method ID");
+        throwWolfSSLException(jenv, "Can't get getPort() method ID");
         return SSL_FAILURE;
     }
     (*jenv)->ExceptionClear(jenv);
@@ -2451,7 +2395,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_dtlsSetPeer
         if ((*jenv)->ExceptionOccurred(jenv))
             (*jenv)->ExceptionClear(jenv);
 
-        (*jenv)->ThrowNew(jenv, excClass, "Can't get getAddress() method ID");
+        throwWolfSSLException(jenv, "Can't get getAddress() method ID");
         return SSL_FAILURE;
     }
     (*jenv)->ExceptionClear(jenv);
@@ -2468,8 +2412,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_dtlsSetPeer
         if ((*jenv)->ExceptionOccurred(jenv))
             (*jenv)->ExceptionClear(jenv);
 
-        (*jenv)->ThrowNew(jenv, excClass,
-                "Can't get isAnyLocalAddress() method ID");
+        throwWolfSSLException(jenv, "Can't get isAnyLocalAddress() method ID");
         return SSL_FAILURE;
     }
     (*jenv)->ExceptionClear(jenv);
@@ -2488,8 +2431,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_dtlsSetPeer
             if ((*jenv)->ExceptionOccurred(jenv))
                 (*jenv)->ExceptionClear(jenv);
 
-            (*jenv)->ThrowNew(jenv, excClass,
-                    "Can't get getHostAddress() method ID");
+            throwWolfSSLException(jenv, "Can't get getHostAddress() method ID");
             return SSL_FAILURE;
         }
         ipAddr = (*jenv)->CallObjectMethod(jenv, addrObj, ipAddrID);
@@ -2547,7 +2489,6 @@ JNIEXPORT jobject JNICALL Java_com_wolfssl_WolfSSLSession_dtlsGetPeer
 
     jmethodID constr;
     jstring ipAddr;
-    jclass excClass = NULL;
     jclass isa = NULL;
 
     (void)jcl;
@@ -2584,13 +2525,12 @@ JNIEXPORT jobject JNICALL Java_com_wolfssl_WolfSSLSession_dtlsGetPeer
     port = ntohs(peer.sin_port);
 
     /* create new InetSocketAddress with this IP/port info */
-    excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
     isa = (*jenv)->FindClass(jenv, "java/net/InetSocketAddress");
     if (!isa) {
         if ((*jenv)->ExceptionOccurred(jenv))
             (*jenv)->ExceptionClear(jenv);
 
-        (*jenv)->ThrowNew(jenv, excClass, "Can't find InetSocketAddress class");
+        throwWolfSSLException(jenv, "Can't find InetSocketAddress class");
         return NULL;
     }
 
@@ -2601,13 +2541,13 @@ JNIEXPORT jobject JNICALL Java_com_wolfssl_WolfSSLSession_dtlsGetPeer
     if (peer.sin_addr.s_addr != INADDR_ANY) {
 
         constr = (*jenv)->GetMethodID(jenv, isa, "<init>",
-                "(Ljava/lang/String;I)V");
+            "(Ljava/lang/String;I)V");
         if (!constr) {
             if ((*jenv)->ExceptionOccurred(jenv))
                 (*jenv)->ExceptionClear(jenv);
 
-            (*jenv)->ThrowNew(jenv, excClass,
-                    "Can't find InetSocketAddress(String,port)");
+            throwWolfSSLException(jenv,
+                "Can't find InetSocketAddress(String,port)");
             return NULL;
         }
 
@@ -2621,8 +2561,8 @@ JNIEXPORT jobject JNICALL Java_com_wolfssl_WolfSSLSession_dtlsGetPeer
             if ((*jenv)->ExceptionOccurred(jenv))
                 (*jenv)->ExceptionClear(jenv);
 
-            (*jenv)->ThrowNew(jenv, excClass,
-                    "Can't find InetSocketAddress(port)");
+            throwWolfSSLException(jenv,
+                "Can't find InetSocketAddress(port)");
             return NULL;
         }
 
@@ -2777,18 +2717,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getMaxOutputSize
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_sessionReused
   (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
-    jclass excClass;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
     if (ssl == NULL) {
-        excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-        if ((*jenv)->ExceptionOccurred(jenv)) {
-            (*jenv)->ExceptionDescribe(jenv);
-            (*jenv)->ExceptionClear(jenv);
-            return SSL_FAILURE;
-        }
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
                 "Input WolfSSLSession object was null in sessionReused()");
         return SSL_FAILURE;
     }
@@ -2915,20 +2848,12 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_getPeerX509AltName
 JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_getVersion
   (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
-    jclass excClass;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
     if (ssl == NULL) {
-        excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-        if ((*jenv)->ExceptionOccurred(jenv)) {
-            (*jenv)->ExceptionDescribe(jenv);
-            (*jenv)->ExceptionClear(jenv);
-            return NULL;
-        }
-        (*jenv)->ThrowNew(jenv, excClass,
-                "Input WolfSSLSession object was null in "
-                "getVersion");
+        throwWolfSSLException(jenv,
+            "Input WolfSSLSession object was null in getVersion");
         return NULL;
     }
 
@@ -2938,20 +2863,12 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_getVersion
 JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_getCurrentCipher
   (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
-    jclass excClass;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
     if (ssl == NULL) {
-        excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-        if ((*jenv)->ExceptionOccurred(jenv)) {
-            (*jenv)->ExceptionDescribe(jenv);
-            (*jenv)->ExceptionClear(jenv);
-            return SSL_FAILURE;
-        }
-        (*jenv)->ThrowNew(jenv, excClass,
-                "Input WolfSSLSession object was null in "
-                "getVersion");
+        throwWolfSSLException(jenv,
+            "Input WolfSSLSession object was null in getVersion");
         return SSL_FAILURE;
     }
 
@@ -2963,7 +2880,6 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_checkDomainName
 {
     int ret;
     const char* dname;
-    jclass excClass;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
@@ -2972,15 +2888,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_checkDomainName
     }
 
     if (ssl == NULL) {
-        excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-        if ((*jenv)->ExceptionOccurred(jenv)) {
-            (*jenv)->ExceptionDescribe(jenv);
-            (*jenv)->ExceptionClear(jenv);
-            return SSL_FAILURE;
-        }
-        (*jenv)->ThrowNew(jenv, excClass,
-                "Input WolfSSLSession object was null in "
-                "checkDomainName");
+        throwWolfSSLException(jenv,
+            "Input WolfSSLSession object was null in checkDomainName");
         return SSL_FAILURE;
     }
 
@@ -2999,7 +2908,6 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setTmpDH
 {
 #ifndef NO_DH
     int ret;
-    jclass excClass;
     unsigned char* pBuf = NULL;
     unsigned char* gBuf = NULL;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
@@ -3010,15 +2918,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setTmpDH
     }
 
     if (ssl == NULL) {
-        excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-        if ((*jenv)->ExceptionOccurred(jenv)) {
-            (*jenv)->ExceptionDescribe(jenv);
-            (*jenv)->ExceptionClear(jenv);
-            return SSL_FAILURE;
-        }
-        (*jenv)->ThrowNew(jenv, excClass,
-                "Input WolfSSLSession object was null in "
-                "setTmpDH");
+        throwWolfSSLException(jenv,
+            "Input WolfSSLSession object was null in setTmpDH");
         return SSL_FAILURE;
     }
 
@@ -3077,7 +2978,6 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setTmpDHFile
 #if !defined(NO_DH) && !defined(NO_FILESYSTEM)
     int ret;
     const char* fname;
-    jclass excClass;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
@@ -3086,15 +2986,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setTmpDHFile
     }
 
     if (ssl == NULL) {
-        excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-        if ((*jenv)->ExceptionOccurred(jenv)) {
-            (*jenv)->ExceptionDescribe(jenv);
-            (*jenv)->ExceptionClear(jenv);
-            return SSL_FAILURE;
-        }
-        (*jenv)->ThrowNew(jenv, excClass,
-                "Input WolfSSLSession object was null in "
-                "setTmpDHFile");
+        throwWolfSSLException(jenv,
+            "Input WolfSSLSession object was null in setTmpDHFile");
         return SSL_FAILURE;
     }
 
@@ -3120,7 +3013,6 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useCertificateBuffer
    jint format)
 {
     int ret = SSL_SUCCESS;
-    jclass excClass;
     unsigned char* buff = NULL;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
@@ -3130,15 +3022,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useCertificateBuffer
     }
 
     if (ssl == NULL) {
-        excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-        if ((*jenv)->ExceptionOccurred(jenv)) {
-            (*jenv)->ExceptionDescribe(jenv);
-            (*jenv)->ExceptionClear(jenv);
-            return SSL_FAILURE;
-        }
-        (*jenv)->ThrowNew(jenv, excClass,
-                "Input WolfSSLSession object was null in "
-                "useCertificateBuffer");
+        throwWolfSSLException(jenv,
+            "Input WolfSSLSession object was null in useCertificateBuffer");
         return SSL_FAILURE;
     }
 
@@ -3168,7 +3053,6 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_usePrivateKeyBuffer
    jint format)
 {
     int ret;
-    jclass excClass;
     unsigned char* buff = NULL;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
@@ -3178,15 +3062,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_usePrivateKeyBuffer
     }
 
     if (ssl == NULL) {
-        excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-        if ((*jenv)->ExceptionOccurred(jenv)) {
-            (*jenv)->ExceptionDescribe(jenv);
-            (*jenv)->ExceptionClear(jenv);
-            return SSL_FAILURE;
-        }
-        (*jenv)->ThrowNew(jenv, excClass,
-                "Input WolfSSLSession object was null in "
-                "usePrivateKeyBuffer");
+        throwWolfSSLException(jenv,
+            "Input WolfSSLSession object was null in usePrivateKeyBuffer");
         return SSL_FAILURE;
     }
 
@@ -3215,7 +3092,6 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useCertificateChainBuffer
   (JNIEnv* jenv, jobject jcl, jlong sslPtr, jbyteArray in, jlong sz)
 {
     int ret;
-    jclass excClass;
     unsigned char* buff = NULL;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
@@ -3225,15 +3101,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useCertificateChainBuffer
     }
 
     if (ssl == NULL) {
-        excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-        if ((*jenv)->ExceptionOccurred(jenv)) {
-            (*jenv)->ExceptionDescribe(jenv);
-            (*jenv)->ExceptionClear(jenv);
-            return SSL_FAILURE;
-        }
-        (*jenv)->ThrowNew(jenv, excClass,
-                "Input WolfSSLSession object was null in "
-                "useCertificateChainBuffer");
+        throwWolfSSLException(jenv,
+            "Input WolfSSLSession object was null in "
+            "useCertificateChainBuffer");
         return SSL_FAILURE;
     }
 
@@ -3288,20 +3158,12 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useCertificateChainBuffer
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setGroupMessages
   (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
-    jclass excClass;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
     if (ssl == NULL) {
-        excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-        if ((*jenv)->ExceptionOccurred(jenv)) {
-            (*jenv)->ExceptionDescribe(jenv);
-            (*jenv)->ExceptionClear(jenv);
-            return SSL_FAILURE;
-        }
-        (*jenv)->ThrowNew(jenv, excClass,
-                "Input WolfSSLSession object was null in "
-                "setGroupMessages");
+        throwWolfSSLException(jenv,
+            "Input WolfSSLSession object was null in setGroupMessages");
         return BAD_FUNC_ARG;
     }
     return wolfSSL_set_group_messages(ssl);
@@ -3311,7 +3173,6 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_enableCRL
   (JNIEnv* jenv, jobject jcl, jlong sslPtr, jint options)
 {
 #ifdef HAVE_CRL
-    jclass excClass;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
@@ -3320,15 +3181,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_enableCRL
     }
 
     if (ssl == NULL) {
-        excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-        if ((*jenv)->ExceptionOccurred(jenv)) {
-            (*jenv)->ExceptionDescribe(jenv);
-            (*jenv)->ExceptionClear(jenv);
-            return SSL_FAILURE;
-        }
-        (*jenv)->ThrowNew(jenv, excClass,
-                "Input WolfSSLSession object was null in "
-                "enableCRL");
+        throwWolfSSLException(jenv,
+            "Input WolfSSLSession object was null in enableCRL");
         return SSL_FAILURE;
     }
 
@@ -3346,7 +3200,6 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_disableCRL
   (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
 #ifdef HAVE_CRL
-    jclass excClass;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
@@ -3355,15 +3208,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_disableCRL
     }
 
     if (ssl == NULL) {
-        excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-        if ((*jenv)->ExceptionOccurred(jenv)) {
-            (*jenv)->ExceptionDescribe(jenv);
-            (*jenv)->ExceptionClear(jenv);
-            return SSL_FAILURE;
-        }
-        (*jenv)->ThrowNew(jenv, excClass,
-                "Input WolfSSLSession object was null in "
-                "disableCRL");
+        throwWolfSSLException(jenv,
+            "Input WolfSSLSession object was null in disableCRL");
         return SSL_FAILURE;
     }
 
@@ -3383,7 +3229,6 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_loadCRL
 #if defined(HAVE_CRL) && !defined(NO_FILESYSTEM)
     int ret;
     const char* crlPath;
-    jclass excClass;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
@@ -3392,15 +3237,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_loadCRL
     }
 
     if (ssl == NULL) {
-        excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-        if ((*jenv)->ExceptionOccurred(jenv)) {
-            (*jenv)->ExceptionDescribe(jenv);
-            (*jenv)->ExceptionClear(jenv);
-            return SSL_FAILURE;
-        }
-        (*jenv)->ThrowNew(jenv, excClass,
-                "Input WolfSSLSession object was null in "
-                "loadCRL");
+        throwWolfSSLException(jenv,
+            "Input WolfSSLSession object was null in loadCRL");
         return SSL_FAILURE;
     }
 
@@ -3427,7 +3265,6 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setCRLCb
 {
 #ifdef HAVE_CRL
     int    ret = 0;
-    jclass excClass;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
@@ -3435,18 +3272,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setCRLCb
         return BAD_FUNC_ARG;
     }
 
-    /* find exception class in case we need it */
-    excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-    if ((*jenv)->ExceptionOccurred(jenv)) {
-        (*jenv)->ExceptionDescribe(jenv);
-        (*jenv)->ExceptionClear(jenv);
-        return SSL_FAILURE;
-    }
-
     if (ssl == NULL) {
-        (*jenv)->ThrowNew(jenv, excClass,
-            "Input WolfSSLSession object was NULL in "
-            "setCRLCb");
+        throwWolfSSLException(jenv,
+            "Input WolfSSLSession object was NULL in setCRLCb");
         return SSL_FAILURE;
     }
 
@@ -3460,8 +3288,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setCRLCb
         /* store Java CRL callback Interface object */
         g_crlCbIfaceObj = (*jenv)->NewGlobalRef(jenv, cb);
         if (g_crlCbIfaceObj == NULL) {
-            (*jenv)->ThrowNew(jenv, excClass,
-                   "Error storing global missingCRLCallback interface");
+            throwWolfSSLException(jenv,
+                "Error storing global missingCRLCallback interface");
         }
 
         ret = wolfSSL_SetCRL_Cb(ssl, NativeMissingCRLCallback);
@@ -3483,7 +3311,6 @@ void NativeMissingCRLCallback(const char* url)
 {
     JNIEnv*   jenv;
     jint      vmret  = 0;
-    jclass    excClass = NULL;
     jclass    crlClass = NULL;
     jmethodID crlMethod = NULL;
     jobjectRefType refcheck;
@@ -3504,14 +3331,6 @@ void NativeMissingCRLCallback(const char* url)
         printf("Unable to get JNIEnv from JavaVM\n");
     }
 
-    /* find exception class */
-    excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-    if ((*jenv)->ExceptionOccurred(jenv)) {
-        (*jenv)->ExceptionDescribe(jenv);
-        (*jenv)->ExceptionClear(jenv);
-        return;
-    }
-
     /* check if our stored object reference is valid */
     refcheck = (*jenv)->GetObjectRefType(jenv, g_crlCbIfaceObj);
     if (refcheck == 2) {
@@ -3519,7 +3338,7 @@ void NativeMissingCRLCallback(const char* url)
         /* lookup WolfSSLMissingCRLCallback class from global object ref */
         crlClass = (*jenv)->GetObjectClass(jenv, g_crlCbIfaceObj);
         if (!crlClass) {
-            (*jenv)->ThrowNew(jenv, excClass,
+            throwWolfSSLException(jenv,
                 "Can't get native WolfSSLMissingCRLCallback class reference");
             return;
         }
@@ -3533,7 +3352,7 @@ void NativeMissingCRLCallback(const char* url)
                 (*jenv)->ExceptionClear(jenv);
             }
 
-            (*jenv)->ThrowNew(jenv, excClass,
+            throwWolfSSLException(jenv,
                 "Error getting missingCRLCallback method from JNI");
             return;
         }
@@ -3555,8 +3374,8 @@ void NativeMissingCRLCallback(const char* url)
             (*jenv)->ExceptionClear(jenv);
         }
 
-        (*jenv)->ThrowNew(jenv, excClass,
-                "Object reference invalid in NativeMissingCRLCallback");
+        throwWolfSSLException(jenv,
+            "Object reference invalid in NativeMissingCRLCallback");
     }
 }
 
@@ -3567,18 +3386,11 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_cipherGetName
 {
     const char* cipherName;
     WOLFSSL_CIPHER* cipher;
-    jclass excClass;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
     if (ssl == NULL) {
-        excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-        if ((*jenv)->ExceptionOccurred(jenv)) {
-            (*jenv)->ExceptionDescribe(jenv);
-            (*jenv)->ExceptionClear(jenv);
-            return NULL;
-        }
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
                 "Input WolfSSLSession object was null in "
                 "cipherGetName");
         return NULL;
@@ -3597,7 +3409,6 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_cipherGetName
 JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getMacSecret
   (JNIEnv* jenv, jobject jcl, jlong sslPtr, jint verify)
 {
-    jclass excClass;
 #ifdef ATOMIC_USER
     int macLength;
     jbyteArray retSecret;
@@ -3606,17 +3417,9 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getMacSecret
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    /* find exception class */
-    excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-    if ((*jenv)->ExceptionOccurred(jenv)) {
-        (*jenv)->ExceptionDescribe(jenv);
-        (*jenv)->ExceptionClear(jenv);
-        return NULL;
-    }
-
 #ifdef ATOMIC_USER
     if (ssl == NULL) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
             "Input WolfSSLSession object was null in "
             "getMacSecret");
         return NULL;
@@ -3632,7 +3435,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getMacSecret
         /* create byte array to return */
         retSecret = (*jenv)->NewByteArray(jenv, macLength);
         if (!retSecret) {
-            (*jenv)->ThrowNew(jenv, excClass,
+            throwWolfSSLException(jenv,
                 "Failed to create byte array in native getMacSecret");
             return NULL;
         }
@@ -3651,7 +3454,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getMacSecret
         return NULL;
     }
 #else
-    (*jenv)->ThrowNew(jenv, excClass,
+    throwWolfSSLException(jenv,
         "wolfSSL not compiled with ATOMIC_USER");
     return NULL;
 #endif
@@ -3660,7 +3463,6 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getMacSecret
 JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getClientWriteKey
   (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
-    jclass excClass;
 #ifdef ATOMIC_USER
     int keyLength;
     jbyteArray retKey;
@@ -3669,17 +3471,9 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getClientWriteKey
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    /* find exception class */
-    excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-    if ((*jenv)->ExceptionOccurred(jenv)) {
-        (*jenv)->ExceptionDescribe(jenv);
-        (*jenv)->ExceptionClear(jenv);
-        return NULL;
-    }
-
 #ifdef ATOMIC_USER
     if (ssl == NULL) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
             "Input WolfSSLSession object was null in "
             "getClientWriteKey");
         return NULL;
@@ -3694,7 +3488,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getClientWriteKey
         /* create byte array to return */
         retKey = (*jenv)->NewByteArray(jenv, keyLength);
         if (!retKey) {
-            (*jenv)->ThrowNew(jenv, excClass,
+            throwWolfSSLException(jenv,
                 "Failed to create byte array in native getClientWriteKey");
             return NULL;
         }
@@ -3713,7 +3507,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getClientWriteKey
         return NULL;
     }
 #else
-    (*jenv)->ThrowNew(jenv, excClass,
+    throwWolfSSLException(jenv,
         "wolfSSL not compiled with ATOMIC_USER");
     return NULL;
 #endif
@@ -3722,7 +3516,6 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getClientWriteKey
 JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getClientWriteIV
   (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
-    jclass excClass;
 #ifdef ATOMIC_USER
     jbyteArray retIV;
     const unsigned char* iv;
@@ -3731,17 +3524,9 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getClientWriteIV
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    /* find exception class */
-    excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-    if ((*jenv)->ExceptionOccurred(jenv)) {
-        (*jenv)->ExceptionDescribe(jenv);
-        (*jenv)->ExceptionClear(jenv);
-        return NULL;
-    }
-
 #ifdef ATOMIC_USER
     if (ssl == NULL) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
             "Input WolfSSLSession object was null in "
             "getClientWriteIV");
         return NULL;
@@ -3756,7 +3541,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getClientWriteIV
         /* create byte array to return */
         retIV = (*jenv)->NewByteArray(jenv, ivLength);
         if (!retIV) {
-            (*jenv)->ThrowNew(jenv, excClass,
+            throwWolfSSLException(jenv,
                 "Failed to create byte array in native getClientWriteIV");
             return NULL;
         }
@@ -3775,7 +3560,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getClientWriteIV
         return NULL;
     }
 #else
-    (*jenv)->ThrowNew(jenv, excClass,
+    throwWolfSSLException(jenv,
         "wolfSSL not compiled with ATOMIC_USER");
     return NULL;
 #endif
@@ -3784,7 +3569,6 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getClientWriteIV
 JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getServerWriteKey
   (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
-    jclass excClass;
 #ifdef ATOMIC_USER
     jbyteArray retKey;
     const unsigned char* key;
@@ -3793,17 +3577,9 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getServerWriteKey
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    /* find exception class */
-    excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-    if ((*jenv)->ExceptionOccurred(jenv)) {
-        (*jenv)->ExceptionDescribe(jenv);
-        (*jenv)->ExceptionClear(jenv);
-        return NULL;
-    }
-
 #ifdef ATOMIC_USER
     if (ssl == NULL) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
             "Input WolfSSLSession object was null in "
             "getServerWriteKey");
         return NULL;
@@ -3818,7 +3594,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getServerWriteKey
         /* create byte array to return */
         retKey = (*jenv)->NewByteArray(jenv, keyLength);
         if (!retKey) {
-            (*jenv)->ThrowNew(jenv, excClass,
+            throwWolfSSLException(jenv,
                 "Failed to create byte array in native getServerWriteKey");
             return NULL;
         }
@@ -3837,7 +3613,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getServerWriteKey
         return NULL;
     }
 #else
-    (*jenv)->ThrowNew(jenv, excClass,
+    throwWolfSSLException(jenv,
         "wolfSSL not compiled with ATOMIC_USER");
     return NULL;
 #endif
@@ -3846,7 +3622,6 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getServerWriteKey
 JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getServerWriteIV
   (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
-    jclass excClass;
 #ifdef ATOMIC_USER
     jbyteArray retIV;
     const unsigned char* iv;
@@ -3855,17 +3630,9 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getServerWriteIV
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    /* find exception class */
-    excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-    if ((*jenv)->ExceptionOccurred(jenv)) {
-        (*jenv)->ExceptionDescribe(jenv);
-        (*jenv)->ExceptionClear(jenv);
-        return NULL;
-    }
-
 #ifdef ATOMIC_USER
     if (ssl == NULL) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
             "Input WolfSSLSession object was null in "
             "getServerWriteIV");
         return NULL;
@@ -3880,7 +3647,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getServerWriteIV
         /* create byte array to return */
         retIV = (*jenv)->NewByteArray(jenv, ivLength);
         if (!retIV) {
-            (*jenv)->ThrowNew(jenv, excClass,
+            throwWolfSSLException(jenv,
                 "Failed to create byte array in native getServerWriteIV");
             return NULL;
         }
@@ -3899,7 +3666,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getServerWriteIV
         return NULL;
     }
 #else
-    (*jenv)->ThrowNew(jenv, excClass,
+    throwWolfSSLException(jenv,
         "wolfSSL not compiled with ATOMIC_USER");
     return NULL;
 #endif
@@ -4036,14 +3803,6 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setTlsHmacInner
         return BAD_FUNC_ARG;
     }
 
-    /* find exception class */
-    jclass excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-    if ((*jenv)->ExceptionOccurred(jenv)) {
-        (*jenv)->ExceptionDescribe(jenv);
-        (*jenv)->ExceptionClear(jenv);
-        return -1;
-    }
-
     ret = wolfSSL_SetTlsHmacInner(ssl, hmacInner, (long)sz, content, verify);
 
     /* copy hmacInner back into inner jbyteArray */
@@ -4052,7 +3811,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setTlsHmacInner
     if ((*jenv)->ExceptionOccurred(jenv)) {
         (*jenv)->ExceptionDescribe(jenv);
         (*jenv)->ExceptionClear(jenv);
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
             "Failed to set byte region in native setTlsHmacInner");
         return -1;
     }
@@ -4063,7 +3822,6 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setTlsHmacInner
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSignCtx
   (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
-    jclass         excClass;
 #if defined(HAVE_PK_CALLBACKS) && defined(HAVE_ECC)
     jclass         sslClass;
 
@@ -4072,17 +3830,9 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSignCtx
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
 #endif
 
-    /* find exception class in case we need it */
-    excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-    if ((*jenv)->ExceptionOccurred(jenv)) {
-        (*jenv)->ExceptionDescribe(jenv);
-        (*jenv)->ExceptionClear(jenv);
-        return;
-    }
-
 #if defined(HAVE_PK_CALLBACKS) && defined(HAVE_ECC)
     if (ssl == NULL) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
             "Input WolfSSLSession object was null in "
             "setEccSignCtx");
         return;
@@ -4091,7 +3841,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSignCtx
     /* get WolfSSLSession class from object ref */
     sslClass = (*jenv)->GetObjectClass(jenv, jcl);
     if (!sslClass) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
                 "Can't get WolfSSLSession object class");
         return;
     }
@@ -4113,7 +3863,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSignCtx
     /* allocate memory for internal JNI object reference */
     myCtx = XMALLOC(sizeof(internCtx), NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if (!myCtx) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
                 "Unable to allocate memory for ECC sign context\n");
         return;
     }
@@ -4124,7 +3874,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSignCtx
     /* store global ref to WolfSSLSession object */
     myCtx->obj = (*jenv)->NewGlobalRef(jenv, jcl);
     if (!myCtx->obj) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
                "Unable to store WolfSSLSession object as global reference");
         return;
     }
@@ -4133,7 +3883,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSignCtx
 #else
     (void)jcl;
     (void)sslPtr;
-    (*jenv)->ThrowNew(jenv, excClass,
+    throwWolfSSLException(jenv,
         "wolfSSL not compiled with PK Callbacks and/or ECC");
     return;
 #endif
@@ -4142,7 +3892,6 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSignCtx
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccVerifyCtx
   (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
-    jclass         excClass;
 #if defined(HAVE_PK_CALLBACKS) && defined(HAVE_ECC)
     jclass         sslClass;
 
@@ -4151,17 +3900,9 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccVerifyCtx
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
 #endif
 
-    /* find exception class in case we need it */
-    excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-    if ((*jenv)->ExceptionOccurred(jenv)) {
-        (*jenv)->ExceptionDescribe(jenv);
-        (*jenv)->ExceptionClear(jenv);
-        return;
-    }
-
 #if defined(HAVE_PK_CALLBACKS) && defined(HAVE_ECC)
     if (ssl == NULL) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
             "Input WolfSSLSession object was null in "
             "setEccVerifyCtx");
         return;
@@ -4170,7 +3911,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccVerifyCtx
     /* get WolfSSLSession class from object ref */
     sslClass = (*jenv)->GetObjectClass(jenv, jcl);
     if (!sslClass) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
                 "Can't get WolfSSLSession object class");
         return;
     }
@@ -4192,7 +3933,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccVerifyCtx
     /* allocate memory for internal JNI object reference */
     myCtx = XMALLOC(sizeof(internCtx), NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if (!myCtx) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
                 "Unable to allocate memory for ECC verify context\n");
         return;
     }
@@ -4203,7 +3944,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccVerifyCtx
     /* store global ref to WolfSSLSession object */
     myCtx->obj = (*jenv)->NewGlobalRef(jenv, jcl);
     if (myCtx->obj == NULL) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
                "Unable to store WolfSSLSession object as global reference");
         return;
     }
@@ -4212,7 +3953,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccVerifyCtx
 #else
     (void)jcl;
     (void)sslPtr;
-    (*jenv)->ThrowNew(jenv, excClass,
+    throwWolfSSLException(jenv,
         "wolfSSL not compiled with PK Callbacks and/or ECC");
     return;
 #endif
@@ -4221,7 +3962,6 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccVerifyCtx
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSharedSecretCtx
   (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
-    jclass         excClass;
 #if defined(HAVE_PK_CALLBACKS) && defined(HAVE_ECC)
     jclass         sslClass;
 
@@ -4230,17 +3970,9 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSharedSecretCtx
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
 #endif
 
-    /* find exception class in case we need it */
-    excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-    if ((*jenv)->ExceptionOccurred(jenv)) {
-        (*jenv)->ExceptionDescribe(jenv);
-        (*jenv)->ExceptionClear(jenv);
-        return;
-    }
-
 #if defined(HAVE_PK_CALLBACKS) && defined(HAVE_ECC)
     if (ssl == NULL) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
             "Input WolfSSLSession object was null in "
             "setEccSharedSecretCtx");
         return;
@@ -4249,7 +3981,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSharedSecretCtx
     /* get WolfSSLSession class from object ref */
     sslClass = (*jenv)->GetObjectClass(jenv, jcl);
     if (!sslClass) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
                 "Can't get WolfSSLSession object class");
         return;
     }
@@ -4271,7 +4003,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSharedSecretCtx
     /* allocate memory for internal JNI object reference */
     myCtx = XMALLOC(sizeof(internCtx), NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if (myCtx == NULL) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
                 "Unable to allocate memory for ECC shared secret context\n");
         return;
     }
@@ -4282,7 +4014,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSharedSecretCtx
     /* store global ref to WolfSSLSession object */
     myCtx->obj = (*jenv)->NewGlobalRef(jenv, jcl);
     if (myCtx->obj == NULL) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
                "Unable to store WolfSSLSession object as global reference");
         return;
     }
@@ -4291,7 +4023,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSharedSecretCtx
 #else
     (void)jcl;
     (void)sslPtr;
-    (*jenv)->ThrowNew(jenv, excClass,
+    throwWolfSSLException(jenv,
         "wolfSSL not compiled with PK Callbacks and/or ECC");
     return;
 #endif
@@ -4300,7 +4032,6 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSharedSecretCtx
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaSignCtx
   (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
-    jclass         excClass;
 #if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
     jclass         sslClass;
 
@@ -4309,17 +4040,9 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaSignCtx
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
 #endif
 
-    /* find exception class in case we need it */
-    excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-    if ((*jenv)->ExceptionOccurred(jenv)) {
-        (*jenv)->ExceptionDescribe(jenv);
-        (*jenv)->ExceptionClear(jenv);
-        return;
-    }
-
 #if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
     if (ssl == NULL) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
             "Input WolfSSLSession object was null in "
             "setRsaSignCtx");
         return;
@@ -4328,7 +4051,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaSignCtx
     /* get WolfSSLSession class from object ref */
     sslClass = (*jenv)->GetObjectClass(jenv, jcl);
     if (!sslClass) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
                 "Can't get WolfSSLSession object class");
         return;
     }
@@ -4350,7 +4073,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaSignCtx
     /* allocate memory for internal JNI object reference */
     myCtx = XMALLOC(sizeof(internCtx), NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if (myCtx == NULL) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
                 "Unable to allocate memory for RSA sign context\n");
         return;
     }
@@ -4361,7 +4084,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaSignCtx
     /* store global ref to WolfSSLSession object */
     myCtx->obj = (*jenv)->NewGlobalRef(jenv, jcl);
     if (myCtx->obj == NULL) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
                "Unable to store WolfSSLSession object as global reference");
         return;
     }
@@ -4370,7 +4093,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaSignCtx
 #else
     (void)jcl;
     (void)sslPtr;
-    (*jenv)->ThrowNew(jenv, excClass,
+    throwWolfSSLException(jenv,
         "wolfSSL not compiled with PK Callbacks and/or RSA support");
     return;
 #endif
@@ -4379,7 +4102,6 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaSignCtx
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaVerifyCtx
   (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
-    jclass         excClass;
 #if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
     jclass         sslClass;
 
@@ -4388,17 +4110,9 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaVerifyCtx
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
 #endif
 
-    /* find exception class in case we need it */
-    excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-    if ((*jenv)->ExceptionOccurred(jenv)) {
-        (*jenv)->ExceptionDescribe(jenv);
-        (*jenv)->ExceptionClear(jenv);
-        return;
-    }
-
 #if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
     if (ssl == NULL) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
             "Input WolfSSLSession object was null in "
             "setRsaVerifyCtx");
         return;
@@ -4407,7 +4121,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaVerifyCtx
     /* get WolfSSLSession class from object ref */
     sslClass = (*jenv)->GetObjectClass(jenv, jcl);
     if (!sslClass) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
                 "Can't get WolfSSLSession object class");
         return;
     }
@@ -4429,7 +4143,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaVerifyCtx
     /* allocate memory for internal JNI object reference */
     myCtx = XMALLOC(sizeof(internCtx), NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if (myCtx == NULL) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
                 "Unable to allocate memory for RSA verify context\n");
         return;
     }
@@ -4440,7 +4154,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaVerifyCtx
     /* store global ref to WolfSSLSession object */
     myCtx->obj = (*jenv)->NewGlobalRef(jenv, jcl);
     if (myCtx->obj == NULL) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
                "Unable to store WolfSSLSession object as global reference");
         return;
     }
@@ -4449,7 +4163,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaVerifyCtx
 #else
     (void)jcl;
     (void)sslPtr;
-    (*jenv)->ThrowNew(jenv, excClass,
+    throwWolfSSLException(jenv,
         "wolfSSL not compiled with PK Callbacks and/or RSA support");
     return;
 #endif
@@ -4458,7 +4172,6 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaVerifyCtx
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaEncCtx
   (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
-    jclass         excClass;
 #if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
     jclass         sslClass;
 
@@ -4467,18 +4180,9 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaEncCtx
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
 #endif
 
-    /* find exception class in case we need it */
-    excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-    if ((*jenv)->ExceptionOccurred(jenv)) {
-        (*jenv)->ExceptionDescribe(jenv);
-        (*jenv)->ExceptionClear(jenv);
-        return;
-    }
-
 #if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
-
     if (ssl == NULL) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
             "Input WolfSSLSession object was null in "
             "setRsaEncCtx");
         return;
@@ -4487,7 +4191,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaEncCtx
     /* get WolfSSLSession class from object ref */
     sslClass = (*jenv)->GetObjectClass(jenv, jcl);
     if (!sslClass) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
                 "Can't get WolfSSLSession object class");
         return;
     }
@@ -4509,7 +4213,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaEncCtx
     /* allocate memory for internal JNI object reference */
     myCtx = XMALLOC(sizeof(internCtx), NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if (myCtx == NULL) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
                 "Unable to allocate memory for RSA encrypt context\n");
         return;
     }
@@ -4520,7 +4224,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaEncCtx
     /* store global ref to WolfSSLSession object */
     myCtx->obj = (*jenv)->NewGlobalRef(jenv, jcl);
     if (myCtx->obj == NULL) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
                "Unable to store WolfSSLSession object as global reference");
         return;
     }
@@ -4529,7 +4233,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaEncCtx
 #else
     (void)jcl;
     (void)sslPtr;
-    (*jenv)->ThrowNew(jenv, excClass,
+    throwWolfSSLException(jenv,
         "wolfSSL not compiled with PK Callbacks and/or RSA support");
     return;
 #endif
@@ -4538,7 +4242,6 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaEncCtx
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaDecCtx
   (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {
-    jclass         excClass;
 #if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
     jclass         sslClass;
 
@@ -4547,17 +4250,9 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaDecCtx
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
 #endif
 
-    /* find exception class in case we need it */
-    excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLException");
-    if ((*jenv)->ExceptionOccurred(jenv)) {
-        (*jenv)->ExceptionDescribe(jenv);
-        (*jenv)->ExceptionClear(jenv);
-        return;
-    }
-
 #if defined(HAVE_PK_CALLBACKS) && !defined(NO_RSA)
     if (ssl == NULL) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
             "Input WolfSSLSession object was null in "
             "setRsaDecCtx");
         return;
@@ -4566,7 +4261,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaDecCtx
     /* get WolfSSLSession class from object ref */
     sslClass = (*jenv)->GetObjectClass(jenv, jcl);
     if (!sslClass) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
                 "Can't get WolfSSLSession object class");
         return;
     }
@@ -4588,7 +4283,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaDecCtx
     /* allocate memory for internal JNI object reference */
     myCtx = XMALLOC(sizeof(internCtx), NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if (myCtx == NULL) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
                 "Unable to allocate memory for RSA decrypt context\n");
         return;
     }
@@ -4599,7 +4294,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaDecCtx
     /* store global ref to WolfSSLSession object */
     myCtx->obj = (*jenv)->NewGlobalRef(jenv, jcl);
     if (myCtx->obj == NULL) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLException(jenv,
                "Unable to store WolfSSLSession object as global reference");
         return;
     }
@@ -4608,7 +4303,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setRsaDecCtx
 #else
     (void)jcl;
     (void)sslPtr;
-    (*jenv)->ThrowNew(jenv, excClass,
+    throwWolfSSLException(jenv,
         "wolfSSL not compiled with PK Callbacks and/or RSA support");
     return;
 #endif
@@ -4620,28 +4315,19 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setPskClientCb
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    /* find exception class */
-    jclass excClass = (*jenv)->FindClass(jenv,
-            "com/wolfssl/WolfSSLJNIException");
-    if ((*jenv)->ExceptionOccurred(jenv)) {
-        (*jenv)->ExceptionDescribe(jenv);
-        (*jenv)->ExceptionClear(jenv);
-        return;
-    }
-
 #ifndef NO_PSK
     if (ssl != NULL) {
         /* set PSK client callback */
         wolfSSL_set_psk_client_callback(ssl, NativePskClientCb);
     } else {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLJNIException(jenv,
                 "Input WolfSSLSession object was null when setting "
                 "NativePskClientCb");
         return;
     }
 
 #else
-    (*jenv)->ThrowNew(jenv, excClass,
+    throwWolfSSLJNIException(jenv,
         "wolfSSL not compiled with PSK support");
     return;
 #endif
@@ -4653,28 +4339,19 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setPskServerCb
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
 
-    /* find exception class */
-    jclass excClass = (*jenv)->FindClass(jenv,
-            "com/wolfssl/WolfSSLJNIException");
-    if ((*jenv)->ExceptionOccurred(jenv)) {
-        (*jenv)->ExceptionDescribe(jenv);
-        (*jenv)->ExceptionClear(jenv);
-        return;
-    }
-
 #ifndef NO_PSK
     if (ssl != NULL) {
         /* set PSK server callback */
         wolfSSL_set_psk_server_callback(ssl, NativePskServerCb);
     } else {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLJNIException(jenv,
                 "Input WolfSSLSession object was null when setting "
                 "NativePskServerCb");
         return;
     }
 
 #else
-    (*jenv)->ThrowNew(jenv, excClass,
+    throwWolfSSLJNIException(jenv,
         "wolfSSL not compiled with PSK support");
     return;
 #endif
@@ -5182,7 +4859,6 @@ int NativeALPNSelectCb(WOLFSSL *ssl, const unsigned char **out,
     unsigned int inlen, void *arg)
 {
     JNIEnv* jenv;                   /* JNI environment */
-    jclass  excClass;               /* WolfSSLJNIException class */
     int     needsDetach = 0;        /* Should we explicitly detach? */
     jint    vmret = 0;
 
@@ -5227,21 +4903,10 @@ int NativeALPNSelectCb(WOLFSSL *ssl, const unsigned char **out,
         return SSL_TLSEXT_ERR_ALERT_FATAL;
     }
 
-    /* find exception class in case we need it */
-    excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLJNIException");
-    if ((*jenv)->ExceptionOccurred(jenv)) {
-        (*jenv)->ExceptionDescribe(jenv);
-        (*jenv)->ExceptionClear(jenv);
-        if (needsDetach) {
-            (*g_vm)->DetachCurrentThread(g_vm);
-        }
-        return SSL_TLSEXT_ERR_ALERT_FATAL;
-    }
-
     /* get stored WolfSSLSession object */
     g_cachedSSLObj = (jobject*) wolfSSL_get_jobject(ssl);
     if (!g_cachedSSLObj) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLJNIException(jenv,
             "Can't get native WolfSSLSession object reference in "
             "NativeALPNSelectCb");
         if (needsDetach) {
@@ -5253,7 +4918,7 @@ int NativeALPNSelectCb(WOLFSSL *ssl, const unsigned char **out,
     /* lookup WolfSSLSession class from object */
     sslClass = (*jenv)->GetObjectClass(jenv, (jobject)(*g_cachedSSLObj));
     if (sslClass == NULL) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLJNIException(jenv,
             "Can't get native WolfSSLSession class reference in "
             "NativeALPNSelectCb");
         if (needsDetach) {
@@ -5271,7 +4936,7 @@ int NativeALPNSelectCb(WOLFSSL *ssl, const unsigned char **out,
             (*jenv)->ExceptionDescribe(jenv);
             (*jenv)->ExceptionClear(jenv);
         }
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLJNIException(jenv,
             "Error getting internalAlpnSelectCallback method from JNI");
         if (needsDetach) {
             (*g_vm)->DetachCurrentThread(g_vm);
@@ -5288,7 +4953,7 @@ int NativeALPNSelectCb(WOLFSSL *ssl, const unsigned char **out,
             (*jenv)->ExceptionDescribe(jenv);
             (*jenv)->ExceptionClear(jenv);
         }
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLJNIException(jenv,
             "Error in wolfSSL_ALPN_GetPeerProtocol()");
         if (needsDetach) {
             (*g_vm)->DetachCurrentThread(g_vm);
@@ -5305,7 +4970,7 @@ int NativeALPNSelectCb(WOLFSSL *ssl, const unsigned char **out,
             (*jenv)->ExceptionDescribe(jenv);
             (*jenv)->ExceptionClear(jenv);
         }
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLJNIException(jenv,
             "Error allocating memory for peer protocols array");
         if (needsDetach) {
             (*g_vm)->DetachCurrentThread(g_vm);
@@ -5329,7 +4994,7 @@ int NativeALPNSelectCb(WOLFSSL *ssl, const unsigned char **out,
             (*jenv)->ExceptionDescribe(jenv);
             (*jenv)->ExceptionClear(jenv);
         }
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLJNIException(jenv,
             "ALPN peer protocol list size is 0");
         if (needsDetach) {
             (*g_vm)->DetachCurrentThread(g_vm);
@@ -5346,7 +5011,7 @@ int NativeALPNSelectCb(WOLFSSL *ssl, const unsigned char **out,
             (*jenv)->ExceptionDescribe(jenv);
             (*jenv)->ExceptionClear(jenv);
         }
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLJNIException(jenv,
             "Failed to create JNI String[] for ALPN protocols");
         if (needsDetach) {
             (*g_vm)->DetachCurrentThread(g_vm);
@@ -5364,7 +5029,7 @@ int NativeALPNSelectCb(WOLFSSL *ssl, const unsigned char **out,
             (*jenv)->ExceptionClear(jenv);
 
             wolfSSL_ALPN_FreePeerProtocol(ssl, &peerProtos);
-            (*jenv)->ThrowNew(jenv, excClass,
+            throwWolfSSLJNIException(jenv,
                 "Failed to add String to JNI String[] for ALPN protocols");
             if (needsDetach) {
                 (*g_vm)->DetachCurrentThread(g_vm);
@@ -5387,7 +5052,7 @@ int NativeALPNSelectCb(WOLFSSL *ssl, const unsigned char **out,
             (*jenv)->ExceptionDescribe(jenv);
             (*jenv)->ExceptionClear(jenv);
         }
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLJNIException(jenv,
             "Failed to create JNI String[1] for output ALPN protocol");
         if (needsDetach) {
             (*g_vm)->DetachCurrentThread(g_vm);
@@ -5402,7 +5067,7 @@ int NativeALPNSelectCb(WOLFSSL *ssl, const unsigned char **out,
     if ((*jenv)->ExceptionOccurred(jenv)) {
         (*jenv)->ExceptionDescribe(jenv);
         (*jenv)->ExceptionClear(jenv);
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLJNIException(jenv,
             "Exception while calling internalAlpnSelectCallback()");
         if (needsDetach) {
             (*g_vm)->DetachCurrentThread(g_vm);
@@ -5418,7 +5083,7 @@ int NativeALPNSelectCb(WOLFSSL *ssl, const unsigned char **out,
                 (*jenv)->ExceptionDescribe(jenv);
                 (*jenv)->ExceptionClear(jenv);
             }
-            (*jenv)->ThrowNew(jenv, excClass,
+            throwWolfSSLJNIException(jenv,
                 "Output String[] for ALPN result not size 1");
             if (needsDetach) {
                 (*g_vm)->DetachCurrentThread(g_vm);
@@ -5434,7 +5099,7 @@ int NativeALPNSelectCb(WOLFSSL *ssl, const unsigned char **out,
                 (*jenv)->ExceptionDescribe(jenv);
                 (*jenv)->ExceptionClear(jenv);
             }
-            (*jenv)->ThrowNew(jenv, excClass,
+            throwWolfSSLJNIException(jenv,
                 "Selected ALPN protocol in String[] is NULL");
             if (needsDetach) {
                 (*g_vm)->DetachCurrentThread(g_vm);
@@ -5597,7 +5262,6 @@ int NativeTls13SecretCb(WOLFSSL *ssl, int id, const unsigned char* secret,
     int secretSz, void* ctx)
 {
     JNIEnv* jenv;                   /* JNI environment */
-    jclass  excClass;               /* WolfSSLJNIException class */
     int     needsDetach = 0;        /* Should we explicitly detach? */
     jint    retval = 0;
     jint    vmret = 0;
@@ -5628,21 +5292,10 @@ int NativeTls13SecretCb(WOLFSSL *ssl, int id, const unsigned char* secret,
         return TLS13_SECRET_CB_E;
     }
 
-    /* Find exception class in case we need it */
-    excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLJNIException");
-    if ((*jenv)->ExceptionOccurred(jenv)) {
-        (*jenv)->ExceptionDescribe(jenv);
-        (*jenv)->ExceptionClear(jenv);
-        if (needsDetach) {
-            (*g_vm)->DetachCurrentThread(g_vm);
-        }
-        return TLS13_SECRET_CB_E;
-    }
-
     /* Get stored WolfSSLSession object */
     g_cachedSSLObj = (jobject*) wolfSSL_get_jobject(ssl);
     if (!g_cachedSSLObj) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLJNIException(jenv,
             "Can't get native WolfSSLSession object reference in "
             "NativeTls13SecretCb");
         if (needsDetach) {
@@ -5654,7 +5307,7 @@ int NativeTls13SecretCb(WOLFSSL *ssl, int id, const unsigned char* secret,
     /* Lookup WolfSSLSession class from object */
     sslClass = (*jenv)->GetObjectClass(jenv, (jobject)(*g_cachedSSLObj));
     if (sslClass == NULL) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLJNIException(jenv,
             "Can't get native WolfSSLSession class reference in "
             "NativeTls13SecretCb");
         if (needsDetach) {
@@ -5671,7 +5324,7 @@ int NativeTls13SecretCb(WOLFSSL *ssl, int id, const unsigned char* secret,
             (*jenv)->ExceptionDescribe(jenv);
             (*jenv)->ExceptionClear(jenv);
         }
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLJNIException(jenv,
             "Error getting internalTls13SecretCallback method from JNI");
         if (needsDetach) {
             (*g_vm)->DetachCurrentThread(g_vm);
@@ -5683,7 +5336,7 @@ int NativeTls13SecretCb(WOLFSSL *ssl, int id, const unsigned char* secret,
         /* Create jbyteArray to hold secret data */
         secretArr = (*jenv)->NewByteArray(jenv, secretSz);
         if (secretArr == NULL) {
-            (*jenv)->ThrowNew(jenv, excClass,
+            throwWolfSSLJNIException(jenv,
                 "Error creating new jbyteArray in NativeTls13SecretCb");
             if (needsDetach) {
                 (*g_vm)->DetachCurrentThread(g_vm);
@@ -5710,7 +5363,7 @@ int NativeTls13SecretCb(WOLFSSL *ssl, int id, const unsigned char* secret,
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
             (*jenv)->ExceptionClear(jenv);
-            (*jenv)->ThrowNew(jenv, excClass,
+            throwWolfSSLJNIException(jenv,
                 "Exception while calling internalTls13SecretCallback()");
             if (needsDetach) {
                 (*g_vm)->DetachCurrentThread(g_vm);
@@ -5738,7 +5391,6 @@ int NativeSessionTicketCb(WOLFSSL* ssl, const unsigned char* ticket,
     int ticketLen, void* ctx)
 {
     JNIEnv* jenv;                   /* JNI environment */
-    jclass  excClass;               /* WolfSSLJNIException class */
     int     needsDetach = 0;        /* Should we explicitly detach? */
     jint    retval = 0;
     jint    vmret = 0;
@@ -5769,21 +5421,10 @@ int NativeSessionTicketCb(WOLFSSL* ssl, const unsigned char* ticket,
         return -1;
     }
 
-    /* Find exception class in case we need it */
-    excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLJNIException");
-    if ((*jenv)->ExceptionOccurred(jenv)) {
-        (*jenv)->ExceptionDescribe(jenv);
-        (*jenv)->ExceptionClear(jenv);
-        if (needsDetach) {
-            (*g_vm)->DetachCurrentThread(g_vm);
-        }
-        return -1;
-    }
-
     /* Get stored WolfSSLSession object */
     g_cachedSSLObj = (jobject*) wolfSSL_get_jobject(ssl);
     if (!g_cachedSSLObj) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLJNIException(jenv,
             "Can't get native WolfSSLSession object reference in "
             "NativeSessionTicketCb");
         if (needsDetach) {
@@ -5795,7 +5436,7 @@ int NativeSessionTicketCb(WOLFSSL* ssl, const unsigned char* ticket,
     /* Lookup WolfSSLSession class from object */
     sslClass = (*jenv)->GetObjectClass(jenv, (jobject)(*g_cachedSSLObj));
     if (sslClass == NULL) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLJNIException(jenv,
             "Can't get native WolfSSLSession class reference in "
             "NativeSessionTicketCb");
         if (needsDetach) {
@@ -5812,7 +5453,7 @@ int NativeSessionTicketCb(WOLFSSL* ssl, const unsigned char* ticket,
             (*jenv)->ExceptionDescribe(jenv);
             (*jenv)->ExceptionClear(jenv);
         }
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLJNIException(jenv,
             "Error getting internalSessionTicketCallback method from JNI");
         if (needsDetach) {
             (*g_vm)->DetachCurrentThread(g_vm);
@@ -5824,7 +5465,7 @@ int NativeSessionTicketCb(WOLFSSL* ssl, const unsigned char* ticket,
         /* Create jbyteArray to hold session ticket */
         ticketArr = (*jenv)->NewByteArray(jenv, ticketLen);
         if (ticketArr == NULL) {
-            (*jenv)->ThrowNew(jenv, excClass,
+            throwWolfSSLJNIException(jenv,
                 "Error creating new jbyteArray in NativeSessionTicketCb");
             if (needsDetach) {
                 (*g_vm)->DetachCurrentThread(g_vm);
@@ -5850,7 +5491,7 @@ int NativeSessionTicketCb(WOLFSSL* ssl, const unsigned char* ticket,
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
             (*jenv)->ExceptionClear(jenv);
-            (*jenv)->ThrowNew(jenv, excClass,
+            throwWolfSSLJNIException(jenv,
                 "Exception while calling internalSessionTicketCallback()");
             if (needsDetach) {
                 (*g_vm)->DetachCurrentThread(g_vm);
@@ -6055,7 +5696,6 @@ int NativeSSLIORecvCb(WOLFSSL *ssl, char *buf, int sz, void *ctx)
     jint       vmret  = 0;
 
     JNIEnv*    jenv;                  /* JNI environment */
-    jclass     excClass;              /* WolfSSLJNIException class */
     int        needsDetach = 0;       /* Should we explicitly detach? */
 
     jobject*   g_cachedSSLObj;        /* WolfSSLSession cached object */
@@ -6082,20 +5722,10 @@ int NativeSSLIORecvCb(WOLFSSL *ssl, char *buf, int sz, void *ctx)
         return WOLFSSL_CBIO_ERR_GENERAL;
     }
 
-    /* find exception class in case we need it */
-    excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLJNIException");
-    if ((*jenv)->ExceptionOccurred(jenv)) {
-        (*jenv)->ExceptionDescribe(jenv);
-        (*jenv)->ExceptionClear(jenv);
-        if (needsDetach)
-            (*g_vm)->DetachCurrentThread(g_vm);
-        return WOLFSSL_CBIO_ERR_GENERAL;
-    }
-
     /* get stored WolfSSLSession jobject */
     g_cachedSSLObj = (jobject*) wolfSSL_get_jobject(ssl);
     if (!g_cachedSSLObj) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLJNIException(jenv,
                 "Can't get native WolfSSLSession object reference in "
                 "NativeSSLIORecvCb");
         if (needsDetach)
@@ -6104,7 +5734,7 @@ int NativeSSLIORecvCb(WOLFSSL *ssl, char *buf, int sz, void *ctx)
     }
 
     if (!g_sslIORecvMethodId) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLJNIException(jenv,
             "Cached recv callback method ID is null in internalIORecvCallback");
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
@@ -6114,7 +5744,7 @@ int NativeSSLIORecvCb(WOLFSSL *ssl, char *buf, int sz, void *ctx)
     /* create jbyteArray to hold received data */
     inData = (*jenv)->NewByteArray(jenv, sz);
     if (!inData) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLJNIException(jenv,
             "Error getting internalIORecvCallback method from JNI");
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
@@ -6176,7 +5806,6 @@ int NativeSSLIOSendCb(WOLFSSL *ssl, char *buf, int sz, void *ctx)
     jint       vmret  = 0;
 
     JNIEnv*    jenv;                  /* JNI environment */
-    jclass     excClass;              /* WolfSSLJNIException class */
     int        needsDetach = 0;       /* Should we explicitly detach? */
 
     jobject*   g_cachedSSLObj;        /* WolfSSLSession cached object */
@@ -6203,20 +5832,10 @@ int NativeSSLIOSendCb(WOLFSSL *ssl, char *buf, int sz, void *ctx)
         return WOLFSSL_CBIO_ERR_GENERAL;
     }
 
-    /* find exception class in case we need it */
-    excClass = (*jenv)->FindClass(jenv, "com/wolfssl/WolfSSLJNIException");
-    if ((*jenv)->ExceptionOccurred(jenv)) {
-        (*jenv)->ExceptionDescribe(jenv);
-        (*jenv)->ExceptionClear(jenv);
-        if (needsDetach)
-            (*g_vm)->DetachCurrentThread(g_vm);
-        return WOLFSSL_CBIO_ERR_GENERAL;
-    }
-
     /* get stored WolfSSLSession jobject */
     g_cachedSSLObj = (jobject*) wolfSSL_get_jobject(ssl);
     if (!g_cachedSSLObj) {
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLJNIException(jenv,
                 "Can't get native WolfSSLSession object reference in "
                 "NativeSSLIOSendCb");
         if (needsDetach)
@@ -6230,7 +5849,7 @@ int NativeSSLIOSendCb(WOLFSSL *ssl, char *buf, int sz, void *ctx)
             (*jenv)->ExceptionDescribe(jenv);
             (*jenv)->ExceptionClear(jenv);
         }
-        (*jenv)->ThrowNew(jenv, excClass,
+        throwWolfSSLJNIException(jenv,
                 "internalIOSendCallback method ID is null in internalIOSendCb");
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
@@ -6242,7 +5861,7 @@ int NativeSSLIOSendCb(WOLFSSL *ssl, char *buf, int sz, void *ctx)
         /* create jbyteArray to hold received data */
         outData = (*jenv)->NewByteArray(jenv, sz);
         if (!outData) {
-            (*jenv)->ThrowNew(jenv, excClass,
+            throwWolfSSLJNIException(jenv,
                     "Error getting internalIOSendCallback method from JNI");
             if (needsDetach)
                 (*g_vm)->DetachCurrentThread(g_vm);

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -2836,6 +2836,28 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_stateStringLong
 #endif
 }
 
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getMaxOutputSize
+  (JNIEnv* jenv, jobject jcl, jlong sslPtr)
+{
+#ifndef NO_TLS
+    int ret;
+    WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
+
+    if (jenv == NULL || ssl == NULL) {
+        return 0;
+    }
+
+    ret = wolfSSL_GetMaxOutputSize(ssl);
+
+    return (jint)ret;
+#else
+    (void)jenv;
+    (void)jcl;
+    (void)sslPtr;
+    return (jint)NOT_COMPILED_IN;
+#endif
+}
+
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_sessionReused
   (JNIEnv* jenv, jobject jcl, jlong sslPtr)
 {

--- a/native/com_wolfssl_WolfSSLSession.h
+++ b/native/com_wolfssl_WolfSSLSession.h
@@ -967,6 +967,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setMTU
 JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_stateStringLong
   (JNIEnv *, jobject, jlong);
 
+/*
+ * Class:     com_wolfssl_WolfSSLSession
+ * Method:    getMaxOutputSize
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getMaxOutputSize
+  (JNIEnv *, jobject, jlong);
+
 #ifdef __cplusplus
 }
 #endif

--- a/native/com_wolfssl_globals.h
+++ b/native/com_wolfssl_globals.h
@@ -25,7 +25,19 @@
 #define _Included_com_wolfssl_globals
 
 /* global JavaVM reference for JNIEnv lookup */
-extern JavaVM*  g_vm;
+extern JavaVM* g_vm;
+
+/* Cache static jmethodIDs for performance, since they are guaranteed to be the
+ * same across all threads once cached. Initialized in JNI_OnLoad() and freed in
+ * JNI_OnUnload(). */
+extern jmethodID g_sslIORecvMethodId;         /* WolfSSLSession.internalIOSSLRecvCallback */
+extern jmethodID g_sslIOSendMethodId;         /* WolfSSLSession.internalIOSSLSendCallback */
+extern jmethodID g_bufferPositionMethodId;    /* ByteBuffer.position() */
+extern jmethodID g_bufferLimitMethodId;       /* ByteBuffer.limit() */
+extern jmethodID g_bufferHasArrayMethodId;    /* ByteBuffer.hasArray() */
+extern jmethodID g_bufferArrayMethodId;       /* ByteBuffer.array() */
+extern jmethodID g_bufferSetPositionMethodId; /* ByteBuffer.position(int) */
+extern jmethodID g_verifyCallbackMethodId;  /* WolfSSLVerifyCallback.verifyCallback */
 
 /* struct to hold I/O class, object refs */
 typedef struct {
@@ -39,4 +51,3 @@ unsigned int NativePskServerCb(WOLFSSL* ssl, const char* identity,
         unsigned char* key, unsigned int max_key_len);
 
 #endif
-

--- a/native/com_wolfssl_globals.h
+++ b/native/com_wolfssl_globals.h
@@ -50,4 +50,8 @@ unsigned int NativePskClientCb(WOLFSSL* ssl, const char* hint, char* identity,
 unsigned int NativePskServerCb(WOLFSSL* ssl, const char* identity,
         unsigned char* key, unsigned int max_key_len);
 
+/* Helper functions to throw exceptions */
+void throwWolfSSLJNIException(JNIEnv* jenv, const char* msg);
+void throwWolfSSLException(JNIEnv* jenv, const char* msg);
+
 #endif

--- a/native/com_wolfssl_globals.h
+++ b/native/com_wolfssl_globals.h
@@ -30,14 +30,20 @@ extern JavaVM* g_vm;
 /* Cache static jmethodIDs for performance, since they are guaranteed to be the
  * same across all threads once cached. Initialized in JNI_OnLoad() and freed in
  * JNI_OnUnload(). */
-extern jmethodID g_sslIORecvMethodId;         /* WolfSSLSession.internalIOSSLRecvCallback */
-extern jmethodID g_sslIOSendMethodId;         /* WolfSSLSession.internalIOSSLSendCallback */
-extern jmethodID g_bufferPositionMethodId;    /* ByteBuffer.position() */
-extern jmethodID g_bufferLimitMethodId;       /* ByteBuffer.limit() */
-extern jmethodID g_bufferHasArrayMethodId;    /* ByteBuffer.hasArray() */
-extern jmethodID g_bufferArrayMethodId;       /* ByteBuffer.array() */
-extern jmethodID g_bufferSetPositionMethodId; /* ByteBuffer.position(int) */
-extern jmethodID g_verifyCallbackMethodId;  /* WolfSSLVerifyCallback.verifyCallback */
+extern jmethodID g_sslIORecvMethodId;              /* WolfSSLSession.internalIOSSLRecvCallback */
+extern jmethodID g_sslIORecvMethodId_BB;           /* WolfSSLSession.internalIOSSLRecvCallback_BB */
+extern jmethodID g_sslIOSendMethodId;              /* WolfSSLSession.internalIOSSLSendCallback */
+extern jmethodID g_sslIOSendMethodId_BB;           /* WolfSSLSession.internalIOSSLSendCallback_BB */
+extern jmethodID g_isArrayIORecvCallbackSet;       /* WolfSSL.isArrayIORecvCallbackSet */
+extern jmethodID g_isArrayIOSendCallbackSet;       /* WolfSSL.isArrayIOSendCallbackSet */
+extern jmethodID g_isByteBufferIORecvCallbackSet;  /* WolfSSL.isByteBufferIORecvCallbackSet */
+extern jmethodID g_isByteBufferIOSendCallbackSet;  /* WolfSSL.isByteBufferIOSendCallbackSet */
+extern jmethodID g_bufferPositionMethodId;         /* ByteBuffer.position() */
+extern jmethodID g_bufferLimitMethodId;            /* ByteBuffer.limit() */
+extern jmethodID g_bufferHasArrayMethodId;         /* ByteBuffer.hasArray() */
+extern jmethodID g_bufferArrayMethodId;            /* ByteBuffer.array() */
+extern jmethodID g_bufferSetPositionMethodId;      /* ByteBuffer.position(int) */
+extern jmethodID g_verifyCallbackMethodId;         /* WolfSSLVerifyCallback.verifyCallback */
 
 /* struct to hold I/O class, object refs */
 typedef struct {

--- a/scripts/infer.sh
+++ b/scripts/infer.sh
@@ -35,6 +35,8 @@ done
 infer --fail-on-issue run -- javac \
     src/java/com/wolfssl/WolfSSL.java \
     src/java/com/wolfssl/WolfSSLALPNSelectCallback.java \
+    src/java/com/wolfssl/WolfSSLByteBufferIORecvCallback.java \
+    src/java/com/wolfssl/WolfSSLByteBufferIOSendCallback.java \
     src/java/com/wolfssl/WolfSSLCertManager.java \
     src/java/com/wolfssl/WolfSSLCertRequest.java \
     src/java/com/wolfssl/WolfSSLCertificate.java \

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -626,6 +626,9 @@ public class WolfSSL {
             getTls13SecretEnum_EXPORTER_SECRET();
 
         this.active = true;
+
+        WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+            WolfSSLDebug.INFO, "wolfSSL library initialization done");
     }
 
     /* ------------------- private/protected methods -------------------- */

--- a/src/java/com/wolfssl/WolfSSLByteBufferIORecvCallback.java
+++ b/src/java/com/wolfssl/WolfSSLByteBufferIORecvCallback.java
@@ -1,0 +1,67 @@
+/* WolfSSLByteBufferIORecvCallback.java
+ *
+ * Copyright (C) 2006-2025 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+package com.wolfssl;
+
+import java.nio.ByteBuffer;
+
+/**
+ * wolfSSL ByteBuffer I/O Receive Callback Interface.
+ *
+ * This interface specifies how applicaitons should implement the I/O receive
+ * callback class to be used by wolfSSL, using a ByteBuffer as the buffer.
+ * <p>
+ * After implementing this interface, it should be passed as a parameter
+ * to the {@link WolfSSLContext#setIORecv(WolfSSLIORecvCallback)
+ * WolfSSLContext.setIORecv()} or
+ * {@link WolfSSLSession#setIORecv(WolfSSLIORecvCallback)
+ * WolfSSLSession.setIORecv()} methods to be registered with the native wolfSSL
+ * library.
+ */
+public interface WolfSSLByteBufferIORecvCallback {
+
+    /**
+     * I/O receive callback method, using ByteBuffer.
+     *
+     * This method acts as the I/O receive callback to be used with wolfSSL.
+     * This can be registered with an SSL session at the WolfSSLContext level
+     * using WolfSSLContext#setIORecv(WolfSSLIORecvCallback), or at the
+     * WolfSSLSession level using
+     * WolfSSLSession#setIORecv(WolfSSLIORecvCallback).
+     *
+     * This method will be called by native wolfSSL when it needs data to
+     * be read from the transport layer. The callback should read data and
+     * place the data into the buffer provided. The number of bytes read should
+     * be returned. The callback should return an error code on error.
+     *
+     * @param ssl   the current SSL session object from which the callback was
+     *              initiated.
+     * @param buf   buffer in which the application should place data which
+     *              has been received from the peer.
+     * @param sz    size of buffer, <b>buf</b>
+     * @param ctx   I/O context to be used.
+     * @return      the number of bytes read, or an error. For possible error
+     *              codes, see the default EmbedRecv() function in
+     *              wolfssl_package/src/io.c
+     */
+    public int receiveCallback(WolfSSLSession ssl, ByteBuffer buf, int sz,
+            Object ctx);
+}
+

--- a/src/java/com/wolfssl/WolfSSLByteBufferIOSendCallback.java
+++ b/src/java/com/wolfssl/WolfSSLByteBufferIOSendCallback.java
@@ -1,0 +1,67 @@
+/* WolfSSLByteBufferIOSendCallback.java
+ *
+ * Copyright (C) 2006-2025 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+package com.wolfssl;
+
+import java.nio.ByteBuffer;
+
+/**
+ * wolfSSL I/O Send Callback Interface.
+ *
+ * This interface specifies how applicaitons should implement the I/O send
+ * callback class to be used by wolfSSL.
+ * <p>
+ * After implementing this interface, it should be passed as a parameter
+ * to the {@link WolfSSLContext#setIOSend(WolfSSLIOSendCallback)
+ * WolfSSLContext.setIOSend()} or
+ * {@link WolfSSLSession#setIOSend(WolfSSLIOSendCallback) 
+ * WolfSSLSession.setIOSend()} methods to be registered with the native wolfSSL
+ * library.
+ */
+public interface WolfSSLByteBufferIOSendCallback {
+
+    /**
+     * I/O send callback method, using ByteBuffer.
+     *
+     * This method acts as the I/O send callback to be used with wolfSSL.
+     * This can be registered with an SSL session at the WolfSSLContext level
+     * using WolfSSLContext#setIOSend(WolfSSLIOSendCallback), or at the
+     * WolfSSLSession level using
+     * WolfSSLSession#setIOSend(WolfSSLIOSendCallback).
+     *
+     * This method will be called by native wolfSSL when it needs to send data.
+     * The callback should send data from the provided ByteBuffer (buf) across
+     * the transport layer. The number of bytes sent should be returned, or
+     * a negative error code on error.
+     *
+     * @param ssl   the current SSL session object from which the callback was
+     *              initiated.
+     * @param buf   buffer containing data to be sent to the peer.
+     * @param sz    size of data in buffer "<b>buf</b>"
+     * @param ctx   I/O context to be used.
+     * @return      the number of bytes sent, or an error. For possible error
+     *              codes, see the default EmbedSend() function in
+     *              wolfssl_package/src/io.c
+     */
+    public int sendCallback(WolfSSLSession ssl, ByteBuffer buf, int sz,
+           Object ctx);
+}
+

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -71,11 +71,21 @@ public class WolfSSLSession {
     private WolfSSLPskClientCallback internPskClientCb = null;
     private WolfSSLPskServerCallback internPskServerCb = null;
 
-    /* user-registerd I/O callbacks, called by internal WolfSSLSession
-     * I/O callback. This is done in order to pass references to
-     * WolfSSLSession object */
-    private WolfSSLIORecvCallback internRecvSSLCb;
-    private WolfSSLIOSendCallback internSendSSLCb;
+    /* User-registerd I/O callbacks:
+     *
+     * These are called by internal WolfSSLSession I/O callback. This is done
+     * in order to pass references to WolfSSLSession object. There are two sets
+     * of I/O callbacks here, one set that will use byte[] and one that will
+     * use ByteBuffer. Only one send and one recv callback can be set at a time
+     * between the two. Native JNI code will give preference to using the
+     * ByteBuffer variants for performance if set, since this will avoid an
+     * extra native allocation (NewByteArray()). The ByteBuffer variant will
+     * wrap the pre-allocated wolfSSL array in a Java direct ByteBuffer
+     * to pass back up to Java. */
+    private WolfSSLIORecvCallback internRecvSSLCb_array;
+    private WolfSSLIOSendCallback internSendSSLCb_array;
+    private WolfSSLByteBufferIORecvCallback internRecvSSLCb_BB;
+    private WolfSSLByteBufferIOSendCallback internSendSSLCb_BB;
 
     /* user-registered ALPN select callback, called by internal WolfSSLSession
      * ALPN select callback */
@@ -237,20 +247,66 @@ public class WolfSSLSession {
         return this.rsaDecCtx;
     }
 
+    /* Methods to detect which I/O callback variants have been set */
+    private boolean isArrayIOSendCallbackSet() {
+        return (internSendSSLCb_array != null);
+    }
+
+    private boolean isByteBufferIOSendCallbackSet() {
+        return (internSendSSLCb_BB != null);
+    }
+
+    private boolean isArrayIORecvCallbackSet() {
+        return (internRecvSSLCb_array != null);
+    }
+
+    private boolean isByteBufferIORecvCallbackSet() {
+        return (internRecvSSLCb_BB != null);
+    }
+
     /* These callbacks will be registered with native wolfSSL library */
-    private int internalIOSSLRecvCallback(WolfSSLSession ssl, byte[] buf,
-                                          int sz)
+
+    /**
+     * Internal wolfSSL I/O receive callback, using byte array.
+     */
+    private int internalIOSSLRecvCallback(WolfSSLSession ssl,
+        byte[] buf, int sz)
     {
         /* call user-registered recv method */
-        return internRecvSSLCb.receiveCallback(ssl, buf, sz,
+        return internRecvSSLCb_array.receiveCallback(ssl, buf, sz,
             ssl.getIOReadCtx());
     }
 
-    private int internalIOSSLSendCallback(WolfSSLSession ssl, byte[] buf,
-                                          int sz)
+    /**
+     * Internal wolfSSL I/O receive callback, using ByteBuffer.
+     */
+    private int internalIOSSLRecvCallback(WolfSSLSession ssl,
+            ByteBuffer buf, int sz)
     {
         /* call user-registered recv method */
-        return internSendSSLCb.sendCallback(ssl, buf, sz,
+        return internRecvSSLCb_BB.receiveCallback(ssl, buf, sz,
+            ssl.getIOReadCtx());
+    }
+
+    /**
+     * Internal wolfSSL I/O send callback, using byte array.
+     */
+    private int internalIOSSLSendCallback(WolfSSLSession ssl,
+        byte[] buf, int sz)
+    {
+        /* call user-registered recv method */
+        return internSendSSLCb_array.sendCallback(ssl, buf, sz,
+            ssl.getIOWriteCtx());
+    }
+
+    /**
+     * Internal wolfSSL I/O send callback, using ByteBuffer.
+     */
+    private int internalIOSSLSendCallback(WolfSSLSession ssl,
+            ByteBuffer buf, int sz)
+    {
+        /* call user-registered recv method */
+        return internSendSSLCb_BB.sendCallback(ssl, buf, sz,
             ssl.getIOWriteCtx());
     }
 
@@ -4368,11 +4424,18 @@ public class WolfSSLSession {
 
     /**
      * Registers a receive callback for wolfSSL to get input data.
-     * By default, wolfSSL uses EmbedReceive() in src/io.c as the callback.
-     * This uses the system's TCP recv() function. The user can register a
-     * function to get input from memory, some other network module, or from
-     * anywhere. Please see the EmbedReceive() function in src/io.c as a
-     * guide for how the function should work and for error codes.
+     *
+     * This receive callback uses WolfSSLIORecvCallback which uses
+     * byte arrays (byte[]). To use direct ByteBuffers, and avoid an extra
+     * JNI array allocaiton, use
+     * setIORecvByteBuffer(WolfSSLByteBufferIORecvCallback).
+     *
+     * By default, wolfSSL uses EmbedReceive() in src/io.c as the callback
+     * which uses the system TCP recv() function. The user can register a
+     * method here to get receive TLS-encoded data from memory, some other
+     * network module, or anywhere else. Please see the EmbedReceive() function
+     * in src/io.c as a guide for how the function should work and for error
+     * codes.
      * <p>
      * In particular, <b>IO_ERR_WANT_READ</b> should be returned for
      * non-blocking receive when no data is ready.
@@ -4394,10 +4457,16 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered setIORecv(" + callback + ")");
+                "entered setIORecv(" + callback + ") - byte array");
+
+            /* Only allow one recv callback registered at a time, if ByteBuffer
+             * version has been set, set to null before setting byte variant. */
+            if (internRecvSSLCb_BB != null) {
+                internRecvSSLCb_BB = null;
+            }
 
             /* set user I/O recv */
-            internRecvSSLCb = callback;
+            internRecvSSLCb_array = callback;
 
             if (callback != null) {
                 /* register internal callback with native library */
@@ -4407,12 +4476,74 @@ public class WolfSSLSession {
     }
 
     /**
-     * Registers a send callback for wolfSSL to write output data.
+     * Registers a receive callback for wolfSSL to get input data.
+     *
+     * This receive callback uses WolfSSLByteBufferIORecvCallback which uses
+     * a direct ByteBuffer. To use a byte array instead use
+     * setIORecv(WolfSSLIORecvCallback), but this will incur one additional
+     * native JNI array allocation.
+     *
+     * By default, wolfSSL uses EmbedReceive() in src/io.c as the callback
+     * which uses the system TCP recv() function. The user can register a
+     * method here to get receive TLS-encoded data from memory, some other
+     * network module, or anywhere else. Please see the EmbedReceive() function
+     * in src/io.c as a guide for how the function should work and for error
+     * codes.
+     * <p>
+     * In particular, <b>IO_ERR_WANT_READ</b> should be returned for
+     * non-blocking receive when no data is ready.
+     *
+     * @param callback  method to be registered as the receive callback for
+     *                  the wolfSSL context. The signature of this function
+     *                  must follow that as shown in
+     *                  WolfSSLByteBufferIORecvCallback#receiveCallback(
+     *                  WolfSSLSession, ByteBuffer, int, long).
+     * @throws IllegalStateException WolfSSLContext has been freed
+     * @throws WolfSSLJNIException Internal JNI error
+     * @see    #setIOSend(WolfSSLIOSendCallback)
+     */
+    public void setIORecvByteBuffer(WolfSSLByteBufferIORecvCallback callback)
+        throws IllegalStateException, WolfSSLJNIException {
+
+        confirmObjectIsActive();
+
+        synchronized (sslLock) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.sslPtr,
+                "entered setIORecv(" + callback + ") - ByteBuffer");
+
+            /* Only allow one recv callback registered at a time, if array
+             * version has been set, set to null before setting ByteBuffer. */
+            if (internRecvSSLCb_array != null) {
+                internRecvSSLCb_array = null;
+            }
+
+            /* set user I/O recv */
+            internRecvSSLCb_BB = callback;
+
+            if (callback != null) {
+                /* Register internal callback with native library, registers
+                 * JNI NativeSSLIORecvCb() with native wolfSSL.
+                 * NativeSSLIORecvCb() will then call back into
+                 * internRecvSSLCb_array/BB(). */
+                setSSLIORecv(this.sslPtr);
+            }
+        }
+    }
+
+    /**
+     * Registers a send callback for wolfSSL to write TLS encoded output data.
+     *
+     * This send callback uses WolfSSLIOSendCallback which uses byte arrays
+     * (byte[]). To use direct ByteBuffers, and avoid an extra JNI array
+     * allocation, use setIOSendByteBuffer(WolfSSLByteBufferIOSendCallback).
+     *
      * By default, wolfSSL uses EmbedSend() in src/io.c as the callback,
-     * which uses the system's TCP send() function. The user can register
-     * a function to send output to memory, some other network module, or
-     * to anywhere. Please see the EmbedSend() function in src/io.c as a
-     * guide for how the function should work and for error codes.
+     * which uses the system TCP send() function. The user can register
+     * a method here to send TLS-encoded output data to memory, some other
+     * network module, or to anywhere else. Please see the EmbedSend() function
+     * in src/io.c as a guide for how the function should work and for error
+     * codes.
      * <p>
      * In particular, <b>IO_ERR_WANT_WRITE</b> should be returned for
      * non-blocking send when the action cannot be taken yet.
@@ -4434,13 +4565,78 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered setIOSend(" + callback + ")");
+                "entered setIOSend(" + callback + ") - byte array");
+
+            /* Only allow one send callback registered at a time, if ByteBuffer
+             * version has been set, set to null before setting byte variant. */
+            if (internSendSSLCb_BB != null) {
+                internSendSSLCb_BB = null;
+            }
 
             /* set user I/O send */
-            internSendSSLCb = callback;
+            internSendSSLCb_array = callback;
 
             if (callback != null) {
-                /* register internal callback with native library */
+                /* Register internal callback with native library, registers
+                 * JNI NativeSSLIOSendCb() with native wolfSSL.
+                 * NativeSSLIOSendCb() will then call back into
+                 * internSendSSLCb_array/BB(). */
+                setSSLIOSend(this.sslPtr);
+            }
+        }
+    }
+
+    /**
+     * Registers a send callback for wolfSSL to write TLS encoded output data.
+     *
+     * This send callback uses WolfSSLByteBufferIOSendCallback which uses a
+     * ByteBuffer. To use a byte array instead, use
+     * setIOSend(WolfSSLIOSendCallback), but this will incur one
+     * additional native JNI array allocation.
+     *
+     * By default, wolfSSL uses EmbedSend() in src/io.c as the callback,
+     * which uses the system TCP send() function. The user can register
+     * a method here to send TLS-encoded output data to memory, some other
+     * network module, or to anywhere else. Please see the EmbedSend() function
+     * in src/io.c as a guide for how the function should work and for error
+     * codes.
+     * <p>
+     * In particular, <b>IO_ERR_WANT_WRITE</b> should be returned for
+     * non-blocking send when the action cannot be taken yet.
+     *
+     * @param callback  method to be registered as the send callback for
+     *                  the wolfSSL context. The signature of this function
+     *                  must follow that as shown in
+     *                  WolfSSLByteBufferIOSendCallback#sendCallback(
+     *                  WolfSSLSession, ByteBuffer, int, Object).
+     * @throws IllegalStateException WolfSSLSession has been freed
+     * @throws WolfSSLJNIException Internal JNI error
+     * @see    #setIORecv(WolfSSLIORecvCallback)
+     */
+    public void setIOSendByteBuffer(WolfSSLByteBufferIOSendCallback callback)
+        throws IllegalStateException, WolfSSLJNIException {
+
+        confirmObjectIsActive();
+
+        synchronized (sslLock) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.sslPtr,
+                "entered setIOSend(" + callback + ") - ByteBuffer");
+
+            /* Only allow one recv callback registered at a time, if array
+             * version has been set, set to null before setting ByteBuffer. */
+            if (internSendSSLCb_array != null) {
+                internSendSSLCb_array = null;
+            }
+
+            /* set user I/O send */
+            internSendSSLCb_BB = callback;
+
+            if (callback != null) {
+                /* Register internal callback with native library, registers
+                 * JNI NativeSSLIOSendCb() with native wolfSSL.
+                 * NativeSSLIOSendCb() will then call back into
+                 * internSendSSLCb_array/BB(). */
                 setSSLIOSend(this.sslPtr);
             }
         }

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -3184,9 +3184,6 @@ public class WolfSSLSession {
         confirmObjectIsActive();
 
         synchronized (sslLock) {
-            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getIOReadCtx()");
-
             return this.ioReadCtx;
         }
     }
@@ -3235,9 +3232,6 @@ public class WolfSSLSession {
         confirmObjectIsActive();
 
         synchronized (sslLock) {
-            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getIOWriteCtx()");
-
             return this.ioWriteCtx;
         }
     }

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -440,6 +440,7 @@ public class WolfSSLSession {
     private native int getThreadsBlockedInPoll(long ssl);
     private native int setMTU(long ssl, int mtu);
     private native String stateStringLong(long ssl);
+    private native int getMaxOutputSize(long ssl);
 
     /* ------------------- session-specific methods --------------------- */
 
@@ -2554,6 +2555,35 @@ public class WolfSSLSession {
         }
 
         return state;
+    }
+
+    /**
+     * Return max record layer size plaintext input size
+     *
+     * @return max record layer size plaintext input size in bytes, or
+     *         negative value on error.
+     *
+     * @throws IllegalStateException WolfSSLContext has been freed
+     */
+    public int getMaxOutputSize() throws IllegalStateException {
+
+        int ret;
+
+        confirmObjectIsActive();
+
+        synchronized (sslLock) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.sslPtr,
+                "entered getOutputSize()");
+
+            ret = getMaxOutputSize(this.sslPtr);
+
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.sslPtr,
+                "max output size: " + ret);
+        }
+
+        return ret;
     }
 
     /**

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
@@ -756,6 +756,10 @@ public class WolfSSLEngine extends SSLEngine {
         /* Force out buffer to be large enough to hold max packet size */
         if (out.remaining() <
             this.engineHelper.getSession().getPacketBufferSize()) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                "out.remaining() too small (" +
+                out.remaining() + "), need at least: " +
+                this.engineHelper.getSession().getPacketBufferSize());
             return new SSLEngineResult(Status.BUFFER_OVERFLOW, hs, 0, 0);
         }
 
@@ -1064,7 +1068,7 @@ public class WolfSSLEngine extends SSLEngine {
     public synchronized SSLEngineResult unwrap(ByteBuffer in, ByteBuffer[] out,
             int ofst, int length) throws SSLException {
 
-        int i, ret = 0, sz = 0, err = 0;
+        int i, ret = 0, err = 0;
         int inPosition = 0;
         int inRemaining = 0;
         int consumed = 0;
@@ -1072,7 +1076,6 @@ public class WolfSSLEngine extends SSLEngine {
         long dtlsPrevDropCount = 0;
         long dtlsCurrDropCount = 0;
         int prevSessionTicketCount = 0;
-        byte[] tmp;
 
         /* Set initial status for SSLEngineResult return */
         Status status = SSLEngineResult.Status.OK;

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
@@ -767,7 +767,7 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
      * @return maximum output buffer size
      */
     @Override
-    public int getPacketBufferSize() {
+    public synchronized int getPacketBufferSize() {
 
         /* JSSE implementations seem to set the SSL/TLS maximum packet size
          * (record size) differently.

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineTest.java
@@ -1662,8 +1662,8 @@ public class WolfSSLEngineTest {
                 session = engine.getSession();
                 packetBufSz = session.getPacketBufferSize();
 
-                /* expected to be 18437 */
-                if (packetBufSz != 18437) {
+                /* expected to be 17k */
+                if (packetBufSz != (17 * 1024)) {
                     error("\t\t... failed");
                     fail("got incorrect packet buffer size (" +
                         enabledProtocols.get(i) + ")");

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
@@ -3393,7 +3393,7 @@ public class WolfSSLSocketTest {
                 throw cliException;
             }
 
-            System.out.println("\t\t... passed");
+            System.out.println("\t... passed");
 
         } finally {
             /* Restore original property value */

--- a/src/test/com/wolfssl/test/WolfSSLContextTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLContextTest.java
@@ -644,13 +644,6 @@ public class WolfSSLContextTest {
                 fail("setMinECCKeySize should fail with negative key size");
             }
 
-            /* key length not % 8 should fail */
-            ret = ctx.setMinECCKeySize(255);
-            if (ret != WolfSSL.BAD_FUNC_ARG) {
-                System.out.println("\t\t... failed");
-                fail("setMinECCKeySize should fail with non % 8 size");
-            }
-
             /* valid key length should succeed */
             ret = ctx.setMinECCKeySize(128);
             if (ret != WolfSSL.SSL_SUCCESS) {


### PR DESCRIPTION
This PR contains work done to increase `SSLEngine` (`WolfSSLEngine`) performance, including:

- Use a single static direct ByteBuffer in `WolfSSLEngine.SendAppData()`, instead of allocating a new array each time the method is called.
- Use a static output array for I/O output callback instead of allocating a new one for each send.
- Cache `jmethodID` values once globally when library is initialized, instead of multiple time throughout execution of code paths.
- Add new helper functions to throw exceptions (`throwWolfSSLJNIException()`, `throwWolfSSLException()`), which causes `FindClass()` to only be called when we need to throw an exception, not every time some JNI functions are called.
- Add ByteBuffer-based wolfSSL I/O callback support, and plug them into `WolfSSLEngine`. This allows our same native `char*` to be used again via wrapping with a direct ByteBuffer, instead of re-allocating another new array and copying data between Java and native C wolfSSL.

This also fixes runtime compatibility with the https://github.com/marianobarrios/tls-channel package:
- Adjusts `SSLSession.getPacketBufferSize()` for `tls-channel` compatibility. `tls-channel` uses a maximum I/O buffer size of 17k, and our `getPacketBufferSize()` was returning something too big.

Changes and performance were tested with a client and server demo that was created using `tls-channel` with wolfJSSE underneath. The client sent 500 MB to the server, the server sent the 500 MB back to the client, then the client compared the received data to the original sent.

Client-side benchmarks prior to these changes:

```
Client Benchmark Results:
Send: 524288000 bytes in 3.350 seconds (149.27 MB/s)
Receive: 524288000 bytes in 3.081 seconds (162.31 MB/s)
```

Client-side benchmarks after these changes show a **26% increase** in send and **31% increase** in receive throughput:

```
Client Benchmark Results:
Send: 524288000 bytes in 2.485 seconds (201.22 MB/s)
Receive: 524288000 bytes in 2.112 seconds (236.69 MB/s)
```
