### PR TITLE
Use `-fPIC` on Aarch64, add GitHub Actions ARM with armasm test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,21 @@ jobs:
       jdk_version: ${{ matrix.jdk_version }}
       wolfssl_configure: ${{ matrix.wolfssl_configure }}
 
+  # Corretto JDK (Linux, Mac) Aarch64 with armasm
+  linux-corretto-aarch64-armasm:
+    strategy:
+      matrix:
+        os: [ 'ubuntu-24.04-arm' ]
+        jdk_version: [ '8', '11', '17', '21' ]
+        wolfssl_configure: [ '--enable-jni --enable-armasm' ]
+    name: ${{ matrix.os }} (Corretto JDK Aarch64 armasm ${{ matrix.jdk_version }}, ${{ matrix.wolfssl_configure}})
+    uses: ./.github/workflows/linux-common.yml
+    with:
+      os: ${{ matrix.os }}
+      jdk_distro: "corretto"
+      jdk_version: ${{ matrix.jdk_version }}
+      wolfssl_configure: ${{ matrix.wolfssl_configure }}
+
   # Temurin JDK (Linux, Mac)
   # JDK 8 seems to have been removed from Temurin macos, with 8 we see the error
   # Could not find satisfied version for SemVer '8'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,8 +10,8 @@
 
 # Code Style
 - Keep lines under 80 characters maximum length
-- Only use multi-line comments, no "//" style ones
-- Remove any trailing white space
+- MUST only use multi-line comments, no "//" style ones
+- MUST remove all trailing white space
 - Use 4 spaces for one tab, no hard tabs
 
 # Source Code Organization

--- a/java.sh
+++ b/java.sh
@@ -87,7 +87,7 @@ elif [ "$OS" == "Linux" ] ; then
     javaIncludes="-I$javaHome/include -I$javaHome/include/linux -I$WOLFSSL_INSTALL_DIR/include"
     javaLibs="-shared"
     jniLibName="libwolfssljni.so"
-    if [ "$ARCH" == "x86_64" ] ; then
+    if [ "$ARCH" == "x86_64" ] || [ "$ARCH" == "aarch64" ]; then
         fpic="-fPIC"
     else
         fpic=""


### PR DESCRIPTION
This PR:
- Adds `-fPIC` to CFLAGS in `.java.sh` for Aarch64 hosts
- Adds a GitHub action that uses the `ubuntu-24.04-arm` runner so we get a test with Aarch64 and `--enable-armasm`

Aarch64 test runners are now available as of Jan 2025: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/