### PR TITLE
Fenrir fixes

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -93,9 +93,13 @@
         </not>
     </condition>
 
-    <taskdef uri="antlib:org.jacoco.ant" resource="org/jacoco/ant/antlib.xml">
-        <classpath path="${env.JACOCO_HOME}/jacocoant.jar"/>
-    </taskdef>
+    <!-- Check if JaCoCo is available -->
+    <condition property="jacoco.available">
+        <and>
+            <isset property="env.JACOCO_HOME"/>
+            <available file="${env.JACOCO_HOME}/jacocoant.jar"/>
+        </and>
+    </condition>
 
     <!-- classpath to compiled wolfssl.jar, for running tests -->
     <path id="classpath">
@@ -430,7 +434,16 @@
         </junit>
     </target>
 
-    <target name="test-jacoco" depends="build-test">
+    <target name="jacoco-taskdef" if="jacoco.available">
+        <taskdef uri="antlib:org.jacoco.ant"
+            resource="org/jacoco/ant/antlib.xml">
+            <classpath path="${env.JACOCO_HOME}/jacocoant.jar"/>
+        </taskdef>
+    </target>
+
+    <target name="test-jacoco"
+        depends="build-test, jacoco-taskdef"
+        if="jacoco.available">
         <jacoco:coverage destfile="${build.dir}/jacoco.exec">
         <junit printsummary="yes" showoutput="yes" haltonfailure="yes" fork="true">
         <classpath>
@@ -460,7 +473,9 @@
         </jacoco:coverage>
     </target>
 
-    <target name="coverage-report">
+    <target name="coverage-report"
+        depends="jacoco-taskdef"
+        if="jacoco.available">
         <jacoco:report>
             <executiondata>
                 <file file="${build.dir}/jacoco.exec"/>

--- a/native/com_wolfssl_WolfCryptEccKey.c
+++ b/native/com_wolfssl_WolfCryptEccKey.c
@@ -28,6 +28,7 @@
 #include <wolfssl/wolfcrypt/ecc.h>
 #include <wolfssl/wolfcrypt/asn.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
+#include <wolfssl/wolfcrypt/memory.h>
 #include "com_wolfssl_WolfCryptEccKey.h"
 
 JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfCryptEccKey_EccPublicKeyToDer
@@ -128,6 +129,12 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfCryptEccKey_EccPrivateKeyToDer
 
     ret = wc_EccPrivateKeyToDer(key, result, resultSz);
     if (ret <= 0) {
+    #if (LIBWOLFSSL_VERSION_HEX >= 0x05008004) && \
+        !defined(WOLFSSL_NO_FORCE_ZERO)
+        wc_ForceZero(result, sizeof(result));
+    #else
+        XMEMSET(result, 0, sizeof(result));
+    #endif
         (*jenv)->ThrowNew(jenv, excClass,
                 "Native call to wc_EccPrivateKeyToDer failed");
         return NULL;
@@ -137,12 +144,24 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfCryptEccKey_EccPrivateKeyToDer
     /* create byte array to return */
     resultArray = (*jenv)->NewByteArray(jenv, resultSz);
     if (!resultArray) {
+    #if (LIBWOLFSSL_VERSION_HEX >= 0x05008004) && \
+        !defined(WOLFSSL_NO_FORCE_ZERO)
+        wc_ForceZero(result, sizeof(result));
+    #else
+        XMEMSET(result, 0, sizeof(result));
+    #endif
         (*jenv)->ThrowNew(jenv, excClass,
                 "Failed to create new byte array in native EccPrivateKeyToDer");
         return NULL;
     }
 
     (*jenv)->SetByteArrayRegion(jenv, resultArray, 0, resultSz, (jbyte*)result);
+    #if (LIBWOLFSSL_VERSION_HEX >= 0x05008004) && \
+        !defined(WOLFSSL_NO_FORCE_ZERO)
+        wc_ForceZero(result, sizeof(result));
+    #else
+        XMEMSET(result, 0, sizeof(result));
+    #endif
     if ((*jenv)->ExceptionOccurred(jenv)) {
         (*jenv)->ExceptionDescribe(jenv);
         (*jenv)->ExceptionClear(jenv);
@@ -207,9 +226,15 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfCryptEccKey_EccPrivateKeyToPKC
 
     ret = wc_EccPrivateKeyToPKCS8(key, result, &resultSz);
     if (ret <= 0) {
+    #if (LIBWOLFSSL_VERSION_HEX >= 0x05008004) && \
+        !defined(WOLFSSL_NO_FORCE_ZERO)
+        wc_ForceZero(result, resultSz);
+    #else
+        XMEMSET(result, 0, resultSz);
+    #endif
         XFREE(result, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         (*jenv)->ThrowNew(jenv, excClass,
-                "Native call to wc_EccPrivateKeyToDer failed");
+                "Native call to wc_EccPrivateKeyToPKCS8 failed");
         return NULL;
     }
     resultSz = ret;
@@ -217,21 +242,35 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfCryptEccKey_EccPrivateKeyToPKC
     /* create byte array to return */
     resultArray = (*jenv)->NewByteArray(jenv, resultSz);
     if (!resultArray) {
+    #if (LIBWOLFSSL_VERSION_HEX >= 0x05008004) && \
+        !defined(WOLFSSL_NO_FORCE_ZERO)
+        wc_ForceZero(result, resultSz);
+    #else
+        XMEMSET(result, 0, resultSz);
+    #endif
         XFREE(result, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         (*jenv)->ThrowNew(jenv, excClass,
-                "Failed to create new byte array in native EccPrivateKeyToPKCS8");
+                "Failed to create new byte array in native "
+                "EccPrivateKeyToPKCS8");
         return NULL;
     }
 
     (*jenv)->SetByteArrayRegion(jenv, resultArray, 0, resultSz, (jbyte*)result);
+    #if (LIBWOLFSSL_VERSION_HEX >= 0x05008004) && \
+        !defined(WOLFSSL_NO_FORCE_ZERO)
+        wc_ForceZero(result, resultSz);
+    #else
+        XMEMSET(result, 0, resultSz);
+    #endif
+
+    XFREE(result, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+
     if ((*jenv)->ExceptionOccurred(jenv)) {
         (*jenv)->ExceptionDescribe(jenv);
         (*jenv)->ExceptionClear(jenv);
-        XFREE(result, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         return NULL;
     }
 
-    XFREE(result, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     return resultArray;
 
 #else

--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -32,6 +32,7 @@
 #include <wolfssl/wolfcrypt/hmac.h>
 #include <wolfssl/wolfcrypt/asn_public.h>
 #include <wolfssl/wolfcrypt/random.h>
+#include <wolfssl/wolfcrypt/memory.h>
 #ifdef HAVE_FIPS
     #include <wolfssl/wolfcrypt/fips_test.h>
 #endif
@@ -1995,13 +1996,25 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_getPkcs8TraditionalOffset
     if ((*jenv)->ExceptionOccurred(jenv)) {
         (*jenv)->ExceptionDescribe(jenv);
         (*jenv)->ExceptionClear(jenv);
-    	XFREE(inBuf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    #if (LIBWOLFSSL_VERSION_HEX >= 0x05008004) && \
+        !defined(WOLFSSL_NO_FORCE_ZERO)
+        wc_ForceZero(inBuf, (long)sz);
+    #else
+        XMEMSET(inBuf, 0, (long)sz);
+    #endif
+        XFREE(inBuf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         return SSL_FAILURE;
     }
 
     inOutIdx = (word32)idx;
     ret = wc_GetPkcs8TraditionalOffset(inBuf, &inOutIdx, (word32)sz);
 
+    #if (LIBWOLFSSL_VERSION_HEX >= 0x05008004) && \
+        !defined(WOLFSSL_NO_FORCE_ZERO)
+        wc_ForceZero(inBuf, (long)sz);
+    #else
+        XMEMSET(inBuf, 0, (long)sz);
+    #endif
     XFREE(inBuf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 
     if (ret < 0)

--- a/native/com_wolfssl_WolfSSLContext.c
+++ b/native/com_wolfssl_WolfSSLContext.c
@@ -29,6 +29,7 @@
 #endif
 #include <wolfssl/ssl.h>
 #include <wolfssl/wolfcrypt/asn.h>
+#include <wolfssl/wolfcrypt/memory.h>
 #include <wolfssl/error-ssl.h>
 
 #include "com_wolfssl_globals.h"
@@ -926,6 +927,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_usePrivateKeyBuffer
     int ret = WOLFSSL_FAILURE;
     byte* buff = NULL;
     word32 buffSz = 0;
+    jboolean isCopy = JNI_FALSE;
     WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
     (void)sz;
@@ -934,13 +936,22 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_usePrivateKeyBuffer
         return (jint)BAD_FUNC_ARG;
     }
 
-    buff = (byte*)(*jenv)->GetByteArrayElements(jenv, in, NULL);
+    buff = (byte*)(*jenv)->GetByteArrayElements(jenv, in, &isCopy);
     buffSz = (*jenv)->GetArrayLength(jenv, in);
 
     if (buff != NULL && buffSz > 0) {
         ret = wolfSSL_CTX_use_PrivateKey_buffer(ctx, buff, buffSz, format);
     }
 
+    /* Only zero if JVM made a copy */
+    if (buff != NULL && isCopy == JNI_TRUE) {
+    #if (LIBWOLFSSL_VERSION_HEX >= 0x05008004) && \
+        !defined(WOLFSSL_NO_FORCE_ZERO)
+        wc_ForceZero(buff, buffSz);
+    #else
+        XMEMSET(buff, 0, buffSz);
+    #endif
+    }
     (*jenv)->ReleaseByteArrayElements(jenv, in, (jbyte*)buff, JNI_ABORT);
 
     return (jint)ret;

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -5209,8 +5209,12 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useSNI
         return BAD_FUNC_ARG;
     }
 
-    dataBuf = (byte*)(*jenv)->GetByteArrayElements(jenv, data, NULL);
     dataSz = (*jenv)->GetArrayLength(jenv, data);
+    if (dataSz > WOLFSSL_MAX_16BIT) {
+        return BAD_FUNC_ARG;
+    }
+
+    dataBuf = (byte*)(*jenv)->GetByteArrayElements(jenv, data, NULL);
 
     if (dataBuf != NULL && dataSz > 0) {
         ret = wolfSSL_UseSNI(ssl, (byte)type, dataBuf, (word16)dataSz);

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -5957,7 +5957,11 @@ int NativeALPNSelectCb(WOLFSSL *ssl, const unsigned char **out,
         }
     }
 
-   return ret;
+    if (needsDetach) {
+        (*g_vm)->DetachCurrentThread(g_vm);
+    }
+
+    return ret;
 }
 
 #endif /* HAVE_ALPN */

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -1574,7 +1574,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_read__JLjava_nio_ByteBuff
         }
 
         size = SSLReadNonblockingWithSelectPoll(ssl, data + position,
-            maxOutputSz, (int)timeout);
+            outSz, (int)timeout);
 
         /* Release array elements if using array-backed buffer.
          * Note: DirectByteBuffer doesn't need releasing data */


### PR DESCRIPTION
## Summary
  - Fix ByteBuffer read using unclamped size parameter, reading more bytes than caller requested (F-2149)
  - Zero sensitive private key material before releasing memory in ECC key export (F-2153, F-2154), CTX private key loading (F-2157), and PKCS#8 offset parsing (F-2158), using `wc_ForceZero()` when available (wolfSSL >= 5.8.4) with `XMEMSET` fallback
  - Fix JVM thread leak on ALPN callback success path due to missing `DetachCurrentThread` (F-2150)
  - Add bounds check for SNI data size before `word16` cast to prevent silent truncation (F-2155)
  - Guard JaCoCo `taskdef` behind availability check to prevent unconditional JAR loading, matching existing SpotBugs pattern (F-2151)