### PR TITLE
Prep for 1.17 release

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,94 @@
+### wolfSSL JNI Release 1.17.0 (TBD)
+
+Release 1.17.0 has bug fixes and new features including:
+
+**New JSSE Functionality:**
+* Add JSSE-level Pre-Shared Key (PSK) support via `WolfSSLParameters` for `SSLSocket` and `SSLEngine` (PR 340)
+* Add Java 9+ module support (JPMS) with conditional `module-info.java` compilation for `jlink` custom runtime compatibility (PR 324)
+* Add `CertPathTrustManagerParameters` and `KeyStoreBuilderParameters` support in `WolfSSLTrustManager` (PR 310)
+
+**New JNI Functionality:**
+* Add `WolfSSL.getSNIFromBuffer()` wrapping `wolfSSL_SNI_GetFromBuffer()` for SNI extraction from raw ClientHello (PR 339)
+* Add RSA-PSS sign/verify and RSA sign check PK callback support (PR 338)
+* Add `pathLen` parameter to `WolfSSLCertificate/WolfSSLCertRequest.addExtension()` for setting Basic Constraints with path length constraint (PR 341)
+* Add CRL generation wrappers in `WolfSSLCRL` (PR 315)
+* Add CRL decode wrappers in `WolfSSLCRL` for parsing and inspecting existing CRL data (PR 333)
+* Add Subject Key Identifier, Authority Key Identifier, CRL Distribution Points, and Netscape Certificate Type extension support in `WolfSSLCertificate` (PR 317)
+* Add X.509 Name Constraints extension support with new `WolfSSLNameConstraints` and `WolfSSLGeneralName` classes for RFC 5280 compliant DNS, email, IP, and URI constraint validation (PR 316)
+* Add extended Authority Information Access (AIA) interface to retrieve OCSP and CA Issuer URLs separately from certificates (PR 323)
+* Add `WolfSSLAltName` class for extended SAN parsing including `otherName` (MS AD UPN), `iPAddress`, and `directoryName` GeneralName types (PR 313)
+
+**New Property Support:**
+* Add `wolfjsse.skipFIPSCAST` Security property to skip automatic FIPS CAST execution during wolfJSSE init (PR 342)
+* Add `wolfssl.skipLibraryLoad` System property to skip automatic `System.loadLibrary()` calls (PR 325)
+
+**JNI and JSSE Changes:**
+* Limit SSLSocket write chunk size to 16384 bytes (2^14) per RFC 8446 (PR 308)
+* Fix `SSLEngine` `BUFFER_UNDERFLOW` handling for partial TLS records where only the header was available (PR 334)
+* Fix `SSLEngine` `BUFFER_OVERFLOW` handling to stash decrypted application data and retry instead of losing data (PR 334)
+* Fix `SSLEngine` close/shutdown state transitions and `close_notify` handshake status reporting (PR 334, 354)
+* Fix `SSLSocket.close()` throwing duplicate exception when the initial connection had already failed (PR 330, 354)
+* Fix `SSLEngine.unwrap()` incorrectly returning `BUFFER_UNDERFLOW` when all supplied bytes were consumed but more ciphertext still needed (PR 351)
+* Preserve `CertificateException` as the cause of `SSLHandshakeException` in both `SSLSocket` and `SSLEngine` paths (PR 334)
+* Throw `SSLHandshakeException` instead of `SSLException` on handshake errors for Spring Boot compatibility (PR 310)
+* Throw `SSLPeerUnverifiedException` from `getPeerCertificates()` on server side when no client auth was requested (PR 310)
+* Improve `SSLEngine` SNI handling: prefer configured SNI for hostname verification, enforce server-side `SNIMatcher` after handshake, enable auto-SNI for `SSLEngine(host, port)`, and fix stale SNI cache on session resumption (PR 334, 349)
+* Support `SSLEngine(host, -1)` unknown-port hints for Netty compatibility (PR 334)
+* Fix session timeout boundary behavior and filter invalid/expired sessions from `SSLSessionContext` enumeration (PR 334)
+* Fix `resizeCache()` discarding existing sessions when the session cache was resized (PR 347)
+* Preserve session value bindings when copying sessions for resumption (PR 334)
+* Return `X500Principal` from `getPeerPrincipal()` and `getLocalPrincipal()` for proper Java X.509 principal compatibility (PR 334)
+* Add `equals()` and `hashCode()` to `WolfSSLX509` for principal comparison compatibility with frameworks that check certificate equality (PR 334)
+* Return non-null signature algorithm arrays from `ExtendedSSLSession` methods (PR 334)
+* Fix `WolfSSLTrustX509.getAcceptedIssuers()` operator precedence bug returning incorrect trusted issuers (PR 334)
+* Fix OCSP chain issuer handling to correctly use provided certificate chain entries (PR 334)
+* Skip certificate-only trust entries without private keys in `chooseClientAlias()` key selection (PR 310)
+* Filter anonymous cipher suites from default enabled cipher suite list, matching SunJSSE `jdk.tls.disabledAlgorithms` behavior (PR 343)
+* Filter available cipher suites based on configured TLS protocol version in `getAvailableCipherSuitesIana()` (PR 318)
+* Fix `WolfSSLSession.read()` ByteBuffer reading more bytes than requested due to unclamped size parameter (PR 353)
+* Fix PSK client identity copy and key length validation against maximum buffer sizes to prevent potential buffer overflows (PR 346)
+* Fix `x509_getDer()` potential crash due to missing `jbyteArray` allocation before `SetByteArrayRegion` (PR 347)
+* Fix possible null dereference in `WolfSSLSession.setServerID()` before `id.length` access (PR 344)
+* Fix possible null crash in `CertManagerLoadCA()` when null certFile or certPath passed from Java (PR 345)
+* Fix possible null dereference in `WolfSSLTrustManager.LoadAndroidSystemCertsManually()` on Android (PR 344)
+- Fix SHA-224 signature type string typo where `SHA244` was used instead of `SHA224` (PR 345)
+- Fix `FD_SETSIZE` bounds check in `socketSelect()` before `FD_SET` calls to prevent undefined behavior with high file descriptors (PR 345)
+- Fix potential I/O stall from stale `pollRx`/`pollTx` flags not being reset between I/O loop iterations (PR 345)
+- Fix JVM thread leaks from missing `DetachCurrentThread` in ALPN, verify, and CRL native callbacks (PR 346, 347, 353)
+- Fix memory leak of `internCtx` on `NewGlobalRef` failure in PK callback setup functions (PR 356)
+- Fix thread-safety issues in `WolfSSLParameters` for `getCipherSuites()`, `setCipherSuites()`, `getApplicationProtocols()`, and `setApplicationProtocols()` (PR 344)
+- Fix thread-safety issue in native PK callbacks when multiple SSL sessions active by removing incorrect static qualifier from `g_cachedSSLObj` (PR 345)
+- Deregister native FIPS error callback on library cleanup to prevent callbacks into garbage-collected Java objects (PR 337)
+- Fix Android FIPS Ready build to define `WOLFSSL_ALWAYS_KEEP_SNI`, fixing SNI matcher test failures (PR 355)
+
+**Example Changes:**
+- Add PSK example applications for `SSLSocket` and `SSLEngine` client/server (PR 340)
+- Add `DualProviderFIPSTest` example for wolfJSSE and wolfJCE dual provider FIPS usage (PR 342)
+- Update Android example app to perform TLS connection using wolfJSSE `SSLSocket` and add FIPS error callback for hash development workflow (PR 355)
+
+**Testing Changes:**
+- Add SpotBugs static analysis build target, exclusion filter, and GitHub Actions workflow (PR 344)
+- Add GitHub Actions workflow for Android FIPS Ready testing with automated hash capture via emulator (PR 355)
+- Add GitHub Actions workflow for FIPS Ready dual provider testing with wolfJSSE and wolfJCE (PR 342)
+- Add GitHub Actions workflow for UndefinedBehaviorSanitizer (UBSan) testing (PR 321)
+- Add GitHub Actions workflow for Linux 32-bit testing with Java 17 (PR 320)
+- Add GitHub Actions workflow for Java Module (JPMS) testing (PR 324)
+- Add GitHub Actions workflow for checking source file list consistency (PR 331)
+- Add `make` target and GitHub Actions workflow for building with all wolfSSL patches enabled (PR 322, 326)
+- Add Java 24 and 25 to GitHub Actions test matrix (PR 319)
+- Update line length check script for correct line numbers and local use (PR 328)
+- Guard JaCoCo `taskdef` behind availability check to prevent build failures when JAR is absent (PR 353)
+
+**Misc Changes:**
+- Update `Makefile` to generate dependency files, support verbose mode, and enable `-Wextra`/`-Werror` compiler flags (PR 332)
+- Add Gradle distribution SHA-256 hash verification in Android build (PR 350)
+- Replace deprecated `jcenter()` with `mavenCentral()` in Android Gradle build (PR 350)
+- Update Android `CMakeLists.txt` to exclude newly-added wolfSSL source files fixing build failures (PR 326, 346)
+
+The wolfSSL JNI/JSSE Manual is available at:
+https://www.wolfssl.com/documentation/manuals/wolfssljni/. For build
+instructions and more details, please check the manual.
+
 ### wolfSSL JNI Release 1.16.0 (12/31/2025)
 
 Release 1.16.0 has bug fixes and new features including:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,89 @@
+### wolfSSL JNI Release 1.17.0 (04/20/2026)
+
+Release 1.17.0 has bug fixes and new features including:
+
+**New JSSE Functionality:**
+* Add JSSE-level Pre-Shared Key (PSK) support via `WolfSSLParameters` for `SSLSocket`/`SSLEngine` (PR 340)
+* Add Java 9+ module support (JPMS) with conditional `module-info.java` compilation for `jlink` compatibility (PR 324)
+* Add `CertPathTrustManagerParameters` and `KeyStoreBuilderParameters` support in `WolfSSLTrustManager` (PR 310)
+
+**New JNI Functionality:**
+* Add `WolfSSL.getSNIFromBuffer()` wrapping `wolfSSL_SNI_GetFromBuffer()` for SNI extraction from raw ClientHello (PR 339)
+* Add RSA-PSS sign/verify and RSA sign check PK callback support (PR 338)
+* Add `pathLen` parameter to `WolfSSLCertificate/WolfSSLCertRequest.addExtension()` for Basic Constraints (PR 341)
+* Add CRL generation wrappers in `WolfSSLCRL` (PR 315)
+* Add CRL decode wrappers in `WolfSSLCRL` for parsing and inspecting existing CRL data (PR 333)
+* Add SKID, AKID, CRL Dist Points, and Netscape Cert Type extension support in `WolfSSLCertificate` (PR 317)
+* Add X.509 Name Constraints extension support with `WolfSSLNameConstraints`/`WolfSSLGeneralName` (PR 316)
+* Add extended AIA interface to retrieve OCSP and CA Issuer URLs separately from certs (PR 323)
+* Add `WolfSSLAltName` class for extended SAN parsing including `otherName` (MS AD UPN), `iPAddress`, and `directoryName` GeneralName types (PR 313)
+
+**New Property Support:**
+* Add `wolfjsse.skipFIPSCAST` Security property to skip automatic FIPS CAST execution during wolfJSSE init (PR 342)
+* Add `wolfssl.skipLibraryLoad` System property to skip automatic `System.loadLibrary()` calls (PR 325)
+
+**JNI and JSSE Changes:**
+* Limit `SSLSocket` write chunk size to 16384 (2^14) bytes (PR 308)
+* Fix `SSLEngine` `BUFFER_UNDERFLOW` handling for partial TLS records where only header was available (PR 334)
+* Fix `SSLEngine` `BUFFER_OVERFLOW` handling to stash decrypted application data and retry instead of losing data (PR 334)
+* Fix `SSLEngine` close/shutdown state transitions and `close_notify` handshake status reporting (PR 334, 354)
+* Fix `SSLSocket.close()` throwing duplicate exception when the initial connection had already failed (PR 330, 354)
+* Fix `SSLEngine.unwrap()` incorrectly returning `BUFFER_UNDERFLOW` when all bytes were consumed but more ciphertext needed (PR 351)
+* Throw `SSLHandshakeException` instead of `SSLException` on handshake errors for Spring Boot compatibility (PR 310)
+* Throw `SSLPeerUnverifiedException` from `getPeerCertificates()` on server side when no client auth requested (PR 310)
+* Improve `SSLEngine` SNI handling: prefer configured SNI for hostname verification, enforce server-side `SNIMatcher` after handshake, enable auto-SNI for `SSLEngine(host, port)`, fix stale SNI cache on session resumption (PR 334, 349)
+* Support `SSLEngine(host, -1)` unknown-port hints for Netty compatibility (PR 334)
+* Fix session timeout boundary behavior and filter invalid/expired sessions from `SSLSessionContext` enumeration (PR 334)
+* Return `X500Principal` from `getPeerPrincipal()` and `getLocalPrincipal()` for proper Java X.509 principal compatibility (PR 334)
+* Add `equals()` and `hashCode()` to `WolfSSLX509` for comparison compatibility with frameworks that check cert equality (PR 334)
+* Return non-null signature algorithm arrays from `ExtendedSSLSession` methods (PR 334)
+* Fix `WolfSSLTrustX509.getAcceptedIssuers()` operator precedence returning incorrect trusted issuers (PR 334)
+* Fix OCSP chain issuer handling to correctly use provided certificate chain entries (PR 334)
+* Skip certificate-only trust entries without private keys in `chooseClientAlias()` key selection (PR 310)
+* Filter anon suites from default enabled cipher suite list, matching `jdk.tls.disabledAlgorithms` behavior (PR 343)
+* Filter available cipher suites based on configured TLS version in `getAvailableCipherSuitesIana()` (PR 318)
+* Fix `WolfSSLSession.read()` ByteBuffer reading more bytes than requested (PR 353)
+* Fix PSK client identity copy / key length validation against max buffer sizes (PR 346)
+* Fix `x509_getDer()` potential crash due to missing `jbyteArray` allocation before `SetByteArrayRegion` (PR 347)
+* Fix possible null dereference in `WolfSSLSession.setServerID()` before `id.length` access (PR 344)
+* Fix possible null crash in `CertManagerLoadCA()` when null certFile or certPath passed from Java (PR 345)
+* Fix possible null dereference in `WolfSSLTrustManager.LoadAndroidSystemCertsManually()` on Android (PR 344)
+- Fix SHA-224 signature type string typo where `SHA244` was used instead of `SHA224` (PR 345)
+- Fix `FD_SETSIZE` bounds check in `socketSelect()` before `FD_SET` calls to prevent undefined behavior with high file descriptors (PR 345)
+- Fix potential I/O stall from stale `pollRx`/`pollTx` flags not being reset between I/O loop iterations (PR 345)
+- Fix JVM thread leaks from missing `DetachCurrentThread` in ALPN, verify, and CRL native callbacks (PR 346, 347, 353)
+- Fix memory leak of `internCtx` on `NewGlobalRef` failure in PK callback setup functions (PR 356)
+- Fix thread-safety issue in native PK callbacks when multiple SSL sessions active (PR 345)
+- Deregister native FIPS error callback on library cleanup to prevent callbacks into garbage-collected Java objects (PR 337)
+
+**Example Changes:**
+- Add PSK example applications for `SSLSocket` and `SSLEngine` client/server (PR 340)
+- Add `DualProviderFIPSTest` example for wolfJSSE and wolfJCE dual provider FIPS usage (PR 342)
+- Update Android example app to perform TLS connection using wolfJSSE `SSLSocket`, add FIPS error callback for hash development workflow (PR 355)
+
+**Testing Changes:**
+- Add SpotBugs static analysis build target, exclusion filter, and GitHub Actions workflow (PR 344)
+- Add GitHub Actions workflow for Android FIPS Ready testing with automated hash capture via emulator (PR 355)
+- Add GitHub Actions workflow for FIPS Ready dual provider testing with wolfJSSE and wolfJCE (PR 342)
+- Add GitHub Actions workflow for UndefinedBehaviorSanitizer (UBSan) testing (PR 321)
+- Add GitHub Actions workflow for Linux 32-bit testing with Java 17 (PR 320)
+- Add GitHub Actions workflow for Java Module (JPMS) testing (PR 324)
+- Add GitHub Actions workflow for checking source file list consistency (PR 331)
+- Add `make` target and GitHub Actions workflow for building with all wolfSSL patches enabled (PR 322, 326)
+- Add Java 24 and 25 to GitHub Actions test matrix (PR 319)
+- Update line length check script for correct line numbers and local use (PR 328)
+- Guard JaCoCo `taskdef` behind availability check to prevent build failures when JAR is absent (PR 353)
+
+**Misc Changes:**
+- Update `Makefile` to generate dependency files, support verbose mode, and enable `-Wextra`/`-Werror` compiler flags (PR 332)
+- Add Gradle distribution SHA-256 hash verification in Android build (PR 350)
+- Replace deprecated `jcenter()` with `mavenCentral()` in Android Gradle build (PR 350)
+- Update Android `CMakeLists.txt` to exclude newly-added wolfSSL source files fixing build failures (PR 326, 346)
+
+The wolfSSL JNI/JSSE Manual is available at:
+https://www.wolfssl.com/documentation/manuals/wolfssljni/. For build
+instructions and more details, please check the manual.
+
 ### wolfSSL JNI Release 1.16.0 (12/31/2025)
 
 Release 1.16.0 has bug fixes and new features including:

--- a/IDE/WIN/README.md
+++ b/IDE/WIN/README.md
@@ -249,7 +249,18 @@ and set the values for `HAVE_FIPS`, `HAVE_FIPS_VERSION`, and
 #define SESSION_CERTS
 #define WOLFSSL_ALT_CERT_CHAINS
 #define WOLFSSL_ALWAYS_VERIFY_CB
+#define WOLFSSL_TLS13
+#define HAVE_FFDHE_2048
 ```
+
+Note: the bundle's `user_settings.h` template only enables
+`WOLFSSL_TLS13` for FIPS v5+ builds, so it must be added explicitly
+here for FIPS v2 to match the TLS 1.3 support that `./configure
+--enable-fips=v2 --enable-jni` gives on Linux/macOS. Without it the
+wolfJSSE provider will not register the `TLSv1.3` algorithm.
+`HAVE_FFDHE_2048` is required alongside `WOLFSSL_TLS13` to configure
+the TLS 1.3 DH key size (otherwise `src/tls.c` fails to compile with
+an `#error` asking for one of the `HAVE_FFDHE_*` defines).
 
 6. Build the `wolfssl-fips` project, which will create a DLL in one of the
 following locations:

--- a/IDE/WIN/wolfssljni.vcxproj
+++ b/IDE/WIN/wolfssljni.vcxproj
@@ -211,7 +211,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;WOLFCRYPTJNI_EXPORTS;WOLFSSL_USER_SETTINGS;WOLFSSL_LIB;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;WOLFCRYPTJNI_EXPORTS;WOLFSSL_USER_SETTINGS;WOLFSSL_LIB;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>false</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -236,7 +236,7 @@ ant</Command>
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;WOLFCRYPTJNI_EXPORTS;WOLFSSL_USER_SETTINGS;WOLFSSL_LIB;HAVE_FIPS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;WOLFCRYPTJNI_EXPORTS;WOLFSSL_USER_SETTINGS;WOLFSSL_LIB;HAVE_FIPS;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>false</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -263,7 +263,7 @@ ant</Command>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;WOLFCRYPTJNI_EXPORTS;WOLFSSL_USER_SETTINGS;WOLFSSL_LIB;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;WOLFCRYPTJNI_EXPORTS;WOLFSSL_USER_SETTINGS;WOLFSSL_LIB;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>false</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -292,7 +292,7 @@ ant</Command>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;WOLFCRYPTJNI_EXPORTS;WOLFSSL_USER_SETTINGS;WOLFSSL_LIB;HAVE_FIPS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;WOLFCRYPTJNI_EXPORTS;WOLFSSL_USER_SETTINGS;WOLFSSL_LIB;HAVE_FIPS;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>false</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -319,7 +319,7 @@ ant</Command>
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;WOLFCRYPTJNI_EXPORTS;WOLFSSL_USER_SETTINGS;WOLFSSL_LIB;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;WOLFCRYPTJNI_EXPORTS;WOLFSSL_USER_SETTINGS;WOLFSSL_LIB;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>false</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -346,7 +346,7 @@ ant
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;WOLFCRYPTJNI_EXPORTS;WOLFSSL_USER_SETTINGS;WOLFSSL_LIB;HAVE_FIPS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;WOLFCRYPTJNI_EXPORTS;WOLFSSL_USER_SETTINGS;WOLFSSL_LIB;HAVE_FIPS;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>false</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -376,7 +376,7 @@ ant
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>
       </SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;WOLFCRYPTJNI_EXPORTS;WOLFSSL_USER_SETTINGS;WOLFSSL_LIB;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;WOLFCRYPTJNI_EXPORTS;WOLFSSL_USER_SETTINGS;WOLFSSL_LIB;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>false</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -408,7 +408,7 @@ ant</Command>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>
       </SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;WOLFCRYPTJNI_EXPORTS;WOLFSSL_USER_SETTINGS;WOLFSSL_LIB;HAVE_FIPS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;WOLFCRYPTJNI_EXPORTS;WOLFSSL_USER_SETTINGS;WOLFSSL_LIB;HAVE_FIPS;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>false</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME = wolfssl-jni-jsse
 VERSION = $(shell grep 'name="implementation.version"' build.xml | sed -re 's/.*value="(.+)".*/\1/')
-DIST_FILES = build.xml  COPYING  docs  examples  IDE  java.sh  lib  LICENSING  Makefile  native  platform \
+DIST_FILES = build.xml  COPYING  examples  IDE  java.sh  LICENSING  Makefile  native  platform \
 	     README.md  rpm  src
 
 ifneq ($(PREFIX),)

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ an application can include this as a dependency in the application's
         <dependency>
             <groupId>com.wolfssl</groupId>
             <artifactId>wolfssl-jsse</artifactId>
-            <version>1.16.0-SNAPSHOT</version>
+            <version>1.17.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
     ...

--- a/build.xml
+++ b/build.xml
@@ -132,9 +132,9 @@
 
     <target name="cleanjni">
         <delete>
-            <fileset dir="${lib.dir}" includes="*.dylib"/>
-            <fileset dir="${lib.dir}" includes="*.so"/>
-            <fileset dir="${native.dir}" includes="*.o"/>
+            <fileset dir="${lib.dir}" includes="*.dylib" erroronmissingdir="false"/>
+            <fileset dir="${lib.dir}" includes="*.so" erroronmissingdir="false"/>
+            <fileset dir="${native.dir}" includes="*.o" erroronmissingdir="false"/>
         </delete>
     </target>
 

--- a/build.xml
+++ b/build.xml
@@ -14,7 +14,7 @@
     <!-- versioning/manifest properties -->
     <property name="implementation.vendor"  value="wolfSSL Inc." />
     <property name="implementation.title"   value="wolfSSL JNI/JSSE" />
-    <property name="implementation.version" value="1.16" />
+    <property name="implementation.version" value="1.17" />
 
     <!-- set properties for this build -->
     <property name="src.dir" value="src/java/"/>

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -222,7 +222,9 @@ static void writeToInterruptPipe(SSLAppData* appData)
 {
     if (appData != NULL) {
         if (appData->interruptFds[1] != -1) {
-            write(appData->interruptFds[1], "1", 1);
+            if (write(appData->interruptFds[1], "1", 1) < 0) {
+                /* Interrupt pipe wakeup is best-effort; ignore failure. */
+            }
         }
     }
 }
@@ -896,9 +898,10 @@ static int socketSelect(SSLAppData* appData, int sockfd, int timeout_ms, int rx,
                  * an error if not there. Another read/write() may have
                  * already read it off. We just want to be interrupted,
                  * byte value does not matter. */
+                ssize_t rd;
                 do {
-                    read(appData->interruptFds[0], tmpBuf, 1);
-                } while (errno == EINTR);
+                    rd = read(appData->interruptFds[0], tmpBuf, 1);
+                } while (rd < 0 && errno == EINTR);
 
                 return WOLFJNI_IO_EVENT_FD_CLOSED;
             }
@@ -1000,9 +1003,10 @@ static int socketPoll(SSLAppData* appData, int sockfd, int timeout_ms,
                 (fds[1].revents & POLLIN)) {
                 /* received data on interrupt pipe, read and return
                  * that descriptor is closed (closing) */
+                ssize_t rd;
                 do {
-                    read(appData->interruptFds[0], tmpBuf, 1);
-                } while (errno == EINTR);
+                    rd = read(appData->interruptFds[0], tmpBuf, 1);
+                } while (rd < 0 && errno == EINTR);
 
                 return WOLFJNI_IO_EVENT_FD_CLOSED;
             }

--- a/platform/android_aosp/jsse_install.sh
+++ b/platform/android_aosp/jsse_install.sh
@@ -14,7 +14,7 @@
 #     1) README.android_asop (located in this same directory)
 #     2) "Installing a JSSE Provider in Android AOSP" document, by wolfSSL
 #
-# Copyright (C) 2022, wolfSSL Inc.
+# Copyright (C) 2026, wolfSSL Inc.
 
 if [ "$#" -lt 3 ]; then
     echo "-------------------------------------------" >&2

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.wolfssl</groupId>
 	<artifactId>wolfssl-jsse</artifactId>
-	<version>1.16.0-SNAPSHOT</version>
+	<version>1.17.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>wolfssl-jsse</name>
     <url>https://www.wolfssl.com</url>

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java
@@ -76,8 +76,8 @@ public final class WolfSSLProvider extends Provider {
      * wolfSSL JSSE Provider class
      */
     public WolfSSLProvider() {
-        super("wolfJSSE", 1.16, "wolfSSL JSSE Provider");
-        /* super("wolfJSSE", "1.16", "wolfSSL JSSE Provider"); */
+        super("wolfJSSE", 1.17, "wolfSSL JSSE Provider");
+        /* super("wolfJSSE", "1.17", "wolfSSL JSSE Provider"); */
 
         /* load native wolfSSLJNI library */
         WolfSSL.loadLibrary();

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLContextTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLContextTest.java
@@ -1038,7 +1038,7 @@ public class WolfSSLContextTest {
         }
 
         if (!haveAnon) {
-            System.out.println("\t... skipped (no anon suites)");
+            System.out.println("\t... skipped");
             return;
         }
 

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineMemoryLeakTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineMemoryLeakTest.java
@@ -50,10 +50,13 @@ import com.wolfssl.provider.jsse.WolfSSLProvider;
 public class WolfSSLEngineMemoryLeakTest {
 
     /**
-     * Global timeout for all tests in this class.
+     * Global timeout for all tests in this class. The 500-engine test
+     * plus multiple GC/finalization rounds can run 60+ seconds on slower
+     * platforms (notably Windows with FIPS enabled), so 180s leaves
+     * comfortable headroom while still catching genuine hangs.
      */
     @Rule
-    public Timeout globalTimeout = new Timeout(60, TimeUnit.SECONDS);
+    public Timeout globalTimeout = new Timeout(180, TimeUnit.SECONDS);
 
     @BeforeClass
     public static void setupProvider() {

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineMemoryLeakTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineMemoryLeakTest.java
@@ -104,8 +104,7 @@ public class WolfSSLEngineMemoryLeakTest {
         final double maxAcceptableGrowthMB = 80.0;
 
         String javaVersion = System.getProperty("java.version");
-        System.out.print("\tmem leak test with " + numEngines +
-                         " engines (JDK " + javaVersion + ")");
+        System.out.print("\tmem leak test with " + numEngines + " engines");
 
         /* Measure baseline memory - use aggressive GC */
         for (int i = 0; i < 3; i++) {

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineMemoryLeakTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineMemoryLeakTest.java
@@ -158,7 +158,7 @@ public class WolfSSLEngineMemoryLeakTest {
     public void testEngineMemoryLeakWithProperClose() throws Exception {
 
         final int numEngines = 100;
-        final double maxAcceptableGrowthMB = 10.0;
+        final double maxAcceptableGrowthMB = 20.0;
 
         System.gc();
         System.gc();

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineTest.java
@@ -2701,7 +2701,7 @@ public class WolfSSLEngineTest {
         }
 
         if (anonSuite == null) {
-            pass("\t... skipped (no anon suites)");
+            pass("\t... skipped");
             return;
         }
 
@@ -2760,7 +2760,7 @@ public class WolfSSLEngineTest {
                KeyManagementException, KeyStoreException,
                CertificateException, IOException, UnrecoverableKeyException {
 
-        System.out.print("\tSSLEngine SSLHandshakeException cause chain");
+        System.out.print("\tSSLHandshakeException cause");
 
         final String rejectMsg = "Intentional engine test rejection";
         TrustManager[] rejectingTMs = { new X509TrustManager() {
@@ -2880,7 +2880,7 @@ public class WolfSSLEngineTest {
 
         /* TLS 1.3 close_notify should return NOT_HANDSHAKING,
          * not NEED_WRAP (RFC 8446 Section 6.1). */
-        System.out.print("\tTesting TLS 1.3 close_notify status");
+        System.out.print("\tTLS 1.3 close_notify status");
 
         String[] proto = {"TLSv1.3"};
         this.ctx = tf.createSSLContext("TLSv1.3", engineProvider);
@@ -2977,7 +2977,7 @@ public class WolfSSLEngineTest {
 
         /* Test that unwrap() returns BUFFER_UNDERFLOW with 0 bytes
          * consumed when given a partial TLS record. */
-        System.out.print("\tTesting BUFFER_UNDERFLOW partial record");
+        System.out.print("\tUnderflow partial record");
 
         this.ctx = tf.createSSLContext("TLS", engineProvider);
         SSLEngine server = this.ctx.createSSLEngine();
@@ -3431,7 +3431,7 @@ public class WolfSSLEngineTest {
 
         /* Test BUFFER_OVERFLOW with small output, then retry
          * with larger buffer. */
-        System.out.print("\tTesting BUFFER_OVERFLOW small output");
+        System.out.print("\tOverflow small output");
 
         this.ctx = tf.createSSLContext("TLS", engineProvider);
         SSLEngine server = this.ctx.createSSLEngine();

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineTest.java
@@ -2323,14 +2323,14 @@ public class WolfSSLEngineTest {
             if (!isClient) {
                 ssc = ServerSocketChannel.open();
                 ssc.socket().bind(new InetSocketAddress(
-                    InetAddress.getLocalHost(), 0));
+                    InetAddress.getLoopbackAddress(), 0));
                 serverPort[0] = ssc.socket().getLocalPort();
                 serverReady[0] = true;
                 sc = ssc.accept();
             } else {
                 sc = SocketChannel.open();
                 sc.connect(new InetSocketAddress(
-                    InetAddress.getLocalHost(), serverPort[0]));
+                    InetAddress.getLoopbackAddress(), serverPort[0]));
                 engine.setEnabledProtocols(new String[] { protocol });
             }
 

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLKeyX509Test.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLKeyX509Test.java
@@ -1118,7 +1118,7 @@ public class WolfSSLKeyX509Test {
                KeyManagementException, CertificateException, IOException,
                NoSuchProviderException, UnrecoverableKeyException {
 
-        System.out.print("\tTesting chooseAlias skips cert-only");
+        System.out.print("\tchooseAlias skips cert-only");
 
         KeyManager[] km = tf.createKeyManager("SunX509", tf.allJKS, provider);
         X509ExtendedKeyManager x509km = (X509ExtendedKeyManager) km[0];

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLServerSocketFactoryTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLServerSocketFactoryTest.java
@@ -267,7 +267,7 @@ public class WolfSSLServerSocketFactoryTest {
         }
 
         if (!haveAnon) {
-            System.out.println("\t\t\t... skipped (no anon suites)");
+            System.out.println("\t\t\t... skipped");
             return;
         }
 

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLServerSocketTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLServerSocketTest.java
@@ -918,7 +918,7 @@ public class WolfSSLServerSocketTest {
         }
 
         if (anonSuite == null) {
-            System.out.println("\t\t... skipped (no anon suites)");
+            System.out.println("\t\t... skipped");
             return;
         }
 

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLServerSocketTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLServerSocketTest.java
@@ -36,6 +36,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.FileNotFoundException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import javax.net.ssl.SSLServerSocketFactory;
 import javax.net.ssl.SSLServerSocket;
@@ -233,7 +234,8 @@ public class WolfSSLServerSocketTest {
 
         /* test that connected socket has the same SSLParameters */
         SSLSocket cs = (SSLSocket) ctx.getSocketFactory().createSocket();
-        cs.connect(new InetSocketAddress(ss.getLocalPort()));
+        cs.connect(new InetSocketAddress(InetAddress.getLoopbackAddress(),
+            ss.getLocalPort()));
 
         final SSLSocket server = (SSLSocket) ss.accept();
         p = server.getSSLParameters();
@@ -473,7 +475,8 @@ public class WolfSSLServerSocketTest {
             .createServerSocket(0);
 
         SSLSocket cs = (SSLSocket)ctx.getSocketFactory().createSocket();
-        cs.connect(new InetSocketAddress(ss.getLocalPort()));
+        cs.connect(new InetSocketAddress(InetAddress.getLoopbackAddress(),
+            ss.getLocalPort()));
 
         /* test getter/setter on server socket */
         assertEquals(ss.getEnableSessionCreation(), true);
@@ -543,7 +546,8 @@ public class WolfSSLServerSocketTest {
         assertTrue(ss.getNeedClientAuth());
 
         SSLSocket cs = (SSLSocket)ctx.getSocketFactory().createSocket();
-        cs.connect(new InetSocketAddress(ss.getLocalPort()));
+        cs.connect(new InetSocketAddress(InetAddress.getLoopbackAddress(),
+            ss.getLocalPort()));
 
         final SSLSocket server = (SSLSocket)ss.accept();
 
@@ -589,7 +593,8 @@ public class WolfSSLServerSocketTest {
         ss.setNeedClientAuth(true);
 
         cs = (SSLSocket)ctx.getSocketFactory().createSocket();
-        cs.connect(new InetSocketAddress(ss.getLocalPort()));
+        cs.connect(new InetSocketAddress(InetAddress.getLoopbackAddress(),
+            ss.getLocalPort()));
 
         final SSLSocket server2 = (SSLSocket)ss.accept();
 
@@ -650,7 +655,8 @@ public class WolfSSLServerSocketTest {
         ss.setNeedClientAuth(false);
 
         cs = (SSLSocket)cliCtx.getSocketFactory().createSocket();
-        cs.connect(new InetSocketAddress(ss.getLocalPort()));
+        cs.connect(new InetSocketAddress(InetAddress.getLoopbackAddress(),
+            ss.getLocalPort()));
 
         final SSLSocket server3 = (SSLSocket)ss.accept();
 
@@ -706,7 +712,8 @@ public class WolfSSLServerSocketTest {
         ss.setUseClientMode(false);
 
         SSLSocket cs = (SSLSocket)ctx.getSocketFactory().createSocket();
-        cs.connect(new InetSocketAddress(ss.getLocalPort()));
+        cs.connect(new InetSocketAddress(InetAddress.getLoopbackAddress(),
+            ss.getLocalPort()));
 
         final SSLSocket server = (SSLSocket)ss.accept();
 
@@ -783,7 +790,8 @@ public class WolfSSLServerSocketTest {
         ss.setNeedClientAuth(true);
 
         SSLSocket cs = (SSLSocket)ctx.getSocketFactory().createSocket();
-        cs.connect(new InetSocketAddress(ss.getLocalPort()));
+        cs.connect(new InetSocketAddress(InetAddress.getLoopbackAddress(),
+            ss.getLocalPort()));
 
         final SSLSocket server = (SSLSocket)ss.accept();
 
@@ -853,7 +861,8 @@ public class WolfSSLServerSocketTest {
         ss.setNeedClientAuth(true);
 
         SSLSocket cs = (SSLSocket)ctx.getSocketFactory().createSocket();
-        cs.connect(new InetSocketAddress(ss.getLocalPort()));
+        cs.connect(new InetSocketAddress(InetAddress.getLoopbackAddress(),
+            ss.getLocalPort()));
 
         final SSLSocket server = (SSLSocket)ss.accept();
 

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSessionContextTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSessionContextTest.java
@@ -612,7 +612,7 @@ public class WolfSSLSessionContextTest {
 
         /* Regression: session must expire at exactly the
          * timeout boundary (diff >= timeout, not diff > timeout) */
-        System.out.print("\tTesting session timeout boundary");
+        System.out.print("\tSession timeout boundary");
 
         String originalProp = Security.getProperty(
             "wolfjsse.clientSessionCache.disabled");
@@ -717,7 +717,7 @@ public class WolfSSLSessionContextTest {
 
         /* Regression: invalidated sessions must be filtered
          * from getIds() and getSession(). */
-        System.out.print("\tTesting invalidation filtered from getIds");
+        System.out.print("\tInvalidation filtered getIds");
 
         String originalProp = Security.getProperty(
             "wolfjsse.clientSessionCache.disabled");

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketFactoryTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketFactoryTest.java
@@ -458,7 +458,7 @@ public class WolfSSLSocketFactoryTest {
         }
 
         if (!haveAnon) {
-            System.out.println("\t\t... skipped (no anon suites)");
+            System.out.println("\t\t... skipped");
             return;
         }
 

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
@@ -1003,6 +1003,7 @@ public class WolfSSLSocketTest {
     protected class InternalMultiThreadedSSLSocketServer extends Thread
     {
         private int serverPort;
+        private volatile int boundPort = -1;
         private CountDownLatch serverOpenLatch = null;
         private int clientConnections = 1;
 
@@ -1013,12 +1014,18 @@ public class WolfSSLSocketTest {
             this.clientConnections = clientConnections;
         }
 
+        public int getBoundPort() {
+            return boundPort;
+        }
+
         @Override
         public void run() {
             try {
                 SSLContext ctx = tf.createSSLContext("TLS", ctxProvider);
                 SSLServerSocket ss = (SSLServerSocket)ctx
                     .getServerSocketFactory().createServerSocket(serverPort);
+
+                boundPort = ss.getLocalPort();
 
                 while (clientConnections > 0) {
                     serverOpenLatch.countDown();
@@ -1030,6 +1037,10 @@ public class WolfSSLSocketTest {
 
             } catch (Exception e) {
                 e.printStackTrace();
+                /* Ensure awaiting main thread doesn't hang on bind failure. */
+                if (serverOpenLatch != null) {
+                    serverOpenLatch.countDown();
+                }
             }
         }
 
@@ -1139,10 +1150,11 @@ public class WolfSSLSocketTest {
         /* Number of SSLSocket client threads to start up */
         int numThreads = 50;
 
-        /* Port of internal HTTPS server. Using 11120 since SSLEngine
-         * extended threading test uses 11119. If both tests end up running
-         * concurrently by JUnit ports could conflict. */
-        final int svrPort = 11120;
+        /* Bind server on an ephemeral port (0) so multiple JVMs running
+         * this test concurrently don't collide on a single hardcoded
+         * port. The actual bound port is retrieved after the server
+         * thread signals it's up. */
+        final int svrPort = 0;
 
         /* Create ExecutorService to launch client SSLSocket threads */
         ExecutorService service = Executors.newFixedThreadPool(numThreads);
@@ -1179,12 +1191,21 @@ public class WolfSSLSocketTest {
         /* Wait for server thread to start up before connecting clients */
         serverOpenLatch.await();
 
+        /* Retrieve the actual bound port. Non-positive means the server
+         * failed to bind; fail fast instead of letting each client thread
+         * throw IllegalArgumentException on an invalid port. */
+        final int actualPort = server.getBoundPort();
+        if (actualPort <= 0) {
+            fail("Server failed to bind to a valid port, got: " +
+                actualPort);
+        }
+
         /* Start up client threads */
         for (int i = 0; i < numThreads; i++) {
             service.submit(new Runnable() {
                 @Override public void run() {
                     SSLSocketClient client =
-                        new SSLSocketClient(localCtx, "localhost", svrPort);
+                        new SSLSocketClient(localCtx, "localhost", actualPort);
                     try {
                         client.connect();
                         success.incrementAndGet(0);
@@ -2359,7 +2380,7 @@ public class WolfSSLSocketTest {
             SSLSocketFactory cliFactory = ctx.getSocketFactory();
 
             SSLSocket cs = (SSLSocket)cliFactory.createSocket();
-            cs.connect(new InetSocketAddress(InetAddress.getLocalHost(),
+            cs.connect(new InetSocketAddress(InetAddress.getLoopbackAddress(),
                                              ss.getLocalPort()));
 
             /* start server */
@@ -2390,8 +2411,8 @@ public class WolfSSLSocketTest {
 
                 /* connection #2, should resume */
                 cs = (SSLSocket)cliFactory.createSocket();
-                cs.connect(new InetSocketAddress(InetAddress.getLocalHost(),
-                                                 ss.getLocalPort()));
+                cs.connect(new InetSocketAddress(
+                    InetAddress.getLoopbackAddress(), ss.getLocalPort()));
                 cs.startHandshake();
                 sessionID2 = cs.getSession().getId();
                 cs.close();
@@ -2462,7 +2483,7 @@ public class WolfSSLSocketTest {
             SSLSocketFactory cliFactory = ctx.getSocketFactory();
 
             SSLSocket cs = (SSLSocket)cliFactory.createSocket();
-            cs.connect(new InetSocketAddress(InetAddress.getLocalHost(),
+            cs.connect(new InetSocketAddress(InetAddress.getLoopbackAddress(),
                                              ss.getLocalPort()));
 
             /* Start server */
@@ -2493,8 +2514,8 @@ public class WolfSSLSocketTest {
 
                 /* connection #2, should NOT resume */
                 cs = (SSLSocket)cliFactory.createSocket();
-                cs.connect(new InetSocketAddress(InetAddress.getLocalHost(),
-                                                 ss.getLocalPort()));
+                cs.connect(new InetSocketAddress(
+                    InetAddress.getLoopbackAddress(), ss.getLocalPort()));
                 cs.startHandshake();
                 sessionID2 = cs.getSession().getId();
                 cs.close();
@@ -2576,7 +2597,7 @@ public class WolfSSLSocketTest {
 
             WolfSSLSocket cs = (WolfSSLSocket)cliFactory.createSocket();
             cs.setUseSessionTickets(true);
-            cs.connect(new InetSocketAddress(InetAddress.getLocalHost(),
+            cs.connect(new InetSocketAddress(InetAddress.getLoopbackAddress(),
                                              ss.getLocalPort()));
 
             /* start server */
@@ -2608,8 +2629,8 @@ public class WolfSSLSocketTest {
                 /* connection #2, should resume */
                 cs = (WolfSSLSocket)cliFactory.createSocket();
                 cs.setUseSessionTickets(true);
-                cs.connect(new InetSocketAddress(InetAddress.getLocalHost(),
-                                                 ss.getLocalPort()));
+                cs.connect(new InetSocketAddress(
+                    InetAddress.getLoopbackAddress(), ss.getLocalPort()));
                 cs.startHandshake();
                 sessionID2 = cs.getSession().getId();
                 cs.close();
@@ -4440,7 +4461,7 @@ public class WolfSSLSocketTest {
 
         SSLSocket cs = (SSLSocket)cliCtx.getSocketFactory().createSocket();
         cs.connect(new InetSocketAddress(
-            InetAddress.getLocalHost(), ss.getLocalPort()));
+            InetAddress.getLoopbackAddress(), ss.getLocalPort()));
 
         final SSLSocket server = (SSLSocket)ss.accept();
 

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
@@ -4366,7 +4366,7 @@ public class WolfSSLSocketTest {
         }
 
         if (anonSuite == null) {
-            System.out.println("\t... skipped (no anon suites)");
+            System.out.println("\t... skipped");
             return;
         }
 
@@ -4426,7 +4426,7 @@ public class WolfSSLSocketTest {
                UnrecoverableKeyException, InterruptedException,
                java.util.concurrent.ExecutionException {
 
-        System.out.print("\tSSLHandshakeException cause chain");
+        System.out.print("\tSSLHandshakeException cause");
 
         /* Create server context with valid certs */
         SSLContext srvCtx = tf.createSSLContext("TLS", ctxProvider);

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLTrustX509Test.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLTrustX509Test.java
@@ -3490,7 +3490,7 @@ public class WolfSSLTrustX509Test {
                KeyStoreException, IOException, CertificateException,
                InvalidAlgorithmParameterException {
 
-        System.out.print("\tTesting init(CertPathTrustManagerParameters)");
+        System.out.print("\tinit(CPTrustManagerParameters)");
 
         /* Load CA certs and create TrustAnchors manually */
         KeyStore caStore = KeyStore.getInstance(
@@ -3543,7 +3543,7 @@ public class WolfSSLTrustX509Test {
                KeyStoreException, IOException, CertificateException,
                InvalidAlgorithmParameterException {
 
-        System.out.print("\tTesting init(KeyStoreBuilderParameters)");
+        System.out.print("\tinit(KeyStoreBuilderParameters)");
 
         KeyStore.Builder ksBuilder = KeyStore.Builder.newInstance(
             WolfSSLTestFactory.isAndroid() ? "BKS" : "JKS",

--- a/src/test/com/wolfssl/test/WolfSSLCRLTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLCRLTest.java
@@ -436,11 +436,11 @@ public class WolfSSLCRLTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException {
 
-        System.out.print("\taddRevokedCert(WolfSSLCertificate)");
+        System.out.print("\taddRevokedCert(cert)");
 
         if (!WolfSSL.CrlGenerationEnabled()) {
             /* CRL generation not enabled in wolfSSL */
-            System.out.println("\t... skipped");
+            System.out.println("\t\t... skipped");
             return;
         }
 
@@ -466,7 +466,7 @@ public class WolfSSLCRLTest {
         /* Test null certificate */
         try {
             crl.addRevokedCert((WolfSSLCertificate)null, new Date());
-            System.out.println("\t... failed");
+            System.out.println("\t\t... failed");
             fail("null certificate should throw exception");
         } catch (IllegalArgumentException e) {
             /* expected */
@@ -476,7 +476,7 @@ public class WolfSSLCRLTest {
         cert.free();
         cert2.free();
         crl.free();
-        System.out.println("\t... passed");
+        System.out.println("\t\t... passed");
     }
 
     @Test
@@ -547,7 +547,7 @@ public class WolfSSLCRLTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException, ReflectiveOperationException {
 
-        System.out.print("\tsign(native PEM key bytes regression)");
+        System.out.print("\tsign(native PEM key bytes)");
 
         if (!WolfSSL.CrlGenerationEnabled()) {
             /* CRL generation not enabled in wolfSSL */
@@ -1275,7 +1275,7 @@ public class WolfSSLCRLTest {
 
         if (!WolfSSL.CrlGenerationEnabled()) {
             /* CRL generation not enabled in wolfSSL */
-            System.out.println("\t\t\t... skipped");
+            System.out.println("\t\t\t\t... skipped");
             return;
         }
 
@@ -1288,7 +1288,7 @@ public class WolfSSLCRLTest {
         /* Operations after free should throw IllegalStateException */
         try {
             crl.setVersion(1);
-            System.out.println("\t\t\t... failed");
+            System.out.println("\t\t\t\t... failed");
             fail("setVersion after free should throw exception");
         } catch (IllegalStateException e) {
             /* expected */
@@ -1296,7 +1296,7 @@ public class WolfSSLCRLTest {
 
         try {
             crl.getVersion();
-            System.out.println("\t\t\t... failed");
+            System.out.println("\t\t\t\t... failed");
             fail("getVersion after free should throw exception");
         } catch (IllegalStateException e) {
             /* expected */
@@ -1305,6 +1305,6 @@ public class WolfSSLCRLTest {
         /* Multiple free() calls should be safe */
         crl.free();
 
-        System.out.println("\t\t\t... passed");
+        System.out.println("\t\t\t\t... passed");
     }
 }

--- a/src/test/com/wolfssl/test/WolfSSLCertificateTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLCertificateTest.java
@@ -724,7 +724,7 @@ public class WolfSSLCertificateTest {
         String ca2 = "https://www.wolfssl.com/ca2.pem";
         WolfSSLCertificate tmp = null;
 
-        System.out.print("\t\tgetOcspUris/getCaIssuerUris");
+        System.out.print("\t\tgetOcsp/getCaIssuerUris");
 
         try {
             if (WolfSSL.FileSystemEnabled() == true) {
@@ -906,7 +906,7 @@ public class WolfSSLCertificateTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException {
 
-        System.out.println("WolfSSLCertificate extension setters");
+        System.out.print("\textension setters");
 
         if (WolfSSL.FileSystemEnabled() == false) {
             System.out.println("\tfilesystem disabled, skipping");
@@ -1012,8 +1012,6 @@ public class WolfSSLCertificateTest {
             runOrAllowNotCompiled(
                 () -> x509.setCrlDistPoints(crlDpDer),
                 "setCrlDistPoints");
-        } else {
-            System.out.println("\t\tsetCrlDistPoints ... no DER available");
         }
 
         runOrAllowNotCompiled(

--- a/src/test/com/wolfssl/test/WolfSSLSessionTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLSessionTest.java
@@ -1550,7 +1550,7 @@ public class WolfSSLSessionTest {
 
             /* Client connection */
             try {
-                cliSock = new Socket(InetAddress.getLocalHost(),
+                cliSock = new Socket(InetAddress.getLoopbackAddress(),
                     srvSocket.getLocalPort());
 
                 cliSes = new WolfSSLSession(cliCtx);
@@ -1750,7 +1750,7 @@ public class WolfSSLSessionTest {
             /* -------------------------------------------------------------- */
             /* Client connection #1 */
             /* -------------------------------------------------------------- */
-            cliSock = new Socket(InetAddress.getLocalHost(),
+            cliSock = new Socket(InetAddress.getLoopbackAddress(),
                 srvSocket.getLocalPort());
 
             cliSes = new WolfSSLSession(cliCtx);
@@ -1810,7 +1810,7 @@ public class WolfSSLSessionTest {
             /* -------------------------------------------------------------- */
             /* Client connection #2, set session and try resumption */
             /* -------------------------------------------------------------- */
-            cliSock = new Socket(InetAddress.getLocalHost(),
+            cliSock = new Socket(InetAddress.getLoopbackAddress(),
                 srvSocket.getLocalPort());
             cliSes = new WolfSSLSession(cliCtx);
 
@@ -1997,7 +1997,7 @@ public class WolfSSLSessionTest {
             /* ------------------------------------------------------ */
             /* Client connection #1 */
             /* ------------------------------------------------------ */
-            cliSock = new Socket(InetAddress.getLocalHost(),
+            cliSock = new Socket(InetAddress.getLoopbackAddress(),
                 srvSocket.getLocalPort());
 
             cliSes = new WolfSSLSession(cliCtx);
@@ -2059,7 +2059,7 @@ public class WolfSSLSessionTest {
             /* ------------------------------------------------------ */
             /* Client connection #2, set session and try resumption */
             /* ------------------------------------------------------ */
-            cliSock = new Socket(InetAddress.getLocalHost(),
+            cliSock = new Socket(InetAddress.getLoopbackAddress(),
                 srvSocket.getLocalPort());
             cliSes = new WolfSSLSession(cliCtx);
 
@@ -2573,7 +2573,7 @@ public class WolfSSLSessionTest {
 
         try {
             /* Client connection */
-            cliSock = new Socket(InetAddress.getLocalHost(),
+            cliSock = new Socket(InetAddress.getLoopbackAddress(),
                 srvSocket.getLocalPort());
 
             cliSes = new WolfSSLSession(cliCtx);
@@ -2770,7 +2770,7 @@ public class WolfSSLSessionTest {
 
         try {
             /* Client connection */
-            cliSock = new Socket(InetAddress.getLocalHost(),
+            cliSock = new Socket(InetAddress.getLoopbackAddress(),
                 srvSocket.getLocalPort());
 
             cliSes = new WolfSSLSession(cliCtx);
@@ -2948,7 +2948,7 @@ public class WolfSSLSessionTest {
 
             try {
                 /* Client connection */
-                cliSock = new Socket(InetAddress.getLocalHost(),
+                cliSock = new Socket(InetAddress.getLoopbackAddress(),
                     srvSocket.getLocalPort());
 
                 cliSes = new WolfSSLSession(cliCtx);
@@ -3117,7 +3117,7 @@ public class WolfSSLSessionTest {
             /* -------------------------------------------------------------- */
             /* Client connection #1 - get session and serialize it */
             /* -------------------------------------------------------------- */
-            cliSock = new Socket(InetAddress.getLocalHost(),
+            cliSock = new Socket(InetAddress.getLoopbackAddress(),
                 srvSocket.getLocalPort());
 
             cliSes = new WolfSSLSession(cliCtx);
@@ -3161,7 +3161,7 @@ public class WolfSSLSessionTest {
             /* -------------------------------------------------------------- */
             /* Client connection #2 - deserialize session and resume */
             /* -------------------------------------------------------------- */
-            cliSock = new Socket(InetAddress.getLocalHost(),
+            cliSock = new Socket(InetAddress.getLoopbackAddress(),
                 srvSocket.getLocalPort());
             cliSes = new WolfSSLSession(cliCtx);
 

--- a/src/test/com/wolfssl/test/WolfSSLSessionTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLSessionTest.java
@@ -3432,8 +3432,7 @@ public class WolfSSLSessionTest {
             /* Test dtlsCidUse() - may return NOT_COMPILED_IN */
             int ret = server.dtlsCidUse();
             if (ret == WolfSSL.NOT_COMPILED_IN) {
-                System.out.println("\t\t... skipped (DTLS CID not " +
-                                   "compiled in)");
+                System.out.println("\t\t... skipped");
                 return;
             }
             assertTrue("Server dtlsCidUse() should succeed",
@@ -3576,8 +3575,7 @@ public class WolfSSLSessionTest {
             /* Enable CID on both sides */
             int ret = server.dtlsCidUse();
             if (ret == WolfSSL.NOT_COMPILED_IN) {
-                System.out.println("\t\t... skipped (DTLS CID not " +
-                                   "compiled in)");
+                System.out.println("\t\t... skipped");
                 return;
             }
 
@@ -3699,8 +3697,7 @@ public class WolfSSLSessionTest {
             /* Enable CID on both sessions */
             int ret1 = server1.dtlsCidUse();
             if (ret1 == WolfSSL.NOT_COMPILED_IN) {
-                System.out.println("\t... skipped (DTLS CID not " +
-                                   "compiled in)");
+                System.out.println("\t... skipped");
                 return;
             }
 
@@ -3813,8 +3810,7 @@ public class WolfSSLSessionTest {
             /* Enable CID */
             int ret = sess.dtlsCidUse();
             if (ret == WolfSSL.NOT_COMPILED_IN) {
-                System.out.println("\t\t... skipped (DTLS CID not " +
-                                   "compiled in)");
+                System.out.println("\t\t... skipped");
                 return;
             }
 
@@ -3925,8 +3921,7 @@ public class WolfSSLSessionTest {
             /* Enable CID */
             int ret = sess.dtlsCidUse();
             if (ret == WolfSSL.NOT_COMPILED_IN) {
-                System.out.println("\t... skipped (DTLS CID not " +
-                                   "compiled in)");
+                System.out.println("\t... skipped");
                 return;
             }
 
@@ -4018,7 +4013,7 @@ public class WolfSSLSessionTest {
         }
 
         if (!dtls13Supported) {
-            System.out.println("\t\t... skipped (DTLSv1.3 not enabled)");
+            System.out.println("\t... skipped");
             return;
         }
 
@@ -4030,8 +4025,7 @@ public class WolfSSLSessionTest {
             /* Enable CID */
             int ret = sess.dtlsCidUse();
             if (ret == WolfSSL.NOT_COMPILED_IN) {
-                System.out.println("\t\t... skipped (DTLS CID not " +
-                                   "compiled in)");
+                System.out.println("\t... skipped");
                 return;
             }
 
@@ -4039,7 +4033,7 @@ public class WolfSSLSessionTest {
             byte[] testCid = new byte[]{0x01, 0x02, 0x03, 0x04, 0x05};
             ret = sess.dtlsCidSet(testCid);
             if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t\t... skipped (dtlsCidSet failed)");
+                System.out.println("\t... skipped");
                 return;
             }
 
@@ -4129,7 +4123,7 @@ public class WolfSSLSessionTest {
         }
 
         if (!dtls13Supported) {
-            System.out.println("\t\t... skipped (DTLSv1.3 not enabled)");
+            System.out.println("\t... skipped (DTLSv1.3 not enabled)");
             return;
         }
 
@@ -4159,14 +4153,13 @@ public class WolfSSLSessionTest {
             /* Enable CID on both sides */
             int ret = server.dtlsCidUse();
             if (ret == WolfSSL.NOT_COMPILED_IN) {
-                System.out.println("\t\t... skipped (DTLS CID not " +
-                                   "compiled in)");
+                System.out.println("\t... skipped");
                 return;
             }
 
             ret = client.dtlsCidUse();
             if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t\t... skipped (Client CID " +
+                System.out.println("\t... skipped (Client CID " +
                                    "enable failed: " + ret + ")");
                 return;
             }
@@ -4177,14 +4170,14 @@ public class WolfSSLSessionTest {
 
             ret = server.dtlsCidSet(serverCid);
             if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t\t... skipped (Server " +
+                System.out.println("\t... skipped (Server " +
                                    "dtlsCidSet failed: " + ret + ")");
                 return;
             }
 
             ret = client.dtlsCidSet(clientCid);
             if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t\t... skipped (Client " +
+                System.out.println("\t... skipped (Client " +
                                    "dtlsCidSet failed: " + ret + ")");
                 return;
             }
@@ -4397,8 +4390,7 @@ public class WolfSSLSessionTest {
             /* Enable CID on both sides */
             int ret = server.dtlsCidUse();
             if (ret == WolfSSL.NOT_COMPILED_IN) {
-                System.out.println("\t\t... skipped (DTLS CID not " +
-                                   "compiled in)");
+                System.out.println("\t\t... skipped");
                 return;
             }
 


### PR DESCRIPTION
This PR preps for the 1.17 release, including version bumps and fixes found during the release cycle.

  - Bump version to 1.17, update ChangeLog for 1.17.0 release
  - Build: drop gitignored `docs/lib` from `DIST_FILES`; make `ant cleanjni` tolerate missing `lib/`
  - Windows: document `WOLFSSL_TLS13` in FIPS v2 `user_settings.h`; define `_CRT_SECURE_NO_WARNINGS` for `/sdl`
  - Android: update copyright in `jsse_install.sh`
  - JNI: check `read`/`write` return values in SSLAppData interrupt pipe helpers
  - Tests: use loopback address for local TCP/SSLServerSocket connects
  - Tests: raise `WolfSSLEngineMemoryLeakTest` timeout to 180s; raise closed-engines leak threshold to 20 MB
  - Tests: align console passed/failed/skipped output