### PR TITLE
Use static pool of direct ByteBuffers for WolfSSLSession read/write()

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,7 +431,14 @@ used as the default descriptor monitoring function.
 wolfJSSE allows for some customization through the `java.security` file
 and use of Security properties.
 
+#### Pre-Existing Java Security Properties
+
 Support is included for the following pre-existing Java Security properties.
+
+| System Property | Default | To Enable | Description |
+| --- | --- | --- | --- |
+| keystore.type | JKS | String | Specifies the default KeyStore type |
+| jdk.tls.disabledAlgorithms | | String | Disables algorithms, TLS protocol versions, and key lengths |
 
 **keystore.type (String)** - Specifies the default KeyStore type. This defaults
 to JKS, but could be set to something else if desired.
@@ -446,12 +453,60 @@ minimum RSA/ECC/DH key sizes. An example of potential use:
 jdk.tls.disabledAlgorithms=SSLv3, TLSv1.1, DH keySize < 1024, EC keySize < 224, RSA keySize < 1024
 ```
 
-The following custom wolfJSSE-specific Security property settings are supported.
-These can be placed into the `java.security` file and will be parsed and used
-by wolfJSSE.
+#### wolfSSL JNI/JSSE Specific Security Properties
+
+The following custom wolfSSL JNI/JSSE specific Security property settings are
+supported. These can be placed into the `java.security` file and will be parsed
+and used by wolfSSL JNI/JSSE.
+
+| System Property | Default | To Enable | Description |
+| --- | --- | --- | --- |
+| wolfssl.readWriteByteBufferPool.disabled | "false" | "true" | Disables the read/write ByteBuffer pool |
+| wolfssl.readWriteByteBufferPool.size | 16 | Integer | Sets the read/write per-thread ByteBuffer pool size |
+| wolfssl.readWriteByteBufferPool.bufferSize | 17408 | String | Sets the read/write per-thread ByteBuffer size |
+| wolfjsse.enabledCipherSuites | | String | Restricts enabled cipher suites |
+| wolfjsse.enabledSupportedCurves | | String | Restricts enabled ECC curves |
+| wolfjsse.enabledSignatureAlgorithms | | String | Restricts enabled signature algorithms |
+| wolfjsse.keystore.type.required | | String | Restricts KeyStore type |
+| wolfjsse.clientSessionCache.disabled | | "true" | Disables client session cache |
+
+**wolfssl.readWriteByteBufferPool.disabled (String)** - Can be used to disable
+the static per-thread ByteBuffer pool used in com.wolfssl.WolfSSLSession
+for native JNI wolfSS\_read() and wolfSSL\_write() calls. This pool is in place
+to prevent unaligned memory access at the JNI level when using byte array
+offsets. This pool is enabled by default unless explicitly disabled by setting
+this property to "true":
+
+```
+wolfssl.readWriteByteBufferPool.disabled=true
+```
+
+**wolfssl.readWriteByteBufferPool.size (Integer)** - Can be used to set the
+maximum per-thread ByteBuffer pool size. This is the maximum number of
+direct ByteBuffer objects that will be allocated and added to the pool. The
+pool starts at size 0, then grows as needed up to this maximum size. The
+default is 16. This should be set to a positive integer value:
+
+```
+wolfssl.readWriteByteBufferPool.size=16
+```
+
+**wolfssl.readWriteByteBufferPool.bufferSize (String)** - Can be used to set
+the size of each direct ByteBuffer in the static per-thread WolfSSLSession
+pool. This is set to 17k (17 * 1024) by default which allows for the maximum
+SSL/TLS record size of 2^14 (16k) plus some extra space for the record header
+overhead. This should be set to a positive integer value. This can be used
+to optimize performance if the size of data an application is reading/writing
+is known. If sized properly, fewer read/write loops will need to be done
+when calling native `wolfSSL_read()` and `wolfSSL_write()` inside
+com.wolfssl.WolfSSLSession read() and write() methods.
+
+```
+wolfssl.readWriteByteBufferPool.bufferSize=17408
+```
 
 **wolfjsse.enabledCipherSuites (String)** - Allows restriction of the enabled
-cipher suiets to those listed in this Security property. When set, applications
+cipher suites to those listed in this Security property. When set, applications
 wil not be able to override or add additional suites at runtime without
 changing this property. This should be a comma-delimited String. Example use:
 

--- a/native/com_wolfssl_WolfSSLSession.h
+++ b/native/com_wolfssl_WolfSSLSession.h
@@ -7,10 +7,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-#undef com_wolfssl_WolfSSLSession_MAX_POOL_SIZE
-#define com_wolfssl_WolfSSLSession_MAX_POOL_SIZE 32L
-#undef com_wolfssl_WolfSSLSession_BUFFER_SIZE
-#define com_wolfssl_WolfSSLSession_BUFFER_SIZE 17408L
 /*
  * Class:     com_wolfssl_WolfSSLSession
  * Method:    newSSL

--- a/native/com_wolfssl_WolfSSLSession.h
+++ b/native/com_wolfssl_WolfSSLSession.h
@@ -7,6 +7,10 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+#undef com_wolfssl_WolfSSLSession_MAX_POOL_SIZE
+#define com_wolfssl_WolfSSLSession_MAX_POOL_SIZE 32L
+#undef com_wolfssl_WolfSSLSession_BUFFER_SIZE
+#define com_wolfssl_WolfSSLSession_BUFFER_SIZE 17408L
 /*
  * Class:     com_wolfssl_WolfSSLSession
  * Method:    newSSL

--- a/native/com_wolfssl_WolfSSLSession.h
+++ b/native/com_wolfssl_WolfSSLSession.h
@@ -96,8 +96,16 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_connect
  * Method:    write
  * Signature: (J[BIII)I
  */
-JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_write
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_write__J_3BIII
   (JNIEnv *, jobject, jlong, jbyteArray, jint, jint, jint);
+
+/*
+ * Class:     com_wolfssl_WolfSSLSession
+ * Method:    write
+ * Signature: (JLjava/nio/ByteBuffer;IIZII)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_write__JLjava_nio_ByteBuffer_2IIZII
+  (JNIEnv *, jobject, jlong, jobject, jint, jint, jboolean, jint, jint);
 
 /*
  * Class:     com_wolfssl_WolfSSLSession

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -2895,8 +2895,9 @@ public class WolfSSLSocket extends SSLSocket {
                 if (ret < 0) {
                     /* print error description string */
                     String errStr = WolfSSL.getErrorString(err);
-                    throw new IOException("Native wolfSSL_write() error: "
-                            + errStr + " (error code: " + err + ")");
+                    throw new IOException("Native wolfSSL_write() error: " +
+                        errStr + " (ret: " + ret + ", error code: " +
+                        err + ")");
                 }
 
             } catch (IllegalStateException e) {


### PR DESCRIPTION
This PR introduces a static per-thread pool of direct ByteBuffers to the `com.wolfssl.WolfSSLSession` class, to be used with `read()` and `write()` calls.

The main reason this is needed is to avoid unaligned memory access in the native JNI code, where previously we were doing pointer addition with the offset (ex: `buffer + offset`), which could result in unaligned memory use.  Using unaligned memory on some platforms (ex: Aarch64) can have performance impacts.  This was observed on a Raspberry Pi 5 (Aarch64) and a customer platform.

Each static buffer pool is per-thread.  Each direct ByteBuffer in the pool is 17k (BUFFER_SIZE), and the maximum pool size per thread is 16.  We will introduce Java Security properties which can be used to tune these values, which will be helpful to customize performance and memory usage based on use case if needed.

New Security property support has been added to disable or customize this functionality:

`wolfssl.readWriteByteBufferPool.disabled` - Disables the read/write ByteBuffer pool
`wolfssl.readWriteByteBufferPool.size`  - Sets the read/write per-thread ByteBuffer pool size
`wolfssl.readWriteByteBufferPool.bufferSize` - Sets the read/write per-thread ByteBuffer size

ZD 19799