### PR TITLE
Fenrir fixes

### DIFF
--- a/native/com_wolfssl_WolfSSLCertRequest.c
+++ b/native/com_wolfssl_WolfSSLCertRequest.c
@@ -380,7 +380,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertRequest_X509_1REQ_1set_1pubke
     (void)jcl;
     (void)keyType;
 
-    if (jenv == NULL || x509 == NULL) {
+    if (jenv == NULL || x509 == NULL || fileBytes == NULL) {
         return WOLFSSL_FAILURE;
     }
 

--- a/native/com_wolfssl_WolfSSLCertRequest.c
+++ b/native/com_wolfssl_WolfSSLCertRequest.c
@@ -623,7 +623,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertRequest_X509_1add_1ext_1via_1
     int ret = WOLFSSL_SUCCESS;
     (void)jcl;
 
-    if (jenv == NULL || x509 == NULL) {
+    if (jenv == NULL || x509 == NULL || extValue == NULL) {
         return WOLFSSL_FAILURE;
     }
 

--- a/native/com_wolfssl_WolfSSLCertRequest.c
+++ b/native/com_wolfssl_WolfSSLCertRequest.c
@@ -250,7 +250,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertRequest_X509_1REQ_1sign
     int ret = WOLFSSL_SUCCESS;
     (void)jcl;
 
-    if (jenv == NULL || x509 == NULL) {
+    if (jenv == NULL || x509 == NULL || keyBytes == NULL ||
+        digestAlg == NULL) {
         return WOLFSSL_FAILURE;
     }
 

--- a/native/com_wolfssl_WolfSSLCertificate.c
+++ b/native/com_wolfssl_WolfSSLCertificate.c
@@ -289,7 +289,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1add_1altname
     int ret = WOLFSSL_SUCCESS;
     (void)jcl;
 
-    if (jenv == NULL || x509 == NULL) {
+    if (jenv == NULL || x509 == NULL || altName == NULL) {
         return WOLFSSL_FAILURE;
     }
 
@@ -325,7 +325,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1add_1ext_1via_1
     int ret = WOLFSSL_SUCCESS;
     (void)jcl;
 
-    if (jenv == NULL || x509 == NULL) {
+    if (jenv == NULL || x509 == NULL || extValue == NULL) {
         return WOLFSSL_FAILURE;
     }
 
@@ -2357,7 +2357,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1is_1extension_1
     WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
     (void)jcl;
 
-    if (jenv == NULL || x509 == NULL) {
+    if (jenv == NULL || x509 == NULL || oidIn == NULL) {
         return 0;
     }
 

--- a/native/com_wolfssl_WolfSSLCertificate.c
+++ b/native/com_wolfssl_WolfSSLCertificate.c
@@ -190,7 +190,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1set_1pubkey_1na
     (void)jcl;
     (void)keyType;
 
-    if (jenv == NULL || x509 == NULL) {
+    if (jenv == NULL || x509 == NULL || fileBytes == NULL) {
         return WOLFSSL_FAILURE;
     }
 

--- a/native/com_wolfssl_WolfSSLCertificate.c
+++ b/native/com_wolfssl_WolfSSLCertificate.c
@@ -893,7 +893,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1sign
     int ret = WOLFSSL_SUCCESS;
     (void)jcl;
 
-    if (jenv == NULL || x509 == NULL) {
+    if (jenv == NULL || x509 == NULL || fileBytes == NULL ||
+        digestAlg == NULL) {
         return WOLFSSL_FAILURE;
     }
 

--- a/native/com_wolfssl_WolfSSLCertificate.c
+++ b/native/com_wolfssl_WolfSSLCertificate.c
@@ -551,7 +551,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1set_1serialNumb
     int ret = WOLFSSL_SUCCESS;
     (void)jcl;
 
-    if (jenv == NULL || x509 == NULL) {
+    if (jenv == NULL || x509 == NULL || serialBytes == NULL) {
         return WOLFSSL_FAILURE;
     }
 

--- a/native/com_wolfssl_WolfSSLContext.c
+++ b/native/com_wolfssl_WolfSSLContext.c
@@ -4165,6 +4165,7 @@ int  NativeRsaSignCb(WOLFSSL* ssl, const unsigned char* in, unsigned int inSz,
         (*jenv)->DeleteLocalRef(jenv, j_outSz);
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
+        return -1;
     }
 
     if (retval == 0) {

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -4507,6 +4507,7 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setEccSignCtx
     if (!myCtx->obj) {
         throwWolfSSLException(jenv,
                "Unable to store WolfSSLSession object as global reference");
+        XFREE(myCtx, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         return;
     }
 


### PR DESCRIPTION
 Fixes F-2937, F-2938, F-2939, F-2940, F-2941, F-2942, F-2943.                                
                                                                                               
  - Null-check jstring params before GetStringUTFChars in X509_add_altname, X509_add_ext_via_nconf_nid (Cert and Req), and X509_is_extension_set                         
  - Null-check fileBytes/keyBytes/digestAlg params before Get calls in X509_sign and X509_REQ_sign                                                                                
  - Null-check fileBytes param in X509_set_pubkey_native_open
  - Null-check serialBytes param in X509_set_serialNumber                                      
  - Null-check fileBytes param in X509_REQ_set_pubkey_native_open                              
  - Add missing return after exception handling in NativeRsaSignCb to prevent JNI local ref double-free                                                                                  
  - Free internCtx on NewGlobalRef failure in seven PK callback context setup functions
  
No unit tests added since these mostly just defensive hardening.