### PR TITLE
JSSE: implement WolfSSLPrincipal.toString() inside WolfSSLX509

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLX509.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLX509.java
@@ -716,5 +716,11 @@ public class WolfSSLX509 extends X509Certificate {
             return this.name;
         }
 
+        @Override
+        public String toString() {
+            return getName();
+        }
+
+
     }
 }


### PR DESCRIPTION
This PR addresses https://github.com/wolfSSL/wolfssljni/issues/280, and implements the `toString()` method inside `WolfSSLPrincipal` (implements java.security.Principal).

Additional JUnit tests are added here to verify behavior correctness, as well as behavior of default `implies()` method implementation from `java.security.Principal`. Since this default behavior works for us, there is no need to re-implement in WolfSSLPrincipal.