### PR TITLE
JNI/JSSE: fix certificate order of array returned from WolfSSLX509StoreCtx.getCerts()

### DIFF
--- a/native/com_wolfssl_WolfSSLX509StoreCtx.c
+++ b/native/com_wolfssl_WolfSSLX509StoreCtx.c
@@ -93,7 +93,11 @@ JNIEXPORT jobjectArray JNICALL Java_com_wolfssl_WolfSSLX509StoreCtx_X509_1STORE_
             }
             XMEMCPY(buf, der, derSz);
             (*jenv)->ReleaseByteArrayElements(jenv, derArr, buf, 0);
-            (*jenv)->SetObjectArrayElement(jenv, certArr, i, derArr);
+            /* Reverse order, so peer cert is first in returned array,
+             * followed by intermediates, lastly by root. Native
+             * wolfSSL_X509_STORE_GetCerts() returns certs in order of
+             * root to peer, but Java/JSSE expects peer to root */
+            (*jenv)->SetObjectArrayElement(jenv, certArr, skNum-1-i, derArr);
             (*jenv)->DeleteLocalRef(jenv, derArr);
         }
     }

--- a/src/java/com/wolfssl/WolfSSLX509StoreCtx.java
+++ b/src/java/com/wolfssl/WolfSSLX509StoreCtx.java
@@ -79,6 +79,9 @@ public class WolfSSLX509StoreCtx {
      * Get certificates in WOLFSSL_X509_STORE_CTX as an array of
      * WolfSSLCertificate objects.
      *
+     * The certificate chain is returned in order of peer to root, with peer
+     * first, then any intermediates, then root last (if present).
+     *
      * @return array of certificates
      * @throws WolfSSLException on error
      * @throws IllegalStateException if object has been freed

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLInternalVerifyCb.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLInternalVerifyCb.java
@@ -274,7 +274,8 @@ public class WolfSSLInternalVerifyCb implements WolfSSLVerifyCallback {
         }
 
         try {
-            /* get WolfSSLCertificate[] from x509StorePtr */
+            /* Get WolfSSLCertificate[] from x509StorePtr, certs from
+             * store.getCerts() should be listed in order of peer to root */
             WolfSSLX509StoreCtx store =
                 new WolfSSLX509StoreCtx(x509StorePtr);
             certs = store.getCerts();


### PR DESCRIPTION
This PR fixes the `WolfSSLX509StoreCtx.freeCerts()` method to correctly return the certificate chain with peer cert first, followed by the rest of the chain.

Native wolfSSL `wolfSSL_X509_STORE_GetCerts()` returns certs in order of root to peer, but JSSE layer expects peer to root for internal verify callback and X509TrustManager.checkClient/ServerTrusted().

This showed up in a test against `httpbin.org:443`, where the reversed certificate order caused hostname verification to fail:

```
2025-07-29 22:26:50.348 [wolfJSSE INFO: TID 1: WolfSSLEngineHelper] calling native wolfSSL_connect()
2025-07-29 22:26:50.441 [wolfJSSE INFO: TID 1: WolfSSLInternalVerifyCb] Native wolfSSL peer verification passed (clientMode: true)
2025-07-29 22:26:50.442 [wolfJSSE INFO: TID 1: WolfSSLInternalVerifyCb] Peer cert: CN=Amazon Root CA 1, O=Amazon, C=US
2025-07-29 22:26:50.442 [wolfJSSE INFO: TID 1: WolfSSLInternalVerifyCb] Peer cert: CN=Amazon RSA 2048 M03, O=Amazon, C=US
2025-07-29 22:26:50.442 [wolfJSSE INFO: TID 1: WolfSSLInternalVerifyCb] Peer cert: CN=httpbin.org
2025-07-29 22:26:50.442 [wolfJSSE INFO: TID 1: WolfSSLInternalVerifyCb] Auth type: RSA
2025-07-29 22:26:50.442 [wolfJSSE INFO: TID 1: WolfSSLInternalVerifyCb] checking hostname verification using SSLSocket
2025-07-29 22:26:50.442 [wolfJSSE INFO: TID 1: WolfSSLTrustX509] entered verifyHostname, using SSLSocket for host info
2025-07-29 22:26:50.442 [wolfJSSE INFO: TID 1: WolfSSLSocket] entered getSSLParameters()
2025-07-29 22:26:50.443 [wolfJSSE INFO: TID 1: WolfSSLTrustX509] verifying hostname, endpoint identification algorithm = HTTPS
2025-07-29 22:26:50.444 [wolfJSSE INFO: TID 1: WolfSSLTrustX509] verifying hostname type HTTPS
2025-07-29 22:26:50.444 [wolfJSSE INFO: TID 1: WolfSSLSocket] entered getHandshakeSession()
2025-07-29 22:26:50.444 [wolfJSSE INFO: TID 1: WolfSSLImplementSSLSession] calling getRequestedServerNames (client)
2025-07-29 22:26:50.444 [wolfJSSE INFO: TID 1: WolfSSLTrustX509] trying hostname verification against SNI: httpbin.org
2025-07-29 22:26:50.445 [wolfJSSE INFO: TID 1: WolfSSLTrustX509] hostname match with SNI failed
```

This can be tested using the example JSSE client against httpbin.org.  This fails before this PR, and passes with it:

```
./java.sh
ant
ant examples

./examples/provider/ClientJSSE.sh -h httpbin.org -p 443 -sysca
```