### PR TITLE
JSSE: get System/Security properties on class initialization for WolfSSLEngineHelper

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLParameters.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLParameters.java
@@ -159,7 +159,7 @@ final class WolfSSLParameters {
             return null;
         } else {
             return Collections.unmodifiableList(
-                    new ArrayList<WolfSSLSNIServerName>(this.serverNames));
+                new ArrayList<WolfSSLSNIServerName>(this.serverNames));
         }
     }
 


### PR DESCRIPTION
This PR refactors `WolfSSLEngineHelper` to get and cache System and Security properties on class creation in the constructor, instead of getting them each time at runtime during handshake/etc operations.  This was changed here specifically for `setLocalServerNames()`, where potential thread contention may occur in the Security class when multiple threads concurrently try to get the values of these properties.