### PR TITLE
Null terminate `NativeALPNSelectCb()` peer protocol list before XSTRTOK

### DIFF
--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -5343,7 +5343,9 @@ int NativeALPNSelectCb(WOLFSSL *ssl, const unsigned char **out,
 
     /* Use wolfSSL_ALPN_GetPeerProtocol() here to get ALPN protocols sent
      * by the peer instead of directly using in/inlen, since this API
-     * splits/formats into a comma-separated, null-terminated list */
+     * splits/formats into a comma-separated list. peerProtosSz does not
+     * include the null terminator byte in the size. It is only the size
+     * of the ALPN list chars proper.*/
     ret = wolfSSL_ALPN_GetPeerProtocol(ssl, &peerProtos, &peerProtosSz);
     if (ret != WOLFSSL_SUCCESS) {
         if ((*jenv)->ExceptionOccurred(jenv)) {
@@ -5359,8 +5361,9 @@ int NativeALPNSelectCb(WOLFSSL *ssl, const unsigned char **out,
     }
 
     /* Make a copy of peer protos since we have to scan through it first
-     * to get total number of tokens */
-    peerProtosCopy = (char*)XMALLOC(peerProtosSz, NULL,
+     * to get total number of tokens. Allocate peerProtosSz+1 to make
+     * sure our list is null terminated for XSTRTOK(). */
+    peerProtosCopy = (char*)XMALLOC(peerProtosSz + 1, NULL,
         DYNAMIC_TYPE_TMP_BUFFER);
     if (peerProtosCopy == NULL) {
         if ((*jenv)->ExceptionOccurred(jenv)) {
@@ -5374,6 +5377,7 @@ int NativeALPNSelectCb(WOLFSSL *ssl, const unsigned char **out,
         }
         return SSL_TLSEXT_ERR_ALERT_FATAL;
     }
+    XMEMSET(peerProtosCopy, 0, peerProtosSz + 1);
     XMEMCPY(peerProtosCopy, peerProtos, peerProtosSz);
 
     /* get count of protocols, used to create Java array of proper size */

--- a/src/test/com/wolfssl/test/WolfSSLContextTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLContextTest.java
@@ -644,13 +644,6 @@ public class WolfSSLContextTest {
                 fail("setMinECCKeySize should fail with negative key size");
             }
 
-            /* key length not % 8 should fail */
-            ret = ctx.setMinECCKeySize(255);
-            if (ret != WolfSSL.BAD_FUNC_ARG) {
-                System.out.println("\t\t... failed");
-                fail("setMinECCKeySize should fail with non % 8 size");
-            }
-
             /* valid key length should succeed */
             ret = ctx.setMinECCKeySize(128);
             if (ret != WolfSSL.SSL_SUCCESS) {


### PR DESCRIPTION
This PR makes a change to `com.wolfssl.WolfSSLSession` native JNI `NativeALPNSelectCb()` to ensure that the peer ALPN protocol list is null terminated before using `XSTRTOK()` to iterate over the list.

Caught with `-fsanitize=address` testing running existing JUnit tests:

```
    [junit] =================================================================
    [junit] ==12036==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x602000049e5b at pc 0x000150d1183c bp 0x70000a59f8a0 sp 0x70000a59f898
    [junit] READ of size 1 at 0x602000049e5b thread T317
    [junit]     #0 0x150d1183b in wc_strtok wc_port.c:1101
    [junit]     #1 0x15035ac4c in NativeALPNSelectCb com_wolfssl_WolfSSLSession.c:5383
    [junit]     #2 0x1510b199d in ALPN_Select tls.c:1858
    [junit]     #3 0x151105e12 in DoTls13ClientHello tls13.c:7116
    [junit]     #4 0x15110fdd6 in DoTls13HandShakeMsgType tls13.c:12722
    [junit]     #5 0x15111c7ac in DoTls13HandShakeMsg tls13.c:13072
    [junit]     #6 0x150e9b6da in DoProcessReplyEx internal.c:22609
    [junit]     #7 0x150e951da in ProcessReplyEx internal.c:22969
    [junit]     #8 0x150e951b6 in ProcessReply internal.c:22962
    [junit]     #9 0x150fc119b in wolfSSL_accept ssl.c:10871
    [junit]     #10 0x150343e4d in Java_com_wolfssl_WolfSSLSession_accept com_wolfssl_WolfSSLSession.c:1629
```

Also includes one ECC test fix which causes JUnit tests to fail after a recent native wolfSSL ECC key size adjustment.