### PR TITLE
JSSE: SunJSSE test fixes

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
@@ -962,6 +962,7 @@ public class WolfSSLEngine extends SSLEngine {
                  * since we won't be sending anything after the alert went
                  * out. */
                 this.outBoundOpen = false;
+                this.closed = true;
             }
             else if (produced == 0) {
                 /* continue handshake or application data */
@@ -1671,6 +1672,7 @@ public class WolfSSLEngine extends SSLEngine {
                                  * close outbound since we won't be receiving
                                  * any more data */
                                 this.outBoundOpen = false;
+                                this.closed = true;
                             }
                             /* Throw SSLHandshakeException if handshake not
                              * finished, otherwise throw SSLException for

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -2055,9 +2055,6 @@ public class WolfSSLSocket extends SSLSocket {
 
         try {
             if (beforeObjectInit == false) {
-                /* Ensure SSL state exists before TLS-specific close path. */
-                checkAndInitSSLSocket();
-
                 /* Check if underlying Socket is still open before closing,
                  * in case application calls SSLSocket.close() multiple times */
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,


### PR DESCRIPTION
Removes `checkAndInitSSLSocket()` call in `WolfSSLSocket.close()`. Function is meant to be called when initializing SSL Socket. Calling during close is counter-intuitive and causes a second, unnecessary exception to be thrown if connection failed during `checkAndInitSSLSocket()` at `EngineHelper.loadKeyAndCertChain()`.

Fixes SunJSSE test `NetSSLCiphersuites/ECCurvesconstraints.java`

Sets `this.closed = true` when receiving a `FATAL_ALERT` in `unwrap()` or if buffered data was sent, inbound was closed and close_notify sent in `wrap()`. Buffer should not receive any more data.

Fixes SunJSSE tests `SSLEngine/EngineCloseOnAlert.java` and `SSLEngineImpl/SSLEngineFailedALPN.java`