### PR TITLE
 unwrap() header peek in SSLEngine to fix BUFFER_UNDERFLOW

### DIFF
--- a/native/com_wolfssl_WolfSSL.h
+++ b/native/com_wolfssl_WolfSSL.h
@@ -187,6 +187,20 @@ extern "C" {
 #define com_wolfssl_WolfSSL_CACHE_MATCH_ERROR -280L
 #undef com_wolfssl_WolfSSL_MAX_RECORD_SIZE
 #define com_wolfssl_WolfSSL_MAX_RECORD_SIZE 16384L
+#undef com_wolfssl_WolfSSL_TLS_RECORD_HEADER_LEN
+#define com_wolfssl_WolfSSL_TLS_RECORD_HEADER_LEN 5L
+#undef com_wolfssl_WolfSSL_TLS_RECORD_LEN_HI_OFF
+#define com_wolfssl_WolfSSL_TLS_RECORD_LEN_HI_OFF 3L
+#undef com_wolfssl_WolfSSL_TLS_RECORD_LEN_LO_OFF
+#define com_wolfssl_WolfSSL_TLS_RECORD_LEN_LO_OFF 4L
+#undef com_wolfssl_WolfSSL_TLS_RECORD_VERS_OFF
+#define com_wolfssl_WolfSSL_TLS_RECORD_VERS_OFF 1L
+#undef com_wolfssl_WolfSSL_TLS_RECORD_VERS_MAJOR
+#define com_wolfssl_WolfSSL_TLS_RECORD_VERS_MAJOR 3L
+#undef com_wolfssl_WolfSSL_TLS_RECORD_CT_MIN
+#define com_wolfssl_WolfSSL_TLS_RECORD_CT_MIN 20L
+#undef com_wolfssl_WolfSSL_TLS_RECORD_CT_MAX
+#define com_wolfssl_WolfSSL_TLS_RECORD_CT_MAX 24L
 #undef com_wolfssl_WolfSSL_WOLFSSL_SNI_HOST_NAME
 #define com_wolfssl_WolfSSL_WOLFSSL_SNI_HOST_NAME 0L
 #undef com_wolfssl_WolfSSL_SSL_TLSEXT_ERR_OK

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -349,6 +349,23 @@ public class WolfSSL {
     /** Maximum SSL record size (16KB) as defined by the protocol. */
     public static final int MAX_RECORD_SIZE = 16384;
 
+    /** TLS record header is: type(1) + version(2) + length(2) */
+    public static final int TLS_RECORD_HEADER_LEN = 5;
+    /** TLS record header length high byte offset */
+    public static final int TLS_RECORD_LEN_HI_OFF = 3;
+    /** TLS record header length lower byte offset */
+    public static final int TLS_RECORD_LEN_LO_OFF = 4;
+    /** TLS record header protocol version offset */
+    public static final int TLS_RECORD_VERS_OFF = 1;
+    /** TLS record header protocol version major */
+    public static final int TLS_RECORD_VERS_MAJOR = 0x03;
+    /** TLS record header valid content type
+     *  (RFC 8446 B.1, RFC 6520), (change_cipher_spec) */
+    public static final int TLS_RECORD_CT_MIN = 20;
+    /** TLS record header valid content type
+     *  (RFC 8446 B.1, RFC 6520), (heartbeat) */
+    public static final int TLS_RECORD_CT_MAX = 24;
+
     /* ------------------ TLS extension specific  ------------------------ */
     /** SNI Host name type, for UseSNI() */
     public static final int WOLFSSL_SNI_HOST_NAME = 0;

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
@@ -110,6 +110,7 @@ public class WolfSSLEngine extends SSLEngine {
 
     /* session stored (WOLFSSL_SESSION), relevant on client side */
     private boolean sessionStored = false;
+    private boolean contPartialRecord = false;
 
     /* TLS 1.3 session ticket received (on client side) */
     private boolean sessionTicketReceived = false;
@@ -141,11 +142,6 @@ public class WolfSSLEngine extends SSLEngine {
     /* Scratch buffer for ssl.read() plaintext. Reused across unwrap() calls
      * and expanded only when a larger output window requires it. */
     private byte[] recvAppDataBuf = new byte[WolfSSL.MAX_RECORD_SIZE];
-
-    /* TLS record header is: type(1) + version(2) + length(2) */
-    private static final int TLS_RECORD_HEADER_LEN = 5;
-    private static final int TLS_RECORD_LEN_HI_OFF = 3;
-    private static final int TLS_RECORD_LEN_LO_OFF = 4;
 
     /* Default size of internalIOSendBuf, 16k to match TLS record size.
      * TODO - add upper bound on I/O send buf resize allocations. */
@@ -365,7 +361,7 @@ public class WolfSSLEngine extends SSLEngine {
 
         synchronized (netDataLock) {
             if (this.netData == null ||
-                this.netData.remaining() < TLS_RECORD_HEADER_LEN) {
+                this.netData.remaining() < WolfSSL.TLS_RECORD_HEADER_LEN) {
                 return null;
             }
             in = this.netData.asReadOnlyBuffer();
@@ -1289,6 +1285,70 @@ public class WolfSSLEngine extends SSLEngine {
         return this.recvAppDataBuf;
     }
 
+    /**
+     * Peek at the record header and return BUFFER_UNDERFLOW before calling
+     * into JNI when the full record is not yet present. Without this, native
+     * wolfSSL consumes partial record bytes via the I/O callback, violating
+     * the JSSE contract that BUFFER_UNDERFLOW must report
+     * bytesConsumed() == 0.
+     *
+     * Skipped if using DTLS.
+     *
+     * @param in input buffer.
+     * @param inRemaining bytes remaining in input buffer.
+     *
+     * @return true if buffer underflow detected, false otherwise.
+     */
+    private boolean peekTlsRecordHeader(ByteBuffer in, int inRemaining) {
+        boolean bufferUnderflow = false;
+        /* DTLS still relies on the native WANT_READ path. */
+        if (inRemaining > 0 && (this.ssl.dtls() == 0)) {
+            int pos = in.position();
+            if (inRemaining < WolfSSL.TLS_RECORD_HEADER_LEN) {
+                /* Not enough for TLS record header */
+                bufferUnderflow = true;
+            }
+            else {
+                /* Check if header is plausible. Content type between
+                 * change_cipher_spec and heartbeat and
+                 * version major corresponds to TLS. */
+                byte headerByte = in.get(pos);
+                if ((headerByte & 0xFF) >= WolfSSL.TLS_RECORD_CT_MIN &&
+                    (headerByte & 0xFF) <= WolfSSL.TLS_RECORD_CT_MAX &&
+                    (in.get(pos + WolfSSL.TLS_RECORD_VERS_OFF)
+                                    & 0xFF) == WolfSSL.TLS_RECORD_VERS_MAJOR) {
+                    /* Peek at record length from header
+                     * bytes 3-4 (big-endian). */
+                    int recLen =
+                        ((in.get(pos + WolfSSL.TLS_RECORD_LEN_HI_OFF)
+                            & 0xFF) << 8) |
+                        (in.get(pos + WolfSSL.TLS_RECORD_LEN_LO_OFF)
+                            & 0xFF);
+                    /* Fall through if recLen exceeds max packet buffer size
+                     * or inRemaining is less than reported record length */
+                    int packetBufSz = this.getSession().getPacketBufferSize();
+                    if (recLen <= packetBufSz &&
+                        inRemaining < WolfSSL.TLS_RECORD_HEADER_LEN + recLen) {
+                        bufferUnderflow = true;
+                    }
+                    else if (recLen > packetBufSz) {
+                        WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                                        () -> "recLen: " + recLen +
+                                        " exceeds max packet buffer size, " +
+                                        "skipping underflow check.");
+                    }
+                }
+                else {
+                    WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                                    () -> "Peeked content-type or version " +
+                                    "major outside TLS range, skipping " +
+                                    "underflow check");
+                }
+            }
+        }
+        return bufferUnderflow;
+    }
+
     @Override
     public synchronized SSLEngineResult unwrap(ByteBuffer in, ByteBuffer out)
             throws SSLException {
@@ -1313,6 +1373,7 @@ public class WolfSSLEngine extends SSLEngine {
         long dtlsPrevDropCount = 0;
         long dtlsCurrDropCount = 0;
         int prevSessionTicketCount = 0;
+        boolean bufferUnderflow = false;
         final int tmpRet;
 
         /* Set initial status for SSLEngineResult return */
@@ -1463,38 +1524,26 @@ public class WolfSSLEngine extends SSLEngine {
                     if (this.handshakeFinished == false) {
                         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                             () -> "starting or continuing handshake");
-                        ret = DoHandshake(false);
+                        if (!this.contPartialRecord) {
+                            /* Client only: TLS 1.3 ssl_accept() I/O callback
+                             * patterns conflict with the pre-peek
+                             * mid-handshake. Post-handshake server unwrap
+                             * always applies peek. */
+                            bufferUnderflow =
+                                this.getUseClientMode() &&
+                                peekTlsRecordHeader(in, inRemaining);
+                        }
+                        if (bufferUnderflow) {
+                            status = SSLEngineResult.Status.BUFFER_UNDERFLOW;
+                        }
+                        else {
+                            ret = DoHandshake(false);
+                        }
                     }
                     else {
-                        /* TLS-only: peek at the record header and
-                         * return BUFFER_UNDERFLOW before calling into
-                         * JNI when the full record is not yet present.
-                         * Without this, native wolfSSL consumes partial
-                         * record bytes via the I/O callback, violating
-                         * the JSSE contract that BUFFER_UNDERFLOW must
-                         * report bytesConsumed() == 0. DTLS still
-                         * relies on the native WANT_READ path. */
-                        boolean bufferUnderflow = false;
-                        if (inRemaining > 0 && (this.ssl.dtls() == 0)) {
-                            synchronized (netDataLock) {
-                                int pos = in.position();
-                                if (inRemaining < TLS_RECORD_HEADER_LEN) {
-                                    /* Not enough for TLS record header */
-                                    bufferUnderflow = true;
-                                } else {
-                                    /* Peek at record length from header
-                                     * bytes 3-4 (big-endian) */
-                                    int recLen =
-                                        ((in.get(pos + TLS_RECORD_LEN_HI_OFF)
-                                            & 0xFF) << 8) |
-                                        (in.get(pos + TLS_RECORD_LEN_LO_OFF)
-                                            & 0xFF);
-                                    if (inRemaining <
-                                        TLS_RECORD_HEADER_LEN + recLen) {
-                                        bufferUnderflow = true;
-                                    }
-                                }
-                            }
+                        if (!this.contPartialRecord) {
+                            bufferUnderflow =
+                                    peekTlsRecordHeader(in, inRemaining);
                         }
 
                         /* Serve stashed data from previous
@@ -1697,7 +1746,8 @@ public class WolfSSLEngine extends SSLEngine {
                         }
                     }
                     else if (!this.handshakeFinished && (ret == 0) &&
-                        (err == 0 || err == WolfSSL.SSL_ERROR_ZERO_RETURN)) {
+                        (err == 0 || err == WolfSSL.SSL_ERROR_ZERO_RETURN)
+                         && !bufferUnderflow) {
 
                         boolean gotCloseNotify = false;
                         synchronized (ioLock) {
@@ -2650,6 +2700,11 @@ public class WolfSSLEngine extends SSLEngine {
                 if (this.ssl.dtls() == 1 && this.handshakeFinished) {
                     this.nativeWantsToRead = 1;
                 }
+                /* Buffer exhausted mid-record: skip the header peek on the
+                 * next unwrap() to pass continuation bytes to DoHandshake. */
+                if (this.netData != null && this.netData.remaining() == 0) {
+                    this.contPartialRecord = true;
+                }
                 return WolfSSL.WOLFSSL_CBIO_ERR_WANT_READ;
             }
 
@@ -2675,6 +2730,10 @@ public class WolfSSLEngine extends SSLEngine {
                 /* Restore position */
                 toRead.position(toReadPos);
             }
+
+            /* Reset to false when all requested bytes were delivered;
+             * set to true when the buffer was exhausted mid-record. */
+            this.contPartialRecord = (max < sz);
 
             return max;
         }

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
@@ -110,6 +110,7 @@ public class WolfSSLEngine extends SSLEngine {
 
     /* session stored (WOLFSSL_SESSION), relevant on client side */
     private boolean sessionStored = false;
+    /* Skip record header peek in next unwrap, continue same TLS record */
     private boolean contPartialRecord = false;
 
     /* TLS 1.3 session ticket received (on client side) */

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineTest.java
@@ -3047,13 +3047,13 @@ public class WolfSSLEngineTest {
     }
 
     @Test
-    public void testHandshakeUnwrapConsumedNotBufferUnderflow()
+    public void testHandshakeUnwrapIncrementalStatus()
         throws NoSuchProviderException, NoSuchAlgorithmException,
                KeyManagementException, KeyStoreException,
                CertificateException, IOException,
                UnrecoverableKeyException {
 
-        System.out.print("\tTest unwrap consumed != BUFFER_UNDERFLOW");
+        System.out.print("\tTest unwrap incremental status");
 
         if (!enabledProtocols.contains("TLSv1.3")) {
             System.out.println("\t... skipped");
@@ -3127,42 +3127,297 @@ public class WolfSSLEngineTest {
         srvFlight.flip();
 
         int total = srvFlight.remaining();
-        if (total < 2) {
+        /* Parse first TLS record header to find exact boundary:
+         * type[1] + version[2] + length[2] = 5 bytes. */
+        if (total < 5) {
             error("\t... failed");
-            fail("server flight too small to split: " + total);
+            fail("server flight too small: " + total);
+        }
+        int firstRecPayload =
+            ((srvFlight.get(srvFlight.position() + 3) & 0xFF) << 8)
+            | (srvFlight.get(srvFlight.position() + 4) & 0xFF);
+        int firstRecordLen = 5 + firstRecPayload;
+        if (total < firstRecordLen) {
+            error("\t... failed");
+            fail("first TLS record extends beyond server flight");
         }
 
-        /* Feed the first half of the server flight to
-         * client.unwrap(). wolfSSL will consume these bytes through
-         * the I/O callback, exhaust the buffer, and return
-         * SSL_ERROR_WANT_READ. With the fix, BUFFER_UNDERFLOW must
-         * NOT be set because inRemaining > 0 (data was provided). */
-        int half = total / 2;
-        byte[] halfBytes = new byte[half];
-        srvFlight.get(halfBytes);
-        ByteBuffer firstHalf = ByteBuffer.wrap(halfBytes);
+        /* Feed exactly the first TLS record to client.unwrap().
+         * Peek confirms it is complete, DoHandshake() runs,
+         * wolfSSL consumes all bytes and returns WANT_READ. */
+        byte[] firstRecBytes = new byte[firstRecordLen];
+        srvFlight.get(firstRecBytes);
+        ByteBuffer firstRecord = ByteBuffer.wrap(firstRecBytes);
 
         ByteBuffer cliAppBuf =
             ByteBuffer.allocateDirect(appBufSize);
-        result = client.unwrap(firstHalf, cliAppBuf);
+        result = client.unwrap(firstRecord, cliAppBuf);
 
-        /* BUFFER_UNDERFLOW must not be returned when input was
-         * consumed - regression for inRemaining == 0 guard fix */
-        if (result.getStatus() ==
-                SSLEngineResult.Status.BUFFER_UNDERFLOW) {
+        /* wolfSSL processed first record but needs more data:
+         * status must be OK, not BUFFER_UNDERFLOW. */
+        if (result.getStatus() != SSLEngineResult.Status.OK) {
             error("\t... failed");
-            fail("unwrap() with consumed handshake data must not " +
-                 "return BUFFER_UNDERFLOW (regression: inRemaining" +
-                 " == 0 guard), bytesConsumed=" +
+            fail("expected Status.OK, got: " +
+                 result.getStatus());
+        }
+
+        /* Handshake needs more data to continue. */
+        if (result.getHandshakeStatus() !=
+                SSLEngineResult.HandshakeStatus.NEED_UNWRAP) {
+            error("\t... failed");
+            fail("expected NEED_UNWRAP, got: " +
+                 result.getHandshakeStatus());
+        }
+
+        /* All bytes consumed via I/O callback. */
+        if (result.bytesConsumed() != firstRecordLen) {
+            error("\t... failed");
+            fail("expected " + firstRecordLen + " bytes " +
+                 "consumed, got: " + result.bytesConsumed());
+        }
+
+        /* No application data produced during handshake. */
+        if (result.bytesProduced() != 0) {
+            error("\t... failed");
+            fail("expected 0 bytes produced, got: " +
+                 result.bytesProduced());
+        }
+
+        /* Server flight must contain more than one record so we
+         * can feed continuation bytes and exercise contPartialRecord.
+         * TLSv1.3 server flight (ServerHello + EncryptedExtensions +
+         * Certificate + CertificateVerify + Finished) always spans
+         * multiple TLS records. */
+        if (srvFlight.remaining() == 0) {
+            error("\t... failed");
+            fail("server flight is a single record; cannot " +
+                 "test contPartialRecord continuation path");
+        }
+
+        /* contPartialRecord=true from first unwrap skips
+         * peek; DoHandshake() gets raw continuation bytes. */
+        int contLen = Math.min(3, srvFlight.remaining());
+        byte[] contBytes = new byte[contLen];
+        srvFlight.get(contBytes);
+        ByteBuffer contBuf = ByteBuffer.wrap(contBytes);
+        ByteBuffer cliAppBuf2 =
+            ByteBuffer.allocateDirect(appBufSize);
+        result = client.unwrap(contBuf, cliAppBuf2);
+
+        /* wolfSSL consumed continuation bytes, needs more:
+         * must be Status.OK, not BUFFER_UNDERFLOW. */
+        if (result.getStatus() !=
+                SSLEngineResult.Status.OK) {
+            error("\t... failed");
+            fail("expected Status.OK for continuation " +
+                 "bytes, got: " + result.getStatus());
+        }
+
+        /* Handshake still needs more data. */
+        if (result.getHandshakeStatus() !=
+                SSLEngineResult.HandshakeStatus.NEED_UNWRAP) {
+            error("\t... failed");
+            fail("expected NEED_UNWRAP for continuation " +
+                 "bytes, got: " +
+                 result.getHandshakeStatus());
+        }
+
+        /* All continuation bytes consumed. */
+        if (result.bytesConsumed() != contLen) {
+            error("\t... failed");
+            fail("expected " + contLen + " continuation " +
+                 "bytes consumed, got: " +
                  result.bytesConsumed());
         }
 
-        /* Input was non-empty so at least some bytes must have
-         * been consumed */
-        if (result.bytesConsumed() == 0) {
+        /* No application data produced. */
+        if (result.bytesProduced() != 0) {
             error("\t... failed");
-            fail("unwrap() consumed 0 bytes from a non-empty " +
-                 "handshake buffer");
+            fail("expected 0 bytes produced, got: " +
+                 result.bytesProduced());
+        }
+
+        pass("\t... passed");
+    }
+
+    @Test
+    public void testHandshakeUnwrapPartialHeader()
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               KeyManagementException, KeyStoreException,
+               CertificateException, IOException,
+               UnrecoverableKeyException {
+
+        /* Test that feeding <5 bytes to client.unwrap() during
+         * handshake returns BUFFER_UNDERFLOW with 0 bytes consumed.
+         * Exercises the inRemaining < TLS_RECORD_HEADER_LEN branch
+         * of peekTlsRecordHeader(). */
+        System.out.print("\tTest unwrap partial header underflow");
+
+        if (!enabledProtocols.contains("TLSv1.3")) {
+            System.out.println("\t... skipped");
+            return;
+        }
+
+        SSLContext ctx13 = tf.createSSLContext("TLSv1.3", engineProvider);
+        SSLEngine server = ctx13.createSSLEngine();
+        SSLEngine client = ctx13.createSSLEngine("localhost", 11111);
+
+        server.setUseClientMode(false);
+        server.setNeedClientAuth(false);
+        client.setUseClientMode(true);
+
+        server.beginHandshake();
+        client.beginHandshake();
+
+        int packetBufSize = client.getSession().getPacketBufferSize();
+        int appBufSize = client.getSession().getApplicationBufferSize();
+
+        /* Wrap ClientHello to put client into NEED_UNWRAP state */
+        ByteBuffer cliToSrv =
+            ByteBuffer.allocateDirect(packetBufSize);
+        ByteBuffer emptyApp = ByteBuffer.allocate(0);
+        SSLEngineResult result = client.wrap(emptyApp, cliToSrv);
+        if (result.getStatus() != SSLEngineResult.Status.OK) {
+            error("\t... failed");
+            fail("client wrap (ClientHello) failed: " +
+                 result.getStatus());
+        }
+
+        if (client.getHandshakeStatus() !=
+                SSLEngineResult.HandshakeStatus.NEED_UNWRAP) {
+            error("\t... failed");
+            fail("expected NEED_UNWRAP after ClientHello, got: " +
+                 client.getHandshakeStatus());
+        }
+
+        /* Feed 2 bytes: less than the 5-byte TLS record header.
+         * Peek must signal BUFFER_UNDERFLOW without calling into
+         * wolfSSL, so 0 bytes are consumed. */
+        ByteBuffer partialHeader =
+            ByteBuffer.wrap(new byte[] { 0x16, 0x03 });
+        ByteBuffer cliAppBuf =
+            ByteBuffer.allocateDirect(appBufSize);
+        result = client.unwrap(partialHeader, cliAppBuf);
+
+        if (result.getStatus() !=
+                SSLEngineResult.Status.BUFFER_UNDERFLOW) {
+            error("\t... failed");
+            fail("expected BUFFER_UNDERFLOW for partial header, " +
+                 "got: " + result.getStatus());
+        }
+
+        if (result.bytesConsumed() != 0) {
+            error("\t... failed");
+            fail("BUFFER_UNDERFLOW must consume 0 bytes, " +
+                 "consumed: " + result.bytesConsumed());
+        }
+
+        /* Engine must remain in NEED_UNWRAP after underflow. */
+        if (result.getHandshakeStatus() !=
+                SSLEngineResult.HandshakeStatus.NEED_UNWRAP) {
+            error("\t... failed");
+            fail("expected NEED_UNWRAP after underflow, got: " +
+                 result.getHandshakeStatus());
+        }
+
+        pass("\t... passed");
+    }
+
+    @Test
+    public void testHandshakeUnwrapOversizedRecord()
+        throws NoSuchProviderException, NoSuchAlgorithmException,
+               KeyManagementException, KeyStoreException,
+               CertificateException, IOException,
+               UnrecoverableKeyException {
+
+        /* Test that a partial record whose header claims
+         * recLen > MAX_RECORD_SIZE (but <= packetBufferSize - 5)
+         * returns BUFFER_UNDERFLOW with 0 bytes consumed. Prior to
+         * fixing the MAX_RECORD_SIZE cap, this range bypassed the
+         * peek entirely and wolfSSL would consume partial bytes. */
+        System.out.print("\tTest unwrap oversized record underflow");
+
+        if (!enabledProtocols.contains("TLSv1.3")) {
+            System.out.println("\t... skipped");
+            return;
+        }
+
+        SSLContext ctx13 = tf.createSSLContext("TLSv1.3", engineProvider);
+        SSLEngine server = ctx13.createSSLEngine();
+        SSLEngine client = ctx13.createSSLEngine("localhost", 11111);
+
+        server.setUseClientMode(false);
+        server.setNeedClientAuth(false);
+        client.setUseClientMode(true);
+
+        server.beginHandshake();
+        client.beginHandshake();
+
+        int packetBufSize = client.getSession().getPacketBufferSize();
+        int appBufSize = client.getSession().getApplicationBufferSize();
+
+        /* Wrap ClientHello to put client into NEED_UNWRAP state */
+        ByteBuffer cliToSrv =
+            ByteBuffer.allocateDirect(packetBufSize);
+        ByteBuffer emptyApp = ByteBuffer.allocate(0);
+        SSLEngineResult result = client.wrap(emptyApp, cliToSrv);
+        if (result.getStatus() != SSLEngineResult.Status.OK) {
+            error("\t... failed");
+            fail("client wrap (ClientHello) failed: " +
+                 result.getStatus());
+        }
+
+        if (client.getHandshakeStatus() !=
+                SSLEngineResult.HandshakeStatus.NEED_UNWRAP) {
+            error("\t... failed");
+            fail("expected NEED_UNWRAP after ClientHello, got: " +
+                 client.getHandshakeStatus());
+        }
+
+        /* recLen = MAX_RECORD_SIZE + 1 must fit within
+         * packetBufferSize (header not counted). Skip if not,
+         * which would indicate an unusual build configuration. */
+        int oversizedRecLen = WolfSSL.MAX_RECORD_SIZE + 1;
+        if (oversizedRecLen > packetBufSize - 5) {
+            System.out.println("\t... skipped");
+            return;
+        }
+
+        /* Craft a 5-byte TLS record header: content type
+         * handshake(0x16), version TLS 1.2 record layer(0x0303),
+         * length = MAX_RECORD_SIZE + 1. Valid content-type and
+         * version bytes ensure the plausibility guard in
+         * peekTlsRecordHeader() does not filter the header before
+         * the length check. */
+        byte recLenHi = (byte) ((oversizedRecLen >> 8) & 0xFF);
+        byte recLenLo = (byte) (oversizedRecLen & 0xFF);
+        ByteBuffer fakeHeader = ByteBuffer.wrap(new byte[] {
+            0x16, 0x03, 0x03, recLenHi, recLenLo
+        });
+
+        ByteBuffer cliAppBuf =
+            ByteBuffer.allocateDirect(appBufSize);
+        result = client.unwrap(fakeHeader, cliAppBuf);
+
+        if (result.getStatus() !=
+                SSLEngineResult.Status.BUFFER_UNDERFLOW) {
+            error("\t... failed");
+            fail("expected BUFFER_UNDERFLOW for oversized partial " +
+                 "record, got: " + result.getStatus());
+        }
+
+        if (result.bytesConsumed() != 0) {
+            error("\t... failed");
+            fail("BUFFER_UNDERFLOW must consume 0 bytes, " +
+                 "consumed: " + result.bytesConsumed());
+        }
+
+        /* Engine must remain in NEED_UNWRAP after underflow. */
+        if (result.getHandshakeStatus() !=
+                SSLEngineResult.HandshakeStatus.NEED_UNWRAP) {
+            error("\t... failed");
+            fail("expected NEED_UNWRAP after underflow, got: " +
+                 result.getHandshakeStatus());
         }
 
         pass("\t... passed");


### PR DESCRIPTION
Adds a pre-check in unwrap() that inspects the TLS record header before calling into wolfSSL, returning BUFFER_UNDERFLOW when the buffer holds a partial record.

Also adds on to the `testHandshakeUnwrapConsumedNotBufferUnderflow` regression test.   