### PR TITLE
JNI: Implement get/set session tickets

### DIFF
--- a/native/com_wolfssl_WolfSSLSession.h
+++ b/native/com_wolfssl_WolfSSLSession.h
@@ -825,6 +825,22 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useSessionTicket
 
 /*
  * Class:     com_wolfssl_WolfSSLSession
+ * Method:    getSessionTicket
+ * Signature: (J)[B
+ */
+JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_getSessionTicket
+  (JNIEnv *, jobject, jlong);
+
+/*
+ * Class:     com_wolfssl_WolfSSLSession
+ * Method:    setSessionTicket
+ * Signature: (J[B)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setSessionTicket
+  (JNIEnv *, jobject, jlong, jbyteArray);
+
+/*
+ * Class:     com_wolfssl_WolfSSLSession
  * Method:    gotCloseNotify
  * Signature: (J)I
  */

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -5186,9 +5186,9 @@ public class WolfSSLSession {
         return this.sessionTicketsEnabled;
     }
 
-    /** 
+    /**
      * Get session ticket for this session if session tickets are enabled.
-     * 
+     *
      * @return session ticket as byte array, or null if not available.
      * @throws IllegalStateException WolfSSLSession has been freed.
      */
@@ -5215,10 +5215,10 @@ public class WolfSSLSession {
 
     /**
      * Set session ticket for this session.
-     * 
+     *
      * @param sessionTicket session ticket to set for this session.
      * @return WolfSSL.SSL_SUCCESS on success, otherwise negative.
-     * 
+     *
      * @throws IllegalStateException WolfSSLSession has been freed
      */
     public int setSessionTicket(byte[] sessionTicket){
@@ -5229,7 +5229,7 @@ public class WolfSSLSession {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                     WolfSSLDebug.INFO, this.sslPtr,
                     () -> "entered setSessionTicket()");
-                
+
                 if (sessionTicket != null && sessionTicket.length > 0) {
                     ret = setSessionTicket(this.sslPtr, sessionTicket);
                 } else {
@@ -5240,8 +5240,12 @@ public class WolfSSLSession {
                 }
 
             }
+        } else {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.sslPtr,
+                () -> "session tickets not enabled");
         }
-        
+
         return ret;
     }
 


### PR DESCRIPTION
Adds wrapper and unit tests for get and set session tickets. Implementation of `getSessionTickets()` and `setSessionTickets()` is compatible with older versions of wolfSSL.

Adds macro `WOLFSSL_MAX_SESSION_TICKET_LEN` with default value 2048, which is used in `getSessionTickets()` to generate a byte array to copy the ticket to before generating a correctly sized jbyteArray.

Unit tests aim to check functionality of new functions and ability to resume TLS1.3 session with session tickets.