### PR TITLE
implement SNI matcher logic

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLParameters.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLParameters.java
@@ -21,7 +21,9 @@
 package com.wolfssl.provider.jsse;
 
 import java.util.List;
+import javax.net.ssl.SNIMatcher;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 
 /**
@@ -45,6 +47,7 @@ final class WolfSSLParameters {
     private boolean needClientAuth = false;
     private String endpointIdAlgorithm = null;
     private List<WolfSSLSNIServerName> serverNames;
+    private List<SNIMatcher> sniMatchers;
     private boolean useCipherSuiteOrder = true;
     String[] applicationProtocols = new String[0];
     private boolean useSessionTickets = false;
@@ -72,7 +75,7 @@ final class WolfSSLParameters {
 
         /* TODO: duplicate other properties here when WolfSSLParameters
          * can handle them */
-
+        cp.setSNIMatchers(this.getSNIMatchers());
         return cp;
     }
 
@@ -184,14 +187,27 @@ final class WolfSSLParameters {
     }
 
     /* TODO, create our own class for SNIMatcher, in case Java doesn't support it */
-    //void setSNIMatchers(Collection<SNIMatcher> matchers) {
-    //    /* TODO */
-    //}
+    void setSNIMatchers(Collection<SNIMatcher> matchers) {
+        if (matchers != null && !matchers.isEmpty()) {
+            if (this.sniMatchers == null) {
+                this.sniMatchers = new ArrayList<SNIMatcher>();
+            }
+            for (SNIMatcher matcher : matchers) {
+                this.sniMatchers.add(matcher);
+            }
+        } else {
+            this.sniMatchers = new ArrayList<SNIMatcher>();
+        }
+    }
 
     /* TODO, create our own class for SNIMatcher, in case Java doesn't support it */
-    //Collection<SNIMatcher> getSNIMatchers() {
-    //    return null; /* TODO */
-    //}
+    List<SNIMatcher> getSNIMatchers() {
+        if (this.sniMatchers != null && !this.sniMatchers.isEmpty()) {
+            return Collections.unmodifiableList(new ArrayList<SNIMatcher>(sniMatchers));
+        } else {
+            return Collections.emptyList();
+        }
+    }
 
     void setUseCipherSuitesOrder(boolean honorOrder) {
         this.useCipherSuiteOrder = honorOrder;

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLParametersHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLParametersHelper.java
@@ -39,6 +39,8 @@ public class WolfSSLParametersHelper
     private static Method setApplicationProtocols = null;
     private static Method getEndpointIdentificationAlgorithm = null;
     private static Method setEndpointIdentificationAlgorithm = null;
+    private static Method getSNIMatchers = null;
+    private static Method setSNIMatchers = null;
     private static Method getMaximumPacketSize = null;
     private static Method setMaximumPacketSize = null;
 
@@ -76,6 +78,12 @@ public class WolfSSLParametersHelper
                                     continue;
                                 case "setEndpointIdentificationAlgorithm":
                                     setEndpointIdentificationAlgorithm = m;
+                                    continue;
+                                case "getSNIMatchers":
+                                    getSNIMatchers = m;
+                                    continue;
+                                case "setSNIMatchers":
+                                    setSNIMatchers = m;
                                     continue;
                                 case "getMaximumPacketSize":
                                     getMaximumPacketSize = m;
@@ -126,7 +134,7 @@ public class WolfSSLParametersHelper
          * do not existing in older JDKs. Since older JDKs will not have them,
          * use Java reflection to detect availability in helper class. */
         if (setServerNames != null || setApplicationProtocols != null ||
-            setEndpointIdentificationAlgorithm != null) {
+            setEndpointIdentificationAlgorithm != null || setSNIMatchers != null) {
 
             try {
                 /* load WolfSSLJDK8Helper at runtime, not compiled
@@ -155,6 +163,10 @@ public class WolfSSLParametersHelper
                     mth.invoke(obj, ret,
                         setEndpointIdentificationAlgorithm, in);
                 }
+                if (setSNIMatchers != null) {
+                    mth = cls.getDeclaredMethod("setSNIMatchers", paramList);
+                    mth.invoke(obj, ret, setSNIMatchers, in);
+                }
 
             } catch (Exception e) {
                 /* ignore, class not found */
@@ -170,6 +182,14 @@ public class WolfSSLParametersHelper
                 setMaximumPacketSize.invoke(ret, in.getMaximumPacketSize());
             }
         } catch (IllegalAccessException | InvocationTargetException e) {
+            /* Not available, just ignore and continue */
+        }
+
+        try {
+            if (setSNIMatchers != null) {
+                ret.setSNIMatchers(in.getSNIMatchers());
+            }
+        } catch (Exception e) {
             /* Not available, just ignore and continue */
         }
 
@@ -222,7 +242,7 @@ public class WolfSSLParametersHelper
          * do not existing in older JDKs. Since older JDKs will not have them,
          * use Java reflection to detect availability in helper class. */
         if (getServerNames != null || getApplicationProtocols != null ||
-            getEndpointIdentificationAlgorithm != null) {
+            getEndpointIdentificationAlgorithm != null || getSNIMatchers != null) {
             try {
                 /* load WolfSSLJDK8Helper at runtime, not compiled on older JDKs */
                 Class<?> cls = Class.forName(
@@ -245,6 +265,10 @@ public class WolfSSLParametersHelper
                 if (getEndpointIdentificationAlgorithm != null) {
                     mth = cls.getDeclaredMethod(
                         "getEndpointIdentificationAlgorithm", paramList);
+                    mth.invoke(obj, in, out);
+                }
+                if (getSNIMatchers != null){
+                    mth = cls.getDeclaredMethod("getSNIMatchers", paramList);
                     mth.invoke(obj, in, out);
                 }
 
@@ -276,6 +300,9 @@ public class WolfSSLParametersHelper
         out.setSNIMatchers(in.getSNIMatchers());
         out.setUseCipherSuitesOrder(in.getUseCipherSuitesOrder());
         */
+
+        out.setSNIMatchers(in.getSNIMatchers());
+
     }
 }
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -1569,6 +1569,10 @@ public class WolfSSLSocket extends SSLSocket {
                 close();
                 throw e;
 
+            } catch (SSLHandshakeException e){
+                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                    () -> "got SSLHandshakeException in doHandshake()");
+                throw e;
             } catch (SSLException e) {
                 final int tmpErr = err;
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,


### PR DESCRIPTION
Implements SNI matcher logic for server side wolfSSLSockets in wolfSSLEngineHelper's `doHandshake()`.

Adds functions 
- `setSNIMatchers()` - initialize or add to sniMatchers list.
- `getSNIMatchers()` - returns the sniMatchers or an empty list if sniMatchers is null or empty
- `matchSNI()` - compares requested SNI to sniMatchers list. Returns true if a match is found. Will ignore matching (return true) if sniMatchers or the requested server names are null or empty.

Passes SunJSSE tests: SSLSocketConsistentSNI.java, SSLSocketExplorer.java, SSLSocketExplorerFailure.java, SSLSocketExplorerMatchedSNI.java, SSLSocketExplorerWithCliSNI.java, SSLSocketExplorerWithSrvSNI.java, SSLSocketExplorerUnmatchedSNI.java.

Also added WolfSSLSocket test for matched and unmatched server names.