### PR TITLE
Switch to Java Logging (`java.util.logging`)

### DIFF
--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -583,12 +583,12 @@ public class WolfSSL {
         int ret;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, "initializing wolfSSL library");
+            WolfSSLDebug.INFO, () -> "initializing wolfSSL library");
 
         ret = init();
         if (ret != SSL_SUCCESS) {
-            throw new WolfSSLException("Failed to initialize wolfSSL library: "
-                    + ret);
+            throw new WolfSSLException(
+                "Failed to initialize wolfSSL library: " + ret);
         }
 
         /* initialize cipher enum values */
@@ -628,7 +628,7 @@ public class WolfSSL {
         this.active = true;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, "wolfSSL library initialization done");
+            WolfSSLDebug.INFO, () -> "wolfSSL library initialization done");
     }
 
     /* ------------------- private/protected methods -------------------- */
@@ -697,7 +697,7 @@ public class WolfSSL {
         int fipsLoaded = 0;
 
         WolfSSLDebug.log(WolfSSL.class, WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, "loading native library: wolfssl");
+            WolfSSLDebug.INFO, () -> "loading native library: wolfssl");
 
         String osName = System.getProperty("os.name");
         if (osName != null && osName.toLowerCase().contains("win")) {
@@ -717,7 +717,7 @@ public class WolfSSL {
         }
 
         WolfSSLDebug.log(WolfSSL.class, WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, "loading native library: wolfssljni");
+            WolfSSLDebug.INFO, () -> "loading native library: wolfssljni");
 
         /* Load wolfssljni library */
         System.loadLibrary("wolfssljni");
@@ -736,7 +736,7 @@ public class WolfSSL {
     public static void loadLibrary(String libName) throws UnsatisfiedLinkError {
 
         WolfSSLDebug.log(WolfSSL.class, WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, "loading native library by name: " + libName);
+            WolfSSLDebug.INFO, () -> "loading native lib by name: " + libName);
 
         System.loadLibrary(libName);
     }
@@ -761,7 +761,7 @@ public class WolfSSL {
         throws UnsatisfiedLinkError {
 
         WolfSSLDebug.log(WolfSSL.class, WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, "loading native library by path: " + libPath);
+            WolfSSLDebug.INFO, () -> "loading native lib by path: " + libPath);
 
         System.load(libPath);
     }
@@ -1592,7 +1592,7 @@ public class WolfSSL {
     public static int cryptoCbRegisterDevice(int devId) {
 
         WolfSSLDebug.log(WolfSSL.class, WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, "registering crypto cb devId: " + devId);
+            WolfSSLDebug.INFO, () -> "registering crypto cb devId: " + devId);
 
         return wc_CryptoCb_RegisterDevice(devId);
     }
@@ -1606,7 +1606,7 @@ public class WolfSSL {
     public static int cryptoCbUnRegisterDevice(int devId) {
 
         WolfSSLDebug.log(WolfSSL.class, WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, "unregistering crypto cb devId: " + devId);
+            WolfSSLDebug.INFO, () -> "unregistering crypto cb devId: " + devId);
 
         wc_CryptoCb_UnRegisterDevice(devId);
 

--- a/src/java/com/wolfssl/WolfSSLCertManager.java
+++ b/src/java/com/wolfssl/WolfSSLCertManager.java
@@ -70,7 +70,7 @@ public class WolfSSLCertManager {
         this.active = true;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, cmPtr, "creating new WolfSSLCertManager");
+            WolfSSLDebug.INFO, cmPtr, () -> "creating new WolfSSLCertManager");
     }
 
     /**
@@ -105,8 +105,8 @@ public class WolfSSLCertManager {
 
         synchronized (cmLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.cmPtr, "entered CertManagerLoadCA(" +
-                f + ", " + d + "");
+                WolfSSLDebug.INFO, this.cmPtr,
+                () -> "entered CertManagerLoadCA(" + f + ", " + d + ")");
 
             return CertManagerLoadCA(this.cmPtr, f, d);
         }
@@ -132,8 +132,8 @@ public class WolfSSLCertManager {
         synchronized (cmLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.cmPtr,
-                "entered CertManagerLoadCABuffer(sz: " + sz +
-                ", format: " + format + "");
+                () -> "entered CertManagerLoadCABuffer(sz: " + sz +
+                ", format: " + format + ")");
 
             return CertManagerLoadCABuffer(this.cmPtr, in, sz, format);
         }
@@ -158,7 +158,7 @@ public class WolfSSLCertManager {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
             WolfSSLDebug.INFO, this.cmPtr,
-            "entered CertManagerLoadCAKeyStore(" + ks + ")");
+            () -> "entered CertManagerLoadCAKeyStore(" + ks + ")");
 
         if (ks == null) {
             throw new WolfSSLException("Input KeyStore is null");
@@ -214,7 +214,7 @@ public class WolfSSLCertManager {
         synchronized (cmLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.cmPtr,
-                "entered CertManagerUnloadCAs()");
+                () -> "entered CertManagerUnloadCAs()");
 
             return CertManagerUnloadCAs(this.cmPtr);
         }
@@ -241,8 +241,8 @@ public class WolfSSLCertManager {
         synchronized (cmLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.cmPtr,
-                "entered CertManagerVerifyBuffer(sz: " + sz + ", format: " +
-                format + ")");
+                () -> "entered CertManagerVerifyBuffer(sz: " + sz +
+                ", format: " + format + ")");
 
             return CertManagerVerifyBuffer(this.cmPtr, in, sz, format);
         }
@@ -263,7 +263,7 @@ public class WolfSSLCertManager {
 
             synchronized (cmLock) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                    WolfSSLDebug.INFO, this.cmPtr, "entered free()");
+                    WolfSSLDebug.INFO, this.cmPtr, () -> "entered free()");
 
                 /* free native resources */
                 CertManagerFree(this.cmPtr);
@@ -288,3 +288,4 @@ public class WolfSSLCertManager {
         super.finalize();
     }
 }
+

--- a/src/java/com/wolfssl/WolfSSLCertRequest.java
+++ b/src/java/com/wolfssl/WolfSSLCertRequest.java
@@ -88,7 +88,8 @@ public class WolfSSLCertRequest {
         }
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, x509ReqPtr, "creating new WolfSSLCertRequest");
+            WolfSSLDebug.INFO, x509ReqPtr,
+            () -> "creating new WolfSSLCertRequest");
 
         synchronized (stateLock) {
             this.active = true;
@@ -134,7 +135,7 @@ public class WolfSSLCertRequest {
         synchronized (x509ReqLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.x509ReqPtr,
-                "entered setSubjectName(" + name + ")");
+                () -> "entered setSubjectName(" + name + ")");
 
             /* TODO somehow lock WolfSSLX509Name object while using pointer? */
             ret = X509_REQ_set_subject_name(this.x509ReqPtr,
@@ -142,8 +143,8 @@ public class WolfSSLCertRequest {
         }
 
         if (ret != WolfSSL.SSL_SUCCESS) {
-            throw new WolfSSLException("Error setting subject name " +
-                                       "(ret: " + ret + ")");
+            throw new WolfSSLException(
+                "Error setting subject name (ret: " + ret + ")");
         }
     }
 
@@ -175,7 +176,7 @@ public class WolfSSLCertRequest {
         synchronized (x509ReqLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.x509ReqPtr,
-                "entered addAttribute(nid: " + nid + ", byte[])");
+                () -> "entered addAttribute(nid: " + nid + ", byte[])");
         }
 
         if (nid != WolfSSL.NID_pkcs9_challengePassword &&
@@ -201,8 +202,8 @@ public class WolfSSLCertRequest {
         }
 
         if (ret != WolfSSL.SSL_SUCCESS) {
-            throw new WolfSSLException("Error setting CSR attribute " +
-                                       "(ret: " + ret + ")");
+            throw new WolfSSLException(
+                "Error setting CSR attribute (ret: " + ret + ")");
         }
     }
 
@@ -228,14 +229,14 @@ public class WolfSSLCertRequest {
         synchronized (x509ReqLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.x509ReqPtr,
-                "entered setVersion(" + version + ")");
+                () -> "entered setVersion(" + version + ")");
 
             ret = X509_REQ_set_version(this.x509ReqPtr, version);
         }
 
         if (ret != WolfSSL.SSL_SUCCESS) {
-            throw new WolfSSLException("Error setting CSR version " +
-                                       "(ret: " + ret + ")");
+            throw new WolfSSLException(
+                "Error setting CSR version (ret: " + ret + ")");
         }
     }
 
@@ -266,8 +267,9 @@ public class WolfSSLCertRequest {
 
         synchronized (x509ReqLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.x509ReqPtr, "entered setPublicKey(" +
-                filePath + ", type: " + keyType + ", format: " + format + ")");
+                WolfSSLDebug.INFO, this.x509ReqPtr,
+                () -> "entered setPublicKey(" + filePath + ", type: " +
+                keyType + ", format: " + format + ")");
         }
 
         if (filePath == null || filePath.isEmpty()) {
@@ -276,14 +278,14 @@ public class WolfSSLCertRequest {
 
         keyFile = new File(filePath);
         if (!keyFile.exists()) {
-            throw new WolfSSLException("Input file does not exist: " +
-                filePath);
+            throw new WolfSSLException(
+                "Input file does not exist: " + filePath);
         }
 
         fileBytes = WolfSSL.fileToBytes(keyFile);
         if (fileBytes == null) {
-            throw new WolfSSLException("Failed to read bytes from file: " +
-                filePath);
+            throw new WolfSSLException(
+                "Failed to read bytes from file: " + filePath);
         }
 
         setPublicKey(fileBytes, keyType, format);
@@ -316,8 +318,8 @@ public class WolfSSLCertRequest {
         synchronized (x509ReqLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.x509ReqPtr,
-                "entered setPublicKey(byte[], type: " + keyType + ", format: " +
-                format + ")");
+                () -> "entered setPublicKey(byte[], type: " + keyType +
+                ", format: " + format + ")");
         }
 
         if (key == null || key.length == 0) {
@@ -375,7 +377,7 @@ public class WolfSSLCertRequest {
         synchronized (x509ReqLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.x509ReqPtr,
-                "entered setPublicKey(" + key + ")");
+                () -> "entered setPublicKey(" + key + ")");
         }
 
         if (key instanceof RSAPublicKey) {
@@ -453,7 +455,7 @@ public class WolfSSLCertRequest {
         synchronized (x509ReqLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.x509ReqPtr,
-                "entered addExtension(nid: " + nid + ", value: " + value +
+                () -> "entered addExtension(nid: " + nid + ", value: " + value +
                 ", isCritical: " + isCritical + ")");
         }
 
@@ -516,7 +518,7 @@ public class WolfSSLCertRequest {
         synchronized (x509ReqLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.x509ReqPtr,
-                "entered addExtension(nid: " + nid + ", value: " + value +
+                () -> "entered addExtension(nid: " + nid + ", value: " + value +
                 ", isCritical: " + isCritical + ")");
         }
 
@@ -569,9 +571,10 @@ public class WolfSSLCertRequest {
 
         synchronized (x509ReqLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.x509ReqPtr, "entered signRequest(" +
-                filePath + ", keyType: " + keyType + ", format: " + format +
-                ", digestAlg: " + digestAlg + ")");
+                WolfSSLDebug.INFO, this.x509ReqPtr,
+                () -> "entered signRequest(" + filePath + ", keyType: " +
+                keyType + ", format: " + format + ", digestAlg: " +
+                digestAlg + ")");
         }
 
         if (filePath == null || filePath.isEmpty()) {
@@ -580,14 +583,14 @@ public class WolfSSLCertRequest {
 
         keyFile = new File(filePath);
         if (!keyFile.exists()) {
-            throw new WolfSSLException("Input file does not exist: " +
-                filePath);
+            throw new WolfSSLException(
+                "Input file does not exist: " + filePath);
         }
 
         fileBytes = WolfSSL.fileToBytes(keyFile);
         if (fileBytes == null) {
-            throw new WolfSSLException("Failed to read bytes from file: " +
-                filePath);
+            throw new WolfSSLException(
+                "Failed to read bytes from file: " + filePath);
         }
 
         signRequest(fileBytes, keyType, format, digestAlg);
@@ -623,7 +626,7 @@ public class WolfSSLCertRequest {
         synchronized (x509ReqLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.x509ReqPtr,
-                "entered signRequest(byte[], keyType: " + keyType +
+                () -> "entered signRequest(byte[], keyType: " + keyType +
                 ", format: " + format + ", digestAlg: " + digestAlg + ")");
         }
 
@@ -655,8 +658,7 @@ public class WolfSSLCertRequest {
 
         if (ret != WolfSSL.SSL_SUCCESS) {
             throw new WolfSSLException(
-                "Error signing native X509_REQ " +
-                "(ret: " + ret + ")");
+                "Error signing native X509_REQ (ret: " + ret + ")");
         }
     }
 
@@ -686,7 +688,7 @@ public class WolfSSLCertRequest {
         synchronized (x509ReqLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.x509ReqPtr,
-                "entered signRequest(key: " + key + ", digestAlg: " +
+                () -> "entered signRequest(key: " + key + ", digestAlg: " +
                 digestAlg + ")");
         }
 
@@ -718,8 +720,7 @@ public class WolfSSLCertRequest {
 
         if (ret != WolfSSL.SSL_SUCCESS) {
             throw new WolfSSLException(
-                "Error signing native X509_REQ " +
-                "(ret: " + ret + ")");
+                "Error signing native X509_REQ (ret: " + ret + ")");
         }
     }
 
@@ -737,7 +738,7 @@ public class WolfSSLCertRequest {
 
         synchronized (x509ReqLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.x509ReqPtr, "entered getDer()");
+                WolfSSLDebug.INFO, this.x509ReqPtr, () -> "entered getDer()");
 
             return X509_REQ_get_der(this.x509ReqPtr);
         }
@@ -757,7 +758,7 @@ public class WolfSSLCertRequest {
 
         synchronized (x509ReqLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.x509ReqPtr, "entered getPem()");
+                WolfSSLDebug.INFO, this.x509ReqPtr, () -> "entered getPem()");
 
             return X509_REQ_get_pem(this.x509ReqPtr);
         }
@@ -802,7 +803,7 @@ public class WolfSSLCertRequest {
             synchronized (x509ReqLock) {
 
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                    WolfSSLDebug.INFO, this.x509ReqPtr, "entered free()");
+                    WolfSSLDebug.INFO, this.x509ReqPtr, () -> "entered free()");
 
                 /* free native resources */
                 X509_REQ_free(this.x509ReqPtr);

--- a/src/java/com/wolfssl/WolfSSLCertificate.java
+++ b/src/java/com/wolfssl/WolfSSLCertificate.java
@@ -143,7 +143,8 @@ public class WolfSSLCertificate implements Serializable {
         this.weOwnX509Ptr = true;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, x509Ptr, "creating new WolfSSLCertificate");
+            WolfSSLDebug.INFO, x509Ptr,
+            () -> "creating new WolfSSLCertificate");
 
         synchronized (stateLock) {
             this.active = true;
@@ -172,7 +173,7 @@ public class WolfSSLCertificate implements Serializable {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
             WolfSSLDebug.INFO, x509Ptr,
-            "creating new WolfSSLCertificate(byte[])");
+            () -> "creating new WolfSSLCertificate(byte[])");
 
         /* x509Ptr has been allocated natively, mark as owned */
         this.weOwnX509Ptr = true;
@@ -214,7 +215,8 @@ public class WolfSSLCertificate implements Serializable {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
             WolfSSLDebug.INFO, x509Ptr,
-            "creating new WolfSSLCertificate(byte[], format: " + format +")");
+            () -> "creating new WolfSSLCertificate(byte[], format: " +
+            format +")");
 
         /* x509Ptr has been allocated natively, mark as owned */
         this.weOwnX509Ptr = true;
@@ -245,8 +247,8 @@ public class WolfSSLCertificate implements Serializable {
         }
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, x509Ptr, "creating new WolfSSLCertificate(" +
-            fileName + ")");
+            WolfSSLDebug.INFO, x509Ptr,
+            () -> "creating new WolfSSLCertificate(" + fileName + ")");
 
         /* x509Ptr has been allocated natively, mark as owned */
         this.weOwnX509Ptr = true;
@@ -288,8 +290,9 @@ public class WolfSSLCertificate implements Serializable {
         }
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, x509Ptr, "creating new WolfSSLCertificate(" +
-            fileName + ", format: " + format + ")");
+            WolfSSLDebug.INFO, x509Ptr,
+            () -> "creating new WolfSSLCertificate(" + fileName +
+            ", format: " + format + ")");
 
         /* x509Ptr has been allocated natively, mark as owned */
         this.weOwnX509Ptr = true;
@@ -320,7 +323,8 @@ public class WolfSSLCertificate implements Serializable {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
             WolfSSLDebug.INFO, x509Ptr,
-            "creating new WolfSSLCertificate(ptr, doFree: " + doFree + ")");
+            () -> "creating new WolfSSLCertificate(ptr, doFree: " +
+            doFree + ")");
 
 
         if (!doFree) {
@@ -392,7 +396,7 @@ public class WolfSSLCertificate implements Serializable {
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.x509Ptr,
-                "entering getSubjectName(" + name + ")");
+                () -> "entering getSubjectName(" + name + ")");
 
             /* TODO somehow lock WolfSSLX509Name object while using pointer? */
             ret = X509_set_subject_name(this.x509Ptr,
@@ -400,8 +404,8 @@ public class WolfSSLCertificate implements Serializable {
         }
 
         if (ret != WolfSSL.SSL_SUCCESS) {
-            throw new WolfSSLException("Error setting subject name " +
-                                       "(ret: " + ret + ")");
+            throw new WolfSSLException(
+                "Error setting subject name (ret: " + ret + ")");
         }
     }
 
@@ -428,7 +432,7 @@ public class WolfSSLCertificate implements Serializable {
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.x509Ptr,
-                "entering getIssuerName(" + name + ")");
+                () -> "entering getIssuerName(" + name + ")");
 
             /* TODO somehow lock WolfSSLX509Name object while using pointer? */
             ret = X509_set_issuer_name(this.x509Ptr,
@@ -436,8 +440,8 @@ public class WolfSSLCertificate implements Serializable {
         }
 
         if (ret != WolfSSL.SSL_SUCCESS) {
-            throw new WolfSSLException("Error setting issuer name " +
-                                       "(ret: " + ret + ")");
+            throw new WolfSSLException(
+                "Error setting issuer name (ret: " + ret + ")");
         }
     }
 
@@ -464,14 +468,14 @@ public class WolfSSLCertificate implements Serializable {
 
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.x509Ptr, "entering setIssuerName(" +
-                cert + ")");
+                WolfSSLDebug.INFO, this.x509Ptr,
+                () -> "entering setIssuerName(" + cert + ")");
         }
 
         x509NamePtr = X509_get_issuer_name_ptr(cert.getX509Ptr());
         if (x509NamePtr == 0) {
-            throw new WolfSSLException("Error getting issuer name from " +
-                "WolfSSLCertificate");
+            throw new WolfSSLException(
+                "Error getting issuer name from WolfSSLCertificate");
         }
 
         synchronized (x509Lock) {
@@ -480,8 +484,8 @@ public class WolfSSLCertificate implements Serializable {
         }
 
         if (ret != WolfSSL.SSL_SUCCESS) {
-            throw new WolfSSLException("Error setting issuer name " +
-                                       "(ret: " + ret + ")");
+            throw new WolfSSLException(
+                "Error setting issuer name (ret: " + ret + ")");
         }
     }
 
@@ -509,8 +513,8 @@ public class WolfSSLCertificate implements Serializable {
 
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.x509Ptr, "entering setIssuerName(" +
-                cert + ")");
+                WolfSSLDebug.INFO, this.x509Ptr,
+                () -> "entering setIssuerName(" + cert + ")");
         }
 
         /* Get DER encoding of certificate */
@@ -521,8 +525,8 @@ public class WolfSSLCertificate implements Serializable {
         }
 
         if (ret != WolfSSL.SSL_SUCCESS) {
-            throw new WolfSSLException("Error setting issuer name " +
-                                       "(ret: " + ret + ")");
+            throw new WolfSSLException(
+                "Error setting issuer name (ret: " + ret + ")");
         }
     }
 
@@ -553,9 +557,9 @@ public class WolfSSLCertificate implements Serializable {
 
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.x509Ptr, "entering setPublicKey(" +
-                filePath + ", keyType: " + keyType + ", format: " +
-                format + ")");
+                WolfSSLDebug.INFO, this.x509Ptr,
+                () -> "entering setPublicKey(" + filePath + ", keyType: " +
+                keyType + ", format: " + format + ")");
         }
 
         if (filePath == null || filePath.isEmpty()) {
@@ -564,14 +568,14 @@ public class WolfSSLCertificate implements Serializable {
 
         keyFile = new File(filePath);
         if (!keyFile.exists()) {
-            throw new WolfSSLException("Input file does not exist: " +
-                filePath);
+            throw new WolfSSLException(
+                "Input file does not exist: " + filePath);
         }
 
         fileBytes = WolfSSL.fileToBytes(keyFile);
         if (fileBytes == null) {
-            throw new WolfSSLException("Failed to read bytes from file: " +
-                filePath);
+            throw new WolfSSLException(
+                "Failed to read bytes from file: " + filePath);
         }
 
         setPublicKey(fileBytes, keyType, format);
@@ -604,8 +608,8 @@ public class WolfSSLCertificate implements Serializable {
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.x509Ptr,
-                "entering setPublicKey(byte[], keyType: " +
-                keyType + ", format: " + format + ")");
+                () -> "entering setPublicKey(byte[], keyType: " + keyType +
+                ", format: " + format + ")");
         }
 
         if (key == null || key.length == 0) {
@@ -662,8 +666,8 @@ public class WolfSSLCertificate implements Serializable {
 
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.x509Ptr, "entering setPublicKey(" +
-                key + ")");
+                WolfSSLDebug.INFO, this.x509Ptr,
+                () -> "entering setPublicKey(" + key + ")");
         }
 
         if (key instanceof RSAPublicKey) {
@@ -706,8 +710,8 @@ public class WolfSSLCertificate implements Serializable {
 
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.x509Ptr, "entering setSerialNumber(" +
-                serial + ")");
+                WolfSSLDebug.INFO, this.x509Ptr,
+                () -> "entering setSerialNumber(" + serial + ")");
         }
 
         if (serial == null) {
@@ -716,8 +720,8 @@ public class WolfSSLCertificate implements Serializable {
 
         serialBytes = serial.toByteArray();
         if (serialBytes == null || serialBytes.length == 0) {
-            throw new WolfSSLException("BigInteger.toByteArray() " +
-                "is null or 0 length");
+            throw new WolfSSLException(
+                "BigInteger.toByteArray() is null or 0 length");
         }
 
         synchronized (x509Lock) {
@@ -749,8 +753,8 @@ public class WolfSSLCertificate implements Serializable {
 
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.x509Ptr, "entering setNotBefore(" +
-                notBefore + ")");
+                WolfSSLDebug.INFO, this.x509Ptr,
+                () -> "entering setNotBefore(" + notBefore + ")");
 
             ret = X509_set_notBefore(this.x509Ptr, notBefore.getTime() / 1000);
         }
@@ -780,8 +784,8 @@ public class WolfSSLCertificate implements Serializable {
 
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.x509Ptr, "entering setNotAfter(" +
-                notAfter + ")");
+                WolfSSLDebug.INFO, this.x509Ptr,
+                () -> "entering setNotAfter(" + notAfter + ")");
 
             ret = X509_set_notAfter(this.x509Ptr, notAfter.getTime() / 1000);
         }
@@ -815,8 +819,8 @@ public class WolfSSLCertificate implements Serializable {
 
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.x509Ptr, "entering addAltName(" +
-                name + ", type: " + type + ")");
+                WolfSSLDebug.INFO, this.x509Ptr,
+                () -> "entering addAltName(" + name + ", type: " + type + ")");
 
             ret = X509_add_altname(this.x509Ptr, name, type);
         }
@@ -882,8 +886,8 @@ public class WolfSSLCertificate implements Serializable {
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.x509Ptr,
-                "entering addExtension(nid: " + nid + ", value: " + value +
-                ", isCritical: " + isCritical + ")");
+                () -> "entering addExtension(nid: " + nid + ", value: " +
+                value + ", isCritical: " + isCritical + ")");
         }
 
         if (nid != WolfSSL.NID_key_usage &&
@@ -945,8 +949,8 @@ public class WolfSSLCertificate implements Serializable {
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.x509Ptr,
-                "entering addExtension(nid: " + nid + ", value: " + value +
-                ", isCritical: " + isCritical + ")");
+                () -> "entering addExtension(nid: " + nid + ", value: " +
+                value + ", isCritical: " + isCritical + ")");
         }
 
         if (nid != WolfSSL.NID_basic_constraints) {
@@ -998,7 +1002,7 @@ public class WolfSSLCertificate implements Serializable {
 
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.x509Ptr, "entering signCert(" +
+                WolfSSLDebug.INFO, this.x509Ptr, () -> "entering signCert(" +
                 filePath + ", keyType: " + keyType + ", format: " + format +
                 ", digestAlg: " + digestAlg + ")");
         }
@@ -1009,14 +1013,14 @@ public class WolfSSLCertificate implements Serializable {
 
         keyFile = new File(filePath);
         if (!keyFile.exists()) {
-            throw new WolfSSLException("Input file does not exist: " +
-                filePath);
+            throw new WolfSSLException(
+                "Input file does not exist: " + filePath);
         }
 
         fileBytes = WolfSSL.fileToBytes(keyFile);
         if (fileBytes == null) {
-            throw new WolfSSLException("Failed to read bytes from file: " +
-                filePath);
+            throw new WolfSSLException(
+                "Failed to read bytes from file: " + filePath);
         }
 
         signCert(fileBytes, keyType, format, digestAlg);
@@ -1052,8 +1056,8 @@ public class WolfSSLCertificate implements Serializable {
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.x509Ptr,
-                "entering signCert(byte[], keyType: " + keyType + ", format: " +
-                format + ", digestAlg: " + digestAlg + ")");
+                () -> "entering signCert(byte[], keyType: " + keyType +
+                ", format: " + format + ", digestAlg: " + digestAlg + ")");
         }
 
         if (key == null || key.length == 0) {
@@ -1083,8 +1087,7 @@ public class WolfSSLCertificate implements Serializable {
 
         if (ret != WolfSSL.SSL_SUCCESS) {
             throw new WolfSSLException(
-                "Error signing native WOLFSSL_X509 " +
-                "(ret: " + ret + ")");
+                "Error signing native WOLFSSL_X509 (ret: " + ret + ")");
         }
     }
 
@@ -1113,8 +1116,9 @@ public class WolfSSLCertificate implements Serializable {
 
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.x509Ptr, "entering signCert(" + key +
-                ", digestAlg: " + digestAlg + ")");
+                WolfSSLDebug.INFO, this.x509Ptr,
+                () -> "entering signCert(" + key + ", digestAlg: " +
+                digestAlg + ")");
         }
 
         if (key == null) {
@@ -1145,8 +1149,7 @@ public class WolfSSLCertificate implements Serializable {
 
         if (ret != WolfSSL.SSL_SUCCESS) {
             throw new WolfSSLException(
-                "Error signing native WOLFSSL_X509 " +
-                "(ret: " + ret + ")");
+                "Error signing native WOLFSSL_X509 (ret: " + ret + ")");
         }
     }
 
@@ -1164,7 +1167,7 @@ public class WolfSSLCertificate implements Serializable {
 
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.x509Ptr, "entering getDer()");
+                WolfSSLDebug.INFO, this.x509Ptr, () -> "entering getDer()");
 
             return X509_get_der(this.x509Ptr);
         }
@@ -1184,7 +1187,7 @@ public class WolfSSLCertificate implements Serializable {
 
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.x509Ptr, "entering getPem()");
+                WolfSSLDebug.INFO, this.x509Ptr, () -> "entering getPem()");
 
             return X509_get_pem(this.x509Ptr);
         }
@@ -1203,7 +1206,7 @@ public class WolfSSLCertificate implements Serializable {
 
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.x509Ptr, "entering getTbs()");
+                WolfSSLDebug.INFO, this.x509Ptr, () -> "entering getTbs()");
 
             return X509_get_tbs(this.x509Ptr);
         }
@@ -1225,7 +1228,7 @@ public class WolfSSLCertificate implements Serializable {
 
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.x509Ptr, "entering getSerial()");
+                WolfSSLDebug.INFO, this.x509Ptr, () -> "entering getSerial()");
 
             sz = X509_get_serial_number(this.x509Ptr, out);
         }
@@ -1253,7 +1256,7 @@ public class WolfSSLCertificate implements Serializable {
 
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.x509Ptr, "entering notBefore()");
+                WolfSSLDebug.INFO, this.x509Ptr, () -> "entering notBefore()");
 
             nb  = X509_notBefore(this.x509Ptr);
         }
@@ -1285,7 +1288,7 @@ public class WolfSSLCertificate implements Serializable {
 
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.x509Ptr, "entering notAfter()");
+                WolfSSLDebug.INFO, this.x509Ptr, () -> "entering notAfter()");
 
             nb = X509_notAfter(this.x509Ptr);
         }
@@ -1315,7 +1318,7 @@ public class WolfSSLCertificate implements Serializable {
 
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.x509Ptr, "entering getVersion()");
+                WolfSSLDebug.INFO, this.x509Ptr, () -> "entering getVersion()");
 
             return X509_version(this.x509Ptr);
         }
@@ -1334,7 +1337,8 @@ public class WolfSSLCertificate implements Serializable {
 
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.x509Ptr, "entering getSignature()");
+                WolfSSLDebug.INFO, this.x509Ptr,
+                () -> "entering getSignature()");
 
             return X509_get_signature(this.x509Ptr);
         }
@@ -1353,7 +1357,8 @@ public class WolfSSLCertificate implements Serializable {
 
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.x509Ptr, "entering getSignatureType()");
+                WolfSSLDebug.INFO, this.x509Ptr,
+                () -> "entering getSignatureType()");
 
             return X509_get_signature_type(this.x509Ptr);
         }
@@ -1372,7 +1377,8 @@ public class WolfSSLCertificate implements Serializable {
 
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.x509Ptr, "entering getSignatureOID)");
+                WolfSSLDebug.INFO, this.x509Ptr,
+                () -> "entering getSignatureOID()");
 
             return X509_get_signature_OID(this.x509Ptr);
         }
@@ -1391,7 +1397,7 @@ public class WolfSSLCertificate implements Serializable {
 
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.x509Ptr, "entering getPubkey()");
+                WolfSSLDebug.INFO, this.x509Ptr, () -> "entering getPubkey()");
 
             return X509_get_pubkey(this.x509Ptr);
         }
@@ -1410,7 +1416,8 @@ public class WolfSSLCertificate implements Serializable {
 
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.x509Ptr, "entering getPubkeyType()");
+                WolfSSLDebug.INFO, this.x509Ptr,
+                () -> "entering getPubkeyType()");
 
             return X509_get_pubkey_type(this.x509Ptr);
         }
@@ -1429,7 +1436,7 @@ public class WolfSSLCertificate implements Serializable {
 
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.x509Ptr, "entering isCA()");
+                WolfSSLDebug.INFO, this.x509Ptr, () -> "entering isCA()");
 
             return X509_get_isCA(this.x509Ptr);
         }
@@ -1448,7 +1455,7 @@ public class WolfSSLCertificate implements Serializable {
 
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.x509Ptr, "entering getPathLen()");
+                WolfSSLDebug.INFO, this.x509Ptr, () -> "entering getPathLen()");
 
             return X509_get_pathLength(this.x509Ptr);
         }
@@ -1467,7 +1474,7 @@ public class WolfSSLCertificate implements Serializable {
 
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.x509Ptr, "entering getSubject()");
+                WolfSSLDebug.INFO, this.x509Ptr, () -> "entering getSubject()");
 
             return X509_get_subject_name(this.x509Ptr);
         }
@@ -1486,7 +1493,7 @@ public class WolfSSLCertificate implements Serializable {
 
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.x509Ptr, "entering getIssuer()");
+                WolfSSLDebug.INFO, this.x509Ptr, () -> "entering getIssuer()");
 
             return X509_get_issuer_name(this.x509Ptr);
         }
@@ -1512,7 +1519,7 @@ public class WolfSSLCertificate implements Serializable {
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.x509Ptr,
-                "entering verify(byte[], pubKeySz: " + pubKeySz + ")");
+                () -> "entering verify(byte[], pubKeySz: " + pubKeySz + ")");
 
             ret  = X509_verify(this.x509Ptr, pubKey, pubKeySz);
         }
@@ -1547,7 +1554,8 @@ public class WolfSSLCertificate implements Serializable {
 
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.x509Ptr, "entering getKeyUsage()");
+                WolfSSLDebug.INFO, this.x509Ptr,
+                () -> "entering getKeyUsage()");
 
             return X509_get_key_usage(this.x509Ptr);
         }
@@ -1569,7 +1577,7 @@ public class WolfSSLCertificate implements Serializable {
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.x509Ptr,
-                "entering getExtension(oid: " + oid + ")");
+                () -> "entering getExtension(oid: " + oid + ")");
 
             if (oid == null) {
                 return null;
@@ -1598,7 +1606,7 @@ public class WolfSSLCertificate implements Serializable {
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.x509Ptr,
-                "entering getExtensionSet(oid: " + oid + ")");
+                () -> "entering getExtensionSet(oid: " + oid + ")");
 
             return X509_is_extension_set(this.x509Ptr, oid);
         }
@@ -1645,8 +1653,9 @@ public class WolfSSLCertificate implements Serializable {
 
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.x509Ptr, "entering checkHost(" +
-                hostname + ", flags: " + flags + ")");
+                WolfSSLDebug.INFO, this.x509Ptr,
+                () -> "entering checkHost(" + hostname + ", flags: " +
+                flags + ")");
 
             return X509_check_host(this.x509Ptr, hostname, flags, 0);
         }
@@ -1675,7 +1684,7 @@ public class WolfSSLCertificate implements Serializable {
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.x509Ptr,
-                "entering getSubjectAltNames()");
+                () -> "entering getSubjectAltNames()");
 
             if (this.altNames != null) {
                 /* already gathered, return cached version */
@@ -1725,7 +1734,7 @@ public class WolfSSLCertificate implements Serializable {
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.x509Ptr,
-                "entering getX509Certificate()");
+                () -> "entering getX509Certificate()");
         }
 
         try {
@@ -1808,7 +1817,8 @@ public class WolfSSLCertificate implements Serializable {
                 /* only free native resources if we own pointer */
                 if (this.weOwnX509Ptr == true) {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                        WolfSSLDebug.INFO, this.x509Ptr, "entering free()");
+                        WolfSSLDebug.INFO, this.x509Ptr,
+                        () -> "entering free()");
 
                     /* free native resources */
                     X509_free(this.x509Ptr);
@@ -1816,7 +1826,7 @@ public class WolfSSLCertificate implements Serializable {
                 else {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                         WolfSSLDebug.INFO, this.x509Ptr,
-                        "entering free(not freeing ptr, we do not own)");
+                        () -> "entering free(not freeing ptr, we do not own)");
                 }
 
                 /* free Java resources */

--- a/src/java/com/wolfssl/WolfSSLContext.java
+++ b/src/java/com/wolfssl/WolfSSLContext.java
@@ -101,7 +101,7 @@ public class WolfSSLContext {
         this.active = true;
 
         WolfSSLDebug.log(WolfSSL.class, WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, sslCtxPtr, "creating new WolfSSLContext");
+            WolfSSLDebug.INFO, sslCtxPtr, () -> "creating new WolfSSLContext");
 
         /* Enable native wolfSSL debug logging if 'wolfssl.debug'
          * System property is set. Also attempted in WolfSSLProvider
@@ -460,7 +460,8 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered useCertificateFile(" + file + ", " + format +")");
+                () -> "entered useCertificateFile(" + file + ", " +
+                format +")");
 
             return useCertificateFile(getContextPtr(), file, format);
         }
@@ -499,7 +500,7 @@ public class WolfSSLContext {
        synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered usePrivateKeyFile(" + file + ", " + format +")");
+                () -> "entered usePrivateKeyFile(" + file + ", " + format +")");
 
              return usePrivateKeyFile(getContextPtr(), file, format);
         }
@@ -556,7 +557,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered loadVerifyLocations(" + file + ", " + path +")");
+                () -> "entered loadVerifyLocations(" + file + ", " + path +")");
 
             return loadVerifyLocations(getContextPtr(), file, path);
         }
@@ -590,7 +591,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered useCertificateChainFile(" + file + ")");
+                () -> "entered useCertificateChainFile(" + file + ")");
 
             return useCertificateChainFile(getContextPtr(), file);
         }
@@ -639,7 +640,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered setVerify(" + mode + ", " + callback + ")");
+                () -> "entered setVerify(" + mode + ", " + callback + ")");
 
             setVerify(getContextPtr(), mode, callback);
         }
@@ -662,7 +663,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered setOptions(" + op + ")");
+                () -> "entered setOptions(" + op + ")");
 
             return setOptions(getContextPtr(), op);
         }
@@ -683,7 +684,8 @@ public class WolfSSLContext {
 
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, getContextPtr(), "entered getOptions()");
+                WolfSSLDebug.INFO, getContextPtr(),
+                () -> "entered getOptions()");
 
             return getOptions(getContextPtr());
         }
@@ -709,7 +711,7 @@ public class WolfSSLContext {
 
             synchronized (ctxLock) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                    WolfSSLDebug.INFO, this.sslCtxPtr, "entered free()");
+                    WolfSSLDebug.INFO, this.sslCtxPtr, () -> "entered free()");
 
                 /* free native resources */
                 freeContext(this.sslCtxPtr);
@@ -754,7 +756,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered memsaveCertCache()");
+                () -> "entered memsaveCertCache()");
 
             return memsaveCertCache(getContextPtr(), mem, sz, used);
         }
@@ -793,7 +795,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered memrestoreCertCache()");
+                () -> "entered memrestoreCertCache()");
 
             return memrestoreCertCache(getContextPtr(), mem, sz);
         }
@@ -821,7 +823,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered getCertCacheMemsize()");
+                () -> "entered getCertCacheMemsize()");
 
             return getCertCacheMemsize(getContextPtr());
         }
@@ -843,7 +845,8 @@ public class WolfSSLContext {
 
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, getContextPtr(), "entered setCacheSize()");
+                WolfSSLDebug.INFO, getContextPtr(),
+                () -> "entered setCacheSize()");
 
             return setCacheSize(getContextPtr(), sz);
         }
@@ -863,7 +866,8 @@ public class WolfSSLContext {
 
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, getContextPtr(), "entered getCacheSize()");
+                WolfSSLDebug.INFO, getContextPtr(),
+                () -> "entered getCacheSize()");
 
             return getCacheSize(getContextPtr());
         }
@@ -903,7 +907,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered setCipherList(" + list + ")");
+                () -> "entered setCipherList(" + list + ")");
 
             return setCipherList(getContextPtr(), list);
         }
@@ -932,7 +936,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered setTmpDh(pSz: " + pSz + ", gSz: " + gSz + ")");
+                () -> "entered setTmpDh(pSz: " + pSz + ", gSz: " + gSz + ")");
 
             return setTmpDH(getContextPtr(), p, pSz, g, gSz);
         }
@@ -965,7 +969,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered setTmpDhFile(" + fname + ", " + format + ")");
+                () -> "entered setTmpDhFile(" + fname + ", " + format + ")");
 
             return setTmpDHFile(getContextPtr(), fname, format);
         }
@@ -1016,7 +1020,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered loadVerifyBuffer(sz: " + sz + ", format: " +
+                () -> "entered loadVerifyBuffer(sz: " + sz + ", format: " +
                 format +")");
 
             return loadVerifyBuffer(getContextPtr(), in, sz, format);
@@ -1059,7 +1063,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered useCertificateBuffer(sz: " + sz + ", format: " +
+                () -> "entered useCertificateBuffer(sz: " + sz + ", format: " +
                 format + ")");
 
             return useCertificateBuffer(getContextPtr(), in, sz, format);
@@ -1105,7 +1109,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered usePrivateKeyBuffer(sz: " + sz + ", format: " +
+                () -> "entered usePrivateKeyBuffer(sz: " + sz + ", format: " +
                 format + ")");
 
             return usePrivateKeyBuffer(getContextPtr(), in, sz, format);
@@ -1151,7 +1155,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered useCertificateChainBuffer(sz: " + sz + ")");
+                () -> "entered useCertificateChainBuffer(sz: " + sz + ")");
 
             return useCertificateChainBuffer(getContextPtr(), in, sz);
         }
@@ -1200,8 +1204,8 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered useCertificateChainBufferFormat(sz: " +
-                sz + ", format: " + format + ")");
+                () -> "entered useCertificateChainBufferFormat(sz: " + sz +
+                ", format: " + format + ")");
 
             return useCertificateChainBufferFormat(
                         getContextPtr(), in, sz, format);
@@ -1224,7 +1228,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered setGroupMessages()");
+                () -> "entered setGroupMessages()");
 
             return setGroupMessages(getContextPtr());
         }
@@ -1258,7 +1262,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered setIORecv(" + callback + ")");
+                () -> "entered setIORecv(" + callback + ")");
 
             /* set user I/O recv */
             internRecvCb = callback;
@@ -1296,7 +1300,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered setIOSend(" + callback + ")");
+                () -> "entered setIOSend(" + callback + ")");
 
             /* set user I/O send */
             internSendCb = callback;
@@ -1334,7 +1338,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered setGenCookie(" + callback + ")");
+                () -> "entered setGenCookie(" + callback + ")");
 
             /* set DTLS cookie generation callback */
             internCookieCb = callback;
@@ -1374,7 +1378,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered enableCRL(" + options + ")");
+                () -> "entered enableCRL(" + options + ")");
 
             return enableCRL(getContextPtr(), options);
         }
@@ -1403,7 +1407,8 @@ public class WolfSSLContext {
 
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, getContextPtr(), "entered disableCRL()");
+                WolfSSLDebug.INFO, getContextPtr(),
+                () -> "entered disableCRL()");
 
             return disableCRL(getContextPtr());
         }
@@ -1456,7 +1461,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered loadCRL(" + path + ", " + type + ", " + monitor);
+                () -> "entered loadCRL(" + path + ", " + type + ", " + monitor);
 
             return loadCRL(getContextPtr(), path, type, monitor);
         }
@@ -1487,7 +1492,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered setCRLCb(" + cb + ")");
+                () -> "entered setCRLCb(" + cb + ")");
 
             return setCRLCb(getContextPtr(), cb);
         }
@@ -1523,7 +1528,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered enableOCSP(" + options + ")");
+                () -> "entered enableOCSP(" + options + ")");
 
             return enableOCSP(getContextPtr(), options);
         }
@@ -1543,7 +1548,8 @@ public class WolfSSLContext {
 
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, getContextPtr(), "entered disableOCSP()");
+                WolfSSLDebug.INFO, getContextPtr(),
+                () -> "entered disableOCSP()");
 
             return disableOCSP(getContextPtr());
         }
@@ -1574,7 +1580,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered setOCSPOverrideUrl(" + url + ")");
+                () -> "entered setOCSPOverrideUrl(" + url + ")");
 
             return setOCSPOverrideUrl(getContextPtr(), url);
         }
@@ -1614,7 +1620,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered setMacEncryptCb(" + callback + ")");
+                () -> "entered setMacEncryptCb(" + callback + ")");
 
             /* set MAC encrypt callback */
             internMacEncryptCb = callback;
@@ -1659,7 +1665,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered setDecryptVerifyCb(" + callback + ")");
+                () -> "entered setDecryptVerifyCb(" + callback + ")");
 
             /* set decrypt/verify callback */
             internDecryptVerifyCb = callback;
@@ -1704,7 +1710,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered setVerifyDecryptCb(" + callback + ")");
+                () -> "entered setVerifyDecryptCb(" + callback + ")");
 
             /* set verify/decrypt callback */
             internVerifyDecryptCb = callback;
@@ -1744,7 +1750,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered setEccSignCb(" + callback + ")");
+                () -> "entered setEccSignCb(" + callback + ")");
 
             /* set ecc sign callback */
             internEccSignCb = callback;
@@ -1784,7 +1790,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered setEccVerifyCb(" + callback + ")");
+                () -> "entered setEccVerifyCb(" + callback + ")");
 
             /* set ecc verify callback */
             internEccVerifyCb = callback;
@@ -1840,7 +1846,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered setEccSharedSecretCb(" + callback + ")");
+                () -> "entered setEccSharedSecretCb(" + callback + ")");
 
             /* set ecc shared secret callback */
             internEccSharedSecretCb = callback;
@@ -1880,7 +1886,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered setRsaSignCb(" + callback + ")");
+                () -> "entered setRsaSignCb(" + callback + ")");
 
             /* set rsa sign callback */
             internRsaSignCb = callback;
@@ -1920,7 +1926,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered setRsaVerifyCb(" + callback + ")");
+                () -> "entered setRsaVerifyCb(" + callback + ")");
 
             /* set rsa verify callback */
             internRsaVerifyCb = callback;
@@ -1960,7 +1966,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered setRsaEncCb(" + callback + ")");
+                () -> "entered setRsaEncCb(" + callback + ")");
 
             /* set rsa public encrypt callback */
             internRsaEncCb = callback;
@@ -1999,7 +2005,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered setRsaDecCb(" + callback + ")");
+                () -> "entered setRsaDecCb(" + callback + ")");
 
             /* set rsa private decrypt callback */
             internRsaDecCb = callback;
@@ -2042,7 +2048,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered setPskClientCb(" + callback + ")");
+                () -> "entered setPskClientCb(" + callback + ")");
 
             /* set PSK client callback */
             internPskClientCb = callback;
@@ -2084,7 +2090,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered setPskServerCb(" + callback + ")");
+                () -> "entered setPskServerCb(" + callback + ")");
 
             /* set PSK server callback */
             internPskServerCb = callback;
@@ -2117,7 +2123,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered usePskIdentityHint()");
+                () -> "entered usePskIdentityHint()");
 
             return usePskIdentityHint(getContextPtr(), hint);
         }
@@ -2152,7 +2158,8 @@ public class WolfSSLContext {
         int curveEnum = 0;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, getContextPtr(), "entered useSupportedCurves(" +
+            WolfSSLDebug.INFO, getContextPtr(),
+            () -> "entered useSupportedCurves(" +
             Arrays.asList(curveNames) + ")");
 
         for (String curve : curveNames) {
@@ -2219,8 +2226,8 @@ public class WolfSSLContext {
 
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, getContextPtr(), "entered setGroups(" +
-                Arrays.asList(groups) + ")");
+                WolfSSLDebug.INFO, getContextPtr(),
+                () -> "entered setGroups(" + Arrays.asList(groups) + ")");
 
             return setGroups(getContextPtr(), groups);
         }
@@ -2245,7 +2252,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered set1SigAlgsList(" + list + ")");
+                () -> "entered set1SigAlgsList(" + list + ")");
 
             return set1SigAlgsList(getContextPtr(), list);
         }
@@ -2269,7 +2276,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered useSecureRenegotiation()");
+                () -> "entered useSecureRenegotiation()");
 
             return useSecureRenegotiation(getContextPtr());
         }
@@ -2294,7 +2301,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered setMinDHKeySize(" + minKeySizeBits + ")");
+                () -> "entered setMinDHKeySize(" + minKeySizeBits + ")");
 
             return setMinDhKeySz(getContextPtr(), minKeySizeBits);
         }
@@ -2319,7 +2326,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered setMinRSAKeySize(" + minKeySizeBits + ")");
+                () -> "entered setMinRSAKeySize(" + minKeySizeBits + ")");
 
             return setMinRsaKeySz(getContextPtr(), minKeySizeBits);
         }
@@ -2344,7 +2351,7 @@ public class WolfSSLContext {
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, getContextPtr(),
-                "entered setMinECCKeySize(" + minKeySizeBits + ")");
+                () -> "entered setMinECCKeySize(" + minKeySizeBits + ")");
 
             return setMinEccKeySz(getContextPtr(), minKeySizeBits);
         }
@@ -2366,7 +2373,7 @@ public class WolfSSLContext {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
             WolfSSLDebug.INFO, getContextPtr(),
-            "entered setDevId(" + devId + ")");
+            () -> "entered setDevId(" + devId + ")");
 
         return setDevId(getContextPtr(), devId);
     }
@@ -2386,7 +2393,7 @@ public class WolfSSLContext {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
             WolfSSLDebug.INFO, getContextPtr(),
-            "entered flushSessions(" + tm + ")");
+            () -> "entered flushSessions(" + tm + ")");
 
         flushSessions(getContextPtr(), tm);
     }
@@ -2405,3 +2412,4 @@ public class WolfSSLContext {
     }
 
 } /* end WolfSSLContext */
+

--- a/src/java/com/wolfssl/WolfSSLDebug.java
+++ b/src/java/com/wolfssl/WolfSSLDebug.java
@@ -21,11 +21,11 @@
 
 package com.wolfssl;
 
-import java.util.Date;
 import java.sql.Timestamp;
-
-import com.wolfssl.WolfSSL;
-import com.wolfssl.WolfSSLLoggingCallback;
+import java.util.logging.*;
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+import java.util.function.Supplier;
 
 /**
  * Central location for all debugging messages
@@ -35,6 +35,16 @@ import com.wolfssl.WolfSSLLoggingCallback;
  * @author wolfSSL
  */
 public class WolfSSLDebug {
+
+    /**
+     * Create one Logger per logging layer:
+     *     com.wolfssl.jni - JNI layer logging
+     *     com.wolfssl.jsse - JSSE layer logging
+     */
+    private static final Logger jniLogger =
+        Logger.getLogger("com.wolfssl.jni");
+    private static final Logger jsseLogger =
+        Logger.getLogger("com.wolfssl.jsse");
 
     /**
      * Check if JSSE level debug logging has been enabled.
@@ -81,14 +91,10 @@ public class WolfSSLDebug {
         }
     }
 
-    /**
-     * Error level debug message
-     */
+    /** Error level debug message */
     public static final String ERROR = "ERROR";
 
-    /**
-     * Info level debug message
-     */
+    /** Info level debug message */
     public static final String INFO = "INFO";
 
     /**
@@ -98,10 +104,175 @@ public class WolfSSLDebug {
      */
     private static WolfSSLNativeLoggingCallback nativeLogCb = null;
 
+    static {
+        configureLoggers();
+    }
+
     /**
-     * Default constructor for wolfJSSE debug class.
+     * Custom handler that flushes after each log record
      */
-    public WolfSSLDebug() {
+    private static class FlushingStreamHandler extends StreamHandler {
+        public FlushingStreamHandler() {
+            super(System.err, new WolfSSLFormatter());
+        }
+
+        @Override
+        public synchronized void publish(LogRecord record) {
+            super.publish(record);
+            flush();
+        }
+    }
+
+    /**
+     * Configure loggers based on system properties
+     */
+    private static void configureLoggers() {
+        /* Remove any existing handlers */
+        for (Handler handler : jniLogger.getHandlers()) {
+            jniLogger.removeHandler(handler);
+        }
+        for (Handler handler : jsseLogger.getHandlers()) {
+            jsseLogger.removeHandler(handler);
+        }
+
+        /* Only configure handlers if debug is enabled for either component */
+        if (DEBUG || DEBUG_JNI) {
+            /* Create custom handler that flushes after each record */
+            FlushingStreamHandler handler = new FlushingStreamHandler();
+
+            if (DEBUG_JSON) {
+                handler.setFormatter(new JSONFormatter());
+            } else {
+                handler.setFormatter(new WolfSSLFormatter());
+            }
+
+            /* Add handlers */
+            if (DEBUG_JNI) {
+                jniLogger.addHandler(handler);
+            }
+            if (DEBUG) {
+                jsseLogger.addHandler(handler);
+            }
+        }
+
+        /* Set log levels based on debug properties */
+        jniLogger.setLevel(DEBUG_JNI ? Level.ALL : Level.OFF);
+        jsseLogger.setLevel(DEBUG ? Level.ALL : Level.OFF);
+
+        /* Disable parent handlers to prevent double logging */
+        jniLogger.setUseParentHandlers(false);
+        jsseLogger.setUseParentHandlers(false);
+    }
+
+    /**
+     * Custom formatter for wolfSSL logs
+     */
+    private static class WolfSSLFormatter extends Formatter {
+        @Override
+        public String format(LogRecord record) {
+
+            if (record == null) {
+                return "null record\n";
+            }
+
+            String sourceClass = record.getSourceClassName();
+            if (sourceClass == null) {
+                sourceClass = "unknown";
+            } else {
+                /* Extract simple class name (after last dot) */
+                int lastDot = sourceClass.lastIndexOf('.');
+                if (lastDot >= 0) {
+                    sourceClass = sourceClass.substring(lastDot + 1);
+                }
+            }
+
+            String component;
+            String loggerName = record.getLoggerName();
+            if (loggerName != null && loggerName.contains("jni")) {
+                component = "wolfJNI";
+            }
+            else {
+                component = "wolfJSSE";
+            }
+
+            Level level = record.getLevel();
+            String levelStr = (level != null) ? level.toString() : "UNKNOWN";
+
+            long threadId = record.getThreadID();
+            String message = record.getMessage();
+            if (message == null) {
+                message = "";
+            }
+
+            return String.format("%s [%s %s: TID %d: %s] %s%n",
+                new Timestamp(record.getMillis()),
+                component,
+                levelStr,
+                threadId,
+                sourceClass,
+                message);
+        }
+    }
+
+    /**
+     * JSON formatter for wolfSSL logs
+     */
+    private static class JSONFormatter extends Formatter {
+        @Override
+        public String format(LogRecord record) {
+            if (record == null) {
+                return "{\"error\": \"null record\"}\n";
+            }
+
+            String sourceClass = record.getSourceClassName();
+            if (sourceClass == null) {
+                sourceClass = "unknown";
+            } else {
+                /* Extract simple class name (after last dot) */
+                int lastDot = sourceClass.lastIndexOf('.');
+                if (lastDot >= 0) {
+                    sourceClass = sourceClass.substring(lastDot + 1);
+                }
+            }
+
+            String component;
+            String loggerName = record.getLoggerName();
+            if (loggerName != null && loggerName.contains("jni")) {
+                component = "wolfJNI";
+            }
+            else {
+                component = "wolfJSSE";
+            }
+
+            Level level = record.getLevel();
+            String levelStr = (level != null) ? level.toString() : "UNKNOWN";
+
+            String threadName = Thread.currentThread().getName();
+            if (threadName == null) {
+                threadName = "unknown";
+            }
+
+            String message = record.getMessage();
+            if (message == null) {
+                message = "";
+            }
+
+            return String.format(
+                "{\n" +
+                "    \"@timestamp\": \"%s\",\n" +
+                "    \"level\": \"%s\",\n" +
+                "    \"logger_name\": \"%s\",\n" +
+                "    \"message\": \"%s\",\n" +
+                "    \"thread_name\": \"%s\",\n" +
+                "    \"thread_id\": \"%d\"\n" +
+                "}\n",
+                new Timestamp(record.getMillis()),
+                levelStr,
+                component,
+                message,
+                threadName,
+                record.getThreadID());
+        }
     }
 
     /**
@@ -142,7 +313,6 @@ public class WolfSSLDebug {
      * @return true if set to "JSON", otherwise false.
      */
     private static boolean jsonOutEnabled() {
-
         String enabled = System.getProperty("wolfjsse.debugFormat");
 
         if ((enabled != null) && (enabled.equalsIgnoreCase("JSON"))) {
@@ -153,114 +323,21 @@ public class WolfSSLDebug {
     }
 
     /**
-     * Check if debug logging is enabled for the specified component, based
-     * on the System properties that are set.
-     *
-     * @param Component to check if debug is enabled for
-     *
-     * @return true if debug is enabled for this Component, otherwise false
-     */
-    private static boolean isDebugEnabled(Component component) {
-
-        /* JSSE debug enabled and component is JSSE */
-        if (DEBUG && (component == Component.JSSE)) {
-            return true;
-        }
-
-        /* JSSE debug enabled and component null (backwards compat) */
-        if (DEBUG && (component == null)) {
-            return true;
-        }
-
-        /* JNI debug enabled and component is JNI */
-        if (DEBUG_JNI && (component == Component.JNI)) {
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
      * Refresh debug enabled/disabled flags based on current
      * System properties.
-     *
-     * Applications may need to call this if they adjust debug
-     * System properties after the WolfSSLDebug class has been called
-     * and initialized the first time. Debug flags (DEBUG, DEBUG_JNI, and
-     * DEBUG_JSON are static class variables.
      */
-    public static void refreshDebugFlags() {
+    public static synchronized void refreshDebugFlags() {
+        boolean oldDebug = DEBUG;
+        boolean oldDebugJNI = DEBUG_JNI;
+
         DEBUG = checkJSSEDebugProperty();
         DEBUG_JNI = checkJNIDebugProperty();
         DEBUG_JSON = jsonOutEnabled();
-    }
 
-    /**
-     * Prints out a message to the console
-     * @param string message to be printed
-     */
-    public static void print(String string) {
-        print(string, null);
-    }
-
-    /**
-     * Prints out a message to the console
-     * @param string message to be printed
-     * @param component JNI/JSSE component being logged, from Component enum
-     */
-    public static void print(String string, Component component) {
-        /* Default to wolfJSSE for backwards compatibility log() method */
-        String componentName = "wolfJSSE";
-
-        if (!isDebugEnabled(component)) {
-            /* Debug logs not enabled for this component */
-            return;
+        /* Only reconfigure if debug state has changed */
+        if (oldDebug != DEBUG || oldDebugJNI != DEBUG_JNI) {
+            configureLoggers();
         }
-
-        if (component != null) {
-            componentName = component.toString();
-        }
-
-        System.out.println(componentName + ": " + string);
-    }
-
-    /**
-     * Internal method to print debug message as JSON for consumption by
-     * tools such as DataDog.
-     */
-    private static synchronized void logJSON(String tag, String msg,
-        long threadID, String threadName, String className) {
-
-        System.out.printf(
-            "{\n" +
-            "    \"@timestamp\": \"%s\",\n" +
-            "    \"level\": \"%s\",\n" +
-            "    \"logger_name\": \"wolfJSSE\",\n" +
-            "    \"message\": \"%s\",\n" +
-            "    \"thread_name\": \"%s\",:\n" +
-            "    \"thread_id\": \"%s\"\n" +
-            "}\n",
-            new Timestamp(new java.util.Date().getTime()),
-            tag, "[" + className + "] " + msg,
-            threadID, threadName
-        );
-    }
-
-    /**
-     * Internal method to print debug message with byte array hex as JSON,
-     * for consumption by tools such as DataDog.
-     */
-    private static synchronized void logJSONHex(String tag, String label,
-        long threadID, String threadName, String className, byte[] in, int sz) {
-
-        /* Convert byte[] to hex string */
-        StringBuilder builder = new StringBuilder();
-        for (byte b: in) {
-            builder.append(String.format("%02X", b));
-        }
-
-        logJSON(tag, label + " [" + sz + "]: " + builder.toString(), threadID,
-                threadName, className);
     }
 
     /**
@@ -276,19 +353,19 @@ public class WolfSSLDebug {
      *         "level": "INFO",
      *         "logger_name": "wolfJSSE",
      *         "message": "debug message",
-     *         "thread_name": "thread_name",:
+     *         "thread_name": "thread_name",
      *         "thread_id": "thread_ID"
      *     }
      *
      * @param <T> class type of cl
      * @param cl class being called from to get debug info
      * @param tag level of debug message i.e. WolfSSLDebug.INFO
-     * @param string message to be printed out
+     * @param messageSupplier supplier of message to be printed out
      */
     public static synchronized <T> void log(Class<T> cl, String tag,
-        String string) {
+        Supplier<String> messageSupplier) {
 
-        log(cl, null, tag, 0, string);
+        log(cl, Component.JSSE, tag, 0, messageSupplier);
     }
 
     /**
@@ -305,7 +382,7 @@ public class WolfSSLDebug {
      *         "level": "INFO",
      *         "logger_name": "wolfJSSE",
      *         "message": "debug message",
-     *         "thread_name": "thread_name",:
+     *         "thread_name": "thread_name",
      *         "thread_id": "thread_ID"
      *     }
      *
@@ -313,12 +390,12 @@ public class WolfSSLDebug {
      * @param component JNI/JSSE component being logged, from Component enum
      * @param cl class being called from to get debug info
      * @param tag level of debug message i.e. WolfSSLDebug.INFO
-     * @param string message to be printed out
+     * @param messageSupplier supplier of message to be printed out
      */
     public static synchronized <T> void log(Class<T> cl, Component component,
-        String tag, String string) {
+        String tag, Supplier<String> messageSupplier) {
 
-        log(cl, component, tag, 0, string);
+        log(cl, component, tag, 0, messageSupplier);
     }
 
     /**
@@ -335,7 +412,7 @@ public class WolfSSLDebug {
      *         "level": "INFO",
      *         "logger_name": "wolfJSSE",
      *         "message": "debug message",
-     *         "thread_name": "thread_name",:
+     *         "thread_name": "thread_name",
      *         "thread_id": "thread_ID"
      *     }
      *
@@ -344,44 +421,34 @@ public class WolfSSLDebug {
      * @param cl class being called from to get debug info
      * @param tag level of debug message i.e. WolfSSLDebug.INFO
      * @param nativePtr native pointer of class object, if available
-     * @param string message to be printed out
+     * @param messageSupplier supplier of message to be printed out
      */
     public static synchronized <T> void log(Class<T> cl, Component component,
-        String tag, long nativePtr, String string) {
-
-        long threadID;
-        String threadName;
-        String className;
-        String componentName;
+        String tag, long nativePtr, Supplier<String> messageSupplier) {
 
         if (!isDebugEnabled(component)) {
-            /* Debug logs not enabled for this component */
             return;
         }
 
-        threadID = Thread.currentThread().getId();
-        threadName = Thread.currentThread().getName();
+        Logger targetLogger;
+        if (component == Component.JNI) {
+            targetLogger = jniLogger;
+        }
+        else {
+            targetLogger = jsseLogger;
+        }
 
-        className = cl.getSimpleName();
+        Level level = tag.equals(ERROR) ? Level.SEVERE : Level.INFO;
+
+        String className = cl.getSimpleName();
         if (nativePtr != 0) {
             className = className + ": " + nativePtr;
         }
 
-        /* Default to wolfJSSE for backwards compatibility log() method */
-        componentName = "wolfJSSE";
-        if (component != null) {
-            componentName = component.toString();
-        }
-
-        if (DEBUG_JSON) {
-            logJSON(tag, string, threadID, threadName, className);
-        }
-        else {
-            System.out.println(
-                new Timestamp(new java.util.Date().getTime()) +
-                " [" + componentName + " " + tag + ": TID " + threadID +
-                ": " + className + "] " + string);
-        }
+        LogRecord record = new LogRecord(level, messageSupplier.get());
+        record.setSourceClassName(cl.getName());
+        record.setLoggerName(targetLogger.getName());
+        targetLogger.log(record);
     }
 
     /**
@@ -397,7 +464,7 @@ public class WolfSSLDebug {
      *         "level": "INFO",
      *         "logger_name": "wolfJSSE",
      *         "message": "label [sz]: array hex string",
-     *         "thread_name": "thread_name",:
+     *         "thread_name": "thread_name",
      *         "thread_id": "thread_ID"
      *     }
      *
@@ -409,41 +476,9 @@ public class WolfSSLDebug {
      * @param sz number of bytes from in array to be printed
      */
     public static synchronized <T> void logHex(Class<T> cl, String tag,
-        String label, byte[] in, int sz) {
+        Supplier<String> label, byte[] in, int sz) {
 
-        logHex(cl, null, tag, 0, label, in, sz);
-    }
-
-    /**
-     * Print out a byte array in hex if debugging is enabled, including
-     * component name passed in.
-     *
-     * Output format can be controlled with the "wolfjsse.debugFormat"
-     * System property. If not set, default debug output format will be used.
-     * If set to "JSON", all debug logs will be output in the following JSON
-     * format, which can be read by DataDog:
-     *
-     *     {
-     *         "@timestamp": "2024-04-05 11:13:07.193",
-     *         "level": "INFO",
-     *         "logger_name": "wolfJSSE",
-     *         "message": "label [sz]: array hex string",
-     *         "thread_name": "thread_name",:
-     *         "thread_id": "thread_ID"
-     *     }
-     *
-     * @param <T> class type for cl
-     * @param cl class this method is being called from
-     * @param component JNI/JSSE component being logged, from Component enum
-     * @param tag level of debug message i.e. WolfSSLDebug.INFO
-     * @param label label string to print with hex
-     * @param in byte array to be printed as hex
-     * @param sz number of bytes from in array to be printed
-     */
-    public static synchronized <T> void logHex(Class<T> cl, Component component,
-        String tag, String label, byte[] in, int sz) {
-
-        logHex(cl, component, tag, 0, label, in, sz);
+        logHex(cl, Component.JSSE, tag, 0, label, in, sz);
     }
 
     /**
@@ -460,7 +495,7 @@ public class WolfSSLDebug {
      *         "level": "INFO",
      *         "logger_name": "wolfJSSE",
      *         "message": "label [sz]: array hex string",
-     *         "thread_name": "thread_name",:
+     *         "thread_name": "thread_name",
      *         "thread_id": "thread_ID"
      *     }
      *
@@ -474,90 +509,76 @@ public class WolfSSLDebug {
      * @param sz number of bytes from in array to be printed
      */
     public static synchronized <T> void logHex(Class<T> cl, Component component,
-        String tag, long nativePtr, String label, byte[] in, int sz) {
+        String tag, long nativePtr, Supplier<String> label, byte[] in, int sz) {
 
-        int i = 0, j = 0;
-        int printSz = 0;
-        long threadID;
-        String threadName;
-        String className;
-        String componentName;
-
-        if (cl == null || in == null || sz == 0) {
+        if (!isDebugEnabled(component) || cl == null || in == null || sz == 0) {
             return;
         }
 
-        if (!isDebugEnabled(component)) {
-            /* Debug logs not enabled for this component */
-            return;
+        Logger targetLogger;
+        if (component == Component.JNI) {
+            targetLogger = jniLogger;
+        }
+        else {
+            targetLogger = jsseLogger;
         }
 
-        threadID = Thread.currentThread().getId();
-        threadName = Thread.currentThread().getName();
-        printSz = Math.min(in.length, sz);
+        Level level = tag.equals(ERROR) ? Level.SEVERE : Level.INFO;
 
-        className = cl.getSimpleName();
+        StringBuilder hexString = new StringBuilder();
+        int printSz = Math.min(in.length, sz);
+
+        for (int i = 0; i < printSz; i++) {
+            if ((i % 16) == 0) {
+                hexString.append(String.format("\n%06X", (i / 16) * 16));
+            }
+            hexString.append(String.format(" %02X", in[i]));
+        }
+
+        String className = cl.getSimpleName();
         if (nativePtr != 0) {
             className = className + ": " + nativePtr;
         }
 
-        /* Default to wolfJSSE for backwards compatibility log() method */
-        componentName = "wolfJSSE";
-        if (component != null) {
-            componentName = component.toString();
-        }
+        LogRecord record = new LogRecord(level, label.get() +
+            " [" + sz + "]: " + hexString.toString());
+        record.setSourceClassName(cl.getName());
+        record.setLoggerName(targetLogger.getName());
+        targetLogger.log(record) ;
+    }
 
-        if (DEBUG_JSON) {
-            logJSONHex(tag, label, threadID, threadName, className, in, sz);
+    /**
+     * Check if debug logging is enabled for the specified component
+     */
+    private static boolean isDebugEnabled(Component component) {
+        if (component == Component.JSSE && DEBUG) {
+            return true;
         }
-        else {
-            System.out.print("[" + componentName + " " + tag + ": TID " +
-                threadID + ": " + className + "] " + label + " [" + sz + "]: ");
-            for (i = 0; i < printSz; i++) {
-                if ((i % 16) == 0) {
-                    System.out.printf("\n[" + componentName + " " + tag +
-                        ": TID " + threadID + ": " + className + "] %06X",
-                        j * 16);
-                    j++;
-                }
-                System.out.printf(" %02X ", in[i]);
-            }
-            System.out.println("");
+        if (component == Component.JNI && DEBUG_JNI) {
+            return true;
         }
+        return false;
     }
 
     /**
      * Enable native wolfSSL debug logging based on value of the
      * 'wolfssl.debug' System property.
-     *
-     * Native wolfSSL must ben compiled with "--enable-debug" or
-     * DEBUG_WOLFSSL defined in order for debug logs to print.
      */
     public static synchronized void setNativeWolfSSLDebugging() {
-
         String wolfsslDebug = System.getProperty("wolfssl.debug");
-
         if ((wolfsslDebug != null) && (wolfsslDebug.equalsIgnoreCase("true"))) {
-
             WolfSSL.debuggingON();
         }
-
-        /* Register our default logging callback for native wolfSSL logs */
         setDefaultNativeLoggingCallback();
     }
 
     /**
-     * Register default native wolfSSL logging callback.
-     * Default callback class is WolfSSLNativeLoggingCallback. This could be
-     * modified in the future to allow a custom user-registerable callback.
+     * Register default native wolfSSL logging callback
      */
     private static synchronized void setDefaultNativeLoggingCallback() {
-
-        /* Only create one logging callback object */
         if (nativeLogCb == null) {
             nativeLogCb = new WolfSSLNativeLoggingCallback();
         }
-
         WolfSSL.setLoggingCb(nativeLogCb);
     }
 }

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -139,7 +139,7 @@ public class WolfSSLSession {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
             WolfSSLDebug.INFO, sslPtr,
-            "creating new WolfSSLSession (with I/O pipe)");
+            () -> "creating new WolfSSLSession (with I/O pipe)");
 
         synchronized (stateLock) {
             this.active = true;
@@ -181,11 +181,11 @@ public class WolfSSLSession {
         if (setupIOPipe) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, sslPtr,
-                "creating new WolfSSLSession (with I/O pipe)");
+                () -> "creating new WolfSSLSession (with I/O pipe)");
         } else {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, sslPtr,
-                "creating new WolfSSLSession (without I/O pipe)");
+                () -> "creating new WolfSSLSession (without I/O pipe)");
         }
 
         synchronized (stateLock) {
@@ -531,8 +531,9 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered useCertificateFile(" +
-                file + ", " + format + ")");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered useCertificateFile(" + file + ", " +
+                format + ")");
 
             return useCertificateFile(this.sslPtr, file, format);
         }
@@ -570,8 +571,9 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered usePrivateKeyFile(" +
-                file + ", " + format + ")");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered usePrivateKeyFile(" + file + ", " +
+                format + ")");
 
             return usePrivateKeyFile(this.sslPtr, file, format);
         }
@@ -605,7 +607,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered useCertificateChainFile(" + file + ")");
+                () -> "entered useCertificateChainFile(" + file + ")");
 
             return useCertificateChainFile(this.sslPtr, file);
         }
@@ -630,14 +632,15 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered setFd(" + sd + ")");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered setFd(" + sd + ")");
 
             ret = setFd(this.sslPtr, sd, 1);
 
             if (ret == WolfSSL.SSL_SUCCESS) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                    WolfSSLDebug.INFO, this.sslPtr, "native fd set to: " +
-                    getFd(this.sslPtr));
+                    WolfSSLDebug.INFO, this.sslPtr,
+                    () -> "native fd set to: " + getFd(this.sslPtr));
             }
 
             return ret;
@@ -661,7 +664,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered setFd(" + sd + ")");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered setFd(" + sd + ")");
 
             return setFd(this.sslPtr, sd, 2);
         }
@@ -690,8 +694,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered setUsingNonblock(" +
-                nonblock + ")");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered setUsingNonblock(" + nonblock + ")");
 
             setUsingNonblock(this.sslPtr, nonblock);
         }
@@ -719,7 +723,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getUsingNonblock()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered getUsingNonblock()");
 
             return getUsingNonblock(this.sslPtr);
         }
@@ -738,18 +743,18 @@ public class WolfSSLSession {
     public int getFd()
         throws IllegalStateException, WolfSSLJNIException {
 
-        int fd = 0;
+        final int fd;
 
         confirmObjectIsActive();
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getFd()");
+                WolfSSLDebug.INFO, this.sslPtr, () -> "entered getFd()");
 
             fd = getFd(this.sslPtr);
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "returning fd: " + fd);
+                WolfSSLDebug.INFO, this.sslPtr, () -> "returning fd: " + fd);
         }
 
         return fd;
@@ -765,7 +770,7 @@ public class WolfSSLSession {
 
         if (ret == WolfSSL.WOLFJNI_IO_EVENT_TIMEOUT) {
             throw new SocketTimeoutException(
-                    "Native socket timed out during " + nativeFunc);
+                "Native socket timed out during " + nativeFunc);
         }
         else if (ret == WolfSSL.WOLFJNI_IO_EVENT_FD_CLOSED) {
             throw new SocketException("Socket fd closed during poll(), " +
@@ -871,20 +876,20 @@ public class WolfSSLSession {
     public int connect(int timeout)
         throws IllegalStateException, SocketTimeoutException, SocketException {
 
-        int ret = WolfSSL.SSL_FAILURE;
+        final int ret;
 
         confirmObjectIsActive();
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered connect(timeout: " +
-                timeout +")");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered connect(timeout: " + timeout +")");
 
             ret = connect(this.sslPtr, timeout);
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "connect() ret: " + ret +
-                ", err: " + getError(ret));
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "connect() ret: " + ret + ", err: " + getError(ret));
         }
 
         throwExceptionFromIOReturnValue(ret, "wolfSSL_connect()");
@@ -928,7 +933,8 @@ public class WolfSSLSession {
     public int write(byte[] data, int length)
         throws IllegalStateException, SocketTimeoutException, SocketException {
 
-        int ret;
+        final int ret;
+        final int err;
         long localPtr;
 
         confirmObjectIsActive();
@@ -940,8 +946,8 @@ public class WolfSSLSession {
         }
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, localPtr, "entered write(length: " +
-            length + ")");
+            WolfSSLDebug.INFO, localPtr,
+            () -> "entered write(length: " + length + ")");
 
         /* not synchronizing on sslLock here since JNI write() locks
          * session mutex around native wolfSSL_write() call. If sslLock
@@ -949,10 +955,11 @@ public class WolfSSLSession {
          * could timeout waiting for corresponding read() operation to
          * occur if needed */
         ret = write(localPtr, data, 0, length, 0);
+        err = getError(ret);
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, localPtr, "write() ret: " + ret +
-            ", err: " + getError(ret));
+            WolfSSLDebug.INFO, localPtr,
+            () -> "write() ret: " + ret + ", err: " + err);
 
         throwExceptionFromIOReturnValue(ret, "wolfSSL_write()");
 
@@ -1039,7 +1046,8 @@ public class WolfSSLSession {
     public int write(byte[] data, int offset, int length, int timeout)
         throws IllegalStateException, SocketTimeoutException, SocketException {
 
-        int ret;
+        final int ret;
+        final int err;
         long localPtr;
 
         confirmObjectIsActive();
@@ -1051,8 +1059,9 @@ public class WolfSSLSession {
         }
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, localPtr, "entered write(offset: " + offset +
-            ", length: " + length + ", timeout: " + timeout + ")");
+            WolfSSLDebug.INFO, localPtr,
+            () -> "entered write(offset: " + offset + ", length: " +
+            length + ", timeout: " + timeout + ")");
 
         /* not synchronizing on sslLock here since JNI write() locks
          * session mutex around native wolfSSL_write() call. If sslLock
@@ -1060,10 +1069,11 @@ public class WolfSSLSession {
          * could timeout waiting for corresponding read() operation to
          * occur if needed */
         ret = write(localPtr, data, offset, length, timeout);
+        err = getError(ret);
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, localPtr, "write() ret: " + ret +
-            ", err: " + getError(ret));
+            WolfSSLDebug.INFO, localPtr,
+            () -> "write() ret: " + ret + ", err: " + err);
 
         throwExceptionFromIOReturnValue(ret, "wolfSSL_write()");
 
@@ -1110,7 +1120,9 @@ public class WolfSSLSession {
     public int read(byte[] data, int sz)
         throws IllegalStateException, SocketTimeoutException, SocketException {
 
-        int ret;
+        final int ret;
+        final int err;
+        final int readSz = sz;
         long localPtr;
 
         confirmObjectIsActive();
@@ -1122,18 +1134,20 @@ public class WolfSSLSession {
         }
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, localPtr, "entered read(sz: " + sz + ")");
+            WolfSSLDebug.INFO, localPtr, () -> "entered read(sz: " +
+            readSz + ")");
 
         /* not synchronizing on sslLock here since JNI read() locks
          * session mutex around native wolfSSL_read() call. If sslLock
          * is locked here, since we call select() inside native JNI we
          * could timeout waiting for corresponding write() operation to
          * occur if needed */
-        ret = read(localPtr, data, 0, sz, 0);
+        ret = read(localPtr, data, 0, readSz, 0);
+        err = getError(ret);
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, localPtr, "read() ret: " + ret +
-            ", err: " + getError(ret));
+            WolfSSLDebug.INFO, localPtr,
+            () -> "read() ret: " + ret + ", err: " + err);
 
         throwExceptionFromIOReturnValue(ret, "wolfSSL_read()");
 
@@ -1224,7 +1238,11 @@ public class WolfSSLSession {
     public int read(byte[] data, int offset, int sz, int timeout)
         throws IllegalStateException, SocketTimeoutException, SocketException {
 
-        int ret;
+        final int ret;
+        final int err;
+        final int readOff = offset;
+        final int readSz = sz;
+        final int readTimeout = timeout;
         long localPtr;
 
         confirmObjectIsActive();
@@ -1236,19 +1254,21 @@ public class WolfSSLSession {
         }
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, localPtr, "entered read(offset: " + offset +
-            ", sz: " + sz + ", timeout: " + timeout + ")");
+            WolfSSLDebug.INFO, localPtr,
+            () -> "entered read(offset: " + readOff + ", sz: " + readSz +
+            ", timeout: " + readTimeout + ")");
 
         /* not synchronizing on sslLock here since JNI read() locks
          * session mutex around native wolfSSL_read() call. If sslLock
          * is locked here, since we call select() inside native JNI we
          * could timeout waiting for corresponding write() operation to
          * occur if needed */
-        ret = read(localPtr, data, offset, sz, timeout);
+        ret = read(localPtr, data, readOff, readSz, readTimeout);
+        err = getError(ret);
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, localPtr, "read() ret: " + ret +
-            ", err: " + getError(ret));
+            WolfSSLDebug.INFO, localPtr,
+            () -> "read() ret: " + ret + ", err: " + err);
 
         throwExceptionFromIOReturnValue(ret, "wolfSSL_read()");
 
@@ -1299,7 +1319,10 @@ public class WolfSSLSession {
     public int read(ByteBuffer data, int sz, int timeout)
         throws IllegalStateException, SocketTimeoutException, SocketException {
 
-        int ret;
+        final int ret;
+        final int err;
+        final int readSz = sz;
+        final int readTimeout = timeout;
         long localPtr;
 
         confirmObjectIsActive();
@@ -1311,8 +1334,9 @@ public class WolfSSLSession {
         }
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, localPtr, "entered read(ByteBuffer, " +
-            "sz: " + sz + ", timeout: " + timeout + ")");
+            WolfSSLDebug.INFO, localPtr,
+            () -> "entered read(ByteBuffer, sz: " + readSz +
+            ", timeout: " + readTimeout + ")");
 
         /* not synchronizing on sslLock here since JNI read() locks
          * session mutex around native wolfSSL_read() call. If sslLock
@@ -1320,15 +1344,16 @@ public class WolfSSLSession {
          * could timeout waiting for corresponding write() operation to
          * occur if needed */
         try {
-            ret = read(localPtr, data, sz, timeout);
+            ret = read(localPtr, data, readSz, readTimeout);
+            err = getError(ret);
         } catch (WolfSSLException e) {
             /* JNI code may throw WolfSSLException on JNI specific errors */
             throw new SocketException(e.getMessage());
         }
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, localPtr, "read() ret: " + ret +
-            ", err: " + getError(ret));
+            WolfSSLDebug.INFO, localPtr,
+            () -> "read() ret: " + ret + ", err: " + err);
 
         throwExceptionFromIOReturnValue(ret, "wolfSSL_read()");
 
@@ -1432,14 +1457,14 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered accept(timeout: " +
-                timeout + ")");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered accept(timeout: " + timeout + ")");
 
             ret = accept(this.sslPtr, timeout);
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "accept() ret: " + ret +
-                ", err: " + getError(ret));
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "accept() ret: " + ret + ", err: " + getError(ret));
         }
 
         throwExceptionFromIOReturnValue(ret, "wolfSSL_accept()");
@@ -1462,13 +1487,15 @@ public class WolfSSLSession {
             synchronized (stateLock) {
                 if (this.active == false) {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                        WolfSSLDebug.INFO, "entered freeSSL(), already freed");
+                        WolfSSLDebug.INFO,
+                        () -> "entered freeSSL(), already freed");
                     /* already freed, just return */
                     return;
                 }
 
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                    WolfSSLDebug.INFO, this.sslPtr, "entered freeSSL()");
+                    WolfSSLDebug.INFO, this.sslPtr,
+                    () -> "entered freeSSL()");
 
                 /* free native resources */
                 freeSSL(this.sslPtr);
@@ -1562,13 +1589,13 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered shutdownSSL(timeout: " + timeout + ")");
+                () -> "entered shutdownSSL(timeout: " + timeout + ")");
 
             ret = shutdownSSL(this.sslPtr, timeout);
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "shutdownSSL() ret: " + ret +
-                ", err: " + getError(ret));
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "shutdownSSL() ret: " + ret + ", err: " + getError(ret));
         }
 
         throwExceptionFromIOReturnValue(ret, "wolfSSL_shutdown()");
@@ -1642,25 +1669,26 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered setSession(ptr: " +
-                session + ")");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered setSession(ptr: " + session + ")");
 
             if ((session != 0) && (wolfsslSessionIsSetup(session) == 1)) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                    WolfSSLDebug.INFO, this.sslPtr, "session pointer (" +
-                    session + ") is setup");
+                    WolfSSLDebug.INFO, this.sslPtr,
+                    () -> "session pointer (" + session + ") is setup");
             }
             else {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                     WolfSSLDebug.INFO, this.sslPtr,
-                    "session pointer is null or not set up");
+                    () -> "session pointer is null or not set up");
             }
 
             ret = setSession(this.sslPtr, session);
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "setSession(session: " +
-                session + ") ret: " + ret + ", err: " + getError(ret));
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "setSession(session: " + session + ") ret: " +
+                ret + ", err: " + getError(ret));
 
             return ret;
         }
@@ -1704,13 +1732,13 @@ public class WolfSSLSession {
      */
     public long getSession() throws IllegalStateException {
 
-        long sessPtr = 0;
+        final long sessPtr;
 
         confirmObjectIsActive();
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getSession()");
+                WolfSSLDebug.INFO, this.sslPtr, () -> "entered getSession()");
 
             /* Calling get1Session() here as an indication that the native
              * JNI level should always return a session pointer that needs
@@ -1722,17 +1750,17 @@ public class WolfSSLSession {
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "get1Session(), ret ptr: " + sessPtr);
+                () -> "get1Session(), ret ptr: " + sessPtr);
 
             if ((sessPtr != 0) && (wolfsslSessionIsSetup(sessPtr) == 1)) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                    WolfSSLDebug.INFO, this.sslPtr, "session pointer (" +
-                    sessPtr + ") is setup");
+                    WolfSSLDebug.INFO, this.sslPtr,
+                    () -> "session pointer (" + sessPtr + ") is setup");
             }
             else {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                     WolfSSLDebug.INFO, this.sslPtr,
-                    "session pointer is null or not set up");
+                    () -> "session pointer is null or not set up");
             }
 
             return sessPtr;
@@ -1759,18 +1787,20 @@ public class WolfSSLSession {
         int ret;
 
         WolfSSLDebug.log(WolfSSLSession.class, WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, "entered sessionIsSetup(" + session + ")");
+            WolfSSLDebug.INFO, () -> "entered sessionIsSetup(" + session + ")");
 
         if (session == 0) {
             WolfSSLDebug.log(WolfSSLSession.class, WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, "sessionIsSetup(), ptr null, returning 0");
+                WolfSSLDebug.INFO,
+                () -> "sessionIsSetup(), ptr null, returning 0");
             return 0;
         }
 
         ret = wolfsslSessionIsSetup(session);
 
         WolfSSLDebug.log(WolfSSLSession.class, WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, "sessionIsSetup(" + session + ") ret: " + ret);
+            WolfSSLDebug.INFO,
+            () -> "sessionIsSetup(" + session + ") ret: " + ret);
 
         return ret;
     }
@@ -1795,7 +1825,7 @@ public class WolfSSLSession {
         int ret;
 
         WolfSSLDebug.log(WolfSSLSession.class, WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, "entered sessionIsResumable()");
+            WolfSSLDebug.INFO, () -> "entered sessionIsResumable()");
 
         if (session == 0) {
             return 0;
@@ -1804,7 +1834,7 @@ public class WolfSSLSession {
         ret = wolfsslSessionIsResumable(session);
 
         WolfSSLDebug.log(WolfSSLSession.class, WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, "session resumable: " + ret);
+            WolfSSLDebug.INFO, () -> "session resumable: " + ret);
 
         return ret;
     }
@@ -1826,42 +1856,44 @@ public class WolfSSLSession {
      */
     public static long duplicateSession(long session) {
 
-        long sessPtr = 0;
+        final long sessPtr;
 
         WolfSSLDebug.log(WolfSSLSession.class, WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, "entered duplicateSession(ptr: " +
-            session + ")");
+            WolfSSLDebug.INFO,
+            () -> "entered duplicateSession(ptr: " + session + ")");
 
         if (session == 0) {
             WolfSSLDebug.log(WolfSSLSession.class, WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, "session pointer is null, not duplicating");
+                WolfSSLDebug.INFO,
+                () -> "session pointer is null, not duplicating");
             return 0;
         }
 
         if (wolfsslSessionIsSetup(session) == 1) {
             WolfSSLDebug.log(WolfSSLSession.class, WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, "session pointer prior to dup (" + session +
-                ") is setup");
+                WolfSSLDebug.INFO,
+                () -> "session ptr prior to dup (" + session + ") is setup");
         }
         else {
             WolfSSLDebug.log(WolfSSLSession.class, WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, "session pointer prior to dup " +
-                "is NOT set up");
+                WolfSSLDebug.INFO,
+                () -> "session ptr prior to dup is NOT set up");
         }
 
         sessPtr = wolfsslSessionDup(session);
 
         WolfSSLDebug.log(WolfSSLSession.class, WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, "duplicated session ptr: " + sessPtr);
+            WolfSSLDebug.INFO, () -> "duplicated session ptr: " + sessPtr);
 
         if ((sessPtr != 0) && (wolfsslSessionIsSetup(sessPtr) == 1)) {
             WolfSSLDebug.log(WolfSSLSession.class, WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, "session pointer after dup (" + sessPtr +
-                ") is setup");
+                WolfSSLDebug.INFO,
+                () -> "session pointer after dup (" + sessPtr + ") is setup");
         }
         else {
             WolfSSLDebug.log(WolfSSLSession.class, WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, "session pointer after dup is NOT set up");
+                WolfSSLDebug.INFO,
+                () -> "session pointer after dup is NOT set up");
         }
 
         return sessPtr;
@@ -1884,8 +1916,8 @@ public class WolfSSLSession {
     public static String sessionGetCipherName(long session) {
 
         WolfSSLDebug.log(WolfSSLSession.class, WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, "entered sessionGetCipherName(ptr: " +
-            session + ")");
+            WolfSSLDebug.INFO,
+            () -> "entered sessionGetCipherName(ptr: " + session + ")");
 
         if (session == 0) {
             return null;
@@ -1905,14 +1937,15 @@ public class WolfSSLSession {
          * with this WOLFSSL object or WolfSSLSession. */
 
         WolfSSLDebug.log(WolfSSLSession.class, WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, "entered freeSession(ptr: " + session + ")");
+            WolfSSLDebug.INFO,
+            () -> "entered freeSession(ptr: " + session + ")");
 
         if (session != 0) {
             freeNativeSession(session);
         }
 
         WolfSSLDebug.log(WolfSSLSession.class, WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, "session freed (ptr: " + session + ")");
+            WolfSSLDebug.INFO, () -> "session freed (ptr: " + session + ")");
 
     }
 
@@ -1932,7 +1965,7 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getSessionID()");
+                WolfSSLDebug.INFO, this.sslPtr, () -> "entered getSessionID()");
 
             long sess = getSession(this.sslPtr);
             if (sess != 0) {
@@ -1943,7 +1976,7 @@ public class WolfSSLSession {
             }
 
             WolfSSLDebug.logHex(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "session ID", sessId,
+                WolfSSLDebug.INFO, this.sslPtr, () -> "session ID", sessId,
                 sessId.length);
 
             return sessId;
@@ -1959,24 +1992,25 @@ public class WolfSSLSession {
      */
     public boolean hasSessionTicket() throws IllegalStateException {
 
-        boolean hasTicket = false;
+        final boolean hasTicket;
 
         confirmObjectIsActive();
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered hasSessionTicket()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered hasSessionTicket()");
 
             long sess = getSession(this.sslPtr);
-            if (sess != 0) {
-                if (hasTicket(sess) == WolfSSL.SSL_SUCCESS) {
-                    hasTicket = true;
-                }
+            if ((sess != 0) && (hasTicket(sess) == WolfSSL.SSL_SUCCESS)) {
+                hasTicket = true;
+            } else {
+                hasTicket = false;
             }
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "session has ticket: " +
-                hasTicket);
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "session has ticket: " + hasTicket);
 
             return hasTicket;
         }
@@ -1997,12 +2031,12 @@ public class WolfSSLSession {
         confirmObjectIsActive();
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, "entered getCacheSize()");
+            WolfSSLDebug.INFO, () -> "entered getCacheSize()");
 
         ret = this.getAssociatedContextPtr().getCacheSize();
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, "cache size: " + ret);
+            WolfSSLDebug.INFO, () -> "cache size: " + ret);
 
         return ret;
     }
@@ -2029,26 +2063,26 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered setServerID(byte[], newSess: " + newSess + ")");
+                () -> "entered setServerID(byte[], newSess: " + newSess + ")");
 
             ret = setServerID(this.sslPtr, id, id.length, newSess);
 
             if (ret == WolfSSL.SSL_SUCCESS) {
                 if (id != null) {
                     WolfSSLDebug.logHex(getClass(), WolfSSLDebug.Component.JNI,
-                        WolfSSLDebug.INFO, this.sslPtr, "set server ID",
-                        id, id.length);
+                        WolfSSLDebug.INFO, this.sslPtr,
+                        () -> "set server ID", id, id.length);
                 }
                 else {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                         WolfSSLDebug.INFO, this.sslPtr,
-                        "server ID byte[] null, not set");
+                        () -> "server ID byte[] null, not set");
                 }
             }
             else {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                     WolfSSLDebug.INFO, this.sslPtr,
-                    "failed to set server ID, ret: " + ret);
+                    () -> "failed to set server ID, ret: " + ret);
             }
 
             return ret;
@@ -2068,26 +2102,26 @@ public class WolfSSLSession {
      */
     public int setSessTimeout(long t) throws IllegalStateException {
 
-        int ret;
+        final int ret;
         long session;
 
         confirmObjectIsActive();
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, "entered setSessTimeout(timeout (sec): " +
-            t + ")");
+            WolfSSLDebug.INFO,
+            () -> "entered setSessTimeout(timeout (sec): " + t + ")");
 
         session = this.getSession();
         if (session == 0) {
             /* session may be null if session cache disabled, wolfSSL
              * doesn't have session ID available, mutex function fails, etc */
             ret = WolfSSL.JNI_SESSION_UNAVAILABLE;
+        } else {
+            ret = setSessTimeout(session, t);
         }
 
-        ret = setSessTimeout(session, t);
-
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, "set session timeout, ret: " + ret);
+            WolfSSLDebug.INFO, () -> "set session timeout, ret: " + ret);
 
         return ret;
     }
@@ -2108,13 +2142,14 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getSessTimeout()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered getSessTimeout()");
 
             ret = getSessTimeout(this.getSession(this.sslPtr));
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "session timeout (sec): " + ret);
+                () -> "session timeout (sec): " + ret);
 
             return ret;
         }
@@ -2138,12 +2173,13 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered setTimeout(timeout: " + t + ")");
+                () -> "entered setTimeout(timeout: " + t + ")");
 
             ret = setTimeout(this.sslPtr, t);
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "set timeout, ret: " + ret);
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "set timeout, ret: " + ret);
 
             return ret;
         }
@@ -2165,12 +2201,12 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getTimeout()");
+                WolfSSLDebug.INFO, this.sslPtr, () -> "entered getTimeout()");
 
             ret = getTimeout(this.sslPtr);
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "timeout: " + ret);
+                WolfSSLDebug.INFO, this.sslPtr, () -> "timeout: " + ret);
 
             return ret;
         }
@@ -2206,7 +2242,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered setCipherList(" + list + ")");
+                () -> "entered setCipherList(" + list + ")");
 
             return setCipherList(this.sslPtr, list);
         }
@@ -2265,7 +2301,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered setSignatureAlgorithms(" + list + ")");
+                () -> "entered setSignatureAlgorithms(" + list + ")");
 
             return set1SigAlgsList(this.sslPtr, list);
         }
@@ -2301,7 +2337,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered useSupportedCurves(" +
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered useSupportedCurves(" +
                 Arrays.asList(curveNames) + ")");
         }
 
@@ -2359,7 +2396,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered dtlsGetCurrentTimeout()");
+                () -> "entered dtlsGetCurrentTimeout()");
 
             return dtlsGetCurrentTimeout(this.sslPtr);
         }
@@ -2389,7 +2426,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered dtlsGotTimeout()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered dtlsGotTimeout()");
 
             return dtlsGotTimeout(this.sslPtr);
         }
@@ -2441,7 +2479,7 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered dtls()");
+                WolfSSLDebug.INFO, this.sslPtr, () -> "entered dtls()");
 
             return dtls(this.sslPtr);
         }
@@ -2469,7 +2507,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered dtlsSetPeer(" + peer + ")");
+                () -> "entered dtlsSetPeer(" + peer + ")");
 
             return dtlsSetPeer(this.sslPtr, peer);
         }
@@ -2556,7 +2594,7 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered dtlsGetPeer()");
+                WolfSSLDebug.INFO, this.sslPtr, () -> "entered dtlsGetPeer()");
 
             return dtlsGetPeer(this.sslPtr);
         }
@@ -2630,13 +2668,13 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered getOutputSize()");
+                () -> "entered getOutputSize()");
 
             ret = getMaxOutputSize(this.sslPtr);
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "max output size: " + ret);
+                () -> "max output size: " + ret);
         }
 
         return ret;
@@ -2665,12 +2703,13 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered sessionReused()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered sessionReused()");
 
             ret = sessionReused(this.sslPtr);
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "session reused: " + ret);
+                WolfSSLDebug.INFO, this.sslPtr, () -> "session reused: " + ret);
         }
 
         return ret;
@@ -2707,7 +2746,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getPeerCertificate()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered getPeerCertificate()");
 
             return getPeerCertificate(this.sslPtr);
         }
@@ -2733,7 +2773,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getPeerX509Issuer()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered getPeerX509Issuer()");
 
             return getPeerX509Issuer(this.sslPtr, x509);
         }
@@ -2759,7 +2800,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getPeerX509Subject()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered getPeerX509Subject()");
 
             return getPeerX509Subject(this.sslPtr, x509);
         }
@@ -2789,7 +2831,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getPeerX509AltName()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered getPeerX509AltName()");
 
             return getPeerX509AltName(this.sslPtr, x509);
         }
@@ -2813,7 +2856,7 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getVersion()");
+                WolfSSLDebug.INFO, this.sslPtr, () -> "entered getVersion()");
 
             return getVersion(this.sslPtr);
         }
@@ -2838,7 +2881,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getCurrentCipher()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered getCurrentCipher()");
 
             return getCurrentCipher(this.sslPtr);
         }
@@ -2867,7 +2911,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered checkDomainName(" + dn + ")");
+                () -> "entered checkDomainName(" + dn + ")");
 
             return checkDomainName(this.sslPtr, dn);
         }
@@ -2896,8 +2940,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered setTmpDH(pSz: " + pSz +
-                ", gSz: " + gSz + ")");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered setTmpDH(pSz: " + pSz + ", gSz: " + gSz + ")");
 
             return setTmpDH(this.sslPtr, p, pSz, g, gSz);
         }
@@ -2929,8 +2973,9 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getTmpDHFile(" +
-                fname + ", format:" + format + ")");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered getTmpDHFile(" + fname + ", format:" +
+                format + ")");
 
             return setTmpDHFile(this.sslPtr, fname, format);
         }
@@ -2971,7 +3016,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered useCertificateBuffer(sz: " + sz + ", format: " +
+                () -> "entered useCertificateBuffer(sz: " + sz + ", format: " +
                 format + ")");
 
             return useCertificateBuffer(this.sslPtr, in, sz, format);
@@ -3016,7 +3061,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered usePrivateKeyBuffer(sz: " + sz + ", format: " +
+                () -> "entered usePrivateKeyBuffer(sz: " + sz + ", format: " +
                 format + ")");
 
             return usePrivateKeyBuffer(this.sslPtr, in, sz, format);
@@ -3061,7 +3106,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered useCertificateChainBuffer(sz: " + sz + ")");
+                () -> "entered useCertificateChainBuffer(sz: " + sz + ")");
 
             return useCertificateChainBuffer(this.sslPtr, in, sz);
         }
@@ -3109,7 +3154,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered useCertificateChainBufferFormat(sz: " + sz +
+                () -> "entered useCertificateChainBufferFormat(sz: " + sz +
                 ", format: " + format + ")");
 
             return useCertificateChainBufferFormat(this.sslPtr, in, sz, format);
@@ -3134,7 +3179,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered setGroupMessages()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered setGroupMessages()");
 
             return setGroupMessages(this.sslPtr);
         }
@@ -3166,7 +3212,7 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered setIOReadCtx()");
+                WolfSSLDebug.INFO, this.sslPtr, () -> "entered setIOReadCtx()");
 
             ioReadCtx = ctx;
         }
@@ -3214,7 +3260,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered setIOWriteCtx()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered setIOWriteCtx()");
 
             ioWriteCtx = ctx;
         }
@@ -3257,7 +3304,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered setGenCookieCtx()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered setGenCookieCtx()");
 
             genCookieCtx = ctx;
         }
@@ -3294,8 +3342,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered enableCRL(" +
-                options + ")");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered enableCRL(" + options + ")");
 
             return enableCRL(this.sslPtr, options);
         }
@@ -3325,7 +3373,7 @@ public class WolfSSLSession {
 
        synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered disableCRL()");
+                WolfSSLDebug.INFO, this.sslPtr, () -> "entered disableCRL()");
 
              return disableCRL(this.sslPtr);
         }
@@ -3376,8 +3424,9 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered loadCRL(" + path +
-                ", type: " + type + ", monitor: " + monitor + ")");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered loadCRL(" + path + ", type: " + type +
+                ", monitor: " + monitor + ")");
 
             return loadCRL(this.sslPtr, path, type, monitor);
         }
@@ -3406,7 +3455,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered setCRLCb(" + cb + ")");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered setCRLCb(" + cb + ")");
 
             return setCRLCb(this.sslPtr, cb);
         }
@@ -3429,7 +3479,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered cipherGetName()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered cipherGetName()");
 
             return cipherGetName(this.sslPtr);
         }
@@ -3456,7 +3507,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getMacSecret()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered getMacSecret()");
 
             return getMacSecret(this.sslPtr, verify);
         }
@@ -3479,7 +3531,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getClientWriteKey()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered getClientWriteKey()");
 
             return getClientWriteKey(this.sslPtr);
         }
@@ -3504,7 +3557,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getClientWriteIV()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered getClientWriteIV()");
 
             return getClientWriteIV(this.sslPtr);
         }
@@ -3527,7 +3581,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getServerWriteKey()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered getServerWriteKey()");
 
             return getServerWriteKey(this.sslPtr);
         }
@@ -3552,7 +3607,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getServerWriteIV()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered getServerWriteIV()");
 
             return getServerWriteIV(this.sslPtr);
         }
@@ -3573,7 +3629,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getKeySize()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered getKeySize()");
 
             return getKeySize(this.sslPtr);
         }
@@ -3598,12 +3655,12 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getSide()");
+                WolfSSLDebug.INFO, this.sslPtr, () -> "entered getSide()");
 
             ret = getSide(this.sslPtr);
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "side: " + ret);
+                WolfSSLDebug.INFO, this.sslPtr, () -> "side: " + ret);
         }
 
         return ret;
@@ -3625,7 +3682,7 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered isTLSv1_1()");
+                WolfSSLDebug.INFO, this.sslPtr, () -> "entered isTLSv1_1()");
 
             return isTLSv1_1(this.sslPtr);
         }
@@ -3654,7 +3711,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getBulkCipher()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered getBulkCipher()");
 
             return getBulkCipher(this.sslPtr);
         }
@@ -3676,7 +3734,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getCipherBlockSize()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered getCipherBlockSize()");
 
             return getCipherBlockSize(this.sslPtr);
         }
@@ -3699,7 +3758,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getAeadMacSize()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered getAeadMacSize()");
 
             return getAeadMacSize(this.sslPtr);
         }
@@ -3722,7 +3782,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getHmacSize()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered getHmacSize()");
 
             return getHmacSize(this.sslPtr);
         }
@@ -3752,7 +3813,7 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getHmacType()");
+                WolfSSLDebug.INFO, this.sslPtr, () -> "entered getHmacType()");
 
             return getHmacType(this.sslPtr);
         }
@@ -3778,7 +3839,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getCipherType()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered getCipherType()");
 
             return getCipherType(this.sslPtr);
         }
@@ -3810,8 +3872,9 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered setTlsHmacInner(sz: " +
-                sz + ", content: " + content + ", verify: " + verify + ")");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered setTlsHmacInner(sz: " + sz + ", content: " +
+                content + ", verify: " + verify + ")");
 
             return setTlsHmacInner(this.sslPtr, inner, sz, content, verify);
         }
@@ -3835,7 +3898,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered setMacEncryptCtx(" + ctx + ")");
+                () -> "entered setMacEncryptCtx(" + ctx + ")");
 
             macEncryptCtx = ctx;
         }
@@ -3859,7 +3922,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered setDecryptVerifyCtx(" + ctx + ")");
+                () -> "entered setDecryptVerifyCtx(" + ctx + ")");
 
             decryptVerifyCtx = ctx;
         }
@@ -3883,7 +3946,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered setVerifyDecryptCtx(" + ctx + ")");
+                () -> "entered setVerifyDecryptCtx(" + ctx + ")");
 
             verifyDecryptCtx = ctx;
         }
@@ -3906,7 +3969,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered setEccSignCtx(" + ctx + ")");
+                () -> "entered setEccSignCtx(" + ctx + ")");
 
             eccSignCtx = ctx;
             setEccSignCtx(this.sslPtr);
@@ -3930,7 +3993,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered setEccVerifyCtx(" + ctx + ")");
+                () -> "entered setEccVerifyCtx(" + ctx + ")");
 
             eccVerifyCtx = ctx;
             setEccVerifyCtx(this.sslPtr);
@@ -3955,7 +4018,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered setEccSharedSecretCtx(" + ctx + ")");
+                () -> "entered setEccSharedSecretCtx(" + ctx + ")");
 
             eccSharedSecretCtx = ctx;
             setEccSharedSecretCtx(this.sslPtr);
@@ -3979,7 +4042,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered setRsaSignCtx(" + ctx + ")");
+                () -> "entered setRsaSignCtx(" + ctx + ")");
 
             rsaSignCtx = ctx;
             setRsaSignCtx(this.sslPtr);
@@ -4004,7 +4067,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered setRsaVerifyCtx(" + ctx + ")");
+                () -> "entered setRsaVerifyCtx(" + ctx + ")");
 
             rsaVerifyCtx = ctx;
             setRsaVerifyCtx(this.sslPtr);
@@ -4029,7 +4092,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered setRsaEncCtx(" + ctx + ")");
+                () -> "entered setRsaEncCtx(" + ctx + ")");
 
             rsaEncCtx = ctx;
             setRsaEncCtx(this.sslPtr);
@@ -4054,7 +4117,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered setRsaDecCtx(" + ctx + ")");
+                () -> "entered setRsaDecCtx(" + ctx + ")");
 
             rsaDecCtx = ctx;
             setRsaDecCtx(this.sslPtr);
@@ -4100,7 +4163,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered setPskClientCb(" + callback + ")");
+                () -> "entered setPskClientCb(" + callback + ")");
 
             /* set PSK client callback */
             internPskClientCb = callback;
@@ -4145,7 +4208,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered setPskServerCb(" + callback + ")");
+                () -> "entered setPskServerCb(" + callback + ")");
 
             /* set PSK server callback */
             internPskServerCb = callback;
@@ -4174,7 +4237,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getPskIdentityHint()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered getPskIdentityHint()");
 
             return getPskIdentityHint(this.sslPtr);
         }
@@ -4199,7 +4263,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getPskIdentity()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered getPskIdentity()");
 
             return getPskIdentity(this.sslPtr);
         }
@@ -4227,7 +4292,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered usePskIdentityHint(" + hint + ")");
+                () -> "entered usePskIdentityHint(" + hint + ")");
 
             return usePskIdentityHint(this.sslPtr, hint);
         }
@@ -4241,18 +4306,20 @@ public class WolfSSLSession {
      */
     public boolean handshakeDone() {
 
-        boolean done = false;
+        final boolean done;
 
         confirmObjectIsActive();
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered handshakeDone()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered handshakeDone()");
 
             done = handshakeDone(this.sslPtr);
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "handshake done: " + done);
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "handshake done: " + done);
         }
 
         return done;
@@ -4269,7 +4336,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered setConnectState()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered setConnectState()");
 
             setConnectState(this.sslPtr);
         }
@@ -4286,7 +4354,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered setAcceptState()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered setAcceptState()");
 
             setAcceptState(this.sslPtr);
         }
@@ -4333,8 +4402,9 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered setVerify(mode: " +
-                mode + ", callback: " + callback + ")");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered setVerify(mode: " + mode + ", callback: " +
+                callback + ")");
 
             setVerify(this.sslPtr, mode, callback);
         }
@@ -4357,7 +4427,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered setOptions(" + op + ")");
+                () -> "entered setOptions(" + op + ")");
 
             return setOptions(this.sslPtr, op);
         }
@@ -4379,7 +4449,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getOptions()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered getOptions()");
 
             return getOptions(this.sslPtr);
         }
@@ -4393,13 +4464,14 @@ public class WolfSSLSession {
      */
     public boolean gotCloseNotify() {
 
-        boolean gotNotify = false;
+        final boolean gotNotify;
 
         confirmObjectIsActive();
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered gotCloseNotify()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered gotCloseNotify()");
 
             int ret = gotCloseNotify(this.sslPtr);
             if (ret == 1) {
@@ -4410,7 +4482,7 @@ public class WolfSSLSession {
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "got close notify: " + gotNotify);
+                () -> "got close notify: " + gotNotify);
 
             return gotNotify;
         }
@@ -4451,7 +4523,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered setIORecv(" + callback + ") - byte array");
+                () -> "entered setIORecv(" + callback + ") - byte array");
 
             /* Only allow one recv callback registered at a time, if ByteBuffer
              * version has been set, set to null before setting byte variant. */
@@ -4504,7 +4576,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered setIORecv(" + callback + ") - ByteBuffer");
+                () -> "entered setIORecv(" + callback + ") - ByteBuffer");
 
             /* Only allow one recv callback registered at a time, if array
              * version has been set, set to null before setting ByteBuffer. */
@@ -4559,7 +4631,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered setIOSend(" + callback + ") - byte array");
+                () -> "entered setIOSend(" + callback + ") - byte array");
 
             /* Only allow one send callback registered at a time, if ByteBuffer
              * version has been set, set to null before setting byte variant. */
@@ -4615,7 +4687,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered setIOSend(" + callback + ") - ByteBuffer");
+                () -> "entered setIOSend(" + callback + ") - ByteBuffer");
 
             /* Only allow one recv callback registered at a time, if array
              * version has been set, set to null before setting ByteBuffer. */
@@ -4655,7 +4727,8 @@ public class WolfSSLSession {
          * blocked on I/O operations, which will already hold sslLock */
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, "entered interruptBlockedIO()");
+            WolfSSLDebug.INFO, this.sslPtr,
+            () -> "entered interruptBlockedIO()");
 
         return interruptBlockedIO(this.sslPtr);
     }
@@ -4674,7 +4747,8 @@ public class WolfSSLSession {
         confirmObjectIsActive();
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, "entered getThreadsBlockedInPoll()");
+            WolfSSLDebug.INFO, this.sslPtr,
+            () -> "entered getThreadsBlockedInPoll()");
 
         return getThreadsBlockedInPoll(this.sslPtr);
     }
@@ -4701,7 +4775,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered useSNI(type: " + type + ")");
+                () -> "entered useSNI(type: " + type + ")");
 
             ret = useSNI(this.sslPtr, type, data);
 
@@ -4730,7 +4804,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered getClientSNIRequest()");
+                () -> "entered getClientSNIRequest()");
 
             if (this.clientSNIRequested == null) {
                 return null;
@@ -4760,7 +4834,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered getSNIRequest(type: " + type + ")");
+                () -> "entered getSNIRequest(type: " + type + ")");
 
             /* Returns a byte array representing SNI host name */
             reqBytes = getSNIRequest(this.sslPtr, type);
@@ -4810,7 +4884,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered useSessionTicket()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered useSessionTicket()");
 
             ret = useSessionTicket(this.sslPtr);
 
@@ -4820,7 +4895,7 @@ public class WolfSSLSession {
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "enabled session tickets for session, ret: " + ret);
+                () -> "enabled session tickets for session, ret: " + ret);
         }
 
         return ret;
@@ -4841,7 +4916,8 @@ public class WolfSSLSession {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
             WolfSSLDebug.INFO, this.sslPtr,
-            "entered sessionTicketsEnabled(): " + this.sessionTicketsEnabled);
+            () -> "entered sessionTicketsEnabled(): " +
+            this.sessionTicketsEnabled);
 
         return this.sessionTicketsEnabled;
     }
@@ -4865,7 +4941,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered useALPN(byte[])");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered useALPN(byte[])");
 
             return sslSetAlpnProtos(this.sslPtr, alpnProtos);
         }
@@ -4898,7 +4975,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered useALPN(String[], int)");
+                () -> "entered useALPN(String[], int)");
         }
 
         if (protocols == null) {
@@ -4929,7 +5006,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getAlpnSelected()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered getAlpnSelected()");
 
             return sslGet0AlpnSelected(this.sslPtr);
         }
@@ -4953,7 +5031,7 @@ public class WolfSSLSession {
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered getAlpnSelectedString()");
+                () -> "entered getAlpnSelectedString()");
         }
 
         alpnSelectedBytes = getAlpnSelected();
@@ -4992,8 +5070,9 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered setAlpnSelectCb(" +
-                cb + ", Object: " + arg + ")");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered setAlpnSelectCb(" + cb + ", Object: " +
+                arg + ")");
 
             ret = setALPNSelectCb(this.sslPtr);
             if (ret == WolfSSL.SSL_SUCCESS) {
@@ -5036,8 +5115,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered setTls13SecretCb(" +
-                cb + ", ctx: " + ctx + ")");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered setTls13SecretCb(" + cb + ", ctx: " + ctx + ")");
 
             ret = setTls13SecretCb(this.sslPtr);
             if (ret == WolfSSL.SSL_SUCCESS) {
@@ -5077,8 +5156,9 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered setSessionTicketCb(" +
-                cb + ", ctx: " + ctx + ")");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered setSessionTicketCb(" + cb + ", ctx: " +
+                ctx + ")");
 
             ret = setSessionTicketCb(this.sslPtr);
             if (ret == WolfSSL.SSL_SUCCESS) {
@@ -5109,7 +5189,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered keepArrays()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered keepArrays()");
 
             keepArrays(this.sslPtr);
         }
@@ -5130,7 +5211,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getClientRandom()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered getClientRandom()");
 
             return getClientRandom(this.sslPtr);
         }
@@ -5154,7 +5236,7 @@ public class WolfSSLSession {
        synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.sslPtr,
-                "entered useSecureRenegotiation()");
+                () -> "entered useSecureRenegotiation()");
 
              return useSecureRenegotiation(this.sslPtr);
         }
@@ -5207,7 +5289,8 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered rehandshake()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered rehandshake()");
 
             return rehandshake(this.sslPtr);
         }
@@ -5225,12 +5308,14 @@ public class WolfSSLSession {
 
         synchronized (sslLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "entered getShutdown()");
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "entered getShutdown()");
 
             ret = getShutdown(this.sslPtr);
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr, "getShutdown(), ret: " + ret);
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "getShutdown(), ret: " + ret);
         }
 
         return ret;

--- a/src/java/com/wolfssl/WolfSSLX509Name.java
+++ b/src/java/com/wolfssl/WolfSSLX509Name.java
@@ -72,7 +72,8 @@ public class WolfSSLX509Name {
         }
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, x509NamePtr, "creating new WolfSSLX509Name");
+            WolfSSLDebug.INFO, x509NamePtr,
+            () -> "creating new WolfSSLX509Name");
 
         synchronized (stateLock) {
             this.active = true;
@@ -128,8 +129,8 @@ public class WolfSSLX509Name {
         int ret = 0;
 
         if (field == null || entry == null) {
-            throw new WolfSSLException("field or entry is null in " +
-                "addEntryByTxt()");
+            throw new WolfSSLException(
+                "field or entry is null in addEntryByTxt()");
         }
 
         synchronized (x509NameLock) {
@@ -139,8 +140,8 @@ public class WolfSSLX509Name {
         }
 
         if (ret != WolfSSL.SSL_SUCCESS) {
-            throw new WolfSSLException("Error setting " + field + " into " +
-                    "WolfSSLX509Name (error: " + ret + ")");
+            throw new WolfSSLException("Error setting " + field +
+                " into WolfSSLX509Name (error: " + ret + ")");
         }
     }
 
@@ -159,8 +160,8 @@ public class WolfSSLX509Name {
         confirmObjectIsActive();
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, this.x509NamePtr, "entered setCountryName(" +
-            countryName + ")");
+            WolfSSLDebug.INFO, this.x509NamePtr,
+            () -> "entered setCountryName(" + countryName + ")");
 
         addEntryByTxt("countryName", countryName);
         this.countryName = countryName;
@@ -182,7 +183,7 @@ public class WolfSSLX509Name {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
             WolfSSLDebug.INFO, this.x509NamePtr,
-            "entered setStateOrProvinceName(" + name + ")");
+            () -> "entered setStateOrProvinceName(" + name + ")");
 
         addEntryByTxt("stateOrProvinceName", name);
         this.stateOrProvinceName = name;
@@ -204,7 +205,7 @@ public class WolfSSLX509Name {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
             WolfSSLDebug.INFO, this.x509NamePtr,
-            "entered setStreetAddress(" + address + ")");
+            () -> "entered setStreetAddress(" + address + ")");
 
         addEntryByTxt("streetAddress", address);
         this.streetAddress = address;
@@ -226,7 +227,7 @@ public class WolfSSLX509Name {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
             WolfSSLDebug.INFO, this.x509NamePtr,
-            "entered setLocalityName(" + name + ")");
+            () -> "entered setLocalityName(" + name + ")");
 
         addEntryByTxt("localityName", name);
         this.localityName = name;
@@ -248,7 +249,7 @@ public class WolfSSLX509Name {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
             WolfSSLDebug.INFO, this.x509NamePtr,
-            "entered setSurname(" + name + ")");
+            () -> "entered setSurname(" + name + ")");
 
         addEntryByTxt("surname", name);
         this.surname = name;
@@ -270,7 +271,7 @@ public class WolfSSLX509Name {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
             WolfSSLDebug.INFO, this.x509NamePtr,
-            "entered setCommonName(" + name + ")");
+            () -> "entered setCommonName(" + name + ")");
 
         addEntryByTxt("commonName", name);
         this.commonName = name;
@@ -292,7 +293,7 @@ public class WolfSSLX509Name {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
             WolfSSLDebug.INFO, this.x509NamePtr,
-            "entered setEmailAddress(" + email + ")");
+            () -> "entered setEmailAddress(" + email + ")");
 
         addEntryByTxt("emailAddress", email);
         this.emailAddress = email;
@@ -314,7 +315,7 @@ public class WolfSSLX509Name {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
             WolfSSLDebug.INFO, this.x509NamePtr,
-            "entered setOrganizationName(" + name + ")");
+            () -> "entered setOrganizationName(" + name + ")");
 
         addEntryByTxt("organizationName", name);
         this.organizationName = name;
@@ -336,7 +337,7 @@ public class WolfSSLX509Name {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
             WolfSSLDebug.INFO, this.x509NamePtr,
-            "entered setOrganizationalUnitName(" + name + ")");
+            () -> "entered setOrganizationalUnitName(" + name + ")");
 
         addEntryByTxt("organizationalUnitName", name);
         this.organizationalUnitName = name;
@@ -358,7 +359,7 @@ public class WolfSSLX509Name {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
             WolfSSLDebug.INFO, this.x509NamePtr,
-            "entered setPostalCode(" + code + ")");
+            () -> "entered setPostalCode(" + code + ")");
 
         addEntryByTxt("postalCode", code);
         this.postalCode = code;
@@ -380,7 +381,7 @@ public class WolfSSLX509Name {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
             WolfSSLDebug.INFO, this.x509NamePtr,
-            "entered setUserId(" + id + ")");
+            () -> "entered setUserId(" + id + ")");
 
         addEntryByTxt("userId", id);
         this.userId = id;
@@ -399,7 +400,7 @@ public class WolfSSLX509Name {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
             WolfSSLDebug.INFO, this.x509NamePtr,
-            "entered getCountryName()");
+            () -> "entered getCountryName()");
 
         return this.countryName;
     }
@@ -417,7 +418,7 @@ public class WolfSSLX509Name {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
             WolfSSLDebug.INFO, this.x509NamePtr,
-            "entered getStateOrProvinceName()");
+            () -> "entered getStateOrProvinceName()");
 
         return this.stateOrProvinceName;
     }
@@ -435,7 +436,7 @@ public class WolfSSLX509Name {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
             WolfSSLDebug.INFO, this.x509NamePtr,
-            "entered getStreetAddress()");
+            () -> "entered getStreetAddress()");
 
         return this.streetAddress;
     }
@@ -453,7 +454,7 @@ public class WolfSSLX509Name {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
             WolfSSLDebug.INFO, this.x509NamePtr,
-            "entered getLocalityName()");
+            () -> "entered getLocalityName()");
 
         return this.localityName;
     }
@@ -471,7 +472,7 @@ public class WolfSSLX509Name {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
             WolfSSLDebug.INFO, this.x509NamePtr,
-            "entered getSurname()");
+            () -> "entered getSurname()");
 
         return this.surname;
     }
@@ -489,7 +490,7 @@ public class WolfSSLX509Name {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
             WolfSSLDebug.INFO, this.x509NamePtr,
-            "entered getCommonName()");
+            () -> "entered getCommonName()");
 
         return this.commonName;
     }
@@ -507,7 +508,7 @@ public class WolfSSLX509Name {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
             WolfSSLDebug.INFO, this.x509NamePtr,
-            "entered getEmailAddress()");
+            () -> "entered getEmailAddress()");
 
         return this.emailAddress;
     }
@@ -525,7 +526,7 @@ public class WolfSSLX509Name {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
             WolfSSLDebug.INFO, this.x509NamePtr,
-            "entered getOrganizationName()");
+            () -> "entered getOrganizationName()");
 
         return this.organizationName;
     }
@@ -543,7 +544,7 @@ public class WolfSSLX509Name {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
             WolfSSLDebug.INFO, this.x509NamePtr,
-            "entered getOrganizationalUnitName()");
+            () -> "entered getOrganizationalUnitName()");
 
         return this.organizationalUnitName;
     }
@@ -561,7 +562,7 @@ public class WolfSSLX509Name {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
             WolfSSLDebug.INFO, this.x509NamePtr,
-            "entered getPostalCode()");
+            () -> "entered getPostalCode()");
 
         return this.postalCode;
     }
@@ -579,7 +580,7 @@ public class WolfSSLX509Name {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
             WolfSSLDebug.INFO, this.x509NamePtr,
-            "entered getUserId()");
+            () -> "entered getUserId()");
 
         return this.userId;
     }
@@ -611,7 +612,8 @@ public class WolfSSLX509Name {
             synchronized (x509NameLock) {
 
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                    WolfSSLDebug.INFO, this.x509NamePtr, "entered free()");
+                    WolfSSLDebug.INFO, this.x509NamePtr,
+                    () -> "entered free()");
 
                 /* free native resources */
                 X509_NAME_free(this.x509NamePtr);

--- a/src/java/com/wolfssl/WolfSSLX509StoreCtx.java
+++ b/src/java/com/wolfssl/WolfSSLX509StoreCtx.java
@@ -48,11 +48,12 @@ public class WolfSSLX509StoreCtx {
     public WolfSSLX509StoreCtx(long ctxPtr) throws WolfSSLException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-            WolfSSLDebug.INFO, ctxPtr, "creating new WolfSSLX509StoreCtx");
+            WolfSSLDebug.INFO, ctxPtr,
+            () -> "creating new WolfSSLX509StoreCtx");
 
         if (ctxPtr == 0) {
-            throw new WolfSSLException("Failed to create " +
-                "WolfSSLX509StoreCtx, input ptr was null");
+            throw new WolfSSLException(
+                "Failed to create WolfSSLX509StoreCtx, input ptr was null");
         }
         this.active = true;
         this.ctxPtr = ctxPtr;
@@ -91,7 +92,7 @@ public class WolfSSLX509StoreCtx {
 
         synchronized (ctxLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.ctxPtr, "entering getCerts()");
+                WolfSSLDebug.INFO, this.ctxPtr, () -> "entering getCerts()");
 
             byte[][] derCerts = X509_STORE_CTX_getDerCerts(this.ctxPtr);
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLContext.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLContext.java
@@ -109,36 +109,36 @@ public class WolfSSLContext extends SSLContextSpi {
                     WolfSSL.SSL_OP_NO_TLSv1_1 | WolfSSL.SSL_OP_NO_TLSv1_2 |
                     WolfSSL.SSL_OP_NO_TLSv1_3;
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "creating WolfSSLContext with TLSv1");
+                    () -> "creating WolfSSLContext with TLSv1");
                 break;
             case TLSv1_1:
                 method = WolfSSL.TLSv1_1_Method();
                 ctxAttr.noOptions = ctxAttr.noOptions |
                     WolfSSL.SSL_OP_NO_TLSv1_2 | WolfSSL.SSL_OP_NO_TLSv1_3;
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "creating WolfSSLContext with TLSv1_1");
+                    () -> "creating WolfSSLContext with TLSv1_1");
                 break;
             case TLSv1_2:
                 method = WolfSSL.TLSv1_2_Method();
                 ctxAttr.noOptions = ctxAttr.noOptions |
                     WolfSSL.SSL_OP_NO_TLSv1_3;
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "creating WolfSSLContext with TLSv1_2");
+                    () -> "creating WolfSSLContext with TLSv1_2");
                 break;
             case TLSv1_3:
                 method = WolfSSL.TLSv1_3_Method();
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "creating WolfSSLContext with TLSv1_3");
+                    () -> "creating WolfSSLContext with TLSv1_3");
                 break;
             case SSLv23:
                 method = WolfSSL.SSLv23_Method();
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "creating WolfSSLContext with SSLv23");
+                    () -> "creating WolfSSLContext with SSLv23");
                 break;
             case DTLSv1_3:
                 method = WolfSSL.DTLSv1_3_Method();
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "creating WolfSSLContext with DTLSv1_3");
+                    () -> "creating WolfSSLContext with DTLSv1_3");
                 break;
             default:
                 throw new IllegalArgumentException(
@@ -151,7 +151,7 @@ public class WolfSSLContext extends SSLContextSpi {
         }
         ctx = new com.wolfssl.WolfSSLContext(method);
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "created new native WOLFSSL_CTX");
+            () -> "created new native WOLFSSL_CTX");
 
         if(ctxAttr.list != null && ctxAttr.list.length > 0) {
             ciphersIana = ctxAttr.list;
@@ -205,7 +205,7 @@ public class WolfSSLContext extends SSLContextSpi {
         int ret = 0;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "setting wolfSSL devId: " + WolfSSL.devId);
+            () -> "setting wolfSSL devId: " + WolfSSL.devId);
 
         try {
             ret = this.ctx.setDevId(WolfSSL.devId);
@@ -245,8 +245,8 @@ public class WolfSSLContext extends SSLContextSpi {
                 list = sb.toString();
                 if (this.ctx.setCipherList(list) != WolfSSL.SSL_SUCCESS) {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                            "error setting WolfSSLContext cipher list: " +
-                            list);
+                        () -> "error setting WolfSSLContext cipher list: " +
+                        list);
                 }
             }
 
@@ -298,12 +298,12 @@ public class WolfSSLContext extends SSLContextSpi {
 
         if (tm == null) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "internal TrustManager is null, no CAs to load");
+                () -> "internal TrustManager is null, no CAs to load");
             return;
         }
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "Using X509TrustManager: " + tm.toString());
+            () -> "Using X509TrustManager: " + tm.toString());
 
         /* We only need to load trusted CA certificates into our native
          * WOLFSSL_CTX if we are doing internal verification with wolfSSL
@@ -315,7 +315,7 @@ public class WolfSSLContext extends SSLContextSpi {
          * here since we do not need to interface with native verification */
         if (!(tm instanceof com.wolfssl.provider.jsse.WolfSSLTrustX509)) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "Deferring verification to checkClientTrusted/ServerTrusted()");
+                () -> "Deferring verification to checkClientTrusted/ServerTrusted()");
             return;
         }
 
@@ -323,18 +323,18 @@ public class WolfSSLContext extends SSLContextSpi {
         X509Certificate[] caList =  tm.getAcceptedIssuers();
         if (caList == null) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "internal TrustManager has no accepted issuers to load");
+                () -> "internal TrustManager has no accepted issuers to load");
             return;
         }
 
         if (caList.length == 0) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "internal TrustManager has no certs");
+                () -> "internal TrustManager has no certs");
             return;
         }
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "Number of certs in X509TrustManager: " + caList.length);
+            () -> "Number of certs in X509TrustManager: " + caList.length);
 
         /* Load accepted issuer certificates into native WOLFSSL_CTX to be
          * used in native wolfSSL verify logic */
@@ -356,17 +356,20 @@ public class WolfSSLContext extends SSLContextSpi {
             } catch (CertificateEncodingException ce) {
                 /* skip loading if encoding error is encountered */
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "skipped loading CA, encoding error");
+                    () -> "skipped loading CA, encoding error");
             } catch (WolfSSLJNIException we) {
                 /* skip loading if wolfSSL fails to load der encoding */
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "skipped loading CA, JNI exception");
+                    () -> "skipped loading CA, JNI exception");
             }
 
+            final String sigAltName = caList[i].getSigAlgName();
+            final String subjectName =
+                caList[i].getSubjectX500Principal().getName(
+                    X500Principal.RFC1779);
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "loaded trusted root cert (" + caList[i].getSigAlgName()
-                    + "): " + caList[i].getSubjectX500Principal().getName(
-                    X500Principal.RFC1779));
+                () -> "loaded trusted root cert (" + sigAltName + "): " +
+                subjectName);
         }
 
         if (caList.length > 0 && loadedCACount == 0) {
@@ -396,8 +399,8 @@ public class WolfSSLContext extends SSLContextSpi {
         SecureRandom sr) throws KeyManagementException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered engineInit(km=" + Arrays.toString(km) +
-            ", tm=" + Arrays.toString(tm) + ", sr=" + sr +")");
+            () -> "entered engineInit(km=" + Arrays.toString(km) + ", tm=" +
+            Arrays.toString(tm) + ", sr=" + sr +")");
 
         try {
             authStore = new WolfSSLAuthStore(km, tm, sr, currentVersion);
@@ -422,7 +425,7 @@ public class WolfSSLContext extends SSLContextSpi {
         throws IllegalStateException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered engineGetSocketFactory()");
+            () -> "entered engineGetSocketFactory()");
 
         if (this.ctx == null || this.authStore == null) {
             throw new IllegalStateException("SSLContext must be initialized " +
@@ -442,7 +445,7 @@ public class WolfSSLContext extends SSLContextSpi {
         throws IllegalStateException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered engineGetServerSocketFactory()");
+            () -> "entered engineGetServerSocketFactory()");
 
         if (this.ctx == null || this.authStore == null) {
             throw new IllegalStateException("SSLContext must be initialized " +
@@ -463,7 +466,7 @@ public class WolfSSLContext extends SSLContextSpi {
         throws IllegalStateException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered engineCreateSSLEngine()");
+            () -> "entered engineCreateSSLEngine()");
 
         if (this.ctx == null || this.authStore == null) {
             throw new IllegalStateException("SSLContext must be initialized " +
@@ -490,7 +493,7 @@ public class WolfSSLContext extends SSLContextSpi {
         throws IllegalStateException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered engineCreateSSLEngine(String host, int port)");
+            () -> "entered engineCreateSSLEngine(String host, int port)");
 
         if (this.ctx == null || this.authStore == null) {
             throw new IllegalStateException("SSLContext must be initialized " +
@@ -532,7 +535,7 @@ public class WolfSSLContext extends SSLContextSpi {
     protected SSLParameters engineGetDefaultSSLParameters() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered engineGetDefaultSSLParameters()");
+            () -> "entered engineGetDefaultSSLParameters()");
 
         return WolfSSLParametersHelper.decoupleParams(this.params);
     }
@@ -545,7 +548,7 @@ public class WolfSSLContext extends SSLContextSpi {
     protected SSLParameters engineGetSupportedSSLParameters() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered engineGetSupportedSSLParameters()");
+            () -> "entered engineGetSupportedSSLParameters()");
 
         return WolfSSLParametersHelper.decoupleParams(this.params);
     }
@@ -617,7 +620,7 @@ public class WolfSSLContext extends SSLContextSpi {
             super(TLS_VERSION.TLSv1);
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "creating new WolfSSLContext using TLSV1_Context");
+                () -> "creating new WolfSSLContext using TLSV1_Context");
         }
     }
 
@@ -632,7 +635,7 @@ public class WolfSSLContext extends SSLContextSpi {
             super(TLS_VERSION.TLSv1_1);
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "creating new WolfSSLContext using TLSV11_Context");
+                () -> "creating new WolfSSLContext using TLSV11_Context");
         }
     }
 
@@ -647,7 +650,7 @@ public class WolfSSLContext extends SSLContextSpi {
             super(TLS_VERSION.TLSv1_2);
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "creating new WolfSSLContext using TLSV12_Context");
+                () -> "creating new WolfSSLContext using TLSV12_Context");
         }
     }
 
@@ -662,7 +665,7 @@ public class WolfSSLContext extends SSLContextSpi {
             super(TLS_VERSION.TLSv1_3);
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "creating new WolfSSLContext using TLSV13_Context");
+                () -> "creating new WolfSSLContext using TLSV13_Context");
         }
     }
 
@@ -679,7 +682,7 @@ public class WolfSSLContext extends SSLContextSpi {
             super(TLS_VERSION.SSLv23);
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "creating new WolfSSLContext using TLSV23_Context");
+                () -> "creating new WolfSSLContext using TLSV23_Context");
         }
     }
 
@@ -694,7 +697,7 @@ public class WolfSSLContext extends SSLContextSpi {
             super(TLS_VERSION.DTLSv1_3);
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "creating new WolfSSLContext using DTLSV13_Context");
+                () -> "creating new WolfSSLContext using DTLSV13_Context");
         }
     }
 
@@ -714,7 +717,7 @@ public class WolfSSLContext extends SSLContextSpi {
             super(TLS_VERSION.SSLv23);
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "creating new WolfSSLContext using DEFAULT_Context");
+                () -> "creating new WolfSSLContext using DEFAULT_Context");
 
             try {
                 this.engineInit(null, null, null);

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
@@ -122,7 +122,7 @@ public class WolfSSLEngineHelper {
         this.authStore = store;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "created new WolfSSLEngineHelper()");
+            () -> "created new WolfSSLEngineHelper()");
     }
 
     /**
@@ -148,7 +148,7 @@ public class WolfSSLEngineHelper {
         this.hostname = hostname;
         this.authStore = store;
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "created new WolfSSLEngineHelper(peer port: " + port +
+            () -> "created new WolfSSLEngineHelper(peer port: " + port +
             ", peer hostname: " + hostname + ")");
     }
 
@@ -178,7 +178,7 @@ public class WolfSSLEngineHelper {
         this.authStore = store;
         this.session = new WolfSSLImplementSSLSession(store);
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "created new WolfSSLEngineHelper(peer port: " + port +
+            () -> "created new WolfSSLEngineHelper(peer port: " + port +
             ", peer IP: " + peerAddr.getHostAddress() + ")");
     }
 
@@ -299,7 +299,7 @@ public class WolfSSLEngineHelper {
 
         int ret;
         int offset;
-        String alias = null;       /* KeyStore alias holding private key */
+        final String alias;       /* KeyStore alias holding private key */
         X509KeyManager km = null;  /* X509KeyManager from KeyStore */
 
         if (this.authStore == null) {
@@ -309,7 +309,7 @@ public class WolfSSLEngineHelper {
         km = this.authStore.getX509KeyManager();
         if (km == null) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.ERROR,
-                    "internal KeyManager is null, no cert/key to load");
+                    () -> "internal KeyManager is null, no cert/key to load");
             return;
         }
 
@@ -347,11 +347,11 @@ public class WolfSSLEngineHelper {
                     "buffer into WOLFSSL, err = " + ret);
             }
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "loaded private key from X509KeyManager " +
+                    () -> "loaded private key from X509KeyManager " +
                     "(alias: " + alias + ")");
         } else {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "no private key found in X509KeyManager " +
+                    () -> "no private key found in X509KeyManager " +
                     "(alias: " + alias + "), skipped loading");
         }
 
@@ -380,13 +380,14 @@ public class WolfSSLEngineHelper {
                 throw new WolfSSLException("Failed to load certificate " +
                     "chain buffer into WOLFSSL, err = " + ret);
             }
+            final int tmpChainLength = chainLength;
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "loaded certificate chain from KeyManager (alias: " +
+                    () -> "loaded certificate chain from KeyManager (alias: " +
                     alias + ", length: " +
-                    chainLength + ")");
+                    tmpChainLength + ")");
         } else {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "no certificate or chain found " +
+                    () -> "no certificate or chain found " +
                     "(alias: " + alias + "), skipped loading");
         }
     }
@@ -401,7 +402,7 @@ public class WolfSSLEngineHelper {
     protected synchronized void setHostAndPort(String hostname, int port) {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered setHostAndPort()");
+            () -> "entered setHostAndPort()");
 
         this.hostname = hostname;
         this.port = port;
@@ -416,7 +417,7 @@ public class WolfSSLEngineHelper {
     protected synchronized void setPeerAddress(InetAddress peerAddr) {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered setPeerAddress()");
+            () -> "entered setPeerAddress()");
 
         this.peerAddr = peerAddr;
     }
@@ -439,7 +440,7 @@ public class WolfSSLEngineHelper {
 
         if (this.session == null) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "this.session is null, creating new " +
+                () -> "this.session is null, creating new " +
                 "WolfSSLImplementSSLSession");
 
             this.session = new WolfSSLImplementSSLSession(authStore);
@@ -692,7 +693,7 @@ public class WolfSSLEngineHelper {
         String proto = ssl.getAlpnSelectedString();
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "selected ALPN protocol = " + proto);
+            () -> "selected ALPN protocol = " + proto);
 
         if (proto == null && this.ssl.handshakeDone()) {
             /* ALPN not used if proto is null and handshake is done */
@@ -727,7 +728,7 @@ public class WolfSSLEngineHelper {
                 list = sb.toString();
                 if (this.ssl.setCipherList(list) != WolfSSL.SSL_SUCCESS) {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                            "error setting cipher list " + list);
+                        () -> "error setting cipher list " + list);
                 }
             }
 
@@ -818,9 +819,9 @@ public class WolfSSLEngineHelper {
         if (tm instanceof com.wolfssl.provider.jsse.WolfSSLTrustX509) {
             /* use internal peer verification logic */
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "X509TrustManager is of type WolfSSLTrustX509");
+                () -> "X509TrustManager is of type WolfSSLTrustX509");
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "Using native internal peer verification logic");
+                () -> "Using native internal peer verification logic");
 
             /* Register Java verify callback for additional hostname
              * verification when SSLParameters Endpoint Identification
@@ -833,9 +834,10 @@ public class WolfSSLEngineHelper {
             /* not our own TrustManager, set up callback so JSSE can use
              * TrustManager.checkClientTrusted/checkServerTrusted() */
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "X509TrustManager is not of type WolfSSLTrustX509");
+                () -> "X509TrustManager is not of type WolfSSLTrustX509");
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "Using checkClientTrusted/ServerTrusted() for verification");
+                () -> "Using checkClientTrusted/ServerTrusted() " +
+                "for verification");
             this.verifyMask = WolfSSL.SSL_VERIFY_PEER;
         }
 
@@ -897,7 +899,7 @@ public class WolfSSLEngineHelper {
          * This allows users to enable legacy hostname-based SNI behavior
          * through java.security configuration rather than JVM arguments. */
         boolean autoSNI = "true".equalsIgnoreCase(
-                        Security.getProperty("wolfjsse.autoSNI"));
+            Security.getProperty("wolfjsse.autoSNI"));
 
         /* Detect HttpsURLConnection usage by checking:
          * - Client mode is set (client-side connection)
@@ -917,12 +919,12 @@ public class WolfSSLEngineHelper {
 
         if (!enableSNI) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "jsse.enableSNIExtension property set to false, " +
+                () -> "jsse.enableSNIExtension property set to false, " +
                 "not adding SNI to ClientHello");
         }
         else if (this.clientMode) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "jsse.enableSNIExtension property set to true, " +
+                () -> "jsse.enableSNIExtension property set to true, " +
                 "enabling SNI");
 
             /* Explicitly set if user has set through SSLParameters */
@@ -936,7 +938,7 @@ public class WolfSSLEngineHelper {
             } else if (autoSNI) {
                 if (this.peerAddr != null && trustNameService) {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "setting SNI extension with " +
+                        () -> "setting SNI extension with " +
                         "InetAddress.getHostName(): " +
                         this.peerAddr.getHostName());
 
@@ -945,25 +947,27 @@ public class WolfSSLEngineHelper {
                 } else if (this.hostname != null) {
                     if (peerAddr != null) {
                         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                            "jdk.tls.trustNameService not set to true, " +
+                            () -> "jdk.tls.trustNameService not set to true, " +
                             "not doing reverse DNS lookup to set SNI");
                         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                            "setting SNI extension with hostname: " +
+                            () -> "setting SNI extension with hostname: " +
                             this.hostname);
                     }
                     else {
                         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                            "peerAddr is null, setting SNI extension with " +
-                            "hostname: " + this.hostname);
+                            () -> "peerAddr is null, setting SNI extension " +
+                            "with hostname: " + this.hostname);
                     }
                     this.ssl.useSNI((byte)0, this.hostname.getBytes());
                 } else {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "hostname and peerAddr are null, not setting SNI");
+                        () -> "hostname and peerAddr are null, " +
+                        "not setting SNI");
                 }
             } else {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "No SNI configured through SSLParameters, not setting SNI");
+                    () -> "No SNI configured through SSLParameters, " +
+                    "not setting SNI");
             }
         }
     }
@@ -994,11 +998,11 @@ public class WolfSSLEngineHelper {
                     "jdk.tls.client.enableSessionTicketExtension");
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "SSLSocket.setUseSessionTickets() set to: " +
+                () -> "SSLSocket.setUseSessionTickets() set to: " +
                 String.valueOf(enableFlag));
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "jdk.tls.client.enableSessionTicketExtension property: " +
+                () -> "jdk.tls.client.enableSessionTicketExtension property: " +
                 enableProperty);
 
             if ((enableFlag == true) ||
@@ -1009,11 +1013,11 @@ public class WolfSSLEngineHelper {
                 this.ssl.useSessionTicket();
 
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "session tickets enabled for this session");
+                    () -> "session tickets enabled for this session");
 
             } else {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "session tickets not enabled on this session");
+                    () -> "session tickets not enabled on this session");
             }
         }
     }
@@ -1037,26 +1041,27 @@ public class WolfSSLEngineHelper {
         if ((alpnProtos != null && alpnProtos.length > 0) &&
             (applicationProtocols != null && applicationProtocols.length > 0)) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "ALPN protocols found in both params.getAlpnProtos() and " +
-                "params.getApplicationProtocols()");
+                () -> "ALPN protocols found in both params.getAlpnProtos() " +
+                "and params.getApplicationProtocols()");
         }
 
         /* try to set from byte[] first, then overwrite with String[] if
          * both have been set */
         if (alpnProtos != null && alpnProtos.length > 0) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "Setting ALPN protocols for WOLFSSL session from byte[" +
+                () -> "Setting ALPN protocols for WOLFSSL session from byte[" +
                 alpnProtos.length + "]");
             this.ssl.useALPN(alpnProtos);
         }
 
         if (applicationProtocols != null && applicationProtocols.length > 0) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "Setting Application Protocols for WOLFSSL session " +
+                () -> "Setting Application Protocols for WOLFSSL session " +
                 "from String[]:");
             for (i = 0; i < applicationProtocols.length; i++) {
+                final int idx = i;
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "\t" + i + ": " + applicationProtocols[i]);
+                    () -> "\t" + idx + ": " + applicationProtocols[idx]);
             }
 
             /* fail on mismatch */
@@ -1066,7 +1071,8 @@ public class WolfSSLEngineHelper {
 
         if (alpnProtos == null && applicationProtocols == null) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "No ALPN protocols set, not setting for this WOLFSSL session");
+                () -> "No ALPN protocols set, not setting for this " +
+                "WOLFSSL session");
         }
     }
 
@@ -1077,15 +1083,15 @@ public class WolfSSLEngineHelper {
         int ret = this.ssl.useSecureRenegotiation();
         if (ret == WolfSSL.SSL_SUCCESS) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "enabled secure renegotiation support for session");
+                () -> "enabled secure renegotiation support for session");
         }
         else if (ret == WolfSSL.NOT_COMPILED_IN) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "native secure renegotiation not compiled in");
+                () -> "native secure renegotiation not compiled in");
         }
         else {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "error enabling secure renegotiation, ret = " + ret);
+                () -> "error enabling secure renegotiation, ret = " + ret);
         }
     }
 
@@ -1103,11 +1109,11 @@ public class WolfSSLEngineHelper {
                 if (ret != WolfSSL.SSL_SUCCESS &&
                     ret != WolfSSL.NOT_COMPILED_IN) {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "error restricting signature algorithms based on " +
-                        "wolfjsse.enabledSignatureAlgorithms property");
+                        () -> "error restricting signature algorithms based " +
+                        "on wolfjsse.enabledSignatureAlgorithms property");
                 } else if (ret == WolfSSL.SSL_SUCCESS) {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "restricted signature algorithms based on " +
+                        () -> "restricted signature algorithms based on " +
                         "wolfjsse.enabledSignatureAlgorithms property");
                 }
             }
@@ -1128,8 +1134,8 @@ public class WolfSSLEngineHelper {
                 if (ret != WolfSSL.SSL_SUCCESS) {
                     if (ret == WolfSSL.NOT_COMPILED_IN) {
                         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                            "Unable to set requested TLS Supported Curves, " +
-                            "native support not compiled in.");
+                            () -> "Unable to set requested TLS Supported " +
+                            "Curves, native support not compiled in.");
                     }
                     else {
                         throw new SSLException(
@@ -1140,7 +1146,7 @@ public class WolfSSLEngineHelper {
                 }
                 else {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "set TLS Supported Curves based on " +
+                        () -> "set TLS Supported Curves based on " +
                         "wolfjsse.enabledSupportedCurves property");
                 }
             }
@@ -1157,21 +1163,23 @@ public class WolfSSLEngineHelper {
             /* Zero size means use implicit sizing logic of implementation,
              * take no special action here if 0. */
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "Maximum packet size found in SSLParameters: " + maxPacketSize);
+                () -> "Maximum packet size found in SSLParameters: " +
+                maxPacketSize);
 
             ret = this.ssl.dtlsSetMTU(maxPacketSize);
             if (ret == WolfSSL.SSL_SUCCESS) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "set maximum packet size (DTLS MTU): " + maxPacketSize);
+                    () -> "set maximum packet size (DTLS MTU): " +
+                    maxPacketSize);
             }
             else if (ret == WolfSSL.NOT_COMPILED_IN) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "DTLS or MTU not compiled in, skipping setting " +
+                    () -> "DTLS or MTU not compiled in, skipping setting " +
                     "max packet size");
             }
             else {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "error setting DTLS MTU, ret = " + ret);
+                    () -> "error setting DTLS MTU, ret = " + ret);
             }
         }
     }
@@ -1187,23 +1195,24 @@ public class WolfSSLEngineHelper {
             ret = this.ssl.disableExtendedMasterSecret();
             if (ret == WolfSSL.SSL_SUCCESS) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "TLS Extended Master Secret disabled due to " +
+                    () -> "TLS Extended Master Secret disabled due to " +
                     "jdk.tls.useExtendedMasterSecret System property");
             }
             else {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "Failed to disable TLS Extended Master Secret, " +
+                    () -> "Failed to disable TLS Extended Master Secret, " +
                     "ret = " + ret);
             }
         }
         else {
             if (WolfSSL.isEnabledTLSExtendedMasterSecret() == 1) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "using TLS Extended Master Secret");
+                    () -> "using TLS Extended Master Secret");
             }
             else {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "not using TLS Extended Master Secret, not compiled in");
+                    () -> "not using TLS Extended Master Secret, " +
+                    "not compiled in");
             }
         }
     }
@@ -1315,7 +1324,7 @@ public class WolfSSLEngineHelper {
             if (this.sessionCreation == false && !this.session.isFromTable) {
                 /* new handshakes can not be made in this case. */
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "session creation not allowed");
+                    () -> "session creation not allowed");
 
                 /* send CloseNotify */
                 /* TODO: SunJSSE sends a Handshake Failure alert instead here */
@@ -1348,7 +1357,8 @@ public class WolfSSLEngineHelper {
      *                      on native socket error
      * @throws SocketTimeoutException if socket timed out
      *
-     * @throws WolfSSLException if it fails to check the DH key size after the handshake.
+     * @throws WolfSSLException if it fails to check the DH key size after
+     *         the handshake.
      */
     protected synchronized int doHandshake(int isSSLEngine, int timeout)
         throws SSLException, SocketTimeoutException, WolfSSLException {
@@ -1365,7 +1375,7 @@ public class WolfSSLEngineHelper {
         if (this.sessionCreation == false && !this.session.isFromTable) {
             /* new handshakes can not be made in this case. */
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "session creation not allowed");
+                () -> "session creation not allowed");
 
             try {
                 /* send CloseNotify */
@@ -1380,11 +1390,12 @@ public class WolfSSLEngineHelper {
 
         if ((this.session == null) || !this.session.isValid()) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "session is marked as invalid, try creating a new session");
+                () -> "session is marked as invalid, try creating a " +
+                "new session");
             if (this.sessionCreation == false) {
                 /* new handshakes can not be made in this case. */
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "session creation not allowed");
+                    () -> "session creation not allowed");
 
                 return WolfSSL.SSL_HANDSHAKE_FAILURE;
             }
@@ -1417,7 +1428,7 @@ public class WolfSSLEngineHelper {
             }
             if (serverId == null) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "null serverId when trying to generate, not setting");
+                    () -> "null serverId when trying to generate, not setting");
             } else {
                 ret = this.ssl.setServerID(serverId, 1);
                 if (ret != WolfSSL.SSL_SUCCESS) {
@@ -1433,14 +1444,14 @@ public class WolfSSLEngineHelper {
             try {
                 if (this.clientMode) {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                            "calling native wolfSSL_connect()");
+                        () -> "calling native wolfSSL_connect()");
                     /* may throw SocketTimeoutException on socket timeout */
                     ret = this.ssl.connect(timeout);
 
                     checkKeySize(ssl, this.clientMode);
                 } else {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                                "calling native wolfSSL_accept()");
+                        () -> "calling native wolfSSL_accept()");
                     ret = this.ssl.accept(timeout);
 
                     checkKeySize(ssl, this.clientMode);
@@ -1466,7 +1477,9 @@ public class WolfSSLEngineHelper {
         return ret;
     }
 
-    private void checkKeySize(WolfSSLSession ssl, boolean clientMode) throws SSLException, WolfSSLException {
+    private void checkKeySize(WolfSSLSession ssl, boolean clientMode)
+        throws SSLException, WolfSSLException {
+
         int keySize = this.ssl.getKeySize();
 
         /*
@@ -1480,7 +1493,8 @@ public class WolfSSLEngineHelper {
             /* Get the minimum DH key size from security settings. */
             int minDHEKeySize;
             try {
-                minDHEKeySize = WolfSSLUtil.getDisabledAlgorithmsKeySizeLimit("DH");
+                minDHEKeySize =
+                    WolfSSLUtil.getDisabledAlgorithmsKeySizeLimit("DH");
 
                 /*
                  * If we're trying to use DHE with
@@ -1488,14 +1502,16 @@ public class WolfSSLEngineHelper {
                 if (isLegacyDHEnabled() && keySize < minDHEKeySize) {
                     if (clientMode) {
                         throw new SSLHandshakeException(
-                                "DH ServerKeyExchange does not comply to algorithm constraints");
+                            "DH ServerKeyExchange does not comply to " +
+                            "algorithm constraints");
                     } else {
                         throw new SSLHandshakeException(
-                                "Received fatal alert: insufficient_security");
+                            "Received fatal alert: insufficient_security");
                     }
                 }
             } catch (WolfSSLException e) {
-                throw new WolfSSLException("Failed to check DH key size constraints: ", e);
+                throw new WolfSSLException(
+                    "Failed to check DH key size constraints: ", e);
             }
         }
     }
@@ -1563,7 +1579,8 @@ public class WolfSSLEngineHelper {
             }
             if (WolfSSLUtil.sessionCacheDisabled()) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "not storing session in cache, cache has been disabled");
+                    () -> "not storing session in cache, cache has " +
+                    "been disabled");
             } else {
                 return this.authStore.addSession(this.session);
             }

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
@@ -128,7 +128,7 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
         if (serverNames != null && !serverNames.isEmpty()) {
             this.sniServerNames = new ArrayList<>(serverNames);
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "Stored SNI server names for session resumption");
+                    () -> "Stored SNI server names for session resumption");
         }
     }
 
@@ -164,7 +164,8 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
         accessed = new Date();
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "created new session (port: " + port + ", host: " + host + ")");
+            () -> "created new session (port: " + port + ", host: " +
+            host + ")");
     }
 
     /**
@@ -197,7 +198,7 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
         }
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "created new session (no host/port yet)");
+            () -> "created new session (no host/port yet)");
     }
 
     /**
@@ -219,7 +220,7 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
         accessed = new Date();
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "created new session (WolfSSLAuthStore)");
+            () -> "created new session (WolfSSLAuthStore)");
     }
 
     /**
@@ -280,7 +281,7 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
         this.binding = null;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "created new session (WolfSSLImplementSSLSession)");
+            () -> "created new session (WolfSSLImplementSSLSession)");
     }
 
     /**
@@ -306,7 +307,8 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
 
         } catch (IllegalStateException e) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "In getId(), WolfSSLSession has been freed, returning null");
+                () -> "In getId(), WolfSSLSession has been freed, " +
+                "returning null");
             return null;
 
         } catch (WolfSSLJNIException e) {
@@ -357,7 +359,7 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
      */
     public synchronized void invalidate() {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "SSLSession.invalidate() called, invalidating session");
+            () -> "SSLSession.invalidate() called, invalidating session");
 
         this.valid = false;
     }
@@ -528,17 +530,18 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
         /* if no peer cert, throw SSLPeerUnverifiedException */
         if (x509 == 0) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "ssl.getPeerCertificates() returned null, trying cached cert");
+                () -> "ssl.getPeerCertificates() returned null, trying " +
+                "cached cert");
 
             if (this.peerCerts != null) {
                 /* If peer cert is already cached, just return that */
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "peer cert already cached, returning it");
+                    () -> "peer cert already cached, returning it");
                 return this.peerCerts.clone();
             }
             else {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "No peer cert sent and none cached");
+                    () -> "No peer cert sent and none cached");
                 throw new SSLPeerUnverifiedException("No peer certificate");
             }
         }
@@ -689,7 +692,8 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
 
     @Override
     public Principal getLocalPrincipal() {
-        /* Logic needs to be added to check for client auth when wrapper is made TODO */
+        /* Logic needs to be added to check for client auth
+         * when wrapper is made TODO */
         X509KeyManager km = authStore.getX509KeyManager();
         java.security.cert.X509Certificate[] certs =
                 km.getCertificateChain(authStore.getCertAlias());
@@ -700,7 +704,8 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
         }
 
         if (certs.length > 0){
-            /* When chain of certificates exceeds one, the user certifcate is the first */
+            /* When chain of certificates exceeds one,
+             * the user certifcate is the first */
             localPrincipal = certs[0].getSubjectDN();
         }
 
@@ -795,15 +800,16 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
         if (ssl != null) {
             nativeMax = ssl.getMaxOutputSize();
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "ssl.getMaxOutputSize() returned: " + nativeMax);
+                () -> "ssl.getMaxOutputSize() returned: " + nativeMax);
 
             if ((nativeMax > 0) && (nativeMax > ret)) {
                 ret = nativeMax;
             }
         }
 
+        final int tmpRet = ret;
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "getPacketBufferSize() returning: " + ret);
+            () -> "getPacketBufferSize() returning: " + tmpRet);
 
         return ret;
     }
@@ -843,15 +849,15 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
      */
     protected synchronized void setResume() {
 
-        long tmpSesPtr = 0;
+        final long tmpSesPtr;
 
         if (ssl != null) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "entered setResume(), trying to get sesPtrLock");
+                () -> "entered setResume(), trying to get sesPtrLock");
 
             synchronized (sesPtrLock) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "got sesPtrLock: this.sesPtr = " + this.sesPtr);
+                    () -> "got sesPtrLock: this.sesPtr = " + this.sesPtr);
 
                 /* Only free existing WOLFSSL_SESSION pointer if this
                  * object is in the WolfSSLAuthStore cache table (store),
@@ -864,7 +870,8 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
                         (!this.isInTable && this.sesPtrUpdatedAfterTable)) {
 
                         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                           "calling WolfSSLSession.freeSession(this.sesPtr)");
+                           () -> "calling WolfSSLSession.freeSession(" +
+                           "this.sesPtr)");
 
                         WolfSSLSession.freeSession(this.sesPtr);
                         /* reset this.sesPtr to 0 in case ssl.getSession() below
@@ -880,7 +887,7 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
              * value has been retrieved. */
             tmpSesPtr = ssl.getSession();
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "called ssl.getSession(), new this.sesPtr = " +
+                () -> "called ssl.getSession(), new this.sesPtr = " +
                 tmpSesPtr);
 
             synchronized (sesPtrLock) {
@@ -912,7 +919,7 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
             this.protocol = this.ssl.getVersion();
         } catch (IllegalStateException | WolfSSLJNIException ex) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "Not able to update stored WOLFSSL protocol");
+                () -> "Not able to update stored WOLFSSL protocol");
         }
 
         /* Also store SNI server names if not already set */
@@ -922,11 +929,12 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
                 if (names != null && !names.isEmpty()) {
                     this.sniServerNames = new ArrayList<>(names);
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                            "Extracted SNI server names from session");
+                            () -> "Extracted SNI server names from session");
                 }
             } catch (UnsupportedOperationException ex) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "Error extracting SNI server names: " + ex.getMessage());
+                        () -> "Error extracting SNI server names: " +
+                        ex.getMessage());
             }
         }
     }
@@ -1028,13 +1036,13 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
         }
 
         try {
-            /* Return SNI name saved by Client 
+            /* Return SNI name saved by Client
              * or return cached request name from Server
              * Currently WolfSSL.WOLFSSL_SNI_HOST_NAME is the only
              * supported type */
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "calling getRequestedServerNames (" +
-                        this.getSideString() + ")");
+                () -> "calling getRequestedServerNames (" +
+                this.getSideString() + ")");
             if (this.ssl.getSide() == WolfSSL.WOLFSSL_CLIENT_END){
                 sniRequestArr = this.ssl.getClientSNIRequest();
             } else {
@@ -1060,14 +1068,14 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
     protected synchronized void finalize() throws Throwable
     {
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered finalize(): this.sesPtr = " + this.sesPtr);
+            () -> "entered finalize(): this.sesPtr = " + this.sesPtr);
 
         /* Only grab lock and free session if sesPtr not 0/null to prevent
          * garbage collector from backing up unnecessarily waiting on lock */
         if (this.sesPtr != 0) {
             synchronized (sesPtrLock) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "got sesPtrLock: " + this.sesPtr);
+                    () -> "got sesPtrLock: " + this.sesPtr);
 
                 /* Our internal WOLFSSL_SESSION pointer should be freed in
                  * the following scenarios:
@@ -1081,7 +1089,7 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession
                 if (this.isInTable ||
                     (!this.isInTable && this.sesPtrUpdatedAfterTable)) {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                       "calling WolfSSLSession.freeSession(this.sesPtr)");
+                       () -> "calling WolfSSLSession.freeSession(this.sesPtr)");
                     WolfSSLSession.freeSession(this.sesPtr);
                     this.sesPtr = 0;
                 }

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLInternalVerifyCb.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLInternalVerifyCb.java
@@ -101,14 +101,14 @@ public class WolfSSLInternalVerifyCb implements WolfSSLVerifyCallback {
         try {
             if (this.callingSocket != null) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "checking hostname verification using SSLSocket");
+                    () -> "checking hostname verification using SSLSocket");
                 /* Throws CertificateException when verify fails */
                 wolfTM.verifyHostname(peer, this.callingSocket,
                     null, clientMode);
             }
             else if (this.callingEngine != null) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "checking hostname verification using SSLEngine");
+                    () -> "checking hostname verification using SSLEngine");
                 /* Throws CertificateException when verify fails */
                 wolfTM.verifyHostname(peer, null,
                     this.callingEngine, clientMode);
@@ -120,8 +120,8 @@ public class WolfSSLInternalVerifyCb implements WolfSSLVerifyCallback {
             }
         } catch (CertificateException e) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "X509ExtendedTrustManager hostname verification failed: " +
-                e.getMessage());
+                () -> "X509ExtendedTrustManager hostname verification " +
+                "failed: " + e.getMessage());
             return 0;
         }
 
@@ -142,14 +142,14 @@ public class WolfSSLInternalVerifyCb implements WolfSSLVerifyCallback {
         String authType) {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "Verifying peer with X509TrustManager: " + this.tm);
+            () -> "Verifying peer with X509TrustManager: " + this.tm);
         if (this.tm instanceof X509ExtendedTrustManager) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "X509TrustManager of type X509ExtendedTrustManager");
+                () -> "X509TrustManager of type X509ExtendedTrustManager");
         }
         else {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "X509TrustManager of type X509TrustManager");
+                () -> "X509TrustManager of type X509TrustManager");
         }
 
         try {
@@ -161,13 +161,15 @@ public class WolfSSLInternalVerifyCb implements WolfSSLVerifyCallback {
                         (X509ExtendedTrustManager)this.tm;
                     if (this.callingSocket != null) {
                         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                          "Calling TrustManager.checkServerTrusted(SSLSocket)");
+                          () -> "Calling TrustManager.checkServerTrusted(" +
+                          "SSLSocket)");
                         xtm.checkServerTrusted(certs, authType,
                             this.callingSocket);
                     }
                     else if (this.callingEngine != null) {
                         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                          "Calling TrustManager.checkServerTrusted(SSLEngine)");
+                          () -> "Calling TrustManager.checkServerTrusted(" +
+                          "SSLEngine)");
                         xtm.checkServerTrusted(certs, authType,
                             this.callingEngine);
                     }
@@ -184,7 +186,7 @@ public class WolfSSLInternalVerifyCb implements WolfSSLVerifyCallback {
                     /* Basic X509TrustManager does not support HTTPS
                      * hostname verification, no SSLSocket/Engine needed */
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "Calling TrustManager.checkServerTrusted()");
+                        () -> "Calling TrustManager.checkServerTrusted()");
                     this.tm.checkServerTrusted(certs, authType);
                 }
 
@@ -194,13 +196,15 @@ public class WolfSSLInternalVerifyCb implements WolfSSLVerifyCallback {
                         (X509ExtendedTrustManager)this.tm;
                     if (this.callingSocket != null) {
                         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                          "Calling TrustManager.checkClientTrusted(SSLSocket)");
+                          () -> "Calling TrustManager.checkClientTrusted(" +
+                          "SSLSocket)");
                         xtm.checkClientTrusted(certs, authType,
                             this.callingSocket);
                     }
                     else if (this.callingEngine != null) {
                         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                          "Calling TrustManager.checkClientTrusted(SSLEngine)");
+                          () -> "Calling TrustManager.checkClientTrusted(" +
+                          "SSLEngine)");
                         xtm.checkClientTrusted(certs, authType,
                             this.callingEngine);
                     }
@@ -217,15 +221,15 @@ public class WolfSSLInternalVerifyCb implements WolfSSLVerifyCallback {
                     /* Basic X509TrustManager does not support HTTPS
                      * hostname verification, no SSLSocket/Engine needed */
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "Calling TrustManager.checkClientTrusted()");
+                        () -> "Calling TrustManager.checkClientTrusted()");
                     this.tm.checkClientTrusted(certs, authType);
                 }
             }
         } catch (Exception e) {
             /* TrustManager rejected certificate, not valid */
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "TrustManager rejected certificates, verification failed: " +
-                e.getMessage());
+                () -> "TrustManager rejected certificates, verification " +
+                "failed: " + e.getMessage());
             return false;
         }
 
@@ -259,14 +263,14 @@ public class WolfSSLInternalVerifyCb implements WolfSSLVerifyCallback {
              * passed if preverify_ok == 1, so we skip doing it again here
              * later on for this case */
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "Native wolfSSL peer verification passed (clientMode: " +
-                    this.clientMode + ")");
+                () -> "Native wolfSSL peer verification passed (clientMode: " +
+                this.clientMode + ")");
         } else {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "NOTE: Native wolfSSL peer verification failed " +
-                    "(clientMode: " + this.clientMode + ")");
+                () -> "NOTE: Native wolfSSL peer verification failed " +
+                "(clientMode: " + this.clientMode + ")");
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "      Continuing with X509TrustManager verification");
+                () -> "      Continuing with X509TrustManager verification");
         }
 
         try {
@@ -278,7 +282,7 @@ public class WolfSSLInternalVerifyCb implements WolfSSLVerifyCallback {
         } catch (WolfSSLException e) {
             /* failed to get certs from native, give app null array */
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "Failed to get certs from x509StorePtr, certs = null: " +
+                () -> "Failed to get certs from x509StorePtr, certs = null: " +
                 e.getMessage());
             certs = null;
         }
@@ -289,14 +293,16 @@ public class WolfSSLInternalVerifyCb implements WolfSSLVerifyCallback {
                 x509certs = new X509Certificate[certs.length];
                 for (int i = 0; i < certs.length; i++) {
                     x509certs[i] = certs[i].getX509Certificate();
+                    final String tmpName =
+                        x509certs[i].getSubjectDN().getName();
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "Peer cert: " + x509certs[i].getSubjectDN().getName());
+                        () -> "Peer cert: " + tmpName);
                 }
             } catch (CertificateException | IOException |
                      WolfSSLJNIException ce) {
                 /* failed to get cert array, give app empty array */
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "Failed to get X509Certificate[] array, set to " +
+                    () -> "Failed to get X509Certificate[] array, set to " +
                     "empty array: " + ce.getMessage());
                 x509certs = new X509Certificate[0];
             }
@@ -312,8 +318,9 @@ public class WolfSSLInternalVerifyCb implements WolfSSLVerifyCallback {
             } else if (sigType.contains("ED25519")) {
                 authType = "ED25519";
             }
+            final String tmpAuthType = authType;
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "Auth type: " + authType);
+                () -> "Auth type: " + tmpAuthType);
 
             /* Free native WolfSSLCertificate memory. At this
              * point x509certs[] is all Java managed memory now. */
@@ -338,7 +345,7 @@ public class WolfSSLInternalVerifyCb implements WolfSSLVerifyCallback {
         if ((!this.clientMode) && (this.params != null) &&
             (!this.params.getNeedClientAuth())) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "Application has disabled client verification with " +
+                () -> "Application has disabled client verification with " +
                 "setNeedClientAuth(false), skipping verification");
             return 1;
         }
@@ -353,8 +360,8 @@ public class WolfSSLInternalVerifyCb implements WolfSSLVerifyCallback {
              * TrustManager with empty certificate chain just consider
              * verification successful at this point */
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "No client cert sent and client auth marked optional, not " +
-                "calling TrustManager for hostname verification");
+                () -> "No client cert sent and client auth marked optional, " +
+                "not calling TrustManager for hostname verification");
         }
         else {
             /* Poll X509TrustManager / X509ExtendedTrustManager for certificate
@@ -362,14 +369,14 @@ public class WolfSSLInternalVerifyCb implements WolfSSLVerifyCallback {
              * otherwise 1 on successful verification */
             if (VerifyCertChainWithTrustManager(x509certs, authType) == false) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "TrustManager verification failed");
+                    () -> "TrustManager verification failed");
                 /* Abort handshake, verification failed */
                 return 0;
             }
         }
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "TrustManager verification successful");
+            () -> "TrustManager verification successful");
 
         /* Continue handshake, verification succeeded */
         return 1;

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLKeyManager.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLKeyManager.java
@@ -77,34 +77,34 @@ public class WolfSSLKeyManager extends KeyManagerFactorySpi {
         String pass = System.getProperty("javax.net.ssl.keyStorePassword");
         String file = System.getProperty("javax.net.ssl.keyStore");
         String type = System.getProperty("javax.net.ssl.keyStoreType");
-        boolean wksAvailable = false;
+        final boolean wksAvailable;
 
         if (file != null) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "Loading certs from: " + file);
+                () -> "Loading certs from: " + file);
 
             /* Check if wolfJCE WKS KeyStore is registered and available */
             wksAvailable = WolfSSLUtil.WKSAvailable();
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "wolfJCE WKS KeyStore type available: " + wksAvailable);
+                () -> "wolfJCE WKS KeyStore type available: " + wksAvailable);
 
             /* Set KeyStore password if javax.net.ssl.keyStorePassword set */
             if (pass != null) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "javax.net.ssl.keyStorePassword system property " +
+                    () -> "javax.net.ssl.keyStorePassword system property " +
                     "set, using password");
                 this.pswd = pass.toCharArray();
             } else {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "javax.net.ssl.keyStorePassword system property " +
+                    () -> "javax.net.ssl.keyStorePassword system property " +
                     "not set");
             }
 
             /* Keystore type given in property, try loading using it */
             if (type != null && !type.trim().isEmpty()) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "javax.net.ssl.keyStoreType set: " + type);
+                    () -> "javax.net.ssl.keyStoreType set: " + type);
 
                 if (requiredType != null && !requiredType.equals(type)) {
                     throw new KeyStoreException(
@@ -128,7 +128,7 @@ public class WolfSSLKeyManager extends KeyManagerFactorySpi {
                 if ((sysStore == null) && WolfSSLUtil.isAndroid() &&
                     (requiredType == null || requiredType.equals("BKS"))) {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "Detected Android VM, trying BKS KeyStore type");
+                        () -> "Detected Android VM, trying BKS KeyStore type");
                     sysStore = WolfSSLUtil.LoadKeyStoreFileByType(
                         file, this.pswd, "BKS");
                 }
@@ -137,8 +137,8 @@ public class WolfSSLKeyManager extends KeyManagerFactorySpi {
                 if (sysStore == null &&
                     (requiredType == null || requiredType.equals("JKS"))) {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "javax.net.ssl.keyStoreType system property not set, " +
-                    "trying type: JKS");
+                        () -> "javax.net.ssl.keyStoreType system property " +
+                        "not set, trying type: JKS");
                     sysStore = WolfSSLUtil.LoadKeyStoreFileByType(
                         file, this.pswd, "JKS");
                 }
@@ -151,7 +151,7 @@ public class WolfSSLKeyManager extends KeyManagerFactorySpi {
             }
             else {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "Loaded certs from KeyStore via System properties");
+                    () -> "Loaded certs from KeyStore via System properties");
             }
         }
 
@@ -165,17 +165,17 @@ public class WolfSSLKeyManager extends KeyManagerFactorySpi {
 
         this.pswd = password;
         KeyStore certs = store;
-        String requiredType = null;
+        final String requiredType;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entering engineInit(KeyStore store, char[] password)");
+            () -> "entering engineInit(KeyStore store, char[] password)");
 
         requiredType = WolfSSLUtil.getRequiredKeyStoreType();
         if (requiredType != null) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "java.security has restricted KeyStore type");
+                () -> "java.security has restricted KeyStore type");
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "wolfjsse.keystore.type.required = " + requiredType);
+                () -> "wolfjsse.keystore.type.required = " + requiredType);
         }
 
         /* If no KeyStore passed in, try to load from system property values
@@ -183,14 +183,14 @@ public class WolfSSLKeyManager extends KeyManagerFactorySpi {
         if (store == null) {
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "input KeyStore null, trying to load KeyStore from " +
+                () -> "input KeyStore null, trying to load KeyStore from " +
                 "system properties");
 
             certs = LoadKeyStoreFromSystemProperties(requiredType);
         }
         else {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "input KeyStore provided, using inside KeyManager");
+                () -> "input KeyStore provided, using inside KeyManager");
         }
 
         /* Verify KeyStore we got matches our requirements, for example
@@ -209,11 +209,11 @@ public class WolfSSLKeyManager extends KeyManagerFactorySpi {
         throws InvalidAlgorithmParameterException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entering engineInit(ManagerFactoryParameters arg0)");
+            () -> "entering engineInit(ManagerFactoryParameters arg0)");
 
         throw new UnsupportedOperationException(
-                "KeyManagerFactory.init(ManagerFactoryParameters) not " +
-                "supported yet");
+            "KeyManagerFactory.init(ManagerFactoryParameters) not " +
+            "supported yet");
     }
 
     @Override
@@ -221,11 +221,11 @@ public class WolfSSLKeyManager extends KeyManagerFactorySpi {
         throws IllegalStateException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered engineGetKeyManagers()");
+            () -> "entered engineGetKeyManagers()");
 
         if (!this.initialized) {
             throw new IllegalStateException("KeyManagerFactory must be " +
-                    "initialized before use, please call init()");
+                "initialized before use, please call init()");
         }
 
         KeyManager[] km = {new WolfSSLKeyX509(this.store, this.pswd)};

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLKeyX509.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLKeyX509.java
@@ -59,7 +59,7 @@ public class WolfSSLKeyX509 extends X509ExtendedKeyManager
         this.password = password;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "creating new WolfSSLKeyX509 object");
+            () -> "creating new WolfSSLKeyX509 object");
     }
 
     /**
@@ -84,7 +84,7 @@ public class WolfSSLKeyX509 extends X509ExtendedKeyManager
             aliases = this.store.aliases();
         } catch (KeyStoreException ex) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.ERROR,
-                             "Error getting aliases from current KeyStore");
+                () -> "Error getting aliases from current KeyStore");
             return null;
         }
 
@@ -96,9 +96,8 @@ public class WolfSSLKeyX509 extends X509ExtendedKeyManager
                 cert = (X509Certificate)this.store.getCertificate(current);
             } catch (KeyStoreException ex) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.ERROR,
-                                 "Error getting certificate from KeyStore " +
-                                 "for alias: " + current +
-                                 ", continuing to next alias");
+                    () -> "Error getting certificate from KeyStore " +
+                    "for alias: " + current + ", continuing to next alias");
                 continue;
             }
 
@@ -142,7 +141,8 @@ public class WolfSSLKeyX509 extends X509ExtendedKeyManager
 
         if (ret.size() == 0) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "No aliases found in KeyStore that match type and/or issuer");
+                () -> "No aliases found in KeyStore that match type " +
+                "and/or issuer");
             return null;
         }
 
@@ -153,7 +153,7 @@ public class WolfSSLKeyX509 extends X509ExtendedKeyManager
     public String[] getClientAliases(String type, Principal[] issuers) {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getClientAliases()");
+            () -> "entered getClientAliases()");
 
         return getAliases(type, issuers);
     }
@@ -166,7 +166,7 @@ public class WolfSSLKeyX509 extends X509ExtendedKeyManager
         int i;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered chooseClientAlias()");
+            () -> "entered chooseClientAlias()");
 
         if (type == null) {
             return null;
@@ -189,7 +189,7 @@ public class WolfSSLKeyX509 extends X509ExtendedKeyManager
         int i;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered chooseEngineClientAlias()");
+            () -> "entered chooseEngineClientAlias()");
 
         if (type == null) {
             return null;
@@ -208,7 +208,7 @@ public class WolfSSLKeyX509 extends X509ExtendedKeyManager
     public String[] getServerAliases(String type, Principal[] issuers) {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getServerAliases(), type: " + type);
+            () -> "entered getServerAliases(), type: " + type);
 
         return getAliases(type, issuers);
     }
@@ -218,7 +218,7 @@ public class WolfSSLKeyX509 extends X509ExtendedKeyManager
         Socket sock) {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered chooseServerAlias(), type: " + type);
+            () -> "entered chooseServerAlias(), type: " + type);
 
         if (type == null || type.isEmpty()) {
             return null;
@@ -233,7 +233,7 @@ public class WolfSSLKeyX509 extends X509ExtendedKeyManager
         SSLEngine engine) {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered chooseEngineServerAlias(), type: " + type);
+            () -> "entered chooseEngineServerAlias(), type: " + type);
 
         if (type == null || type.isEmpty()) {
             return null;
@@ -249,7 +249,7 @@ public class WolfSSLKeyX509 extends X509ExtendedKeyManager
         X509Certificate[] ret = null;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getCertificateChain(), alias: " + alias);
+            () -> "entered getCertificateChain(), alias: " + alias);
 
         if (store == null || alias == null) {
             return null;
@@ -289,14 +289,14 @@ public class WolfSSLKeyX509 extends X509ExtendedKeyManager
         PrivateKey key = null;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getPrivateKey(), alias: " + alias);
+            () -> "entered getPrivateKey(), alias: " + alias);
 
         try {
             key = (PrivateKey)store.getKey(alias, password);
         } catch (Exception e) {
             /* @TODO unable to get key */
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "failed to load private key: " + e);
+                () -> "failed to load private key: " + e);
         }
         return key;
     }

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java
@@ -57,15 +57,17 @@ public final class WolfSSLProvider extends Provider {
          */
         public void errorCallback(int ok, int err, String hash) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "In FIPS error callback, ok = " + ok + " err = " + err);
+                () -> "In FIPS error callback, ok = " + ok + " err = " + err);
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "hash = " + hash);
+                () -> "hash = " + hash);
 
             if (err == -203) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                 "In core integrity hash check failure, copy above hash");
+                    () -> "In core integrity hash check failure, copy " +
+                    "above hash");
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                 "into verifyCore[] in fips_test.c and rebuild native wolfSSL");
+                    () -> "into verifyCore[] in fips_test.c and rebuild " +
+                    "native wolfSSL");
             }
         }
     }
@@ -86,14 +88,14 @@ public final class WolfSSLProvider extends Provider {
         if (rc != WolfSSL.SSL_SUCCESS) {
             if (rc == WolfSSL.NOT_COMPILED_IN) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "FIPS callback not set, not using wolfCrypt FIPS");
+                    () -> "FIPS callback not set, not using wolfCrypt FIPS");
             } else {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "Error setting wolfCrypt FIPS Callback, ret = " + rc);
+                    () -> "Error setting wolfCrypt FIPS Callback, ret = " + rc);
             }
         } else {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "Registered wolfCrypt FIPS error callback");
+                () -> "Registered wolfCrypt FIPS error callback");
         }
 
         try {
@@ -101,7 +103,7 @@ public final class WolfSSLProvider extends Provider {
             sslLib = new WolfSSL();
         } catch (WolfSSLException e) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "Failed to initialize native wolfSSL library");
+                () -> "Failed to initialize native wolfSSL library");
         }
 
         /* Enable native wolfSSL debug logging if 'wolfssl.debug' System

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLServerSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLServerSocket.java
@@ -64,7 +64,7 @@ public class WolfSSLServerSocket extends SSLServerSocket {
         super();
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "creating new WolfSSLServerSocket()");
+            () -> "creating new WolfSSLServerSocket()");
 
         /* defer creating WolfSSLSocket until accept() is called */
         this.context = context;
@@ -89,7 +89,7 @@ public class WolfSSLServerSocket extends SSLServerSocket {
         super(port);
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "creating new WolfSSLServerSocket(port: " + port + ")");
+            () -> "creating new WolfSSLServerSocket(port: " + port + ")");
 
         /* defer creating WolfSSLSocket until accept() is called */
         this.context = context;
@@ -116,7 +116,7 @@ public class WolfSSLServerSocket extends SSLServerSocket {
         super(port, backlog);
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "creating new WolfSSLServerSocket(port: " + port +
+            () -> "creating new WolfSSLServerSocket(port: " + port +
             ", backlog: " + backlog + ")");
 
         /* defer creating WolfSSLSocket until accept() is called */
@@ -147,7 +147,7 @@ public class WolfSSLServerSocket extends SSLServerSocket {
         super(port, backlog, address);
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "creating new WolfSSLServerSocket(port: " + port +
+            () -> "creating new WolfSSLServerSocket(port: " + port +
             ", backlog: " + backlog + ", InetAddress)");
 
         /* defer creating WolfSSLSocket until accept() is called */
@@ -160,7 +160,7 @@ public class WolfSSLServerSocket extends SSLServerSocket {
     synchronized public String[] getEnabledCipherSuites() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getEnabledCipherSuites()");
+            () -> "entered getEnabledCipherSuites()");
 
         return WolfSSLUtil.sanitizeSuites(params.getCipherSuites());
     }
@@ -170,7 +170,7 @@ public class WolfSSLServerSocket extends SSLServerSocket {
         throws IllegalArgumentException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered setEnabledCipherSuites()");
+            () -> "entered setEnabledCipherSuites()");
 
         if (suites == null) {
             throw new IllegalArgumentException("input array is null");
@@ -193,14 +193,14 @@ public class WolfSSLServerSocket extends SSLServerSocket {
         /* propogated down to WolfSSLEngineHelper in WolfSSLSocket creation */
         params.setCipherSuites(suites);
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "enabled cipher suites set to: " + Arrays.toString(suites));
+            () -> "enabled cipher suites set to: " + Arrays.toString(suites));
     }
 
     @Override
     public String[] getSupportedCipherSuites() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getSupportedCipherSuites()");
+            () -> "entered getSupportedCipherSuites()");
 
         return WolfSSLUtil.sanitizeSuites(WolfSSL.getCiphersIana());
     }
@@ -209,7 +209,7 @@ public class WolfSSLServerSocket extends SSLServerSocket {
     synchronized public String[] getSupportedProtocols() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getSupportedProtocols()");
+            () -> "entered getSupportedProtocols()");
 
         return WolfSSLUtil.sanitizeProtocols(
             params.getProtocols(), WolfSSL.TLS_VERSION.INVALID);
@@ -219,7 +219,7 @@ public class WolfSSLServerSocket extends SSLServerSocket {
     synchronized public String[] getEnabledProtocols() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getEnabledProtocols()");
+            () -> "entered getEnabledProtocols()");
 
         return WolfSSLUtil.sanitizeProtocols(
             params.getProtocols(), WolfSSL.TLS_VERSION.INVALID);
@@ -230,7 +230,7 @@ public class WolfSSLServerSocket extends SSLServerSocket {
         throws IllegalArgumentException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered setEnabledProtocols()");
+            () -> "entered setEnabledProtocols()");
 
         if (protocols == null) {
             throw new IllegalArgumentException("input array is null");
@@ -257,26 +257,26 @@ public class WolfSSLServerSocket extends SSLServerSocket {
         /* propogated down to WolfSSLEngineHelper in WolfSSLSocket creation */
         params.setProtocols(protocols);
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "enabled protocols set to: " + Arrays.toString(protocols));
+            () -> "enabled protocols set to: " + Arrays.toString(protocols));
     }
 
     @Override
     synchronized public void setNeedClientAuth(boolean need) {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered setNeedClientAuth()");
+            () -> "entered setNeedClientAuth()");
 
         /* propogated down to WolfSSLEngineHelper in WolfSSLSocket creation */
         params.setNeedClientAuth(need);
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "need client auth set to: " + need);
+            () -> "need client auth set to: " + need);
     }
 
     @Override
     synchronized public boolean getNeedClientAuth() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getNeedClientAuth()");
+            () -> "entered getNeedClientAuth()");
 
         return params.getNeedClientAuth();
     }
@@ -285,19 +285,19 @@ public class WolfSSLServerSocket extends SSLServerSocket {
     synchronized public void setWantClientAuth(boolean want) {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered setWantClientAuth()");
+            () -> "entered setWantClientAuth()");
 
         /* propogated down to WolfSSLEngineHelper in WolfSSLSocket creation */
         params.setWantClientAuth(want);
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "want client auth set to: " + want);
+                () -> "want client auth set to: " + want);
     }
 
     @Override
     synchronized public boolean getWantClientAuth() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getWantClientAuth()");
+            () -> "entered getWantClientAuth()");
 
         return params.getWantClientAuth();
     }
@@ -307,11 +307,11 @@ public class WolfSSLServerSocket extends SSLServerSocket {
         throws IllegalArgumentException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered setUseClientMode()");
+            () -> "entered setUseClientMode()");
 
         clientMode = mode;
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "use client mode set to: " + mode);
+            () -> "use client mode set to: " + mode);
     }
 
     @Override
@@ -323,18 +323,18 @@ public class WolfSSLServerSocket extends SSLServerSocket {
     synchronized public void setEnableSessionCreation(boolean flag) {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered setEnableSessionCreation()");
+            () -> "entered setEnableSessionCreation()");
 
         enableSessionCreation = flag;
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "enable session creation set to: " + flag);
+            () -> "enable session creation set to: " + flag);
     }
 
     @Override
     synchronized public boolean getEnableSessionCreation() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getEnableSessionCreation()");
+            () -> "entered getEnableSessionCreation()");
 
         return enableSessionCreation;
     }
@@ -347,7 +347,7 @@ public class WolfSSLServerSocket extends SSLServerSocket {
     synchronized public void setSSLParameters(SSLParameters params) {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered setSSLParameters()");
+            () -> "entered setSSLParameters()");
 
         if (params != null) {
             WolfSSLParametersHelper.importParams(params, this.params);
@@ -363,7 +363,7 @@ public class WolfSSLServerSocket extends SSLServerSocket {
     synchronized public SSLParameters getSSLParameters() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getSSLParameters()");
+            () -> "entered getSSLParameters()");
 
         return WolfSSLParametersHelper.decoupleParams(this.params);
     }
@@ -372,16 +372,16 @@ public class WolfSSLServerSocket extends SSLServerSocket {
     synchronized public Socket accept() throws IOException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered accept()");
+            () -> "entered accept()");
 
         /* protected method inherited from ServerSocket, returns
            a connected socket */
         Socket sock = new Socket();
         implAccept(sock);
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "Socket connected to client: " +
-                sock.getInetAddress().getHostAddress() + ", port: " +
-                sock.getPort());
+            () -> "Socket connected to client: " +
+            sock.getInetAddress().getHostAddress() + ", port: " +
+            sock.getPort());
 
         /* create new WolfSSLSocket wrapping connected Socket */
         WolfSSLSocket socket = new WolfSSLSocket(context, authStore, params,

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLServerSocketFactory.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLServerSocketFactory.java
@@ -56,7 +56,7 @@ public class WolfSSLServerSocketFactory extends SSLServerSocketFactory {
         this.params = params;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "creating new WolfSSLServerSocketFactory");
+            () -> "creating new WolfSSLServerSocketFactory");
     }
 
     /**
@@ -68,7 +68,7 @@ public class WolfSSLServerSocketFactory extends SSLServerSocketFactory {
     public String[] getDefaultCipherSuites() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getDefaultCipherSuites()");
+            () -> "entered getDefaultCipherSuites()");
 
         return WolfSSLUtil.sanitizeSuites(WolfSSL.getCiphersIana());
     }
@@ -82,7 +82,7 @@ public class WolfSSLServerSocketFactory extends SSLServerSocketFactory {
     public String[] getSupportedCipherSuites() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getSupportedCipherSuites()");
+            () -> "entered getSupportedCipherSuites()");
 
         return getDefaultCipherSuites();
     }
@@ -97,7 +97,7 @@ public class WolfSSLServerSocketFactory extends SSLServerSocketFactory {
     public ServerSocket createServerSocket() throws IOException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered createServerSocket()");
+            () -> "entered createServerSocket()");
 
         return new WolfSSLServerSocket(ctx, authStore, params);
     }
@@ -114,7 +114,7 @@ public class WolfSSLServerSocketFactory extends SSLServerSocketFactory {
     public ServerSocket createServerSocket(int port) throws IOException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered createServerSocket(port: " + port + ")");
+            () -> "entered createServerSocket(port: " + port + ")");
 
         return new WolfSSLServerSocket(ctx, authStore, params, port);
     }
@@ -134,7 +134,7 @@ public class WolfSSLServerSocketFactory extends SSLServerSocketFactory {
         throws IOException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered createServerSocket(port: " + port +
+            () -> "entered createServerSocket(port: " + port +
             ", backlog: " + backlog + ")");
 
         return new WolfSSLServerSocket(ctx, authStore, params, port, backlog);
@@ -156,7 +156,7 @@ public class WolfSSLServerSocketFactory extends SSLServerSocketFactory {
         InetAddress ifAddress) throws IOException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered createServerSocket(port: " + port +
+            () -> "entered createServerSocket(port: " + port +
             ", backlog: " + backlog + ", InetAddress)");
 
         return new WolfSSLServerSocket(ctx, authStore, params, port,

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -137,7 +137,7 @@ public class WolfSSLSocket extends SSLSocket {
         this.autoClose = true;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "creating new WolfSSLSocket(clientMode: " +
+            () -> "creating new WolfSSLSocket(clientMode: " +
             String.valueOf(clientMode) + ")");
 
         try {
@@ -177,7 +177,7 @@ public class WolfSSLSocket extends SSLSocket {
         this.autoClose = true;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "creating new WolfSSLSocket(clientMode: " +
+            () -> "creating new WolfSSLSocket(clientMode: " +
             String.valueOf(clientMode) + ", InetAddress, port: " +
             port + ")");
 
@@ -221,7 +221,7 @@ public class WolfSSLSocket extends SSLSocket {
         this.autoClose = true;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "creating new WolfSSLSocket(clientMode: " +
+            () -> "creating new WolfSSLSocket(clientMode: " +
             String.valueOf(clientMode) + ", InetAddress, port: " +
             port + ", InetAddress, localPort: " + localPort + ")");
 
@@ -262,7 +262,7 @@ public class WolfSSLSocket extends SSLSocket {
         this.autoClose = true;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "creating new WolfSSLSocket(clientMode: " +
+            () -> "creating new WolfSSLSocket(clientMode: " +
             String.valueOf(clientMode) + ", host: " + host + ", port: " +
             port + ")");
 
@@ -306,7 +306,7 @@ public class WolfSSLSocket extends SSLSocket {
         this.autoClose = true;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "creating new WolfSSLSocket(clientMode: " +
+            () -> "creating new WolfSSLSocket(clientMode: " +
             String.valueOf(clientMode) + ", host: " + host + ", port: " +
             port + ", InetAddress, locaPort: " + localPort + ")");
 
@@ -354,7 +354,7 @@ public class WolfSSLSocket extends SSLSocket {
         this.autoClose = autoClose;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "creating new WolfSSLSocket(clientMode: " +
+            () -> "creating new WolfSSLSocket(clientMode: " +
             String.valueOf(clientMode) + ", Socket, host: " + host +
             ", port: " + port + ", autoClose: " +
             String.valueOf(autoClose) + ")");
@@ -406,7 +406,7 @@ public class WolfSSLSocket extends SSLSocket {
         this.autoClose = autoClose;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "creating new WolfSSLSocket(clientMode: " +
+            () -> "creating new WolfSSLSocket(clientMode: " +
             String.valueOf(clientMode) + ", Socket, autoClose: " +
             String.valueOf(autoClose) + ")");
 
@@ -453,8 +453,8 @@ public class WolfSSLSocket extends SSLSocket {
         this.autoClose = autoClose;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "creating new WolfSSLSocket(Socket, InputStream, autoClose: " +
-            String.valueOf(autoClose) + ")");
+            () -> "creating new WolfSSLSocket(Socket, InputStream, " +
+            "autoClose: " + String.valueOf(autoClose) + ")");
 
         if (s == null ) {
             throw new NullPointerException("Socket is null");
@@ -496,7 +496,7 @@ public class WolfSSLSocket extends SSLSocket {
         /* Initialize WolfSSLSession object, wraps WOLFSSL structure. */
         ssl = new WolfSSLSession(ctx);
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "created new native WOLFSSL");
+            () -> "created new native WOLFSSL");
     }
 
     /**
@@ -524,7 +524,7 @@ public class WolfSSLSocket extends SSLSocket {
                     setFd();
                 } catch (WolfSSLException e) {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "Failed to set native fd, may try again later");
+                        () -> "Failed to set native fd, may try again later");
                 }
             }
 
@@ -535,7 +535,7 @@ public class WolfSSLSocket extends SSLSocket {
             try {
                 /* Load private key and cert chain from WolfSSLAuthStore */
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "loading private key and cert chain");
+                    () -> "loading private key and cert chain");
 
                 if (this.socket != null) {
                     EngineHelper.LoadKeyAndCertChain(this.socket, null);
@@ -571,7 +571,7 @@ public class WolfSSLSocket extends SSLSocket {
 
         if (this.ioCallbacksSet) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "wolfSSL I/O callbacks already set, skipping");
+                () -> "wolfSSL I/O callbacks already set, skipping");
             return;
         }
 
@@ -612,7 +612,7 @@ public class WolfSSLSocket extends SSLSocket {
                         "Failed to set native Socket fd");
                 }
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "registered SSLSocket(this) with native wolfSSL");
+                    () -> "registered SSLSocket(this) with native wolfSSL");
 
             } else {
                 ret = ssl.setFd(this.socket);
@@ -621,17 +621,18 @@ public class WolfSSLSocket extends SSLSocket {
                      * Try using I/O callbacks instead with
                      * Input/OutputStream */
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "Failed to set native SocketImpl fd, " +
+                        () -> "Failed to set native SocketImpl fd, " +
                         "trying I/O callbacks");
 
                     setIOCallbacks();
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "registered underlying Socket with " +
+                        () -> "registered underlying Socket with " +
                         "wolfSSL I/O callbacks");
                 }
                 else {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "registered Socket(this.socket) with native wolfSSL");
+                        () -> "registered Socket(this.socket) with " +
+                        "native wolfSSL");
                 }
             }
 
@@ -892,8 +893,8 @@ public class WolfSSLSocket extends SSLSocket {
      */
     @Override
     public final void sendUrgentData(int data) throws IOException {
-        throw new SocketException("sendUrgentData() not supported by "
-                + "WolfSSLSocket");
+        throw new SocketException(
+            "sendUrgentData() not supported by WolfSSLSocket");
     }
 
     /**
@@ -917,7 +918,7 @@ public class WolfSSLSocket extends SSLSocket {
     @Override
     public final void setOOBInline(boolean on) throws SocketException {
         throw new SocketException("setOOBInline is ineffective, as sending " +
-                "urgent data is not supported with SSLSocket");
+            "urgent data is not supported with SSLSocket");
     }
 
     /**
@@ -1016,8 +1017,8 @@ public class WolfSSLSocket extends SSLSocket {
      */
     @Override
     public final void shutdownInput() throws IOException {
-        throw new UnsupportedOperationException("shutdownInput() not " +
-                "supported by wolfSSLSocket");
+        throw new UnsupportedOperationException(
+            "shutdownInput() not supported by wolfSSLSocket");
     }
 
     /**
@@ -1025,8 +1026,8 @@ public class WolfSSLSocket extends SSLSocket {
      */
     @Override
     public final void shutdownOutput() throws IOException {
-        throw new UnsupportedOperationException("shutdownOutput() not " +
-                "supported by wolfSSLSocket");
+        throw new UnsupportedOperationException(
+            "shutdownOutput() not supported by wolfSSLSocket");
     }
 
     /**
@@ -1039,7 +1040,7 @@ public class WolfSSLSocket extends SSLSocket {
     public synchronized String[] getSupportedCipherSuites() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getSupportedCipherSuites()");
+            () -> "entered getSupportedCipherSuites()");
 
         /* getAllCiphers() is a static method, calling directly on class */
         return WolfSSLEngineHelper.getAllCiphers();
@@ -1056,7 +1057,7 @@ public class WolfSSLSocket extends SSLSocket {
     public synchronized String[] getEnabledCipherSuites() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getEnabledCipherSuites()");
+            () -> "entered getEnabledCipherSuites()");
 
         if (this.isClosed()) {
             return null;
@@ -1078,18 +1079,18 @@ public class WolfSSLSocket extends SSLSocket {
         throws IllegalArgumentException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered setEnabledCipherSuites()");
+            () -> "entered setEnabledCipherSuites()");
 
         if (this.isClosed()) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "SSLSocket closed, not setting enabled cipher suites");
+                () -> "SSLSocket closed, not setting enabled cipher suites");
             return;
         }
 
         /* sets cipher suite(s) to be used for connection */
         EngineHelper.setCiphers(suites);
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "enabled cipher suites set to: " + Arrays.toString(suites));
+            () -> "enabled cipher suites set to: " + Arrays.toString(suites));
     }
 
     /**
@@ -1105,7 +1106,7 @@ public class WolfSSLSocket extends SSLSocket {
     public synchronized String getApplicationProtocol() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getApplicationProtocol()");
+            () -> "entered getApplicationProtocol()");
 
         /* If socket has been closed, return an empty string */
         if (this.isClosed()) {
@@ -1132,7 +1133,7 @@ public class WolfSSLSocket extends SSLSocket {
     public synchronized String getHandshakeApplicationProtocol() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getHandshakeApplicationProtocol()");
+            () -> "entered getHandshakeApplicationProtocol()");
 
         if (this.handshakeStarted && !this.handshakeComplete) {
             return EngineHelper.getAlpnSelectedProtocolString();
@@ -1151,7 +1152,7 @@ public class WolfSSLSocket extends SSLSocket {
         getHandshakeApplicationProtocolSelector() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getHandshakeApplicationProtocolSelector()");
+            () -> "entered getHandshakeApplicationProtocolSelector()");
 
         return this.alpnSelector;
     }
@@ -1179,10 +1180,10 @@ public class WolfSSLSocket extends SSLSocket {
     public synchronized void setHandshakeApplicationProtocolSelector(
         BiFunction<SSLSocket,List<String>,String> selector) {
 
-        int ret = 0;
+        final int ret;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered setHandshakeApplicationProtocolSelector()");
+            () -> "entered setHandshakeApplicationProtocolSelector()");
 
         if (selector != null) {
             ALPNSelectCallback alpnCb = new ALPNSelectCallback();
@@ -1192,7 +1193,7 @@ public class WolfSSLSocket extends SSLSocket {
                 ret = this.ssl.setAlpnSelectCb(alpnCb, this);
                 if (ret != WolfSSL.SSL_SUCCESS) {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "Native setAlpnSelectCb() failed, ret = " + ret +
+                        () -> "Native setAlpnSelectCb() failed, ret = " + ret +
                         ", not setting selector");
                     return;
                 }
@@ -1202,7 +1203,8 @@ public class WolfSSLSocket extends SSLSocket {
 
             } catch (WolfSSLJNIException e) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "Exception while calling ssl.setAlpnSelectCb, not setting");
+                    () -> "Exception while calling ssl.setAlpnSelectCb, " +
+                    "not setting");
             }
         }
     }
@@ -1219,28 +1221,28 @@ public class WolfSSLSocket extends SSLSocket {
 
             SSLSocket sock = (SSLSocket)arg;
             List<String> peerProtos = new ArrayList<String>();
-            String selected = null;
+            final String selected;
 
             if (alpnSelector == null) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "alpnSelector null inside ALPNSelectCallback");
+                    () -> "alpnSelector null inside ALPNSelectCallback");
                 return WolfSSL.SSL_TLSEXT_ERR_ALERT_FATAL;
             }
 
             if (!(arg instanceof SSLSocket)) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "alpnSelectCallback arg not type of SSLSocket");
+                    () -> "alpnSelectCallback arg not type of SSLSocket");
                 return WolfSSL.SSL_TLSEXT_ERR_ALERT_FATAL;
             }
 
             if (in.length == 0) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "peer protocol list is 0 inside alpnSelectCallback");
+                    () -> "peer protocol list is 0 inside alpnSelectCallback");
                 return WolfSSL.SSL_TLSEXT_ERR_ALERT_FATAL;
             }
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "ALPN protos sent by peer: " + Arrays.toString(in));
+                () -> "ALPN protos sent by peer: " + Arrays.toString(in));
 
             for (String s: in) {
                 peerProtos.add(s);
@@ -1249,18 +1251,18 @@ public class WolfSSLSocket extends SSLSocket {
 
             if (selected == null) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "ALPN protocol string is null, no peer match");
+                    () -> "ALPN protocol string is null, no peer match");
                 return WolfSSL.SSL_TLSEXT_ERR_ALERT_FATAL;
             }
             else {
                 if (selected.isEmpty()) {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "ALPN not being used, selected proto empty");
+                        () -> "ALPN not being used, selected proto empty");
                     return WolfSSL.SSL_TLSEXT_ERR_NOACK;
                 }
 
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "ALPN protocol selected by callback: " + selected);
+                    () -> "ALPN protocol selected by callback: " + selected);
                 out[0] = selected;
                 return WolfSSL.SSL_TLSEXT_ERR_OK;
 
@@ -1277,7 +1279,7 @@ public class WolfSSLSocket extends SSLSocket {
     public synchronized String[] getSupportedProtocols() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getSupportedProtocols()");
+            () -> "entered getSupportedProtocols()");
 
         /* returns all protocol version supported by native wolfSSL.
         /* getAllProtocols() is a static method, calling directly on class */
@@ -1293,7 +1295,7 @@ public class WolfSSLSocket extends SSLSocket {
     public synchronized String[] getEnabledProtocols() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getEnabledProtocols()");
+            () -> "entered getEnabledProtocols()");
 
         if (this.isClosed()) {
             return null;
@@ -1316,18 +1318,18 @@ public class WolfSSLSocket extends SSLSocket {
         throws IllegalArgumentException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered setEnabledProtocols()");
+            () -> "entered setEnabledProtocols()");
 
         if (this.isClosed()) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "SSLSocket closed, not setting enabled protocols");
+                () -> "SSLSocket closed, not setting enabled protocols");
             return;
         }
 
         /* sets protocol versions to be enabled for use with this session */
         EngineHelper.setProtocols(protocols);
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "enabled protocols set to: " + Arrays.toString(protocols));
+            () -> "enabled protocols set to: " + Arrays.toString(protocols));
     }
 
     /**
@@ -1373,11 +1375,11 @@ public class WolfSSLSocket extends SSLSocket {
     public synchronized SSLSession getSession() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getSession()");
+            () -> "entered getSession()");
 
         if (this.isClosed()) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "SSLSocket has been closed, returning invalid session");
+                () -> "SSLSocket has been closed, returning invalid session");
 
             /* return invalid session object with cipher suite
              * "SSL_NULL_WITH_NULL_NULL" */
@@ -1393,14 +1395,15 @@ public class WolfSSLSocket extends SSLSocket {
         } catch (Exception e) {
             /* Log error, but continue. Session returned will be empty */
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "Handshake attempt failed in SSLSocket.getSession()");
+                () -> "Handshake attempt failed in SSLSocket.getSession()");
 
             /* close SSLSocket */
             try {
                 close();
             } catch (Exception ex) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "close attempt failed in SSLSocket.getSession(): " + ex);
+                    () -> "close attempt failed in SSLSocket.getSession(): " +
+                    ex);
             }
 
             /* return invalid session object with cipher suite
@@ -1425,7 +1428,7 @@ public class WolfSSLSocket extends SSLSocket {
     public synchronized SSLSession getHandshakeSession() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getHandshakeSession()");
+            () -> "entered getHandshakeSession()");
 
         if ((this.handshakeStarted == false) || this.isClosed()) {
             return null;
@@ -1449,11 +1452,11 @@ public class WolfSSLSocket extends SSLSocket {
         HandshakeCompletedListener listener) throws IllegalArgumentException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered addHandshakeCompletedListener()");
+            () -> "entered addHandshakeCompletedListener()");
 
         if (listener == null) {
-            throw new IllegalArgumentException("HandshakeCompletedListener " +
-                "is null");
+            throw new IllegalArgumentException(
+                "HandshakeCompletedListener is null");
         }
 
         if (hsListeners == null) {
@@ -1462,7 +1465,7 @@ public class WolfSSLSocket extends SSLSocket {
 
         hsListeners.add(listener);
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "registered new HandshakeCompletedListener");
+                () -> "registered new HandshakeCompletedListener");
     }
 
     /**
@@ -1478,11 +1481,11 @@ public class WolfSSLSocket extends SSLSocket {
         HandshakeCompletedListener listener) throws IllegalArgumentException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered removeHandshakeCompletedListener()");
+            () -> "entered removeHandshakeCompletedListener()");
 
         if (listener == null) {
-            throw new IllegalArgumentException("HandshakeCompletedListener " +
-                "is null");
+            throw new IllegalArgumentException(
+                "HandshakeCompletedListener is null");
         }
 
         if (hsListeners != null) {
@@ -1493,7 +1496,7 @@ public class WolfSSLSocket extends SSLSocket {
             }
         }
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "removed HandshakeCompletedListener");
+            () -> "removed HandshakeCompletedListener");
     }
 
     /**
@@ -1508,13 +1511,13 @@ public class WolfSSLSocket extends SSLSocket {
         String errStr = "";
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered startHandshake(), trying to get handshakeLock");
+            () -> "entered startHandshake(), trying to get handshakeLock");
 
         checkAndInitSSLSocket();
 
         synchronized (handshakeLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "thread got handshakeLock (initHandshake)");
+                () -> "thread got handshakeLock (initHandshake)");
 
             if (!this.isConnected()) {
                 throw new SocketException("Socket is not connected");
@@ -1529,7 +1532,7 @@ public class WolfSSLSocket extends SSLSocket {
                  *   - Return early if session still valid.
                  *   - Otherwise proceed with new handshake. */
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "handshake already finished, returning early");
+                    () -> "handshake already finished, returning early");
                 return;
             }
 
@@ -1544,15 +1547,15 @@ public class WolfSSLSocket extends SSLSocket {
             this.handshakeStarted = true;
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "thread exiting handshakeLock (initHandshake)");
+                () -> "thread exiting handshakeLock (initHandshake)");
         }
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-             "trying to get ioLock (handshake)");
+            () -> "trying to get ioLock (handshake)");
 
         synchronized (ioLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                 "thread got ioLock (handshake)");
+                () -> "thread got ioLock (handshake)");
 
             try {
                 ret = EngineHelper.doHandshake(0, this.getSoTimeout());
@@ -1562,14 +1565,16 @@ public class WolfSSLSocket extends SSLSocket {
             /* close socket if the handshake is unsuccessful */
             } catch (SocketTimeoutException e) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "got socket timeout in doHandshake()");
+                    () -> "got socket timeout in doHandshake()");
                 close();
                 throw e;
 
             } catch (SSLException e) {
+                final int tmpErr = err;
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "native handshake failed in doHandshake(): error code: " +
-                    err + ", TID " + Thread.currentThread().getId() + ")");
+                    () -> "native handshake failed in doHandshake(): " +
+                    "error code: " + tmpErr + ", TID " +
+                    Thread.currentThread().getId() + ")");
                 close();
                 throw e;
             } catch (WolfSSLException e) {
@@ -1585,15 +1590,15 @@ public class WolfSSLSocket extends SSLSocket {
             }
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                 "thread exiting ioLock (handshake)");
+                () -> "thread exiting ioLock (handshake)");
         }
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "trying to get handshakeLock (handshakeComplete)");
+            () -> "trying to get handshakeLock (handshakeComplete)");
 
         synchronized (handshakeLock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "thread got handshakeLock (handshakeComplete)");
+                () -> "thread got handshakeLock (handshakeComplete)");
             /* mark handshake completed */
             handshakeComplete = true;
         }
@@ -1608,15 +1613,15 @@ public class WolfSSLSocket extends SSLSocket {
             }
         }
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "completed SSL/TLS handshake, listeners notified");
+            () -> "completed SSL/TLS handshake, listeners notified");
 
         /* print debug info about connection, if enabled */
         if (EngineHelper.getSession() != null) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "SSL/TLS protocol version: " +
+                () -> "SSL/TLS protocol version: " +
                 EngineHelper.getSession().getProtocol());
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "SSL/TLS cipher suite: " +
+                () -> "SSL/TLS cipher suite: " +
                 EngineHelper.getSession().getCipherSuite());
         }
     }
@@ -1636,7 +1641,7 @@ public class WolfSSLSocket extends SSLSocket {
         throws IllegalArgumentException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered setUseClientMode()");
+            () -> "entered setUseClientMode()");
 
         if (!this.isClosed()) {
             EngineHelper.setUseClientMode(mode);
@@ -1644,7 +1649,7 @@ public class WolfSSLSocket extends SSLSocket {
         this.isClientMode = mode;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "socket client mode set to: " + mode);
+            () -> "socket client mode set to: " + mode);
     }
 
     /**
@@ -1656,7 +1661,7 @@ public class WolfSSLSocket extends SSLSocket {
     public synchronized boolean getUseClientMode() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getUseClientMode()");
+            () -> "entered getUseClientMode()");
 
         return this.isClientMode;
     }
@@ -1674,7 +1679,7 @@ public class WolfSSLSocket extends SSLSocket {
     public synchronized void setNeedClientAuth(boolean need) {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered setNeedClientAuth(need: " + String.valueOf(need) + ")");
+            () -> "entered setNeedClientAuth(need: " + String.valueOf(need) + ")");
 
         if (!this.isClosed()) {
             EngineHelper.setNeedClientAuth(need);
@@ -1691,7 +1696,7 @@ public class WolfSSLSocket extends SSLSocket {
     public synchronized boolean getNeedClientAuth() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getNeedClientAuth()");
+            () -> "entered getNeedClientAuth()");
 
         /* When socket is closed, EngineHelper gets set to null. Since we
          * don't cache needClientAuth value, return false after closure. */
@@ -1716,7 +1721,7 @@ public class WolfSSLSocket extends SSLSocket {
     public synchronized void setWantClientAuth(boolean want) {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered setWantClientAuth(want: " + String.valueOf(want) + ")");
+            () -> "entered setWantClientAuth(want: " + String.valueOf(want) + ")");
 
         if (!this.isClosed()) {
             EngineHelper.setWantClientAuth(want);
@@ -1737,7 +1742,7 @@ public class WolfSSLSocket extends SSLSocket {
     public synchronized boolean getWantClientAuth() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getWantClientAuth()");
+            () -> "entered getWantClientAuth()");
 
         /* When socket is closed, EngineHelper gets set to null. Since we
          * don't cache wantClientAuth value, return false after closure. */
@@ -1760,7 +1765,7 @@ public class WolfSSLSocket extends SSLSocket {
     public synchronized void setEnableSessionCreation(boolean flag) {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered setEnableSessionCreation(flag: " +
+            () -> "entered setEnableSessionCreation(flag: " +
             String.valueOf(flag) + ")");
 
         if (!this.isClosed()) {
@@ -1777,7 +1782,7 @@ public class WolfSSLSocket extends SSLSocket {
     public synchronized boolean getEnableSessionCreation() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getEnableSessionCreation()");
+            () -> "entered getEnableSessionCreation()");
 
         if (this.isClosed()) {
             return false;
@@ -1794,7 +1799,7 @@ public class WolfSSLSocket extends SSLSocket {
     public synchronized void setUseSessionTickets(boolean useTickets) {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered setUseSessionTickets(flag: " +
+            () -> "entered setUseSessionTickets(flag: " +
             String.valueOf(useTickets) + ")");
 
         EngineHelper.setUseSessionTickets(useTickets);
@@ -1811,7 +1816,7 @@ public class WolfSSLSocket extends SSLSocket {
     public synchronized InputStream getInputStream() throws IOException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getInputStream()");
+            () -> "entered getInputStream()");
 
         checkAndInitSSLSocket();
 
@@ -1826,7 +1831,7 @@ public class WolfSSLSocket extends SSLSocket {
         if (inStream == null) {
             inStream = new WolfSSLInputStream(ssl, this);
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "created WolfSSLInputStream");
+                () -> "created WolfSSLInputStream");
         }
 
         return inStream;
@@ -1843,7 +1848,7 @@ public class WolfSSLSocket extends SSLSocket {
     public synchronized OutputStream getOutputStream() throws IOException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getOutputStream()");
+            () -> "entered getOutputStream()");
 
         checkAndInitSSLSocket();
 
@@ -1858,7 +1863,7 @@ public class WolfSSLSocket extends SSLSocket {
         if (outStream == null) {
             outStream = new WolfSSLOutputStream(ssl, this);
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "created WolfSSLOutputStream");
+                () -> "created WolfSSLOutputStream");
         }
 
         return outStream;
@@ -1911,7 +1916,7 @@ public class WolfSSLSocket extends SSLSocket {
     public synchronized void setSSLParameters(SSLParameters params) {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered setSSLParameters()");
+            () -> "entered setSSLParameters()");
 
         if (params != null) {
             WolfSSLParametersHelper.importParams(params, this.params);
@@ -1927,7 +1932,7 @@ public class WolfSSLSocket extends SSLSocket {
     public synchronized SSLParameters getSSLParameters() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getSSLParameters()");
+            () -> "entered getSSLParameters()");
 
         return WolfSSLParametersHelper.decoupleParams(this.params);
     }
@@ -1974,7 +1979,7 @@ public class WolfSSLSocket extends SSLSocket {
         boolean handshakeFinished = false;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered close()");
+            () -> "entered close()");
 
         /* Test if this is called before WolfSSLSocket object has initialized,
          * meaning this is called directly from super(). If so, we skip
@@ -1993,17 +1998,18 @@ public class WolfSSLSocket extends SSLSocket {
                 /* Check if underlying Socket is still open before closing,
                  * in case application calls SSLSocket.close() multiple times */
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "trying to get handshakeLock (close)");
+                    () -> "trying to get handshakeLock (close)");
 
                 synchronized (handshakeLock) {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "thread got handshakeLock (close)");
+                        () -> "thread got handshakeLock (close)");
 
                     if (this.connectionClosed == true ||
                         (this.socket != null && this.socket.isClosed()) ||
                         (this.socket == null && super.isClosed())) {
                         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                            "Socket already closed, skipping TLS shutdown");
+                            () -> "Socket already closed, skipping " +
+                            "TLS shutdown");
                         return;
                     }
 
@@ -2012,30 +2018,30 @@ public class WolfSSLSocket extends SSLSocket {
                 }
 
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "signaling any blocked I/O threads to wake up");
+                    () -> "signaling any blocked I/O threads to wake up");
                 ssl.interruptBlockedIO();
 
                 /* Try TLS shutdown procedure, only if handshake has finished */
                 if (ssl != null && handshakeFinished) {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                            "shutting down SSL/TLS connection");
+                        () -> "shutting down SSL/TLS connection");
 
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "thread trying to get ioLock (shutdown)");
+                        () -> "thread trying to get ioLock (shutdown)");
 
                     synchronized (ioLock) {
                         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                                         "thread got ioLock (shutdown)");
+                            () -> "thread got ioLock (shutdown)");
 
                         if ((this.getUseClientMode() == true) &&
                             (handshakeFinished == true)) {
                             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                                "saving WOLFSSL_SESSION into cache");
+                                () -> "saving WOLFSSL_SESSION into cache");
                             EngineHelper.saveSession();
                         }
                         else {
                             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                                "not saving WOLFSSL_SESSION into cache, " +
+                                () -> "not saving WOLFSSL_SESSION into cache, " +
                                 "not client or handshake not complete");
                         }
 
@@ -2052,20 +2058,20 @@ public class WolfSSLSocket extends SSLSocket {
                             }
 
                             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                                    "ssl.shutdownSSL() ret = " + ret);
+                                () -> "ssl.shutdownSSL() ret = " + ret);
 
                         } catch (SocketException | SocketTimeoutException e) {
                             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                            "Exception while trying to ssl.shutdownSSL(), " +
-                            "ignoring to finish cleanup");
+                                () -> "Exception while trying to " +
+                                "ssl.shutdownSSL(), ignore to finish cleanup");
                         }
 
                         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                            "thread trying to get handshakeLock");
+                            () -> "thread trying to get handshakeLock");
 
                         synchronized (handshakeLock) {
                             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                                "thread got handshakeLock");
+                                () -> "thread got handshakeLock");
 
                             this.connectionClosed = true;
 
@@ -2078,17 +2084,19 @@ public class WolfSSLSocket extends SSLSocket {
                                 readCtx instanceof ConsumedRecvCtx) {
                                 ConsumedRecvCtx rctx = (ConsumedRecvCtx)readCtx;
                                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                                  "calling ConsumedRecvCtx.closeDataStreams()");
+                                    () -> "calling ConsumedRecvCtx." +
+                                    "closeDataStreams()");
                                 rctx.closeDataStreams();
                             }
 
                             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                                "thread exiting handshakeLock (shutdown)");
+                                () -> "thread exiting handshakeLock " +
+                                "(shutdown)");
 
                         } /* handshakeLock */
 
                         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                            "thread exiting ioLock (shutdown)");
+                            () -> "thread exiting ioLock (shutdown)");
 
                     } /* ioLock */
 
@@ -2098,13 +2106,13 @@ public class WolfSSLSocket extends SSLSocket {
                      * has been set or not. */
                     if (this.inStream != null) {
                         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                            "close(), closing InputStream");
+                            () -> "close(), closing InputStream");
                         this.inStream.close(false);
                         this.inStream = null;
                     }
                     if (this.outStream != null) {
                         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                            "close(), closing OutputStream");
+                            () -> "close(), closing OutputStream");
                         this.outStream.close(false);
                         this.outStream = null;
                     }
@@ -2116,7 +2124,7 @@ public class WolfSSLSocket extends SSLSocket {
                  * release interruptFds[] pipe() and free up descriptor. */
                 synchronized (ioLock) {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "thread got ioLock (freeSSL)");
+                        () -> "thread got ioLock (freeSSL)");
 
                     /* Connection is closed, free native WOLFSSL session
                      * to release native memory earlier than garbage
@@ -2124,7 +2132,7 @@ public class WolfSSLSocket extends SSLSocket {
                      * have any threads still waiting in poll/select. */
                     if (this.ssl.getThreadsBlockedInPoll() == 0) {
                         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                            "calling this.ssl.freeSSL()");
+                            () -> "calling this.ssl.freeSSL()");
                         this.ssl.freeSSL();
                         this.ssl = null;
                     }
@@ -2134,7 +2142,7 @@ public class WolfSSLSocket extends SSLSocket {
                     this.EngineHelper = null;
 
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "thread exiting ioLock (shutdown)");
+                        () -> "thread exiting ioLock (shutdown)");
                 } /* ioLock */
             }
 
@@ -2142,19 +2150,21 @@ public class WolfSSLSocket extends SSLSocket {
                 if (this.socket != null) {
                     this.socket.close();
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                            "socket (external) closed: " + this.socket);
+                        () -> "socket (external) closed: " + this.socket);
                 } else {
                     super.close();
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                            "socket (super) closed: " + super.toString());
+                        () -> "socket (super) closed: " + super.toString());
                 }
             } else {
                 if (this.socket != null) {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "socket (external) not closed, autoClose set to false");
+                        () -> "socket (external) not closed, autoClose " +
+                        "set to false");
                 } else {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "socket (super) not closed, autoClose set to false");
+                        () -> "socket (super) not closed, autoClose " +
+                        "set to false");
                 }
             }
 
@@ -2191,15 +2201,15 @@ public class WolfSSLSocket extends SSLSocket {
     public synchronized void connect(SocketAddress endpoint, int timeout)
         throws IOException {
 
-        InetSocketAddress address = null;
+        final InetSocketAddress address;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered connect(SocketAddress endpoint, int timeout / " +
+            () -> "entered connect(SocketAddress endpoint, int timeout / " +
             timeout + " ms)");
 
         if (!(endpoint instanceof InetSocketAddress)) {
-            throw new IllegalArgumentException("endpoint is not of type " +
-                "InetSocketAddress");
+            throw new IllegalArgumentException(
+                "endpoint is not of type InetSocketAddress");
         }
 
         if (this.socket != null) {
@@ -2210,7 +2220,7 @@ public class WolfSSLSocket extends SSLSocket {
 
         address = (InetSocketAddress)endpoint;
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "Underlying Java Socket connected to peer: " + address);
+            () -> "Underlying Java Socket connected to peer: " + address);
 
         /* register host/port for session resumption in case where
            createSocket() was called without host/port, but
@@ -2332,7 +2342,7 @@ public class WolfSSLSocket extends SSLSocket {
             }
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "sent " + sz + " bytes");
+                () -> "sent " + sz + " bytes");
             return sz;
         }
     }
@@ -2363,7 +2373,7 @@ public class WolfSSLSocket extends SSLSocket {
         public int receiveCallback(WolfSSLSession ssl,
             byte[] buf, int sz, Object ctx) {
 
-            int ret = 0;
+            final int ret;
             SocketRecvCtx recvCtx = (SocketRecvCtx)ctx;
             Socket sock = recvCtx.getSocket();
             InputStream inStream = null;
@@ -2398,7 +2408,7 @@ public class WolfSSLSocket extends SSLSocket {
             }
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "received " + ret + " bytes");
+                () -> "received " + ret + " bytes");
             return ret;
         }
     }
@@ -2490,7 +2500,7 @@ public class WolfSSLSocket extends SSLSocket {
                 }
             } catch (IOException e) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.ERROR,
-                        "error reading from Socket InputStream");
+                    () -> "error reading from Socket InputStream");
                 ret = WolfSSL.WOLFSSL_CBIO_ERR_GENERAL;
             }
 
@@ -2536,12 +2546,12 @@ public class WolfSSLSocket extends SSLSocket {
 
                     if (this.socket.isClosed()) {
                         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                            "socket (input) already closed");
+                            () -> "socket (input) already closed");
                     }
                     else {
                         this.socket.close();
                         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                            "socket (input) closed: " + this.socket);
+                            () -> "socket (input) closed: " + this.socket);
                     }
                 }
 
@@ -2552,7 +2562,7 @@ public class WolfSSLSocket extends SSLSocket {
             }
             else {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "InputStream already in process of being closed");
+                    () -> "InputStream already in process of being closed");
             }
 
             return;
@@ -2599,7 +2609,7 @@ public class WolfSSLSocket extends SSLSocket {
             throws NullPointerException, IndexOutOfBoundsException,
                    IOException {
 
-            int ret = 0;
+            final int ret;
 
             if (b == null) {
                 throw new NullPointerException("Input array is null");
@@ -2618,11 +2628,11 @@ public class WolfSSLSocket extends SSLSocket {
 
             /* check if connection has already been closed/shutdown */
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "trying to get socket.handshakeLock (read)");
+                () -> "trying to get socket.handshakeLock (read)");
 
             synchronized (socket.handshakeLock) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "thread got socket.handshakeLock (read)");
+                    () -> "thread got socket.handshakeLock (read)");
 
                 if (socket.connectionClosed == true) {
                     throw new SocketException("Connection already shutdown");
@@ -2638,7 +2648,7 @@ public class WolfSSLSocket extends SSLSocket {
                 }
             } catch (SocketTimeoutException e) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "got socket timeout in read()");
+                    () -> "got socket timeout in read()");
                 throw e;
             }
 
@@ -2656,21 +2666,21 @@ public class WolfSSLSocket extends SSLSocket {
                 int timeout = socket.getSoTimeout();
 
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "ssl.read() socket timeout = " + timeout);
+                    () -> "ssl.read() socket timeout = " + timeout);
 
                 ret = ssl.read(b, off, len, timeout);
                 err = ssl.getError(ret);
 
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "ssl.read(off: " + off + ", len: " + len + ") ret = " +
-                    ret + ", err = " + err);
+                    () -> "ssl.read(off: " + off + ", len: " + len +
+                    ") ret = " + ret + ", err = " + err);
 
                 /* check for end of stream */
                 if ((err == WolfSSL.SSL_ERROR_ZERO_RETURN) ||
                     ((err == WolfSSL.SSL_ERROR_SOCKET_PEER_CLOSED) &&
                      (ret == 0))) {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "ssl.read() got SSL_ERROR_ZERO_RETURN, " + err +
+                        () -> "ssl.read() got SSL_ERROR_ZERO_RETURN, " + err +
                         ", end of stream");
 
                     /* End of stream */
@@ -2685,14 +2695,14 @@ public class WolfSSLSocket extends SSLSocket {
                         /* Socket error, indicate to caller by returning
                          * end of stream */
                         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                            "Native wolfSSL_read() error: " + errStr +
+                            () -> "Native wolfSSL_read() error: " + errStr +
                             " (error code: " + err + "ret: " + ret +
                             "), end of stream");
                         return -1;
 
                     } else {
                         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                            "Native wolfSSL_read() error: " + errStr +
+                            () -> "Native wolfSSL_read() error: " + errStr +
                             " (error code: " + err + ", ret: " + ret + ")");
                         throw new IOException("Native wolfSSL_read() " +
                             "error: " + errStr +
@@ -2760,12 +2770,12 @@ public class WolfSSLSocket extends SSLSocket {
 
                     if (this.socket.isClosed()) {
                         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                            "socket (output) already closed");
+                            () -> "socket (output) already closed");
                     }
                     else {
                         this.socket.close();
                         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                            "socket (output) closed: " + this.socket);
+                            () -> "socket (output) closed: " + this.socket);
                     }
                 }
 
@@ -2776,7 +2786,7 @@ public class WolfSSLSocket extends SSLSocket {
             }
             else {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "OutputStream already in process of being closed");
+                    () -> "OutputStream already in process of being closed");
             }
 
             return;
@@ -2822,11 +2832,11 @@ public class WolfSSLSocket extends SSLSocket {
 
             /* check if connection has already been closed/shutdown */
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "trying to get socket.handshakeLock (write)");
+                () -> "trying to get socket.handshakeLock (write)");
 
             synchronized (socket.handshakeLock) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "thread got socket.handshakeLock (write)");
+                    () -> "thread got socket.handshakeLock (write)");
                 if (socket.connectionClosed == true) {
                     throw new SocketException(
                         "Connection already shutdown");
@@ -2841,7 +2851,7 @@ public class WolfSSLSocket extends SSLSocket {
                 }
             } catch (SocketTimeoutException e) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "got socket timeout in write()");
+                    () -> "got socket timeout in write()");
                 throw e;
             }
 
@@ -2855,19 +2865,19 @@ public class WolfSSLSocket extends SSLSocket {
                 int timeout = socket.getSoTimeout();
 
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "ssl.write() socket timeout = " + timeout);
+                    () -> "ssl.write() socket timeout = " + timeout);
 
                 ret = ssl.write(b, off, len, timeout);
                 err = ssl.getError(ret);
 
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "ssl.write(off: " + off + ", len: " + len +
+                    () -> "ssl.write(off: " + off + ", len: " + len +
                     ") returned ret = " + ret + ", err = " + err);
 
                 /* check for end of stream */
                 if (err == WolfSSL.SSL_ERROR_ZERO_RETURN) {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "ssl.write() got SSL_ERROR_ZERO_RETURN, " +
+                        () -> "ssl.write() got SSL_ERROR_ZERO_RETURN, " +
                         "end of stream");
 
                     /* check to see if we received a close notify alert.
@@ -2887,7 +2897,7 @@ public class WolfSSLSocket extends SSLSocket {
 
             } catch (IllegalStateException e) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                                 "got IllegalStateException: " + e +
+                                 () -> "got IllegalStateException: " + e +
                                  ", throwing IOException");
                 throw new IOException(e);
             }

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocketFactory.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocketFactory.java
@@ -59,7 +59,7 @@ public class WolfSSLSocketFactory extends SSLSocketFactory {
     public WolfSSLSocketFactory() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "created new default WolfSSLSocketFactory");
+            () -> "created new default WolfSSLSocketFactory");
 
         this.isDefault = 1;
         this.isDefaultInitialized = 0;
@@ -82,7 +82,7 @@ public class WolfSSLSocketFactory extends SSLSocketFactory {
             WolfSSLAuthStore authStore, WolfSSLParameters params) {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "created new WolfSSLSocketFactory");
+            () -> "created new WolfSSLSocketFactory");
 
         this.ctx = ctx;
         this.authStore = authStore;
@@ -98,7 +98,7 @@ public class WolfSSLSocketFactory extends SSLSocketFactory {
         if (this.isDefault == 1 && this.isDefaultInitialized == 0) {
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "creating and initializing DEFAULT_Context");
+                () -> "creating and initializing DEFAULT_Context");
 
             this.jsseCtx =
                 new com.wolfssl.provider.jsse.WolfSSLContext.DEFAULT_Context();
@@ -111,7 +111,7 @@ public class WolfSSLSocketFactory extends SSLSocketFactory {
             this.params = jsseCtx.getInternalSSLParams();
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "DEFAULT_Context created and initialized");
+                () -> "DEFAULT_Context created and initialized");
         }
     }
 
@@ -124,7 +124,7 @@ public class WolfSSLSocketFactory extends SSLSocketFactory {
     public String[] getDefaultCipherSuites() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getDefaultCipherSuites()");
+            () -> "entered getDefaultCipherSuites()");
 
         return WolfSSLUtil.sanitizeSuites(WolfSSL.getCiphersIana());
     }
@@ -138,7 +138,7 @@ public class WolfSSLSocketFactory extends SSLSocketFactory {
     public String[] getSupportedCipherSuites() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getSupportedCipherSuites()");
+            () -> "entered getSupportedCipherSuites()");
 
         return getDefaultCipherSuites();
     }
@@ -153,7 +153,7 @@ public class WolfSSLSocketFactory extends SSLSocketFactory {
     public Socket createSocket() throws IOException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered createSocket()");
+            () -> "entered createSocket()");
 
         try {
             initDefaultContext();
@@ -179,7 +179,7 @@ public class WolfSSLSocketFactory extends SSLSocketFactory {
         throws IOException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered createSocket(InetAddress host, int port)");
+            () -> "entered createSocket(InetAddress host, int port)");
 
         try {
             initDefaultContext();
@@ -208,8 +208,8 @@ public class WolfSSLSocketFactory extends SSLSocketFactory {
         InetAddress localAddress, int localPort) throws IOException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered createSocket(InetAddress host, port: " + port + ", " +
-            "InetAddress localAddress, localPort: " + localPort + ")");
+            () -> "entered createSocket(InetAddress host, port: " + port +
+            ", InetAddress localAddress, localPort: " + localPort + ")");
 
         try {
             initDefaultContext();
@@ -236,7 +236,8 @@ public class WolfSSLSocketFactory extends SSLSocketFactory {
         throws IOException, UnknownHostException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered createSocket(host: " + host + ", port: " + port + ")");
+            () -> "entered createSocket(host: " + host + ", port: " +
+            port + ")");
 
         try {
             initDefaultContext();
@@ -265,7 +266,7 @@ public class WolfSSLSocketFactory extends SSLSocketFactory {
         int localPort) throws IOException, UnknownHostException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered createSocket(host: " + host + ", port: " + port +
+            () -> "entered createSocket(host: " + host + ", port: " + port +
             ", InetAddress localHost, localPort: " + localPort + ")");
 
         try {
@@ -296,7 +297,7 @@ public class WolfSSLSocketFactory extends SSLSocketFactory {
         boolean autoClose) throws IOException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered createSocket(Socket: " + s.getClass() + ", host: " +
+            () -> "entered createSocket(Socket: " + s.getClass() + ", host: " +
             host + ", port: " + port + ", autoClose: " +
             String.valueOf(autoClose) + ")");
 
@@ -329,7 +330,7 @@ public class WolfSSLSocketFactory extends SSLSocketFactory {
         boolean autoClose) throws IOException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered createSocket(Socket: " + s.getClass() +
+            () -> "entered createSocket(Socket: " + s.getClass() +
             ", InputStream consumed, autoClose: "
             + String.valueOf(autoClose) + ")");
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLTrustManager.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLTrustManager.java
@@ -25,7 +25,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.ByteArrayInputStream;
 import java.security.Security;
 import java.security.KeyStore;
@@ -93,24 +92,24 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
 
         if (tsFile != null) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "Loading certs from: " + tsFile);
+                () -> "Loading certs from: " + tsFile);
 
             /* Set KeyStore password if javax.net.ssl.keyStorePassword set */
             if (tsPass != null) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "javax.net.ssl.trustStorePassword system property " +
+                    () -> "javax.net.ssl.trustStorePassword system property " +
                     "set, using password");
                 passArr = tsPass.toCharArray();
             } else {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "javax.net.ssl.trustStorePassword system property " +
+                    () -> "javax.net.ssl.trustStorePassword system property " +
                     "not set");
             }
 
             /* System keystore type set, try loading using it first */
             if (tsType != null && !tsType.trim().isEmpty()) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "javax.net.ssl.trustStoreType set: " + tsType);
+                    () -> "javax.net.ssl.trustStoreType set: " + tsType);
 
                 if (requiredType != null && !requiredType.equals(tsType)) {
                     throw new KeyStoreException(
@@ -135,7 +134,7 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
                 if (sysStore == null && WolfSSLUtil.isAndroid() &&
                     (requiredType == null || requiredType.equals("BKS"))) {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "Detected Android VM, trying BKS KeyStore type");
+                        () -> "Detected Android VM, trying BKS KeyStore type");
                     sysStore = WolfSSLUtil.LoadKeyStoreFileByType(
                         tsFile, passArr, "BKS");
                 }
@@ -144,8 +143,8 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
                 if (sysStore == null &&
                     (requiredType == null || requiredType.equals("JKS"))) {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "javax.net.ssl.trustStoreType system property not set, " +
-                    "trying type: JKS");
+                        () -> "javax.net.ssl.trustStoreType system property " +
+                        "not set, trying type: JKS");
                     sysStore = WolfSSLUtil.LoadKeyStoreFileByType(
                         tsFile, passArr, "JKS");
                 }
@@ -158,7 +157,7 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
             }
             else {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "Loaded certs from KeyStore via System properties");
+                    () -> "Loaded certs from KeyStore via System properties");
             }
         }
 
@@ -203,8 +202,9 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
         String storeType = Security.getProperty("keystore.type");
         if (storeType != null) {
             storeType = storeType.toUpperCase();
+            final String tmpStoreType = storeType;
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "keystore.type Security property set: " + storeType);
+                () -> "keystore.type Security property set: " + tmpStoreType);
         }
 
         if (wksAvailable) {
@@ -234,32 +234,36 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
         }
 
         if (f.exists()) {
+            final String absPath = f.getAbsolutePath();
 
             if (requiredType != null && !requiredType.equals(storeType)) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "Skipping loading of system KeyStore, required type " +
-                    "does not match wolfjsse.keystore.type.required");
+                    () -> "Skipping loading of system KeyStore, required " +
+                    "type does not match wolfjsse.keystore.type.required");
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "Skipped loading: " + f.getAbsolutePath());
+                    () -> "Skipped loading: " + absPath);
                 return null;
             }
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                   "Loading certs from " + f.getAbsolutePath());
+               () -> "Loading certs from " + absPath);
 
             try {
                 sysStore = KeyStore.getInstance(storeType);
             } catch (KeyStoreException e) {
+                final String tmpStoreType = storeType;
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "Not able to get KeyStore of type: " + storeType);
+                    () -> "Not able to get KeyStore of type: " + tmpStoreType);
                 return null;
             }
             try {
                 sysStore.load(null, null);
             } catch (IOException | NoSuchAlgorithmException |
                      CertificateException e) {
+                final String tmpStoreType = storeType;
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "Not able to load empty KeyStore(" + storeType + ")");
+                    () -> "Not able to load empty KeyStore(" +
+                    tmpStoreType + ")");
                 return null;
             }
 
@@ -271,8 +275,8 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
                 stream = new FileInputStream(f);
             } catch (FileNotFoundException e) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "Not able to open KeyStore file for reading: " +
-                    f.getAbsolutePath());
+                    () -> "Not able to open KeyStore file for reading: " +
+                    absPath);
             }
 
             try {
@@ -281,8 +285,8 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
             } catch (IOException | NoSuchAlgorithmException |
                      CertificateException e) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "Not able to load KeyStore with file stream: " +
-                    f.getAbsolutePath());
+                    () -> "Not able to load KeyStore with file stream: " +
+                    absPath);
 
             } finally {
                 try {
@@ -295,7 +299,7 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
 
         } else {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "$JAVA_HOME/(jre/)lib/security/" +
+                () -> "$JAVA_HOME/(jre/)lib/security/" +
                 certBundleName + ": not found");
         }
 
@@ -333,7 +337,7 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
         String tsPass, String requiredType) {
 
         char[] passArr = null;
-        File f = null;
+        final File f;
         FileInputStream stream = null;
         KeyStore sysStore = null;
 
@@ -341,8 +345,9 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
         String storeType = Security.getProperty("keystore.type");
         if (storeType != null) {
             storeType = storeType.toUpperCase();
+            final String tmpStoreType = storeType;
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "keystore.type Security property set: " + storeType);
+                () -> "keystore.type Security property set: " + tmpStoreType);
         }
 
         f = new File("/etc/ssl/certs/java/cacerts");
@@ -351,15 +356,15 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
 
             if (requiredType != null && !requiredType.equals(storeType)) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "Skipping loading of system KeyStore, required type " +
-                    "does not match wolfjsse.keystore.type.required");
+                    () -> "Skipping loading of system KeyStore, required " +
+                    "type does not match wolfjsse.keystore.type.required");
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "Skipped loading: " + f.getAbsolutePath());
+                    () -> "Skipped loading: " + f.getAbsolutePath());
                 return null;
             }
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                   "Loading certs from " + f.getAbsolutePath());
+                   () -> "Loading certs from " + f.getAbsolutePath());
 
             if (tsPass != null) {
                 passArr = tsPass.toCharArray();
@@ -369,7 +374,7 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
                 stream = new FileInputStream(f);
             } catch (FileNotFoundException e) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "Not able to open KeyStore file for reading: " +
+                    () -> "Not able to open KeyStore file for reading: " +
                     f.getAbsolutePath());
             }
 
@@ -380,8 +385,8 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
             } catch (IOException | NoSuchAlgorithmException |
                      CertificateException | KeyStoreException e) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "Not able to get or load KeyStore with file stream: " +
-                    f.getAbsolutePath());
+                    () -> "Not able to get or load KeyStore with file " +
+                    "stream: " + f.getAbsolutePath());
                 sysStore = null;
 
             } finally {
@@ -395,7 +400,7 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
 
         } else {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "/etc/ssl/certs/java/cacerts: not found");
+                () -> "/etc/ssl/certs/java/cacerts: not found");
         }
 
         return sysStore;
@@ -421,7 +426,7 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
 
         if (requiredType != null && !requiredType.equals("AndroidCAStore")) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "Skipping loading of AndroidCAStore, required type " +
+                () -> "Skipping loading of AndroidCAStore, required type " +
                 "does not match wolfjsse.keystore.type.required");
             return null;
         }
@@ -432,7 +437,7 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
         } catch (KeyStoreException e) {
             /* Error finding AndroidCAStore */
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "AndroidCAStore KeyStore not found, not loading");
+                () -> "AndroidCAStore KeyStore not found, not loading");
             return null;
         }
 
@@ -440,12 +445,12 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
             sysStore.load(null, null);
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "Using AndroidCAStore KeyStore for default system certs");
+                () -> "Using AndroidCAStore KeyStore for default system certs");
 
         } catch (IOException | NoSuchAlgorithmException |
                  CertificateException e) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "Not able to load AndroidCAStore with null args");
+                () -> "Not able to load AndroidCAStore with null args");
             return null;
         }
 
@@ -471,7 +476,7 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
         CertificateFactory cfactory = null;
         ByteArrayInputStream bis = null;
         Certificate tmpCert = null;
-        String storeType = null;
+        final String storeType;
         String androidRoot = System.getenv("ANDROID_ROOT");
 
         if (androidRoot != null) {
@@ -488,7 +493,7 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
             } catch (KeyStoreException e) {
                 /* Unable to get or load empty KeyStore type */
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "Unable to get or load KeyStore instance, type: " +
+                    () -> "Unable to get or load KeyStore instance, type: " +
                     storeType);
                 return null;
             }
@@ -499,7 +504,7 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
             } catch (IOException | NoSuchAlgorithmException |
                      CertificateException e) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "Not able to load BKS KeyStore with null args");
+                    () -> "Not able to load BKS KeyStore with null args");
                 return null;
             }
 
@@ -511,11 +516,11 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
 
             String caStoreDir = androidRoot.concat("etc/security/cacerts");
             File cadir = new File(caStoreDir);
-            String[] cafiles = null;
+            final String[] cafiles;
 
             if (cadir == null) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "Unable to open etc/security/cacerts, none loaded");
+                    () -> "Unable to open etc/security/cacerts, none loaded");
                 return null;
             }
 
@@ -523,13 +528,13 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
                 cafiles = cadir.list();
                 if (cafiles != null) {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "Found " + cafiles.length +
+                        () -> "Found " + cafiles.length +
                         " CA files to load into KeyStore");
                 }
             } catch (Exception e) {
                 /* Denied access reading cacerts directory */
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.ERROR,
-                    "Permission error when trying to read system " +
+                    () -> "Permission error when trying to read system " +
                     "CA certificates");
                 return null;
             }
@@ -539,7 +544,7 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
                 cfactory = CertificateFactory.getInstance("X.509");
             } catch (CertificateException e) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "Not able to get X.509 CertificateFactory instance");
+                    () -> "Not able to get X.509 CertificateFactory instance");
                 return null;
             }
 
@@ -554,9 +559,10 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
                     certPem = new WolfSSLCertificate(
                         fullCertPath, WolfSSL.SSL_FILETYPE_PEM);
                 } catch (WolfSSLException we) {
+                    final String tmpPath = fullCertPath;
                     /* skip, error parsing PEM */
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "Skipped loading cert: " + fullCertPath);
+                        () -> "Skipped loading cert: " + tmpPath);
                     if (certPem != null) {
                         certPem.free();
                     }
@@ -566,9 +572,10 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
                 try {
                     derArray = certPem.getDer();
                 } catch (WolfSSLJNIException e) {
+                    final String tmpPath = fullCertPath;
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "Error getting DER from PEM cert, skipping: " +
-                        fullCertPath);
+                        () -> "Error getting DER from PEM cert, skipping: " +
+                        tmpPath);
                 } finally {
                     certPem.free();
                 }
@@ -579,10 +586,11 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
                     tmpCert = cfactory.generateCertificate(bis);
 
                 } catch (CertificateException ce) {
+                    final String tmpPath = fullCertPath;
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.ERROR,
-                        "Error generating certificate from " +
+                        () -> "Error generating certificate from " +
                         "ByteArrayInputStream, skipped loading cert: " +
-                        fullCertPath);
+                        tmpPath);
                     continue;
 
                 } finally {
@@ -598,10 +606,11 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
                 try {
                     sysStore.setCertificateEntry(aliasString, tmpCert);
                 } catch (KeyStoreException kse) {
+                    final String tmpPath = fullCertPath;
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.ERROR,
-                        "Error setting certificate entry in " +
+                        () -> "Error setting certificate entry in " +
                         "KeyStore, skipping loading cert: " +
-                        fullCertPath);
+                        tmpPath);
                     continue;
                 }
 
@@ -612,7 +621,7 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
             if (aliasCnt == 0) {
                 /* No certs loaded, don't return empty KeyStore */
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    "No root certificates loaded from etc/security/cacerts");
+                    () -> "No root certificates loaded from etc/security/cacerts");
                 return null;
             }
         }
@@ -651,35 +660,35 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
     protected void engineInit(KeyStore in) throws KeyStoreException {
 
         KeyStore certs = in;
-        String javaHome = null;
-        boolean wksAvailable = false;
+        final String javaHome;
+        final boolean wksAvailable;
         String pass = System.getProperty("javax.net.ssl.trustStorePassword");
         String file = System.getProperty("javax.net.ssl.trustStore");
         String type = System.getProperty("javax.net.ssl.trustStoreType");
-        String requiredType = null;
+        final String requiredType;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered engineInit(KeyStore in)");
+            () -> "entered engineInit(KeyStore in)");
 
         requiredType = WolfSSLUtil.getRequiredKeyStoreType();
         if (requiredType != null) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "java.security has restricted KeyStore type");
+                () -> "java.security has restricted KeyStore type");
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "wolfjsse.keystore.type.required = " + requiredType);
+                () -> "wolfjsse.keystore.type.required = " + requiredType);
         }
 
         /* [1] Just use KeyStore passed in by user if available */
         if (in == null) {
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "input KeyStore null, trying to load system CA certs");
+                () -> "input KeyStore null, trying to load system CA certs");
 
             /* Check if wolfJCE WKS KeyStore is registered and available */
             wksAvailable = WolfSSLUtil.WKSAvailable();
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "wolfJCE WKS KeyStore type available: " + wksAvailable);
+                () -> "wolfJCE WKS KeyStore type available: " + wksAvailable);
 
             /* [2] Try to load from system property details */
             certs = LoadKeyStoreFromSystemProperties(
@@ -690,12 +699,15 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
                 javaHome = WolfSSLUtil.GetJavaHome();
                 if (javaHome == null) {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "$JAVA_HOME not set, unable to load system CA certs");
+                        () -> "$JAVA_HOME not set, unable to load system " +
+                        "CA certs");
                 }
                 else {
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                        "$JAVA_HOME = " + javaHome);
+                        () -> "$JAVA_HOME = " + javaHome);
                 }
+            } else {
+                javaHome = null;
             }
 
             /* [3] Try to load system jssecacerts */
@@ -728,7 +740,7 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
         }
         else {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "input KeyStore provided, using for trusted certs");
+                () -> "input KeyStore provided, using for trusted certs");
         }
 
         /* Verify KeyStore we got matches our requirements, for example
@@ -747,7 +759,7 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
         throws InvalidAlgorithmParameterException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered engineInit(ManagerFactoryParameters arg0)");
+            () -> "entered engineInit(ManagerFactoryParameters arg0)");
 
         throw new UnsupportedOperationException(
             "TrustManagerFactory.init(ManagerFactoryParameters) " +
@@ -759,11 +771,11 @@ public class WolfSSLTrustManager extends TrustManagerFactorySpi {
         throws IllegalStateException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered engineGetTrustManagers()");
+            () -> "entered engineGetTrustManagers()");
 
         if (!this.initialized) {
             throw new IllegalStateException("TrustManagerFactory must be " +
-                    "initialized before use, please call init()");
+                "initialized before use, please call init()");
         }
 
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLUtil.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLUtil.java
@@ -81,10 +81,11 @@ public class WolfSSLUtil {
             Security.getProperty("jdk.tls.disabledAlgorithms");
         List<?> disabledList = null;
 
+        final String tmpDisabledAlgos = disabledAlgos;
         WolfSSLDebug.log(WolfSSLUtil.class, WolfSSLDebug.INFO,
-            "sanitizing enabled protocols");
+            () -> "sanitizing enabled protocols");
         WolfSSLDebug.log(WolfSSLUtil.class, WolfSSLDebug.INFO,
-            "jdk.tls.disabledAlgorithms: " + disabledAlgos);
+            () -> "jdk.tls.disabledAlgorithms: " + tmpDisabledAlgos);
 
         /* If WolfSSL.INVALID is passed in as currentVersion, no filtering
          * is done based on current protocol */
@@ -149,10 +150,11 @@ public class WolfSSLUtil {
             return suites;
         }
 
+        final String tmpSuites = enabledSuites;
         WolfSSLDebug.log(WolfSSLUtil.class, WolfSSLDebug.INFO,
-            "sanitizing enabled cipher suites");
+            () -> "sanitizing enabled cipher suites");
         WolfSSLDebug.log(WolfSSLUtil.class, WolfSSLDebug.INFO,
-            "wolfjsse.enabledCipherSuites: " + enabledSuites);
+            () -> "wolfjsse.enabledCipherSuites: " + tmpSuites);
 
         /* Remove spaces after commas, split into List */
         enabledSuites = enabledSuites.replaceAll(", ",",");
@@ -204,10 +206,11 @@ public class WolfSSLUtil {
             return null;
         }
 
+        final String tmpSigAlgos = sigAlgos;
         WolfSSLDebug.log(WolfSSLUtil.class, WolfSSLDebug.INFO,
-            "restricting enabled ClientHello signature algorithms");
+            () -> "restricting enabled ClientHello signature algorithms");
         WolfSSLDebug.log(WolfSSLUtil.class, WolfSSLDebug.INFO,
-            "wolfjsse.enabledSigAlgos: " + sigAlgos);
+            () -> "wolfjsse.enabledSigAlgos: " + tmpSigAlgos);
 
         /* Remove spaces between colons if present */
         sigAlgos = sigAlgos.replaceAll(" : ", ":");
@@ -231,10 +234,11 @@ public class WolfSSLUtil {
             return null;
         }
 
+        final String tmpCurves = curves;
         WolfSSLDebug.log(WolfSSLUtil.class, WolfSSLDebug.INFO,
-            "restricting enabled ClientHello supported curves");
+            () -> "restricting enabled ClientHello supported curves");
         WolfSSLDebug.log(WolfSSLUtil.class, WolfSSLDebug.INFO,
-            "wolfjsse.enabledSupportedCurves: " + curves);
+            () -> "wolfjsse.enabledSupportedCurves: " + tmpCurves);
 
         /* Remove spaces between commas if present */
         curves = curves.replaceAll(", ", ",");
@@ -396,12 +400,13 @@ public class WolfSSLUtil {
                 match = p.matcher(s);
                 if (match.find()) {
                     ret = Integer.parseInt(match.group());
+                    final int tmpRet = ret;
                     WolfSSLDebug.log(WolfSSLUtil.class, WolfSSLDebug.INFO,
-                        algo + " key size limitation found " +
-                        "[jdk.tls.disabledAlgorithms]: " + ret);
+                        () -> algo + " key size limitation found " +
+                        "[jdk.tls.disabledAlgorithms]: " + tmpRet);
                 }
             }
-        } 
+        }
 
         return ret;
     }
@@ -490,7 +495,7 @@ public class WolfSSLUtil {
 
             } catch (Exception e) {
                 WolfSSLDebug.log(WolfSSLUtil.class, WolfSSLDebug.ERROR,
-                   "Error initializing KeyStore with load(null, null)");
+                    () -> "Error initializing KeyStore with load(null, null)");
                 return null;
             }
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLX509.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLX509.java
@@ -86,7 +86,7 @@ public class WolfSSLX509 extends X509Certificate {
         this.cert = new WolfSSLCertificate(der);
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "created new WolfSSLX509(byte[] der)");
+            () -> "created new WolfSSLX509(byte[] der)");
     }
 
     /**
@@ -101,7 +101,7 @@ public class WolfSSLX509 extends X509Certificate {
         this.cert = new WolfSSLCertificate(derName);
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "created new WolfSSLX509(String derName)");
+            () -> "created new WolfSSLX509(String derName)");
     }
 
     /**
@@ -120,7 +120,7 @@ public class WolfSSLX509 extends X509Certificate {
         this.cert = new WolfSSLCertificate(x509, doFree);
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "created new WolfSSLX509(long x509, boolean doFree)");
+            () -> "created new WolfSSLX509(long x509, boolean doFree)");
     }
 
     @Override
@@ -128,7 +128,7 @@ public class WolfSSLX509 extends X509Certificate {
         throws CertificateExpiredException, CertificateNotYetValidException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered checkValidity()");
+            () -> "entered checkValidity()");
 
         this.checkValidity(new Date());
     }
@@ -138,7 +138,7 @@ public class WolfSSLX509 extends X509Certificate {
         throws CertificateExpiredException, CertificateNotYetValidException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered checkValidity(Date date)");
+            () -> "entered checkValidity(Date date)");
 
         if (this.cert == null) {
             throw new CertificateExpiredException();
@@ -159,7 +159,7 @@ public class WolfSSLX509 extends X509Certificate {
     public int getVersion() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getVersion()");
+            () -> "entered getVersion()");
 
         if (this.cert == null) {
             return 0;
@@ -171,7 +171,7 @@ public class WolfSSLX509 extends X509Certificate {
     public BigInteger getSerialNumber() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getSerialNumber()");
+            () -> "entered getSerialNumber()");
 
         if (this.cert == null) {
             return null;
@@ -183,7 +183,7 @@ public class WolfSSLX509 extends X509Certificate {
     public Principal getIssuerDN() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getIssuerDN()");
+            () -> "entered getIssuerDN()");
 
         if (this.cert == null) {
             return null;
@@ -196,7 +196,7 @@ public class WolfSSLX509 extends X509Certificate {
     public Principal getSubjectDN() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getSubjectDN()");
+            () -> "entered getSubjectDN()");
 
         if (this.cert == null) {
             return null;
@@ -209,7 +209,7 @@ public class WolfSSLX509 extends X509Certificate {
     public Date getNotBefore() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getNotBefore()");
+            () -> "entered getNotBefore()");
 
         if (this.cert == null) {
             return null;
@@ -221,7 +221,7 @@ public class WolfSSLX509 extends X509Certificate {
     public Date getNotAfter() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getNotAfter()");
+            () -> "entered getNotAfter()");
 
         if (this.cert == null) {
             return null;
@@ -233,7 +233,7 @@ public class WolfSSLX509 extends X509Certificate {
     public byte[] getTBSCertificate() throws CertificateEncodingException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getTBSCertificate()");
+            () -> "entered getTBSCertificate()");
 
         if (this.cert == null) {
             return null;
@@ -245,7 +245,7 @@ public class WolfSSLX509 extends X509Certificate {
     public byte[] getSignature() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getSignature()");
+            () -> "entered getSignature()");
 
         if (this.cert == null) {
             return null;
@@ -257,7 +257,7 @@ public class WolfSSLX509 extends X509Certificate {
     public String getSigAlgName() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getSigAlgName()");
+            () -> "entered getSigAlgName()");
 
         if (this.cert == null) {
             return null;
@@ -269,7 +269,7 @@ public class WolfSSLX509 extends X509Certificate {
     public String getSigAlgOID() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getSigAlgOID()");
+            () -> "entered getSigAlgOID()");
 
         if (this.cert == null) {
             return null;
@@ -281,7 +281,7 @@ public class WolfSSLX509 extends X509Certificate {
     public byte[] getSigAlgParams() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getSigAlgParams()");
+            () -> "entered getSigAlgParams()");
 
         throw new UnsupportedOperationException(
             "X509Certificate.getSigAlgParams() not supported yet");
@@ -291,7 +291,7 @@ public class WolfSSLX509 extends X509Certificate {
     public boolean[] getIssuerUniqueID() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getIssuerUniqueID()");
+            () -> "entered getIssuerUniqueID()");
 
         throw new UnsupportedOperationException(
             "X509Certificate.getIssuerUniqueID() not supported yet");
@@ -301,7 +301,7 @@ public class WolfSSLX509 extends X509Certificate {
     public boolean[] getSubjectUniqueID() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getSubjectUniqueID()");
+            () -> "entered getSubjectUniqueID()");
 
         throw new UnsupportedOperationException(
             "X509Certificate.getSubjectUniqueID() not supported yet");
@@ -311,7 +311,7 @@ public class WolfSSLX509 extends X509Certificate {
     public boolean[] getKeyUsage() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getKeyUsage()");
+            () -> "entered getKeyUsage()");
 
         if (this.cert == null) {
             return null;
@@ -323,7 +323,7 @@ public class WolfSSLX509 extends X509Certificate {
     public int getBasicConstraints() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getBasicConstraints()");
+            () -> "entered getBasicConstraints()");
 
         if (this.cert == null) {
             return 0;
@@ -342,7 +342,7 @@ public class WolfSSLX509 extends X509Certificate {
     public byte[] getEncoded() throws CertificateEncodingException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getEncoded()");
+            () -> "entered getEncoded()");
 
         if (this.cert == null) {
             return null;
@@ -365,7 +365,7 @@ public class WolfSSLX509 extends X509Certificate {
         throws CertificateParsingException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getSubjectAlternativeNames()");
+            () -> "entered getSubjectAlternativeNames()");
 
         if (this.cert == null) {
             return null;
@@ -381,7 +381,7 @@ public class WolfSSLX509 extends X509Certificate {
         boolean ret;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered verify(PublicKey key)");
+            () -> "entered verify(PublicKey key)");
 
         if (key == null) {
             throw new InvalidKeyException();
@@ -407,7 +407,7 @@ public class WolfSSLX509 extends X509Certificate {
         byte[] sigBuf;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered verify(PublicKey key, String sigProvider)");
+            () -> "entered verify(PublicKey key, String sigProvider)");
 
         if (key == null || sigProvider == null) {
             throw new InvalidKeyException();
@@ -440,7 +440,7 @@ public class WolfSSLX509 extends X509Certificate {
         byte[] sigBuf;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered verify(PublicKey key, Provider p)");
+            () -> "entered verify(PublicKey key, Provider p)");
 
         if (key == null || p == null) {
             throw new InvalidKeyException();
@@ -473,7 +473,7 @@ public class WolfSSLX509 extends X509Certificate {
     public String toString() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered toString()");
+            () -> "entered toString()");
 
         if (this.cert == null) {
             /* return empty string instead of null */
@@ -506,7 +506,7 @@ public class WolfSSLX509 extends X509Certificate {
         X509EncodedKeySpec spec = null;
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getPublicKey()");
+            () -> "entered getPublicKey()");
 
         if (this.cert == null) {
             return null;
@@ -542,7 +542,7 @@ public class WolfSSLX509 extends X509Certificate {
     public boolean hasUnsupportedCriticalExtension() {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered hasUnsupportedCriticalExtension()");
+            () -> "entered hasUnsupportedCriticalExtension()");
 
         /* @TODO further testing*/
         return false;
@@ -554,7 +554,7 @@ public class WolfSSLX509 extends X509Certificate {
         Set<String> ret = new TreeSet<String>();
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getCriticalExtensionOIDs()");
+            () -> "entered getCriticalExtensionOIDs()");
 
         if (this.cert == null) {
             return null;
@@ -578,7 +578,7 @@ public class WolfSSLX509 extends X509Certificate {
         Set<String> ret = new TreeSet<String>();
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getNonCriticalExtensionOIDs()");
+            () -> "entered getNonCriticalExtensionOIDs()");
 
         if (this.cert == null) {
             return null;
@@ -599,7 +599,7 @@ public class WolfSSLX509 extends X509Certificate {
     public byte[] getExtensionValue(String oid) {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "entered getExtensionValue()");
+            () -> "entered getExtensionValue()");
 
         if (this.cert == null) {
             return null;
@@ -704,14 +704,14 @@ public class WolfSSLX509 extends X509Certificate {
             this.name = reformatList(in);
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "created new WolfSSLPrincipal");
+                () -> "created new WolfSSLPrincipal");
         }
 
         @Override
         public String getName() {
 
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                "entered getName()");
+                () -> "entered getName()");
 
             return this.name;
         }

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLX509X.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLX509X.java
@@ -54,7 +54,7 @@ public class WolfSSLX509X extends X509Certificate {
     public WolfSSLX509X(byte[] der) throws WolfSSLException{
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "created new WolfSSLX509X(byte[] der)");
+            () -> "created new WolfSSLX509X(byte[] der)");
 
         this.cert = new WolfSSLX509(der);
     }
@@ -69,7 +69,7 @@ public class WolfSSLX509X extends X509Certificate {
     public WolfSSLX509X(String derName) throws WolfSSLException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "created new WolfSSLX509X(String derName)");
+            () -> "created new WolfSSLX509X(String derName)");
 
         this.cert = new WolfSSLX509(derName);
     }
@@ -88,7 +88,7 @@ public class WolfSSLX509X extends X509Certificate {
     public WolfSSLX509X(long x509, boolean doFree) throws WolfSSLException {
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            "created new WolfSSLX509X(long x509, boolean doFree)");
+            () -> "created new WolfSSLX509X(long x509, boolean doFree)");
 
         this.cert = new WolfSSLX509(x509, doFree);
     }
@@ -219,3 +219,4 @@ public class WolfSSLX509X extends X509Certificate {
     }
 
 }
+

--- a/src/test/com/wolfssl/test/WolfSSLSessionTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLSessionTest.java
@@ -986,7 +986,7 @@ public class WolfSSLSessionTest {
         WolfSSLSession cliSes = null;
 
         ByteArrayOutputStream outStream = null;
-        PrintStream originalSysOut = System.out;
+        PrintStream originalSysErr = System.err;
 
         /* Create client/server WolfSSLContext objects, Server context
          * must be final since used inside inner class. */
@@ -1005,17 +1005,15 @@ public class WolfSSLSessionTest {
         String originalProp = System.getProperty("wolfssljni.debug");
         System.setProperty("wolfssljni.debug", "true");
 
+        /* Set up output stream and redirect System.err */
+        outStream = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(outStream));
+
         /* Refresh debug flags, since WolfSSLDebug static class has already
          * been intiailzed before and static class variables have been set. */
         WolfSSLDebug.refreshDebugFlags();
 
         try {
-            /* wolfSSL JNI debug logs are printed to stdout via
-             * System.out.println(). Redirect stdout so we can check output, and
-             * it doesn't clutter up ant test output. */
-            outStream = new ByteArrayOutputStream();
-            System.setOut(new PrintStream(outStream));
-
             /* Create ServerSocket first to get ephemeral port */
             final ServerSocket srvSocket = new ServerSocket(0);
 
@@ -1144,7 +1142,7 @@ public class WolfSSLSessionTest {
 
             /* Restore original property value */
             if (originalProp == null || originalProp.isEmpty()) {
-                System.setProperty("wolfssljni.debug", "");
+                System.setProperty("wolfssljni.debug", "false");
             }
             else {
                 System.setProperty("wolfssljni.debug", originalProp);
@@ -1153,8 +1151,8 @@ public class WolfSSLSessionTest {
             /* Refresh debug flags */
             WolfSSLDebug.refreshDebugFlags();
 
-            /* Restore System.out direction */
-            System.setOut(originalSysOut);
+            /* Restore System.err direction */
+            System.setErr(originalSysErr);
 
             /* Verify we have debug output and some expected strings */
             if (outStream == null) {


### PR DESCRIPTION
This PR switches wolfssljni to use the Java Logging (`java.util.logging`) framework instead of using plain `System.out.println()` statements.

Using `System.out.println()` is not ideal for performance nor memory usage, since Strings are always allocated even if debug logging is disabled. Using Java Logging, and switching debug calls to use lambda style defers String allocation/creation until the debug log is actually used/printed.

Using `tls-channel` and benchmarking SSLEngine throughput when transferring large amounts of data, this is a performance optimization that builds upon https://github.com/wolfSSL/wolfssljni/pull/257.  With these debug changes, throughput performance is increased by an additional 26.8%.