### PR TITLE
Get ASN algorithm enum values dynamically in `WolfSSL.java`

### DIFF
--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -434,6 +434,117 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSL_nativeFree
     }
 }
 
+/* Functions to get native NID enum values. These must be dynamically
+ * obtained since the native wolfSSL values can change depending on
+ * wolfSSL configuration. */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getNID_1surname
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+    return NID_surname;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getNID_1serialNumber
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+    return NID_serialNumber;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getNID_1pkcs9_1unstructuredName
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+    return NID_pkcs9_unstructuredName;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getNID_1pkcs9_1contentType
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+    return NID_pkcs9_contentType;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getNID_1pkcs9_1challengePassword
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+    return NID_pkcs9_challengePassword;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getNID_1givenName
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+    return NID_givenName;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getNID_1initials
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+    return NID_initials;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getNID_1key_1usage
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+    return NID_key_usage;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getNID_1subject_1alt_1name
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+    return NID_subject_alt_name;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getNID_1basic_1constraints
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+    return NID_basic_constraints;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getNID_1ext_1key_1usage
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+    return NID_ext_key_usage;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getNID_1dnQualifier
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+    return NID_dnQualifier;
+}
+
 /* functions to return BulkCipherAlgorithm enum values from ./wolfssl/ssl.h  */
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getBulkCipherAlgorithmEnumNULL
   (JNIEnv* jenv, jclass jcl)
@@ -577,6 +688,42 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getHmacEnumSHA512
     (void)jcl;
 
     return WC_HASH_TYPE_SHA512;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getKeyTypeEnumDSA
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+    return DSAk;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getKeyTypeEnumRSA
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+    return RSAk;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getKeyTypeEnumECDSA
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+    return ECDSAk;
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getKeyTypeEnumED25519
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+    return ED25519k;
 }
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getTls13SecretEnum_1CLIENT_1EARLY_1TRAFFIC_1SECRET

--- a/native/com_wolfssl_WolfSSL.h
+++ b/native/com_wolfssl_WolfSSL.h
@@ -207,16 +207,6 @@ extern "C" {
 #define com_wolfssl_WolfSSL_NO_PASSWORD -176L
 #undef com_wolfssl_WolfSSL_TLS13_SECRET_CB_E
 #define com_wolfssl_WolfSSL_TLS13_SECRET_CB_E -438L
-#undef com_wolfssl_WolfSSL_DSAk
-#define com_wolfssl_WolfSSL_DSAk 515L
-#undef com_wolfssl_WolfSSL_RSAk
-#define com_wolfssl_WolfSSL_RSAk 645L
-#undef com_wolfssl_WolfSSL_NTRUk
-#define com_wolfssl_WolfSSL_NTRUk 274L
-#undef com_wolfssl_WolfSSL_ECDSAk
-#define com_wolfssl_WolfSSL_ECDSAk 518L
-#undef com_wolfssl_WolfSSL_ED25519k
-#define com_wolfssl_WolfSSL_ED25519k 256L
 #undef com_wolfssl_WolfSSL_ASN_OTHER_TYPE
 #define com_wolfssl_WolfSSL_ASN_OTHER_TYPE 0L
 #undef com_wolfssl_WolfSSL_ASN_RFC822_TYPE
@@ -229,30 +219,6 @@ extern "C" {
 #define com_wolfssl_WolfSSL_ASN_URI_TYPE 6L
 #undef com_wolfssl_WolfSSL_ASN_IP_TYPE
 #define com_wolfssl_WolfSSL_ASN_IP_TYPE 7L
-#undef com_wolfssl_WolfSSL_NID_surname
-#define com_wolfssl_WolfSSL_NID_surname 4L
-#undef com_wolfssl_WolfSSL_NID_serialNumber
-#define com_wolfssl_WolfSSL_NID_serialNumber 5L
-#undef com_wolfssl_WolfSSL_NID_pkcs9_unstructuredName
-#define com_wolfssl_WolfSSL_NID_pkcs9_unstructuredName 49L
-#undef com_wolfssl_WolfSSL_NID_pkcs9_contentType
-#define com_wolfssl_WolfSSL_NID_pkcs9_contentType 50L
-#undef com_wolfssl_WolfSSL_NID_pkcs9_challengePassword
-#define com_wolfssl_WolfSSL_NID_pkcs9_challengePassword 54L
-#undef com_wolfssl_WolfSSL_NID_givenName
-#define com_wolfssl_WolfSSL_NID_givenName 100L
-#undef com_wolfssl_WolfSSL_NID_initials
-#define com_wolfssl_WolfSSL_NID_initials 101L
-#undef com_wolfssl_WolfSSL_NID_key_usage
-#define com_wolfssl_WolfSSL_NID_key_usage 129L
-#undef com_wolfssl_WolfSSL_NID_subject_alt_name
-#define com_wolfssl_WolfSSL_NID_subject_alt_name 131L
-#undef com_wolfssl_WolfSSL_NID_basic_constraints
-#define com_wolfssl_WolfSSL_NID_basic_constraints 133L
-#undef com_wolfssl_WolfSSL_NID_ext_key_usage
-#define com_wolfssl_WolfSSL_NID_ext_key_usage 151L
-#undef com_wolfssl_WolfSSL_NID_dnQualifier
-#define com_wolfssl_WolfSSL_NID_dnQualifier 174L
 #undef com_wolfssl_WolfSSL_WOLFSSL_NAMED_GROUP_INVALID
 #define com_wolfssl_WolfSSL_WOLFSSL_NAMED_GROUP_INVALID 0L
 #undef com_wolfssl_WolfSSL_WOLFSSL_ECC_SECT163K1
@@ -344,6 +310,102 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_init
  */
 JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSL_nativeFree
   (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getNID_surname
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getNID_1surname
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getNID_serialNumber
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getNID_1serialNumber
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getNID_pkcs9_unstructuredName
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getNID_1pkcs9_1unstructuredName
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getNID_pkcs9_contentType
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getNID_1pkcs9_1contentType
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getNID_pkcs9_challengePassword
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getNID_1pkcs9_1challengePassword
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getNID_givenName
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getNID_1givenName
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getNID_initials
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getNID_1initials
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getNID_key_usage
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getNID_1key_1usage
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getNID_subject_alt_name
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getNID_1subject_1alt_1name
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getNID_basic_constraints
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getNID_1basic_1constraints
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getNID_ext_key_usage
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getNID_1ext_1key_1usage
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getNID_dnQualifier
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getNID_1dnQualifier
+  (JNIEnv *, jclass);
 
 /*
  * Class:     com_wolfssl_WolfSSL
@@ -471,6 +533,38 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getHmacEnumSHA384
  * Signature: ()I
  */
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getHmacEnumSHA512
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getKeyTypeEnumDSA
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getKeyTypeEnumDSA
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getKeyTypeEnumRSA
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getKeyTypeEnumRSA
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getKeyTypeEnumECDSA
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getKeyTypeEnumECDSA
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
+ * Method:    getKeyTypeEnumED25519
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getKeyTypeEnumED25519
   (JNIEnv *, jclass);
 
 /*

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -420,15 +420,13 @@ public class WolfSSL {
 
     /* key types */
     /** DSA key type */
-    public static final int DSAk     = 515;
+    public static int DSAk;
     /** RSA key type */
-    public static final int RSAk     = 645;
-    /** NTRU key type */
-    public static final int NTRUk    = 274;
+    public static int RSAk;
     /** ECDSA key type */
-    public static final int ECDSAk   = 518;
+    public static int ECDSAk;
     /** Ed25519 key type */
-    public static final int ED25519k = 256;
+    public static int ED25519k;
 
     /* GeneralName types. Match native values in asn.h */
     /** ASN other type */
@@ -446,29 +444,29 @@ public class WolfSSL {
 
     /* NIDs, from native asn.h */
     /** Surname NID */
-    public static final int NID_surname                 = 4;
+    public static int NID_surname;
     /** Serial number NID */
-    public static final int NID_serialNumber            = 5;
+    public static int NID_serialNumber;
     /** PKCS9 Unstructured name NID */
-    public static final int NID_pkcs9_unstructuredName  = 49;
+    public static int NID_pkcs9_unstructuredName;
     /** PKCS9 contentType NID */
-    public static final int NID_pkcs9_contentType       = 50;
+    public static int NID_pkcs9_contentType;
     /** PKCS9 challenge password NID */
-    public static final int NID_pkcs9_challengePassword = 54;
+    public static int NID_pkcs9_challengePassword;
     /** Given name NID */
-    public static final int NID_givenName               = 100;
+    public static int NID_givenName;
     /** Initials NID */
-    public static final int NID_initials                = 101;
+    public static int NID_initials;
     /** Key Usage NID */
-    public static final int NID_key_usage               = 129;
+    public static int NID_key_usage;
     /** Subject Alternative Name NID */
-    public static final int NID_subject_alt_name        = 131;
+    public static int NID_subject_alt_name;
     /** Basic Constraints NID */
-    public static final int NID_basic_constraints       = 133;
+    public static int NID_basic_constraints;
     /** Extended Key Usage NID */
-    public static final int NID_ext_key_usage           = 151;
+    public static int NID_ext_key_usage;
     /** Domain name qualifier NID */
-    public static final int NID_dnQualifier             = 174;
+    public static int NID_dnQualifier;
 
     /* is this object active, or has it been cleaned up? */
     private boolean active = false;
@@ -591,6 +589,20 @@ public class WolfSSL {
                 "Failed to initialize wolfSSL library: " + ret);
         }
 
+        /* Populate NID values from native wolfSSL enums */
+        NID_surname = getNID_surname();
+        NID_serialNumber = getNID_serialNumber();
+        NID_pkcs9_unstructuredName = getNID_pkcs9_unstructuredName();
+        NID_pkcs9_contentType = getNID_pkcs9_contentType();
+        NID_pkcs9_challengePassword = getNID_pkcs9_challengePassword();
+        NID_givenName = getNID_givenName();
+        NID_initials = getNID_initials();
+        NID_key_usage = getNID_key_usage();
+        NID_subject_alt_name = getNID_subject_alt_name();
+        NID_basic_constraints = getNID_basic_constraints();
+        NID_ext_key_usage = getNID_ext_key_usage();
+        NID_dnQualifier = getNID_dnQualifier();
+
         /* initialize cipher enum values */
         wolfssl_aes         = getBulkCipherAlgorithmEnumAES();
         wolfssl_cipher_null = getBulkCipherAlgorithmEnumNULL();
@@ -608,6 +620,12 @@ public class WolfSSL {
         SHA256 = getHmacEnumSHA256();
         SHA384 = getHmacEnumSHA384();
         SHA512 = getHmacEnumSHA512();
+
+        /* initialize key type enum values */
+        DSAk     = getKeyTypeEnumDSA();
+        RSAk     = getKeyTypeEnumRSA();
+        ECDSAk   = getKeyTypeEnumECDSA();
+        ED25519k = getKeyTypeEnumED25519();
 
         /* initialize TLS 1.3 secret callback ID enums */
         CLIENT_EARLY_TRAFFIC_SECRET =
@@ -641,6 +659,19 @@ public class WolfSSL {
      */
     public static native void nativeFree(long ptr);
 
+    static native int getNID_surname();
+    static native int getNID_serialNumber();
+    static native int getNID_pkcs9_unstructuredName();
+    static native int getNID_pkcs9_contentType();
+    static native int getNID_pkcs9_challengePassword();
+    static native int getNID_givenName();
+    static native int getNID_initials();
+    static native int getNID_key_usage();
+    static native int getNID_subject_alt_name();
+    static native int getNID_basic_constraints();
+    static native int getNID_ext_key_usage();
+    static native int getNID_dnQualifier();
+
     static native int getBulkCipherAlgorithmEnumNULL();
     static native int getBulkCipherAlgorithmEnumRC4();
     static native int getBulkCipherAlgorithmEnumRC2();
@@ -658,6 +689,11 @@ public class WolfSSL {
     static native int getHmacEnumSHA256();
     static native int getHmacEnumSHA384();
     static native int getHmacEnumSHA512();
+
+    static native int getKeyTypeEnumDSA();
+    static native int getKeyTypeEnumRSA();
+    static native int getKeyTypeEnumECDSA();
+    static native int getKeyTypeEnumED25519();
 
     static native int getTls13SecretEnum_CLIENT_EARLY_TRAFFIC_SECRET();
     static native int getTls13SecretEnum_CLIENT_HANDSHAKE_TRAFFIC_SECRET();

--- a/src/java/com/wolfssl/WolfSSLCertRequest.java
+++ b/src/java/com/wolfssl/WolfSSLCertRequest.java
@@ -332,15 +332,12 @@ public class WolfSSLCertRequest {
                 "Invalid key format, must be PEM or DER");
         }
 
-        switch (keyType) {
-            case WolfSSL.RSAk:
-                evpKeyType = EVP_PKEY_RSA;
-                break;
-            case WolfSSL.ECDSAk:
-                evpKeyType = EVP_PKEY_EC;
-                break;
-            default:
-                throw new WolfSSLException("Unsupported public key type");
+        if (keyType == WolfSSL.RSAk) {
+            evpKeyType = EVP_PKEY_RSA;
+        } else if (keyType == WolfSSL.ECDSAk) {
+            evpKeyType = EVP_PKEY_EC;
+        } else {
+            throw new WolfSSLException("Unsupported public key type");
         }
 
         synchronized (x509ReqLock) {
@@ -640,15 +637,12 @@ public class WolfSSLCertRequest {
                 "Invalid key format, must be PEM or DER");
         }
 
-        switch (keyType) {
-            case WolfSSL.RSAk:
-                evpKeyType = EVP_PKEY_RSA;
-                break;
-            case WolfSSL.ECDSAk:
-                evpKeyType = EVP_PKEY_EC;
-                break;
-            default:
-                throw new WolfSSLException("Unsupported private key type");
+        if (keyType == WolfSSL.RSAk) {
+            evpKeyType = EVP_PKEY_RSA;
+        } else if (keyType == WolfSSL.ECDSAk) {
+            evpKeyType = EVP_PKEY_EC;
+        } else {
+            throw new WolfSSLException("Unsupported private key type");
         }
 
         synchronized (x509ReqLock) {

--- a/src/java/com/wolfssl/WolfSSLCertificate.java
+++ b/src/java/com/wolfssl/WolfSSLCertificate.java
@@ -622,15 +622,12 @@ public class WolfSSLCertificate implements Serializable {
                 "Invalid key format, must be PEM or DER");
         }
 
-        switch (keyType) {
-            case WolfSSL.RSAk:
-                evpKeyType = EVP_PKEY_RSA;
-                break;
-            case WolfSSL.ECDSAk:
-                evpKeyType = EVP_PKEY_EC;
-                break;
-            default:
-                throw new WolfSSLException("Unsupported public key type");
+        if (keyType == WolfSSL.RSAk) {
+            evpKeyType = EVP_PKEY_RSA;
+        } else if (keyType == WolfSSL.ECDSAk) {
+            evpKeyType = EVP_PKEY_EC;
+        } else {
+            throw new WolfSSLException("Unsupported public key type");
         }
 
         synchronized (x509Lock) {
@@ -1070,15 +1067,12 @@ public class WolfSSLCertificate implements Serializable {
                 "Invalid key format, must be PEM or DER");
         }
 
-        switch (keyType) {
-            case WolfSSL.RSAk:
-                evpKeyType = EVP_PKEY_RSA;
-                break;
-            case WolfSSL.ECDSAk:
-                evpKeyType = EVP_PKEY_EC;
-                break;
-            default:
-                throw new WolfSSLException("Unsupported private key type");
+        if (keyType == WolfSSL.RSAk) {
+            evpKeyType = EVP_PKEY_RSA;
+        } else if (keyType == WolfSSL.ECDSAk) {
+            evpKeyType = EVP_PKEY_EC;
+        } else {
+            throw new WolfSSLException("Unsupported private key type");
         }
 
         synchronized (x509Lock) {


### PR DESCRIPTION
This PR adjusts the `com.wolfssl.WolfSSL` class to dynamically get algorithm and key type ASN NID enum values (ex: RSAk, NID_surname, etc) instead of using hard-coded values. This is much more flexible in case these values change at the native level.

These hard coded values broke some unit tests after https://github.com/wolfSSL/wolfssl/commit/1e3718ea7b92b04d9d81dbf8e7d6032ca0a904cb was merged into native wolfSSL.