### PR TITLE
Check EngineHelper for null in SSLSocket.close()

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -534,13 +534,18 @@ public class WolfSSLSocket extends SSLSocket {
 
             try {
                 /* Load private key and cert chain from WolfSSLAuthStore */
-                WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    () -> "loading private key and cert chain");
+                if (EngineHelper != null) {
+                    WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                        () -> "loading private key and cert chain");
 
-                if (this.socket != null) {
-                    EngineHelper.LoadKeyAndCertChain(this.socket, null);
+                    if (this.socket != null) {
+                        EngineHelper.LoadKeyAndCertChain(this.socket, null);
+                    } else {
+                        EngineHelper.LoadKeyAndCertChain(this, null);
+                    }
                 } else {
-                    EngineHelper.LoadKeyAndCertChain(this, null);
+                    throw new WolfSSLException(
+                        "EngineHelper null, cannot load key and cert chain");
                 }
 
                 isInitialized = true;
@@ -2067,7 +2072,9 @@ public class WolfSSLSocket extends SSLSocket {
                             (handshakeFinished == true)) {
                             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                                 () -> "saving WOLFSSL_SESSION into cache");
-                            EngineHelper.saveSession();
+                            if (EngineHelper != null) {
+                                EngineHelper.saveSession();
+                            }
                         }
                         else {
                             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
@@ -2106,7 +2113,9 @@ public class WolfSSLSocket extends SSLSocket {
                             this.connectionClosed = true;
 
                             /* Release native verify callback (JNI global) */
-                            this.EngineHelper.unsetVerifyCallback();
+                            if (this.EngineHelper != null) {
+                                this.EngineHelper.unsetVerifyCallback();
+                            }
 
                             /* Close ConsumedRecvCtx data stream */
                             Object readCtx = this.ssl.getIOReadCtx();
@@ -2179,8 +2188,10 @@ public class WolfSSLSocket extends SSLSocket {
                     }
 
                     /* Reset internal WolfSSLEngineHelper to null */
-                    this.EngineHelper.clearObjectState();
-                    this.EngineHelper = null;
+                    if (this.EngineHelper != null) {
+                        this.EngineHelper.clearObjectState();
+                        this.EngineHelper = null;
+                    }
 
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                         () -> "thread exiting ioLock (shutdown)");

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
@@ -3869,5 +3869,56 @@ public class WolfSSLSocketTest {
 
         System.out.println("\t... passed");
     }
+
+    @Test
+    public void testCloseWithNullEngineHelper()
+        throws NoSuchFieldException, IllegalAccessException {
+
+        System.out.print("\tclose() with null EngineHelper");
+
+        /* Create a normal WolfSSLSocket first using the factory */
+        SSLSocketFactory factory = null;
+        for (SSLSocketFactory f : sockFactories) {
+            if (f != null) {
+                factory = f;
+                break;
+            }
+        }
+        assertNotNull("No SSLSocketFactory available for test", factory);
+
+        WolfSSLSocket socket = null;
+        try {
+            /* Create a socket but don't connect it */
+            socket = (WolfSSLSocket) factory.createSocket();
+
+            /* Use reflection to set EngineHelper to null, simulating the
+             * scenario where constructor failed after partial
+             * initialization */
+            Field engineHelperField =
+                WolfSSLSocket.class.getDeclaredField("EngineHelper");
+            engineHelperField.setAccessible(true);
+            engineHelperField.set(socket, null);
+
+        } catch (Exception e) {
+            fail("Failed to create test socket or set EngineHelper to null: "
+                 + e.getMessage());
+        }
+
+        /* Verify that calling close() on the socket with null EngineHelper
+         * does not throw NullPointerException */
+        try {
+            if (socket != null) {
+                socket.close();
+            }
+            /* Test should fail here if NPE occurs */
+        } catch (NullPointerException npe) {
+            fail("close() threw NullPointerException when EngineHelper " +
+                "is null: " + npe.getMessage());
+        } catch (IOException e) {
+            /* IOException from close() is acceptable */
+        }
+
+        System.out.println("\t... passed");
+    }
 }
 


### PR DESCRIPTION
This PR adds null pointer checking to `WolfSSLSocket`, specifically for the issue in `close()` where `this.EngineHelper.clearObjectState();` could have been called in some scenarios if `this.EngineHelper` had already been set to null.

A regression test has also been added as part of this PR.