### PR TITLE
Replace JUnit passed/failed/skipped status with per-method timing

### DIFF
--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLContextTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLContextTest.java
@@ -21,8 +21,11 @@
 
 package com.wolfssl.provider.jsse.test;
 
+import org.junit.Assume;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.BeforeClass;
+import org.junit.rules.TestRule;
 import static org.junit.Assert.*;
 
 import java.util.List;
@@ -30,6 +33,7 @@ import java.util.Arrays;
 import java.util.ArrayList;
 
 import com.wolfssl.WolfSSLException;
+import com.wolfssl.test.TimedTestWatcher;
 
 import java.io.FileInputStream;
 import javax.net.SocketFactory;
@@ -60,6 +64,9 @@ import java.lang.reflect.Method;
 
 public class WolfSSLContextTest {
 
+    @Rule
+    public TestRule testWatcher = TimedTestWatcher.create();
+
     private static WolfSSLTestFactory tf;
     private static final char[] jksPass = "wolfSSL test".toCharArray();
     private static final String ctxProvider = "wolfJSSE";
@@ -87,11 +94,7 @@ public class WolfSSLContextTest {
         Provider p = Security.getProvider("wolfJSSE");
         assertNotNull(p);
 
-        System.out.print("\tGetting provider name");
-        if (p.getName().contains("wolfJSSE")) {
-            System.out.println("\t\t... passed");
-        } else {
-            System.out.println("\t\t... failed");
+        if (!p.getName().contains("wolfJSSE")) {
             fail("Failed to get proper wolfJSSE provider name");
         }
 
@@ -129,8 +132,6 @@ public class WolfSSLContextTest {
 
         SSLContext ctx;
 
-        System.out.print("\tTesting protocol support");
-
         /* try to get all available protocols we expect to have */
         for (int i = 0; i < enabledProtocols.size(); i++) {
             ctx = SSLContext.getInstance(enabledProtocols.get(i),
@@ -141,12 +142,11 @@ public class WolfSSLContextTest {
         try {
             ctx = SSLContext.getInstance("NotValid", ctxProvider);
 
-            System.out.println("\t... failed");
             fail("SSLContext.getInstance should throw " +
                  "NoSuchAlgorithmException when given bad protocol");
 
         } catch (NoSuchAlgorithmException nsae) {
-            System.out.println("\t... passed");
+            /* expected */
         }
     }
 
@@ -161,8 +161,6 @@ public class WolfSSLContextTest {
         KeyStore pKey, cert;
         SSLSocketFactory ssf;
 
-        System.out.print("\tgetSocketFactory()");
-
         try {
             /* set up KeyStore */
             InputStream stream = new FileInputStream(tf.clientJKS);
@@ -173,7 +171,7 @@ public class WolfSSLContextTest {
             stream = new FileInputStream(tf.clientJKS);
             cert = KeyStore.getInstance(tf.keyStoreType);
             cert.load(stream, jksPass);
-                stream.close();
+            stream.close();
 
             /* trust manager (certificates) */
             tm = TrustManagerFactory.getInstance("SunX509");
@@ -200,16 +198,12 @@ public class WolfSSLContextTest {
             ssf = ctx.getSocketFactory();
             assertNotNull(ssf);
         }
-
-        System.out.println("\t\t... passed");
     }
 
     @Test
     public void testInit() throws NoSuchProviderException,
         NoSuchAlgorithmException, IllegalStateException,
         KeyManagementException {
-
-        System.out.print("\tinit()");
 
         SecureRandom rand = new SecureRandom();
         SSLContext ctx = null;
@@ -222,7 +216,6 @@ public class WolfSSLContextTest {
                     ctxProvider);
                 ctx.init(null, null, rand);
             } catch (Exception e) {
-                System.out.println("\t\t\t\t... failed");
                 e.printStackTrace();
                 fail("Failed to initialize SSLContext with null params");
             }
@@ -236,20 +229,15 @@ public class WolfSSLContextTest {
                     ctxProvider);
                 ctx.init(null, null, null);
             } catch (Exception e) {
-                System.out.println("\t\t\t\t... failed");
                 fail("Failed to initialize SSLContext with null params");
             }
         }
-
-        System.out.println("\t\t\t\t... passed");
     }
 
     @Test
     public void testGetSessionContext() throws NoSuchProviderException,
         NoSuchAlgorithmException, IllegalStateException,
         KeyManagementException {
-
-        System.out.print("\tgetSessionContext()");
 
         SSLContext ctx = null;
 
@@ -260,7 +248,6 @@ public class WolfSSLContextTest {
                     ctxProvider);
                 ctx.init(null, null, null);
             } catch (Exception e) {
-                System.out.println("\t\t... failed");
                 fail("Failed to init SSLContext");
                 return;
             }
@@ -270,7 +257,6 @@ public class WolfSSLContextTest {
                 SSLSessionContext sess = ctx.getServerSessionContext();
                 assertNotNull(sess);
             } catch (UnsupportedOperationException e) {
-                System.out.println("\t\t... failed");
                 fail("Failed to get SSLSessionContext");
             }
 
@@ -279,18 +265,14 @@ public class WolfSSLContextTest {
                 SSLSessionContext sess = ctx.getClientSessionContext();
                 assertNotNull(sess);
             } catch (UnsupportedOperationException e) {
-                System.out.println("\t\t... failed");
                 fail("Failed to return client SSLSessionContext");
             }
         }
-        System.out.println("\t\t... passed");
     }
 
     @Test
     public void testGetSessionContextBeforeInit()
         throws NoSuchProviderException, NoSuchAlgorithmException {
-
-        System.out.print("\tgetSessionContext before init");
 
         SSLContext ctx = null;
         SSLSessionContext sess = null;
@@ -302,7 +284,6 @@ public class WolfSSLContextTest {
             /* getServerSessionContext() should work before init() */
             sess = ctx.getServerSessionContext();
             if (sess == null) {
-                System.out.println("\t... failed");
                 fail("getServerSessionContext() returned null before init()");
                 return;
             }
@@ -310,7 +291,6 @@ public class WolfSSLContextTest {
             /* getClientSessionContext() should work before init() */
             sess = ctx.getClientSessionContext();
             if (sess == null) {
-                System.out.println("\t... failed");
                 fail("getClientSessionContext() returned null before init()");
                 return;
             }
@@ -319,7 +299,6 @@ public class WolfSSLContextTest {
             int timeout = sess.getSessionTimeout();
             sess.setSessionTimeout(timeout);
         }
-        System.out.println("\t... passed");
     }
 
     @Test
@@ -327,18 +306,15 @@ public class WolfSSLContextTest {
         NoSuchAlgorithmException, IllegalStateException,
         KeyManagementException {
 
-        System.out.print("\tgetSupportedSSLParameters()");
-
         SSLContext ctx = null;
 
         for (int i = 0; i < enabledProtocols.size(); i++) {
 
             try {
                 ctx = SSLContext.getInstance(enabledProtocols.get(i),
-                        ctxProvider);
+                    ctxProvider);
                 ctx.init(null, null, null);
             } catch (Exception e) {
-                System.out.println("\t\t... failed");
                 fail("Failed to init SSLContext");
                 return;
             }
@@ -347,30 +323,25 @@ public class WolfSSLContextTest {
             try {
                 SSLParameters params = ctx.getSupportedSSLParameters();
                 if (params == null) {
-                    System.out.println("\t... failed");
                     fail("Failed to valid supported SSLParameters");
                 }
 
                 /* make sure protocol list is not null */
                 String[] protocols = params.getProtocols();
                 if (protocols == null || protocols.length == 0) {
-                    System.out.println("\t... failed");
                     fail("SSLParameters.getProtocols() returned null");
                 }
 
                 /* make sure cipher suite list is not null */
                 String[] ciphers = params.getCipherSuites();
                 if (ciphers == null || ciphers.length == 0) {
-                    System.out.println("\t... failed");
                     fail("SSLParameters.getCipherSuites() returned null");
                 }
 
             } catch (UnsupportedOperationException e) {
-                System.out.println("\t... failed");
                 fail("UnsupportedOperationException thrown but not expected");
             }
         }
-        System.out.println("\t... passed");
     }
 
     @Test
@@ -378,18 +349,15 @@ public class WolfSSLContextTest {
         NoSuchAlgorithmException, IllegalStateException,
         KeyManagementException {
 
-        System.out.print("\tgetDefaultSSLParameters()");
-
         SSLContext ctx = null;
 
         for (int i = 0; i < enabledProtocols.size(); i++) {
 
             try {
                 ctx = SSLContext.getInstance(enabledProtocols.get(i),
-                        ctxProvider);
+                    ctxProvider);
                 ctx.init(null, null, null);
             } catch (Exception e) {
-                System.out.println("\t\t... failed");
                 fail("Failed to init SSLContext");
                 return;
             }
@@ -398,28 +366,24 @@ public class WolfSSLContextTest {
             try {
                 SSLParameters params = ctx.getDefaultSSLParameters();
                 if (params == null) {
-                    System.out.println("\t... failed");
                     fail("Failed to valid default SSLParameters");
                 }
 
                 /* make sure protocol list is not null */
                 String[] protocols = params.getProtocols();
                 if (protocols == null || protocols.length == 0) {
-                    System.out.println("\t... failed");
                     fail("SSLParameters.getProtocols() returned null");
                 }
 
                 /* make sure cipher suite list is not null */
                 String[] ciphers = params.getCipherSuites();
                 if (ciphers == null || ciphers.length == 0) {
-                    System.out.println("\t... failed");
                     fail("SSLParameters.getCipherSuites() returned null");
                 }
 
                 /* needClientAuth should default to false */
                 boolean needClientAuth = params.getNeedClientAuth();
                 if (needClientAuth == true) {
-                    System.out.println("\t... failed");
                     fail("SSLParameters.getNeedClientAuth() should default " +
                          "to false");
                 }
@@ -427,18 +391,14 @@ public class WolfSSLContextTest {
                 /* wantClientAuth should default to false */
                 boolean wantClientAuth = params.getWantClientAuth();
                 if (wantClientAuth == true) {
-                    System.out.println("\t... failed");
                     fail("SSLParameters.getWantClientAuth() should default " +
                          "to false");
                 }
 
             } catch (UnsupportedOperationException e) {
-                System.out.println("\t... failed");
                 fail("UnsupportedOperationException thrown but not expected");
             }
         }
-
-        System.out.println("\t... passed");
     }
 
     /* Returns ArrayList of expected default SSLcontext protocols, assuming
@@ -527,11 +487,8 @@ public class WolfSSLContextTest {
         String[] defaultSSLContextProtocols = null;
         ArrayList<String> expectedList = null;
 
-        System.out.print("\tjdk.tls.disabledAlgorithms");
-
         List<?> enabledNativeProtocols = Arrays.asList(WolfSSL.getProtocols());
         if (enabledNativeProtocols == null) {
-            System.out.println("\t... failed");
             fail("WolfSSL.getProtocols() returned null");
         }
 
@@ -566,10 +523,8 @@ public class WolfSSLContextTest {
                 if (!Arrays.equals(defaultSSLContextProtocols,
                         expectedList.toArray(
                             new String[expectedList.size()]))) {
-                    System.out.print("\t... failed");
                     fail("Default SSLContext(" + allProtocols[i] +
-                         ") protocol list did not match " +
-                         "expected. Got: " +
+                         ") protocol list did not match expected. Got: " +
                          Arrays.toString(defaultSSLContextProtocols) +
                          " Expected: " + Arrays.toString(expectedList.toArray(
                             new String[expectedList.size()])));
@@ -583,7 +538,6 @@ public class WolfSSLContextTest {
                 if (!Arrays.equals(sockEnabledProtocols,
                         expectedList.toArray(
                             new String[expectedList.size()]))) {
-                    System.out.print("\t... failed");
                     fail("Default SSLSocket protocol list did not " +
                          "match expected");
                 }
@@ -613,7 +567,6 @@ public class WolfSSLContextTest {
                     if (!Arrays.equals(defaultSSLContextProtocols,
                             expectedList.toArray(
                                 new String[expectedList.size()]))) {
-                        System.out.print("\t... failed");
                         fail("Default SSLContext protocol list did not " +
                              "match expected");
                     }
@@ -626,7 +579,6 @@ public class WolfSSLContextTest {
                     if (!Arrays.equals(sockEnabledProtocols,
                             expectedList.toArray(
                                 new String[expectedList.size()]))) {
-                        System.out.print("\t... failed");
                         fail("Default SSLSocket protocol list did not " +
                              "match expected");
                     }
@@ -636,8 +588,8 @@ public class WolfSSLContextTest {
             /* Test with TLSv1, TLSv1.1 protocols disabled */
             Security.setProperty("jdk.tls.disabledAlgorithms",
                 "TLSv1, TLSv1.1");
-            for (int i = 0; i < allProtocols.length; i++) {
 
+            for (int i = 0; i < allProtocols.length; i++) {
                 if (!enabledNativeProtocols.contains(allProtocols[i])) {
                     /* protocol not available in native library, skip */
                     continue;
@@ -656,7 +608,6 @@ public class WolfSSLContextTest {
                 if (!Arrays.equals(defaultSSLContextProtocols,
                         expectedList.toArray(
                             new String[expectedList.size()]))) {
-                    System.out.print("\t... failed");
                     fail("Default SSLContext protocol list did not " +
                          "match expected");
                 }
@@ -669,7 +620,6 @@ public class WolfSSLContextTest {
                 if (!Arrays.equals(sockEnabledProtocols,
                         expectedList.toArray(
                             new String[expectedList.size()]))) {
-                    System.out.print("\t... failed");
                     fail("Default SSLSocket protocol list did not " +
                          "match expected");
                 }
@@ -678,8 +628,8 @@ public class WolfSSLContextTest {
             /* Test with TLSv1.1, TLSv1.2 protocols disabled */
             Security.setProperty("jdk.tls.disabledAlgorithms",
                 "TLSv1.1, TLSv1.2");
-            for (int i = 0; i < allProtocols.length; i++) {
 
+            for (int i = 0; i < allProtocols.length; i++) {
                 if (!enabledNativeProtocols.contains(allProtocols[i])) {
                     /* protocol not available in native library, skip */
                     continue;
@@ -698,7 +648,6 @@ public class WolfSSLContextTest {
                 if (!Arrays.equals(defaultSSLContextProtocols,
                         expectedList.toArray(
                             new String[expectedList.size()]))) {
-                    System.out.print("\t... failed");
                     fail("Default SSLContext protocol list did not " +
                          "match expected");
                 }
@@ -711,7 +660,6 @@ public class WolfSSLContextTest {
                 if (!Arrays.equals(sockEnabledProtocols,
                         expectedList.toArray(
                             new String[expectedList.size()]))) {
-                    System.out.print("\t... failed");
                     fail("Default SSLSocket protocol list did not " +
                          "match expected");
                 }
@@ -721,8 +669,6 @@ public class WolfSSLContextTest {
             Security.setProperty("jdk.tls.disabledAlgorithms",
                 originalProperty);
         } /* jdkTlsDisabledAlgorithmsLock */
-
-        System.out.println("\t... passed");
     }
 
     /** Helper method for testWolfJSSEEnabledCipherSuites() */
@@ -769,11 +715,8 @@ public class WolfSSLContextTest {
         String[] defaultSSLContextSuites = null;
         WolfSSL.TLS_VERSION version = WolfSSL.TLS_VERSION.INVALID;
 
-        System.out.print("\twolfjsse.enabledCipherSuites");
-
         List<?> enabledNativeProtocols = Arrays.asList(WolfSSL.getProtocols());
         if (enabledNativeProtocols == null) {
-            System.out.println("\t... failed");
             fail("WolfSSL.getProtocols() returned null");
         }
 
@@ -792,7 +735,6 @@ public class WolfSSLContextTest {
             /* get TLS_VERSION enum value from protocol version */
             version = getWolfSSLTLSVersion(allProtocols[i]);
             if (version == WolfSSL.TLS_VERSION.INVALID) {
-                System.out.print("\t... failed");
                 fail("Invalid TLS version");
             }
 
@@ -823,9 +765,7 @@ public class WolfSSLContextTest {
                 ctx.getDefaultSSLParameters().getCipherSuites();
 
             if (!Arrays.equals(defaultSSLContextSuites, nativeSuites)) {
-                System.out.print("\t... failed");
-                fail("Default SSLContext cipher list did not " +
-                     "match expected");
+                fail("Default SSLContext cipher list did not match expected");
             }
 
             sf = ctx.getSocketFactory();
@@ -835,9 +775,7 @@ public class WolfSSLContextTest {
             String[] sockEnabledSuites = sock.getEnabledCipherSuites();
 
             if (!Arrays.equals(sockEnabledSuites, nativeSuites)) {
-                System.out.print("\t... failed");
-                fail("SSLSocket enabled cipher list did not " +
-                     "match expected");
+                fail("SSLSocket enabled cipher list did not match expected");
             }
 
             /* ------------------------------------------------------------- */
@@ -856,7 +794,6 @@ public class WolfSSLContextTest {
 
             if (!Arrays.equals(defaultSSLContextSuites,
                     new String[] { nativeSuites[0] } )) {
-                System.out.print("\t... failed");
                 fail("Default SSLContext cipher list did not " +
                      "match expected single suite");
             }
@@ -868,7 +805,6 @@ public class WolfSSLContextTest {
             sockEnabledSuites = sock.getEnabledCipherSuites();
             if (!Arrays.equals(sockEnabledSuites,
                     new String[] { nativeSuites[0] } )) {
-                System.out.print("\t... failed");
                 fail("SSLSocket enabled cipher list did not " +
                      "match expected single suite");
             }
@@ -877,7 +813,6 @@ public class WolfSSLContextTest {
             sockEnabledSuites = sock.getSupportedCipherSuites();
             if (!Arrays.equals(sockEnabledSuites,
                     new String[] { nativeSuites[0] } )) {
-                System.out.print("\t... failed");
                 fail("SSLSocket supported cipher list did not " +
                      "match expected single suite");
             }
@@ -890,7 +825,7 @@ public class WolfSSLContextTest {
 
             if (nativeSuites.length >= 2) {
                 Security.setProperty("wolfjsse.enabledCipherSuites",
-                        nativeSuites[0] + ", " + nativeSuites[1]);
+                    nativeSuites[0] + ", " + nativeSuites[1]);
 
                 ctx = SSLContext.getInstance(allProtocols[i]);
                 ctx.init(null, null, null);
@@ -900,7 +835,6 @@ public class WolfSSLContextTest {
 
                 if (!Arrays.equals(defaultSSLContextSuites,
                         new String[] { nativeSuites[0], nativeSuites[1] } )) {
-                    System.out.print("\t... failed");
                     fail("Default SSLContext cipher list did not " +
                          "match expected single suite");
                 }
@@ -912,7 +846,6 @@ public class WolfSSLContextTest {
                 sockEnabledSuites = sock.getEnabledCipherSuites();
                 if (!Arrays.equals(sockEnabledSuites,
                         new String[] { nativeSuites[0], nativeSuites[1] } )) {
-                    System.out.print("\t... failed");
                     fail("SSLSocket enabled cipher list did not " +
                          "match expected single suite");
                 }
@@ -924,7 +857,6 @@ public class WolfSSLContextTest {
                         .containsAll(Arrays.asList(
                             new String[] {
                                 nativeSuites[0], nativeSuites[1] }))) {
-                    System.out.print("\t... failed");
                     fail("SSLSocket supported cipher list did not " +
                          "match expected single suite");
                 }
@@ -959,7 +891,6 @@ public class WolfSSLContextTest {
 
                 if (!Arrays.equals(sockEnabledSuites,
                         new String[] { nativeSuites[0] } )) {
-                    System.out.print("\t... failed");
                     fail("Default SSLSocket cipher list did not " +
                          "match expected single suite");
                 }
@@ -975,14 +906,10 @@ public class WolfSSLContextTest {
         else {
             Security.setProperty("wolfjsse.enabledCipherSuites", "");
         }
-
-        System.out.println("\t... passed");
     }
 
     @Test
     public void testSanitizeProtocolsNullInput() {
-
-        System.out.print("\tTesting sanitizeProtocols(null)");
 
         try {
             Class<?> utilClass = Class.forName(
@@ -997,15 +924,11 @@ public class WolfSSLContextTest {
                 null, (String[]) null, WolfSSL.TLS_VERSION.TLSv1_2);
 
             if (result != null) {
-                System.out.println("\t... failed");
                 fail("sanitizeProtocols(null) should return null");
                 return;
             }
 
-            System.out.println("\t... passed");
-
         } catch (Exception e) {
-            System.out.println("\t... failed");
             fail("Exception during sanitizeProtocols test: " + e.getMessage());
         }
     }
@@ -1026,8 +949,6 @@ public class WolfSSLContextTest {
     @Test
     public void testContextDefaultParamsExcludeAnon() throws Exception {
 
-        System.out.print("\tdefault params exclude anon");
-
         String[] allCiphers = WolfSSL.getCiphersIana();
         boolean haveAnon = false;
         for (String s : allCiphers) {
@@ -1037,10 +958,7 @@ public class WolfSSLContextTest {
             }
         }
 
-        if (!haveAnon) {
-            System.out.println("\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(haveAnon);
 
         Security.setProperty("wolfjsse.enabledCipherSuites", "");
         SSLContext ctx = SSLContext.getInstance("TLS", ctxProvider);
@@ -1051,8 +969,6 @@ public class WolfSSLContextTest {
         assertNotNull(defaults);
         assertFalse("Default params should not contain anon",
             arrayHasAnonSuite(defaults));
-
-        System.out.println("\t... passed");
     }
 }
 

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineMemoryLeakTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineMemoryLeakTest.java
@@ -21,9 +21,11 @@
 
 package com.wolfssl.provider.jsse.test;
 
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.BeforeClass;
 import org.junit.Rule;
+import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
 import static org.junit.Assert.*;
 
@@ -35,6 +37,7 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 
 import com.wolfssl.provider.jsse.WolfSSLProvider;
+import com.wolfssl.test.TimedTestWatcher;
 
 /**
  * Memory leak regression test for WolfSSLEngine.
@@ -48,6 +51,9 @@ import com.wolfssl.provider.jsse.WolfSSLProvider;
  * - Verify callback references (WolfSSLInternalVerifyCb.callingEngine)
  */
 public class WolfSSLEngineMemoryLeakTest {
+
+    @Rule
+    public TestRule testWatcher = TimedTestWatcher.create();
 
     /**
      * Global timeout for all tests in this class. The 500-engine test
@@ -66,14 +72,6 @@ public class WolfSSLEngineMemoryLeakTest {
         Security.addProvider(new WolfSSLProvider());
     }
 
-    private void pass(String msg) {
-        WolfSSLTestFactory.pass(msg);
-    }
-
-    private void error(String msg) {
-        WolfSSLTestFactory.fail(msg);
-    }
-
     /**
      * Test that abandoned SSLEngine instances can be garbage collected.
      *
@@ -87,10 +85,7 @@ public class WolfSSLEngineMemoryLeakTest {
     public void testEngineMemoryLeakWithAbandonedEngines() throws Exception {
 
         /* Skip on Android due to performance and timeout issues */
-        if (WolfSSLTestFactory.isAndroid()) {
-            System.out.println("\tmem leak test\t\t\t... skipped (Android)");
-            return;
-        }
+        Assume.assumeFalse(WolfSSLTestFactory.isAndroid());
 
         /* Number of engines to create. Use a smaller number for unit tests
          * to keep test time reasonable (few seconds). */
@@ -105,9 +100,6 @@ public class WolfSSLEngineMemoryLeakTest {
          * We use a conservative threshold that detects major leaks while
          * accounting for JVM differences. */
         final double maxAcceptableGrowthMB = 80.0;
-
-        String javaVersion = System.getProperty("java.version");
-        System.out.print("\tmem leak test with " + numEngines + " engines");
 
         /* Measure baseline memory - use aggressive GC */
         for (int i = 0; i < 3; i++) {
@@ -145,11 +137,8 @@ public class WolfSSLEngineMemoryLeakTest {
             numEngines, memoryGrowthMB, maxAcceptableGrowthMB);
 
         if (memoryGrowthMB > maxAcceptableGrowthMB) {
-            error("\t... failed");
             fail(message);
         }
-
-        pass("\t... passed");
     }
 
     /**
@@ -166,8 +155,6 @@ public class WolfSSLEngineMemoryLeakTest {
         System.gc();
         Thread.sleep(100);
         long baselineMemory = getUsedMemoryBytes();
-
-        System.out.print("\tmem leak test closed engines");
 
         /* Create engines and explicitly close them */
         for (int i = 0; i < numEngines; i++) {
@@ -204,11 +191,8 @@ public class WolfSSLEngineMemoryLeakTest {
             numEngines, memoryGrowthMB, maxAcceptableGrowthMB);
 
         if (memoryGrowthMB > maxAcceptableGrowthMB) {
-            error("\t... failed");
             fail(message);
         }
-
-        pass("\t... passed");
     }
 
     /**

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineTest.java
@@ -73,19 +73,26 @@ import java.util.concurrent.atomic.AtomicIntegerArray;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
 import static org.junit.Assert.assertTrue;
 
 import com.wolfssl.provider.jsse.WolfSSLEngine;
+import com.wolfssl.test.TimedTestWatcher;
 
 /**
  *
  * @author wolfSSL
  */
 public class WolfSSLEngineTest {
+
+    @Rule
+    public TestRule testWatcher = TimedTestWatcher.create();
+
     public final static char[] jksPass = "wolfSSL test".toCharArray();
     public final static String engineProvider = "wolfJSSE";
     private static WolfSSLTestFactory tf;
@@ -141,7 +148,6 @@ public class WolfSSLEngineTest {
         }
     }
 
-
     @Test
     public void testSSLEngine()
         throws NoSuchProviderException, NoSuchAlgorithmException,
@@ -151,18 +157,16 @@ public class WolfSSLEngineTest {
         SSLEngine e;
 
         /* create new SSLEngine */
-        System.out.print("\tSSLEngine creation");
 
         for (int i = 0; i < enabledProtocols.size(); i++) {
             this.ctx = tf.createSSLContext(enabledProtocols.get(i),
                                            engineProvider);
             e = this.ctx.createSSLEngine();
             if (e == null) {
-                error("\t\t... failed");
-                fail("failed to create engine for " + enabledProtocols.get(i));
+                fail("failed to create engine for " +
+                    enabledProtocols.get(i));
             }
         }
-        pass("\t\t... passed");
     }
 
     @Test
@@ -175,12 +179,7 @@ public class WolfSSLEngineTest {
         String sup[];
         boolean ok = false;
 
-        System.out.print("\tSetting ciphersuite");
-
-        if (!WolfSSL.TLSv12Enabled()) {
-            pass("\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.TLSv12Enabled());
 
         for (int i = 0; i < enabledProtocols.size(); i++) {
 
@@ -196,7 +195,6 @@ public class WolfSSLEngineTest {
 
             e = this.ctx.createSSLEngine();
             if (e == null) {
-                error("\t\t... failed");
                 fail("failed to create engine");
                 return;
             }
@@ -208,9 +206,8 @@ public class WolfSSLEngineTest {
                 }
             }
             if (!ok) {
-                error("\t\t... failed");
                 fail("failed to find " + enabledProtocols.get(i) +
-                     " in supported protocols");
+                    " in supported protocols");
             }
 
             sup = e.getEnabledProtocols();
@@ -220,9 +217,8 @@ public class WolfSSLEngineTest {
                 }
             }
             if (!ok) {
-                error("\t\t... failed");
                 fail("failed to find " + enabledProtocols.get(i) +
-                     " in enabled protocols");
+                    " in enabled protocols");
             }
 
             /* check supported cipher suites */
@@ -230,12 +226,10 @@ public class WolfSSLEngineTest {
             e.setEnabledCipherSuites(new String[] {sup[0]});
             if (e.getEnabledCipherSuites() == null ||
                     !sup[0].equals(e.getEnabledCipherSuites()[0])) {
-                error("\t\t... failed");
                 fail("unexpected empty cipher list");
             }
         }
 
-        pass("\t\t... passed");
     }
 
     @Test
@@ -277,7 +271,6 @@ public class WolfSSLEngineTest {
         Certificate[] certs;
 
         /* create new SSLEngine */
-        System.out.print("\tBasic connection: " + protocol);
 
         this.ctx = tf.createSSLContext(protocol, engineProvider);
         server = this.ctx.createSSLEngine();
@@ -286,7 +279,6 @@ public class WolfSSLEngineTest {
         ciphers = client.getSupportedCipherSuites();
         certs = server.getSession().getLocalCertificates();
         if (certs == null) {
-            error("\t... failed");
             fail("no certs available from server SSLEngine.getSession()");
         }
         else {
@@ -328,27 +320,23 @@ public class WolfSSLEngineTest {
         server.setNeedClientAuth(false);
         client.setUseClientMode(true);
         ret = tf.testConnection(server, client, new String[] { cipher },
-                new String[] { protocol }, "Test cipher suite");
+            new String[] { protocol }, "Test cipher suite");
         if (ret != 0) {
-            error("\t... failed");
             fail("failed to create engine");
         }
 
         /* check if inbound is still open */
         if (server.isInboundDone() && client.isInboundDone()) {
-            error("\t... failed");
             fail("inbound done too early");
         }
 
         /* check if outbound is still open */
         if (server.isOutboundDone() && client.isOutboundDone()) {
-            error("\t... failed");
             fail("outbound done too early");
         }
 
         /* check get client */
         if (!client.getUseClientMode() || server.getUseClientMode()) {
-            error("\t... failed");
             fail("invalid client mode");
         }
 
@@ -356,19 +344,16 @@ public class WolfSSLEngineTest {
         try {
             tf.CloseConnection(server, client, false);
         } catch (SSLException ex) {
-            error("\t... failed");
             fail("failed to create engine");
         }
 
         /* check if inbound is still open */
         if (!server.isInboundDone() || !client.isInboundDone()) {
-            error("\t... failed");
             fail("inbound is not done");
         }
 
         /* check if outbound is still open */
         if (!server.isOutboundDone() || !client.isOutboundDone()) {
-            error("\t... failed");
             fail("outbound is not done");
         }
 
@@ -376,11 +361,9 @@ public class WolfSSLEngineTest {
         try {
             server.closeInbound();
         } catch (SSLException ex) {
-            error("\t... failed");
             fail("close inbound failure");
         }
 
-        pass("\t... passed");
     }
 
     @Test
@@ -394,7 +377,6 @@ public class WolfSSLEngineTest {
         int ret;
 
         /* create new SSLEngine */
-        System.out.print("\tbeginHandshake()");
 
         for (int i = 0; i < enabledProtocols.size(); i++) {
 
@@ -409,18 +391,16 @@ public class WolfSSLEngineTest {
              * IllegalStateException */
             try {
                 server.beginHandshake();
-                error("\t\t... failed");
                 fail("beginHandshake() before setUseClientMode() should " +
-                     "throw IllegalStateException");
+                    "throw IllegalStateException");
             } catch (IllegalStateException e) {
                 /* expected */
             }
 
             try {
                 client.beginHandshake();
-                error("\t\t... failed");
                 fail("beginHandshake() before setUseClientMode() should " +
-                     "throw IllegalStateException");
+                    "throw IllegalStateException");
             } catch (IllegalStateException e) {
                 /* expected */
             }
@@ -434,14 +414,12 @@ public class WolfSSLEngineTest {
                 server.beginHandshake();
                 client.beginHandshake();
             } catch (SSLException e) {
-                error("\t\t... failed");
                 fail("failed to begin handshake");
             }
 
             ret = tf.testConnection(server, client, null, null,
                 "Test in/out bound");
             if (ret != 0) {
-                error("\t\t... failed");
                 fail("failed to create engine");
             }
 
@@ -449,21 +427,18 @@ public class WolfSSLEngineTest {
              * since renegotiation is not yet supported in wolfJSSE */
             try {
                 server.beginHandshake();
-                error("\t\t... failed");
                 fail("beginHandshake() called again should throw SSLException");
             } catch (SSLException e) {
                 /* expected */
             }
             try {
                 client.beginHandshake();
-                error("\t\t... failed");
                 fail("beginHandshake() called again should throw SSLException");
             } catch (SSLException e) {
                 /* expected */
             }
         }
 
-        pass("\t\t... passed");
     }
 
     @Test
@@ -477,7 +452,6 @@ public class WolfSSLEngineTest {
         int ret;
 
         /* create new SSLEngine */
-        System.out.print("\tisIn/OutboundDone()");
 
         for (int i = 0; i < enabledProtocols.size(); i++) {
 
@@ -494,33 +468,28 @@ public class WolfSSLEngineTest {
             ret = tf.testConnection(server, client, null, null,
                 "Test in/out bound");
             if (ret != 0) {
-                error("\t\t... failed");
                 fail("failed to create engine");
             }
 
             /* check if inbound is still open */
             if (server.isInboundDone() && client.isInboundDone()) {
-                error("\t\t... failed");
                 fail("inbound done too early");
             }
 
             /* check if outbound is still open */
             if (server.isOutboundDone() && client.isOutboundDone()) {
-                error("\t\t... failed");
                 fail("outbound done too early");
             }
 
             /* close inbound before peer responded to shutdown should fail */
             try {
                 server.closeInbound();
-                error("\t\t... failed");
                 fail("was able to incorrectly close inbound");
             } catch (SSLException ex) {
                 /* expected to fail here */
             }
         }
 
-        pass("\t\t... passed");
     }
 
     @Test
@@ -531,8 +500,6 @@ public class WolfSSLEngineTest {
 
         SSLEngine client;
         SSLEngine server;
-
-        System.out.print("\tsetUseClientMode()");
 
         for (int i = 0; i < enabledProtocols.size(); i++) {
 
@@ -546,7 +513,6 @@ public class WolfSSLEngineTest {
             server.setNeedClientAuth(false);
             try {
                 tf.testConnection(server, client, null, null, "Testing");
-                error("\t\t... failed");
                 fail("did not fail without setUseClientMode()");
             } catch (IllegalStateException e) {
                 /* expected */
@@ -560,7 +526,6 @@ public class WolfSSLEngineTest {
             client.setUseClientMode(true);
             try {
                 tf.testConnection(server, client, null, null, "Testing");
-                error("\t\t... failed");
                 fail("did not fail without server.setUseClientMode()");
             } catch (IllegalStateException e) {
                 /* expected */
@@ -574,7 +539,6 @@ public class WolfSSLEngineTest {
             server.setUseClientMode(false);
             try {
                 tf.testConnection(server, client, null, null, "Testing");
-                error("\t\t... failed");
                 fail("did not fail without client.setUseClientMode()");
             } catch (IllegalStateException e) {
                 /* expected */
@@ -591,12 +555,10 @@ public class WolfSSLEngineTest {
                 tf.testConnection(server, client, null, null, "Testing");
             } catch (IllegalStateException e) {
                 e.printStackTrace();
-                error("\t\t... failed");
                 fail("failed with setUseClientMode(), should succeed");
             }
         }
 
-        pass("\t\t... passed");
     }
 
     @Test
@@ -610,7 +572,6 @@ public class WolfSSLEngineTest {
         int ret;
 
         /* create new SSLEngine */
-        System.out.print("\tMutual authentication");
 
         for (int i = 0; i < enabledProtocols.size(); i++) {
 
@@ -628,13 +589,11 @@ public class WolfSSLEngineTest {
             ret = tf.testConnection(server, client, null, null,
                 "Test mutual auth");
             if (ret != 0) {
-                error("\t\t... failed");
                 fail("failed to create connection with engine");
             }
 
             /* want client auth should be overwritten by need client auth */
             if (!server.getNeedClientAuth() || server.getWantClientAuth()) {
-                error("\t\t... failed");
                 fail("failed with mutual auth getter check");
             }
 
@@ -653,12 +612,10 @@ public class WolfSSLEngineTest {
             ret = tf.testConnection(server, client, null, null,
                 "Test in/out bound");
             if (ret == 0) {
-                error("\t\t... failed");
                 fail("failed to create engine");
             }
         }
 
-        pass("\t\t... passed");
     }
 
     /**
@@ -719,8 +676,6 @@ public class WolfSSLEngineTest {
             new PeerAuthConfig(false, false, false, false, true)
         };
 
-        System.out.print("\tsetWantClientAuth(default KM)");
-
         for (int i = 0; i < enabledProtocols.size(); i++) {
             for (PeerAuthConfig c : configsDefaultManagers) {
 
@@ -741,20 +696,17 @@ public class WolfSSLEngineTest {
                 ret = tf.testConnection(server, client, null, null, "Test");
                 if ((c.expectSuccess && ret != 0) ||
                     (!c.expectSuccess && ret == 0)) {
-                    error("\t... failed");
                     fail("SSLEngine want/needClientAuth failed: \n" +
-                         "\n  cWantClientAuth = " + c.clientWantClientAuth +
-                         "\n  cNeedClientAuth = " + c.clientNeedClientAuth +
-                         "\n  sWantClientAuth = " + c.serverWantClientAuth +
-                         "\n  sNeedClientAuth = " + c.serverNeedClientAuth +
-                         "\n  expectSuccess = " + c.expectSuccess +
-                         "\n  got ret = " + ret +
-                         "\n  protocol = " + enabledProtocols.get(i));
+                        "\n  cWantClientAuth = " + c.clientWantClientAuth +
+                        "\n  cNeedClientAuth = " + c.clientNeedClientAuth +
+                        "\n  sWantClientAuth = " + c.serverWantClientAuth +
+                        "\n  sNeedClientAuth = " + c.serverNeedClientAuth +
+                        "\n  expectSuccess = " + c.expectSuccess +
+                        "\n  got ret = " + ret +
+                        "\n  protocol = " + enabledProtocols.get(i));
                 }
             }
         }
-
-        pass("\t... passed");
     }
 
     @Test
@@ -790,8 +742,6 @@ public class WolfSSLEngineTest {
             new PeerAuthConfig(false, false, false, false, true)
         };
 
-        System.out.print("\tsetWantClientAuth(no client KM)");
-
         for (int i = 0; i < enabledProtocols.size(); i++) {
             for (PeerAuthConfig c : configs) {
 
@@ -815,20 +765,17 @@ public class WolfSSLEngineTest {
                 ret = tf.testConnection(server, client, null, null, "Test");
                 if ((c.expectSuccess && ret != 0) ||
                     (!c.expectSuccess && ret == 0)) {
-                    error("\t... failed");
                     fail("SSLEngine want/needClientAuth failed: \n" +
-                         "\n  cWantClientAuth = " + c.clientWantClientAuth +
-                         "\n  cNeedClientAuth = " + c.clientNeedClientAuth +
-                         "\n  sWantClientAuth = " + c.serverWantClientAuth +
-                         "\n  sNeedClientAuth = " + c.serverNeedClientAuth +
-                         "\n  expectSuccess = " + c.expectSuccess +
-                         "\n  got ret = " + ret +
-                         "\n  protocol = " + enabledProtocols.get(i));
+                        "\n  cWantClientAuth = " + c.clientWantClientAuth +
+                        "\n  cNeedClientAuth = " + c.clientNeedClientAuth +
+                        "\n  sWantClientAuth = " + c.serverWantClientAuth +
+                        "\n  sNeedClientAuth = " + c.serverNeedClientAuth +
+                        "\n  expectSuccess = " + c.expectSuccess +
+                        "\n  got ret = " + ret +
+                        "\n  protocol = " + enabledProtocols.get(i));
                 }
             }
         }
-
-        pass("\t... passed");
     }
 
     @Test
@@ -866,8 +813,6 @@ public class WolfSSLEngineTest {
             new PeerAuthConfig(false, false, false, false, false)
         };
 
-        System.out.print("\tsetWantClientAuth(no server KM)");
-
         for (int i = 0; i < enabledProtocols.size(); i++) {
             for (PeerAuthConfig c : configs) {
 
@@ -891,20 +836,17 @@ public class WolfSSLEngineTest {
                 ret = tf.testConnection(server, client, null, null, "Test");
                 if ((c.expectSuccess && ret != 0) ||
                     (!c.expectSuccess && ret == 0)) {
-                    error("\t... failed");
                     fail("SSLEngine want/needClientAuth failed: \n" +
-                         "\n  cWantClientAuth = " + c.clientWantClientAuth +
-                         "\n  cNeedClientAuth = " + c.clientNeedClientAuth +
-                         "\n  sWantClientAuth = " + c.serverWantClientAuth +
-                         "\n  sNeedClientAuth = " + c.serverNeedClientAuth +
-                         "\n  expectSuccess = " + c.expectSuccess +
-                         "\n  got ret = " + ret +
-                         "\n  protocol = " + enabledProtocols.get(i));
+                        "\n  cWantClientAuth = " + c.clientWantClientAuth +
+                        "\n  cNeedClientAuth = " + c.clientNeedClientAuth +
+                        "\n  sWantClientAuth = " + c.serverWantClientAuth +
+                        "\n  sNeedClientAuth = " + c.serverNeedClientAuth +
+                        "\n  expectSuccess = " + c.expectSuccess +
+                        "\n  got ret = " + ret +
+                        "\n  protocol = " + enabledProtocols.get(i));
                 }
             }
         }
-
-        pass("\t... passed");
     }
 
     @Test
@@ -968,8 +910,6 @@ public class WolfSSLEngineTest {
             new PeerAuthConfig(false, false, false, false, true)
         };
 
-        System.out.print("\tsetWantClientAuth(ext KM all)");
-
         for (int i = 0; i < enabledProtocols.size(); i++) {
             for (PeerAuthConfig c : configsDefaultManagers) {
 
@@ -996,20 +936,17 @@ public class WolfSSLEngineTest {
                 ret = tf.testConnection(server, client, null, null, "Test");
                 if ((c.expectSuccess && ret != 0) ||
                     (!c.expectSuccess && ret == 0)) {
-                    error("\t... failed");
                     fail("SSLEngine want/needClientAuth failed: \n" +
-                         "\n  cWantClientAuth = " + c.clientWantClientAuth +
-                         "\n  cNeedClientAuth = " + c.clientNeedClientAuth +
-                         "\n  sWantClientAuth = " + c.serverWantClientAuth +
-                         "\n  sNeedClientAuth = " + c.serverNeedClientAuth +
-                         "\n  expectSuccess = " + c.expectSuccess +
-                         "\n  got ret = " + ret +
-                         "\n  protocol = " + enabledProtocols.get(i));
+                        "\n  cWantClientAuth = " + c.clientWantClientAuth +
+                        "\n  cNeedClientAuth = " + c.clientNeedClientAuth +
+                        "\n  sWantClientAuth = " + c.serverWantClientAuth +
+                        "\n  sNeedClientAuth = " + c.serverNeedClientAuth +
+                        "\n  expectSuccess = " + c.expectSuccess +
+                        "\n  got ret = " + ret +
+                        "\n  protocol = " + enabledProtocols.get(i));
                 }
             }
         }
-
-        pass("\t... passed");
     }
 
     @Test
@@ -1088,8 +1025,6 @@ public class WolfSSLEngineTest {
             new PeerAuthConfig(false, false, false, false, true)
         };
 
-        System.out.print("\tsetWantClientAuth(ext KM no)");
-
         for (int i = 0; i < enabledProtocols.size(); i++) {
             for (PeerAuthConfig c : configsDefaultManagers) {
 
@@ -1116,22 +1051,18 @@ public class WolfSSLEngineTest {
                 ret = tf.testConnection(server, client, null, null, "Test");
                 if ((c.expectSuccess && ret != 0) ||
                     (!c.expectSuccess && ret == 0)) {
-                    error("\t... failed");
                     fail("SSLEngine want/needClientAuth failed: \n" +
-                         "\n  cWantClientAuth = " + c.clientWantClientAuth +
-                         "\n  cNeedClientAuth = " + c.clientNeedClientAuth +
-                         "\n  sWantClientAuth = " + c.serverWantClientAuth +
-                         "\n  sNeedClientAuth = " + c.serverNeedClientAuth +
-                         "\n  expectSuccess = " + c.expectSuccess +
-                         "\n  got ret = " + ret +
-                         "\n  protocol = " + enabledProtocols.get(i));
+                        "\n  cWantClientAuth = " + c.clientWantClientAuth +
+                        "\n  cNeedClientAuth = " + c.clientNeedClientAuth +
+                        "\n  sWantClientAuth = " + c.serverWantClientAuth +
+                        "\n  sNeedClientAuth = " + c.serverNeedClientAuth +
+                        "\n  expectSuccess = " + c.expectSuccess +
+                        "\n  got ret = " + ret +
+                        "\n  protocol = " + enabledProtocols.get(i));
                 }
             }
         }
-
-        pass("\t... passed");
     }
-
 
     @Test
     public void testReuseSession()
@@ -1142,8 +1073,6 @@ public class WolfSSLEngineTest {
         SSLEngine server;
         SSLEngine client;
         int ret;
-
-        System.out.print("\tSession reuse");
 
         /* wolfjsse.clientSessionCache.disabled could be set in users
          * java.security file which would cause this test to not work
@@ -1167,7 +1096,6 @@ public class WolfSSLEngineTest {
                 ret = tf.testConnection(server, client, null, null,
                     "Test reuse");
                 if (ret != 0) {
-                    error("\t\t\t... failed");
                     fail("failed to create engine");
                 }
 
@@ -1175,7 +1103,6 @@ public class WolfSSLEngineTest {
                     /* test close connection */
                     tf.CloseConnection(server, client, false);
                 } catch (SSLException ex) {
-                    error("\t\t\t... failed");
                     fail("failed to create engine");
                 }
 
@@ -1188,25 +1115,20 @@ public class WolfSSLEngineTest {
                 ret = tf.testConnection(server, client, null, null,
                     "Test reuse");
                 if (ret != 0) {
-                    error("\t\t\t... failed");
                     fail("failed to create engine");
                 }
                 try {
                     /* test close connection */
                     tf.CloseConnection(server, client, false);
                 } catch (SSLException ex) {
-                    error("\t\t\t... failed");
                     fail("failed to create engine");
                 }
 
                 if (client.getEnableSessionCreation() ||
                     !server.getEnableSessionCreation()) {
-                    error("\t\t\t... failed");
                     fail("bad enabled session creation");
                 }
             }
-
-            pass("\t\t\t... passed");
 
         } finally {
             if (originalProp != null && !originalProp.isEmpty()) {
@@ -1228,19 +1150,11 @@ public class WolfSSLEngineTest {
             KeyManagementException, KeyStoreException, IOException,
             CertificateException, UnrecoverableKeyException {
 
-        System.out.print("\tEngine session resumption SNI");
-
         /* Requires WOLFSSL_ALWAYS_KEEP_SNI, enabled by default with
          * --enable-jni in wolfSSL 5.7.6+ (PR 8283) */
-        if (WolfSSL.getLibVersionHex() < 0x05007006L) {
-            System.out.println("\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.getLibVersionHex() >= 0x05007006L);
 
-        if (!enabledProtocols.contains("TLSv1.3")) {
-            System.out.println("\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(enabledProtocols.contains("TLSv1.3"));
 
         /* wolfjsse.clientSessionCache.disabled could be set in users
          * java.security file which would cause this test to not work
@@ -1282,7 +1196,6 @@ public class WolfSSLEngineTest {
 
                 ret = tf.testConnection(server1, client1, null, null, "Hello");
                 if (ret != 0) {
-                    error("\t... failed");
                     fail("Initial connection with explicit SNI failed");
                 }
             } finally {
@@ -1315,14 +1228,10 @@ public class WolfSSLEngineTest {
                 }
             }
             if (ret != 0) {
-                error("\t... failed");
                 fail("Resumed connection did not carry session-cached SNI");
             }
 
-            pass("\t... passed");
-
         } catch (Exception e) {
-            error("\t... failed");
             e.printStackTrace();
             fail("testEngineSessionResumptionSNI failed with exception: " + e);
         } finally {
@@ -1373,8 +1282,6 @@ public class WolfSSLEngineTest {
         failures.set(0, 0);
         success.set(0, 0);
 
-        System.out.print("\tExtended threading use");
-
         /* Start up simple TLS test server */
         CountDownLatch serverOpenLatch = new CountDownLatch(1);
         InternalMultiThreadedSSLSocketServer server = null;
@@ -1410,20 +1317,17 @@ public class WolfSSLEngineTest {
             returnWithoutTimeout = latch.await(10, TimeUnit.SECONDS);
 
             /* check failure count and success count against thread count */
-            if (failures.get(0) == 0 && success.get(0) == numThreads) {
-                pass("\t\t... passed");
-            } else {
+            if (failures.get(0) != 0 || success.get(0) != numThreads) {
                 if (returnWithoutTimeout == true) {
-                    error("\t\t... failed");
                     fail("SSLEngine threading error: " +
-                         failures.get(0) + " failures, " +
-                         success.get(0) + " success, " +
-                         numThreads + " num threads total");
+                        failures.get(0) + " failures, " +
+                        success.get(0) + " success, " +
+                        numThreads + " num threads total");
                 } else {
-                    error("\t\t... failed");
                     fail("SSLEngine threading error, threads timed out");
                 }
             }
+
         } finally {
             /* Ensure proper cleanup in all cases */
 
@@ -1511,7 +1415,7 @@ public class WolfSSLEngineTest {
 
             hsStatus = engine.getHandshakeStatus();
             while (hsStatus != SSLEngineResult.HandshakeStatus.FINISHED &&
-                  hsStatus != SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING) {
+                hsStatus != SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING) {
                 switch (hsStatus) {
                     case NEED_WRAP:
                         netData.clear();
@@ -1542,8 +1446,7 @@ public class WolfSSLEngineTest {
                                 throw new Exception(
                                     "BUFFER_UNDERFLOW during engine.wrap()");
                             default:
-                                throw new Exception(
-                                    "Unknown HandshakeStatus");
+                                throw new Exception("Unknown HandshakeStatus");
                         }
                         break;
                     case NEED_UNWRAP:
@@ -1618,8 +1521,7 @@ public class WolfSSLEngineTest {
                         throw new Exception(
                             "BUFFER_UNDERFLOW during engine.wrap()");
                     default:
-                        throw new Exception(
-                            "Unknown HandshakeStatus");
+                        throw new Exception("Unknown HandshakeStatus");
                 }
             }
 
@@ -1657,8 +1559,7 @@ public class WolfSSLEngineTest {
                                 "BUFFER_UNDERFLOW during engine.unwrap()");
                         }
                     default:
-                        throw new Exception(
-                            "Unknown HandshakeStatus");
+                        throw new Exception("Unknown HandshakeStatus");
                 }
             }
 
@@ -1686,8 +1587,7 @@ public class WolfSSLEngineTest {
                             throw new Exception(
                                 "BUFFER_UNDERFLOW during engine.unwrap()");
                         default:
-                            throw new Exception(
-                                "Unknown HandshakeStatus");
+                            throw new Exception("Unknown HandshakeStatus");
                     }
                 }
             }
@@ -1800,22 +1700,12 @@ public class WolfSSLEngineTest {
         }
     } /* InternalMultiThreadedSSLSocketServer */
 
-    private void pass(String msg) {
-        WolfSSLTestFactory.pass(msg);
-    }
-
-    private void error(String msg) {
-        WolfSSLTestFactory.fail(msg);
-    }
-
     @Test
     public void testGetApplicationBufferSize() {
 
         int appBufSz = 0;
         SSLEngine engine;
         SSLSession session;
-
-        System.out.print("\tgetApplicationBufferSize()");
 
         try {
             for (int i = 0; i < enabledProtocols.size(); i++) {
@@ -1828,18 +1718,15 @@ public class WolfSSLEngineTest {
 
                 /* expected to be 16384 */
                 if (appBufSz != 16384) {
-                    error("\t... failed");
                     fail("got incorrect application buffer size (" +
                         enabledProtocols.get(i) + ")");
                 }
             }
         } catch (Exception e) {
             e.printStackTrace();
-            error("\t... failed");
             fail("unexpected Exception during getApplicationBufferSize test");
         }
 
-        pass("\t... passed");
     }
 
     @Test
@@ -1848,8 +1735,6 @@ public class WolfSSLEngineTest {
         int packetBufSz = 0;
         SSLEngine engine;
         SSLSession session;
-
-        System.out.print("\tgetPacketBufferSize()");
 
         try {
             for (int i = 0; i < enabledProtocols.size(); i++) {
@@ -1862,18 +1747,15 @@ public class WolfSSLEngineTest {
 
                 /* expected to be 17k */
                 if (packetBufSz != (17 * 1024)) {
-                    error("\t\t... failed");
                     fail("got incorrect packet buffer size (" +
                         enabledProtocols.get(i) + ")");
                 }
             }
         } catch (Exception e) {
             e.printStackTrace();
-            error("\t\t... failed");
             fail("unexpected Exception during getPacketBufferSize test");
         }
 
-        pass("\t\t... passed");
     }
 
     @Test
@@ -1890,8 +1772,6 @@ public class WolfSSLEngineTest {
 
         /* big input buffer to test, 16k */
         byte[] bigInput = new byte[16384];
-
-        System.out.print("\tTesting large data transfer");
 
         try {
             /* create SSLContext */
@@ -1947,7 +1827,6 @@ public class WolfSSLEngineTest {
                     cIn.flip();
 
                     if (!sOut.equals(cIn)) {
-                        error("\t... failed");
                         fail("server output does not match client input");
                     }
                     sOut.position(sOut.limit());
@@ -1960,7 +1839,6 @@ public class WolfSSLEngineTest {
                     sIn.flip();
 
                     if (!cOut.equals(sIn)) {
-                        error("\t... failed");
                         fail("client output does not match server input");
                     }
                     cOut.position(cOut.limit());
@@ -1974,11 +1852,9 @@ public class WolfSSLEngineTest {
                 }
             }
         } catch (Exception e) {
-            error("\t... failed");
             e.printStackTrace();
             fail("failed large input test with Exception");
         }
-        pass("\t... passed");
     }
 
     @Test
@@ -1997,8 +1873,6 @@ public class WolfSSLEngineTest {
         ByteBuffer clientToServer;
         ByteBuffer serverToClient;
 
-        System.out.print("\tTesting split input data");
-
         try {
             /* create SSLContext */
             this.ctx = tf.createSSLContext("TLS", engineProvider);
@@ -2010,7 +1884,7 @@ public class WolfSSLEngineTest {
 
             /* create client SSLEngine */
             SSLEngine client = this.ctx.createSSLEngine(
-                                   "wolfSSL client test", 11111);
+                "wolfSSL client test", 11111);
             client.setUseClientMode(true);
 
             SSLSession session = client.getSession();
@@ -2054,21 +1928,19 @@ public class WolfSSLEngineTest {
 
                     /* check server out matches client in */
                     ByteBuffer cExpectedIn = ByteBuffer.wrap(
-                            "Hello client, from server".getBytes());
+                        "Hello client, from server".getBytes());
                     cIn.flip();
 
                     if (!cIn.equals(cExpectedIn)) {
-                        error("\t... failed");
                         fail("server output does not match expected");
                     }
 
                     /* check client out matches server in */
                     ByteBuffer sExpectedIn = ByteBuffer.wrap(
-                            "Hello server, from client".getBytes());
+                        "Hello server, from client".getBytes());
                     sIn.flip();
 
                     if (!sIn.equals(sExpectedIn)) {
-                        error("\t... failed");
                         fail("client output does not match expected");
                     }
 
@@ -2078,11 +1950,9 @@ public class WolfSSLEngineTest {
                 }
             }
         } catch (Exception e) {
-            error("\t... failed");
             e.printStackTrace();
             fail("failed split input test with Exception");
         }
-        pass("\t... passed");
     }
 
     @Test
@@ -2091,13 +1961,8 @@ public class WolfSSLEngineTest {
                KeyManagementException, KeyStoreException, IOException,
                CertificateException, UnrecoverableKeyException {
 
-        System.out.print("\tDTLSv1.3 basic connection");
-
         /* Skip if DTLSv1.3 not enabled */
-        if (!enabledProtocols.contains("DTLSv1.3")) {
-            System.out.println("\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(enabledProtocols.contains("DTLSv1.3"));
 
         SSLEngine client = null;
         SSLEngine server = null;
@@ -2128,10 +1993,7 @@ public class WolfSSLEngineTest {
             new Random().nextBytes(largeData);
             tf.testConnection(client, server, null, null, new String(largeData));
 
-            pass("\t... passed");
-
         } catch (Exception e) {
-            error("\t... failed");
             e.printStackTrace();
             fail("Failed DTLSv1.3 test with exception: " + e);
         }
@@ -2195,13 +2057,8 @@ public class WolfSSLEngineTest {
                KeyManagementException, KeyStoreException, IOException,
                CertificateException, UnrecoverableKeyException {
 
-        System.out.print("\tDTLSv1.3 session resumption");
-
         /* Skip if DTLSv1.3 not enabled */
-        if (!enabledProtocols.contains("DTLSv1.3")) {
-            System.out.println("\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(enabledProtocols.contains("DTLSv1.3"));
 
         try {
 
@@ -2210,10 +2067,7 @@ public class WolfSSLEngineTest {
             /* Test expected not resumption case */
             dtls13ResumeTest("wolfSSL client", "wolfSSL client 2", false);
 
-            pass("\t... passed");
-
         } catch (Exception e) {
-            error("\t... failed");
             e.printStackTrace();
             fail("Failed DTLSv1.3 session resumption test " +
                  "with exception: " + e);
@@ -2227,8 +2081,6 @@ public class WolfSSLEngineTest {
      */
     @Test
     public void testNonBlockingIO() throws Exception {
-
-        System.out.print("\tNon-blocking I/O");
 
         for (int i = 0; i < enabledProtocols.size(); i++) {
             String protocol = enabledProtocols.get(i);
@@ -2288,21 +2140,17 @@ public class WolfSSLEngineTest {
             clientThread.join(5000);
 
             if (serverThread.isAlive() || clientThread.isAlive()) {
-                error("... failed");
                 fail("Test timed out for " + protocol);
             }
 
             if (serverException[0] != null) {
-                error("... failed");
                 throw serverException[0];
             }
             if (clientException[0] != null) {
-                error("... failed");
                 throw clientException[0];
             }
         }
 
-        pass("\t\t... passed");
     }
 
     private void doNonBlockingIO(String protocol, int[] serverPort,
@@ -2642,8 +2490,6 @@ public class WolfSSLEngineTest {
     @Test
     public void testGetPeerCertificateChainNoClientAuth() throws Exception {
 
-        System.out.print("\tgetPeerCertChain no client auth");
-
         String protocol = null;
         for (String p : enabledProtocols) {
             if (!p.equals("TLS") && !p.contains("DTLS")) {
@@ -2652,10 +2498,7 @@ public class WolfSSLEngineTest {
             }
         }
 
-        if (protocol == null) {
-            pass("\t... skipped");
-            return;
-        }
+        Assume.assumeNotNull(protocol);
 
         SSLContext ctx = tf.createSSLContext(protocol, engineProvider);
 
@@ -2674,19 +2517,15 @@ public class WolfSSLEngineTest {
         try {
             javax.security.cert.X509Certificate[] certs =
                 serverSession.getPeerCertificateChain();
-            error("\t... failed");
             fail("Expected SSLPeerUnverifiedException, got " +
                  (certs == null ? "null" : "certs"));
         } catch (SSLPeerUnverifiedException e) {
             /* Expected */
         }
 
-        pass("\t... passed");
     }
     @Test
     public void testEngineAnonCipherSuiteFiltering() throws Exception {
-
-        System.out.print("\tanon cipher suite filtering");
 
         String[] allCiphers = WolfSSL.getCiphersIana();
         String anonSuite = null;
@@ -2701,10 +2540,7 @@ public class WolfSSLEngineTest {
             }
         }
 
-        if (anonSuite == null) {
-            pass("\t... skipped");
-            return;
-        }
+        Assume.assumeNotNull(anonSuite);
 
         Security.setProperty("wolfjsse.enabledCipherSuites", "");
         this.ctx = tf.createSSLContext("TLS", engineProvider);
@@ -2715,7 +2551,6 @@ public class WolfSSLEngineTest {
         assertNotNull(enabled);
         for (String s : enabled) {
             if (s != null && s.contains("_anon_")) {
-                error("\t... failed");
                 fail("Default enabled should not contain anon suite: " + s);
             }
         }
@@ -2752,7 +2587,6 @@ public class WolfSSLEngineTest {
         assertNotNull(enabled);
         assertEquals(2, enabled.length);
 
-        pass("\t... passed");
     }
 
     @Test
@@ -2760,8 +2594,6 @@ public class WolfSSLEngineTest {
         throws NoSuchProviderException, NoSuchAlgorithmException,
                KeyManagementException, KeyStoreException,
                CertificateException, IOException, UnrecoverableKeyException {
-
-        System.out.print("\tSSLHandshakeException cause");
 
         final String rejectMsg = "Intentional engine test rejection";
         TrustManager[] rejectingTMs = { new X509TrustManager() {
@@ -2865,12 +2697,10 @@ public class WolfSSLEngineTest {
         }
 
         if (!sawExpected) {
-            error("\t... failed");
             fail("Expected SSLHandshakeException " +
                 "with CertificateException cause");
         }
 
-        pass("\t... passed");
     }
 
     @Test
@@ -2881,15 +2711,11 @@ public class WolfSSLEngineTest {
 
         /* TLS 1.3 close_notify should return NOT_HANDSHAKING,
          * not NEED_WRAP (RFC 8446 Section 6.1). */
-        System.out.print("\tTLS 1.3 close_notify status");
 
         String[] proto = {"TLSv1.3"};
         this.ctx = tf.createSSLContext("TLSv1.3", engineProvider);
-        if (this.ctx == null) {
-            /* TLS 1.3 not available, skip */
-            pass("\t... skipped");
-            return;
-        }
+        /* TLS 1.3 not available, skip */
+        Assume.assumeNotNull(this.ctx);
 
         SSLEngine server = this.ctx.createSSLEngine();
         SSLEngine client = this.ctx.createSSLEngine("wolfSSL test", 11111);
@@ -2906,14 +2732,12 @@ public class WolfSSLEngineTest {
         int ret = tf.testConnection(server, client, null, null,
             "close_notify test");
         if (ret != 0) {
-            error("\t... failed");
             fail("failed to create connection");
         }
 
         /* Client sends close_notify */
         client.closeOutbound();
         if (client.getHandshakeStatus() != HandshakeStatus.NEED_WRAP) {
-            error("\t... failed");
             fail("closeOutbound should result in NEED_WRAP");
         }
 
@@ -2925,7 +2749,6 @@ public class WolfSSLEngineTest {
         /* Wrap the close_notify */
         SSLEngineResult result = client.wrap(ByteBuffer.allocate(0), netBuf);
         if (result.getStatus() != SSLEngineResult.Status.CLOSED) {
-            error("\t... failed");
             fail("wrap after closeOutbound should return CLOSED");
         }
 
@@ -2954,20 +2777,17 @@ public class WolfSSLEngineTest {
             /* After wrapping close_notify, should be NOT_HANDSHAKING
              * (not stuck in NEED_WRAP forever) */
             if (serverStatus == HandshakeStatus.NEED_WRAP) {
-                error("\t... failed");
                 fail("server stuck in NEED_WRAP after wrapping " +
-                     "close_notify response");
+                    "close_notify response");
             }
         }
 
         /* Final state should be NOT_HANDSHAKING */
         if (serverStatus != HandshakeStatus.NOT_HANDSHAKING) {
-            error("\t... failed");
             fail("expected NOT_HANDSHAKING after close_notify " +
-                 "exchange, got " + serverStatus);
+                "exchange, got " + serverStatus);
         }
 
-        pass("\t... passed");
     }
 
     @Test
@@ -2978,7 +2798,6 @@ public class WolfSSLEngineTest {
 
         /* Test that unwrap() returns BUFFER_UNDERFLOW with 0 bytes
          * consumed when given a partial TLS record. */
-        System.out.print("\tUnderflow partial record");
 
         this.ctx = tf.createSSLContext("TLS", engineProvider);
         SSLEngine server = this.ctx.createSSLEngine();
@@ -2994,7 +2813,6 @@ public class WolfSSLEngineTest {
         int ret = tf.testConnection(server, client, null, null,
             "underflow test");
         if (ret != 0) {
-            error("\t... failed");
             fail("failed to create connection");
         }
 
@@ -3006,14 +2824,12 @@ public class WolfSSLEngineTest {
 
         SSLEngineResult result = client.wrap(appBuf, netBuf);
         if (result.getStatus() != SSLEngineResult.Status.OK) {
-            error("\t... failed");
             fail("wrap failed: " + result.getStatus());
         }
         netBuf.flip();
         int fullRecordLen = netBuf.remaining();
 
         if (fullRecordLen < 6) {
-            error("\t... failed");
             fail("TLS record too short to test partial");
         }
 
@@ -3032,19 +2848,16 @@ public class WolfSSLEngineTest {
         result = server.unwrap(partialBuf, outBuf);
 
         if (result.getStatus() != SSLEngineResult.Status.BUFFER_UNDERFLOW) {
-            error("\t... failed");
             fail("expected BUFFER_UNDERFLOW for partial " +
                  "TLS record, got " + result.getStatus());
         }
 
         /* Should consume 0 bytes on BUFFER_UNDERFLOW */
         if (result.bytesConsumed() != 0) {
-            error("\t... failed");
             fail("BUFFER_UNDERFLOW should consume 0 bytes" +
                  ", consumed " + result.bytesConsumed());
         }
 
-        pass("\t... passed");
     }
 
     @Test
@@ -3054,12 +2867,7 @@ public class WolfSSLEngineTest {
                CertificateException, IOException,
                UnrecoverableKeyException {
 
-        System.out.print("\tTest unwrap incremental status");
-
-        if (!enabledProtocols.contains("TLSv1.3")) {
-            System.out.println("\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(enabledProtocols.contains("TLSv1.3"));
 
         SSLContext ctx13 = tf.createSSLContext("TLSv1.3", engineProvider);
         SSLEngine server = ctx13.createSSLEngine();
@@ -3081,9 +2889,7 @@ public class WolfSSLEngineTest {
         ByteBuffer emptyApp = ByteBuffer.allocate(0);
         SSLEngineResult result = client.wrap(emptyApp, cliToSrv);
         if (result.getStatus() != SSLEngineResult.Status.OK) {
-            error("\t... failed");
-            fail("client wrap (ClientHello) failed: " +
-                 result.getStatus());
+            fail("client wrap (ClientHello) failed: " + result.getStatus());
         }
         cliToSrv.flip();
 
@@ -3092,18 +2898,15 @@ public class WolfSSLEngineTest {
             ByteBuffer.allocateDirect(appBufSize);
         result = server.unwrap(cliToSrv, srvAppBuf);
         if (result.getStatus() != SSLEngineResult.Status.OK) {
-            error("\t... failed");
-            fail("server unwrap (ClientHello) failed: " +
-                 result.getStatus());
+            fail("server unwrap (ClientHello) failed: " + result.getStatus());
         }
 
         /* Collect entire TLS 1.3 server first flight (ServerHello,
          * optional Change Cipher Spec, encrypted flight). */
         if (server.getHandshakeStatus() !=
                 HandshakeStatus.NEED_WRAP) {
-            error("\t... failed");
-            fail("expected server NEED_WRAP after ClientHello, " +
-                 "got: " + server.getHandshakeStatus());
+            fail("expected server NEED_WRAP after ClientHello, got: " +
+                server.getHandshakeStatus());
         }
 
         ByteBuffer srvFlight =
@@ -3114,12 +2917,10 @@ public class WolfSSLEngineTest {
                 ByteBuffer.allocateDirect(packetBufSize);
             result = server.wrap(emptyApp, srvNet);
             if (result.getStatus() != SSLEngineResult.Status.OK) {
-                error("\t... failed");
                 fail("server wrap failed: " + result.getStatus());
             }
             srvNet.flip();
             if (srvNet.remaining() > srvFlight.remaining()) {
-                error("\t... failed");
                 fail("server flight exceeded srvFlight capacity");
             }
             srvFlight.put(srvNet);
@@ -3131,7 +2932,6 @@ public class WolfSSLEngineTest {
         /* Parse first TLS record header to find exact boundary:
          * type[1] + version[2] + length[2] = 5 bytes. */
         if (total < 5) {
-            error("\t... failed");
             fail("server flight too small: " + total);
         }
         int firstRecPayload =
@@ -3139,7 +2939,6 @@ public class WolfSSLEngineTest {
             | (srvFlight.get(srvFlight.position() + 4) & 0xFF);
         int firstRecordLen = 5 + firstRecPayload;
         if (total < firstRecordLen) {
-            error("\t... failed");
             fail("first TLS record extends beyond server flight");
         }
 
@@ -3150,38 +2949,30 @@ public class WolfSSLEngineTest {
         srvFlight.get(firstRecBytes);
         ByteBuffer firstRecord = ByteBuffer.wrap(firstRecBytes);
 
-        ByteBuffer cliAppBuf =
-            ByteBuffer.allocateDirect(appBufSize);
+        ByteBuffer cliAppBuf = ByteBuffer.allocateDirect(appBufSize);
         result = client.unwrap(firstRecord, cliAppBuf);
 
         /* wolfSSL processed first record but needs more data:
          * status must be OK, not BUFFER_UNDERFLOW. */
         if (result.getStatus() != SSLEngineResult.Status.OK) {
-            error("\t... failed");
-            fail("expected Status.OK, got: " +
-                 result.getStatus());
+            fail("expected Status.OK, got: " + result.getStatus());
         }
 
         /* Handshake needs more data to continue. */
         if (result.getHandshakeStatus() !=
                 SSLEngineResult.HandshakeStatus.NEED_UNWRAP) {
-            error("\t... failed");
-            fail("expected NEED_UNWRAP, got: " +
-                 result.getHandshakeStatus());
+            fail("expected NEED_UNWRAP, got: " + result.getHandshakeStatus());
         }
 
         /* All bytes consumed via I/O callback. */
         if (result.bytesConsumed() != firstRecordLen) {
-            error("\t... failed");
-            fail("expected " + firstRecordLen + " bytes " +
-                 "consumed, got: " + result.bytesConsumed());
+            fail("expected " + firstRecordLen + " bytes consumed, got: " +
+                result.bytesConsumed());
         }
 
         /* No application data produced during handshake. */
         if (result.bytesProduced() != 0) {
-            error("\t... failed");
-            fail("expected 0 bytes produced, got: " +
-                 result.bytesProduced());
+            fail("expected 0 bytes produced, got: " + result.bytesProduced());
         }
 
         /* Server flight must contain more than one record so we
@@ -3190,7 +2981,6 @@ public class WolfSSLEngineTest {
          * Certificate + CertificateVerify + Finished) always spans
          * multiple TLS records. */
         if (srvFlight.remaining() == 0) {
-            error("\t... failed");
             fail("server flight is a single record; cannot " +
                  "test contPartialRecord continuation path");
         }
@@ -3201,44 +2991,34 @@ public class WolfSSLEngineTest {
         byte[] contBytes = new byte[contLen];
         srvFlight.get(contBytes);
         ByteBuffer contBuf = ByteBuffer.wrap(contBytes);
-        ByteBuffer cliAppBuf2 =
-            ByteBuffer.allocateDirect(appBufSize);
+        ByteBuffer cliAppBuf2 = ByteBuffer.allocateDirect(appBufSize);
         result = client.unwrap(contBuf, cliAppBuf2);
 
         /* wolfSSL consumed continuation bytes, needs more:
          * must be Status.OK, not BUFFER_UNDERFLOW. */
-        if (result.getStatus() !=
-                SSLEngineResult.Status.OK) {
-            error("\t... failed");
-            fail("expected Status.OK for continuation " +
-                 "bytes, got: " + result.getStatus());
+        if (result.getStatus() != SSLEngineResult.Status.OK) {
+            fail("expected Status.OK for continuation bytes, got: " +
+                result.getStatus());
         }
 
         /* Handshake still needs more data. */
         if (result.getHandshakeStatus() !=
                 SSLEngineResult.HandshakeStatus.NEED_UNWRAP) {
-            error("\t... failed");
-            fail("expected NEED_UNWRAP for continuation " +
-                 "bytes, got: " +
-                 result.getHandshakeStatus());
+            fail("expected NEED_UNWRAP for continuation bytes, got: " +
+                result.getHandshakeStatus());
         }
 
         /* All continuation bytes consumed. */
         if (result.bytesConsumed() != contLen) {
-            error("\t... failed");
-            fail("expected " + contLen + " continuation " +
-                 "bytes consumed, got: " +
-                 result.bytesConsumed());
+            fail("expected " + contLen + " continuation bytes consumed, got: " +
+                result.bytesConsumed());
         }
 
         /* No application data produced. */
         if (result.bytesProduced() != 0) {
-            error("\t... failed");
-            fail("expected 0 bytes produced, got: " +
-                 result.bytesProduced());
+            fail("expected 0 bytes produced, got: " + result.bytesProduced());
         }
 
-        pass("\t... passed");
     }
 
     @Test
@@ -3252,12 +3032,7 @@ public class WolfSSLEngineTest {
          * handshake returns BUFFER_UNDERFLOW with 0 bytes consumed.
          * Exercises the inRemaining < TLS_RECORD_HEADER_LEN branch
          * of peekTlsRecordHeader(). */
-        System.out.print("\tTest unwrap partial header underflow");
-
-        if (!enabledProtocols.contains("TLSv1.3")) {
-            System.out.println("\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(enabledProtocols.contains("TLSv1.3"));
 
         SSLContext ctx13 = tf.createSSLContext("TLSv1.3", engineProvider);
         SSLEngine server = ctx13.createSSLEngine();
@@ -3279,49 +3054,39 @@ public class WolfSSLEngineTest {
         ByteBuffer emptyApp = ByteBuffer.allocate(0);
         SSLEngineResult result = client.wrap(emptyApp, cliToSrv);
         if (result.getStatus() != SSLEngineResult.Status.OK) {
-            error("\t... failed");
-            fail("client wrap (ClientHello) failed: " +
-                 result.getStatus());
+            fail("client wrap (ClientHello) failed: " + result.getStatus());
         }
 
         if (client.getHandshakeStatus() !=
                 SSLEngineResult.HandshakeStatus.NEED_UNWRAP) {
-            error("\t... failed");
             fail("expected NEED_UNWRAP after ClientHello, got: " +
-                 client.getHandshakeStatus());
+                client.getHandshakeStatus());
         }
 
         /* Feed 2 bytes: less than the 5-byte TLS record header.
          * Peek must signal BUFFER_UNDERFLOW without calling into
          * wolfSSL, so 0 bytes are consumed. */
-        ByteBuffer partialHeader =
-            ByteBuffer.wrap(new byte[] { 0x16, 0x03 });
-        ByteBuffer cliAppBuf =
-            ByteBuffer.allocateDirect(appBufSize);
+        ByteBuffer partialHeader = ByteBuffer.wrap(new byte[] { 0x16, 0x03 });
+        ByteBuffer cliAppBuf = ByteBuffer.allocateDirect(appBufSize);
         result = client.unwrap(partialHeader, cliAppBuf);
 
-        if (result.getStatus() !=
-                SSLEngineResult.Status.BUFFER_UNDERFLOW) {
-            error("\t... failed");
-            fail("expected BUFFER_UNDERFLOW for partial header, " +
-                 "got: " + result.getStatus());
+        if (result.getStatus() != SSLEngineResult.Status.BUFFER_UNDERFLOW) {
+            fail("expected BUFFER_UNDERFLOW for partial header, got: " +
+                result.getStatus());
         }
 
         if (result.bytesConsumed() != 0) {
-            error("\t... failed");
-            fail("BUFFER_UNDERFLOW must consume 0 bytes, " +
-                 "consumed: " + result.bytesConsumed());
+            fail("BUFFER_UNDERFLOW must consume 0 bytes, consumed: " +
+                result.bytesConsumed());
         }
 
         /* Engine must remain in NEED_UNWRAP after underflow. */
         if (result.getHandshakeStatus() !=
-                SSLEngineResult.HandshakeStatus.NEED_UNWRAP) {
-            error("\t... failed");
+            SSLEngineResult.HandshakeStatus.NEED_UNWRAP) {
             fail("expected NEED_UNWRAP after underflow, got: " +
                  result.getHandshakeStatus());
         }
 
-        pass("\t... passed");
     }
 
     @Test
@@ -3336,12 +3101,7 @@ public class WolfSSLEngineTest {
          * returns BUFFER_UNDERFLOW with 0 bytes consumed. Prior to
          * fixing the MAX_RECORD_SIZE cap, this range bypassed the
          * peek entirely and wolfSSL would consume partial bytes. */
-        System.out.print("\tTest unwrap oversized record underflow");
-
-        if (!enabledProtocols.contains("TLSv1.3")) {
-            System.out.println("\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(enabledProtocols.contains("TLSv1.3"));
 
         SSLContext ctx13 = tf.createSSLContext("TLSv1.3", engineProvider);
         SSLEngine server = ctx13.createSSLEngine();
@@ -3358,19 +3118,15 @@ public class WolfSSLEngineTest {
         int appBufSize = client.getSession().getApplicationBufferSize();
 
         /* Wrap ClientHello to put client into NEED_UNWRAP state */
-        ByteBuffer cliToSrv =
-            ByteBuffer.allocateDirect(packetBufSize);
+        ByteBuffer cliToSrv = ByteBuffer.allocateDirect(packetBufSize);
         ByteBuffer emptyApp = ByteBuffer.allocate(0);
         SSLEngineResult result = client.wrap(emptyApp, cliToSrv);
         if (result.getStatus() != SSLEngineResult.Status.OK) {
-            error("\t... failed");
-            fail("client wrap (ClientHello) failed: " +
-                 result.getStatus());
+            fail("client wrap (ClientHello) failed: " + result.getStatus());
         }
 
         if (client.getHandshakeStatus() !=
                 SSLEngineResult.HandshakeStatus.NEED_UNWRAP) {
-            error("\t... failed");
             fail("expected NEED_UNWRAP after ClientHello, got: " +
                  client.getHandshakeStatus());
         }
@@ -3379,10 +3135,7 @@ public class WolfSSLEngineTest {
          * packetBufferSize (header not counted). Skip if not,
          * which would indicate an unusual build configuration. */
         int oversizedRecLen = WolfSSL.MAX_RECORD_SIZE + 1;
-        if (oversizedRecLen > packetBufSize - 5) {
-            System.out.println("\t... skipped");
-            return;
-        }
+        Assume.assumeFalse(oversizedRecLen > packetBufSize - 5);
 
         /* Craft a 5-byte TLS record header: content type
          * handshake(0x16), version TLS 1.2 record layer(0x0303),
@@ -3400,28 +3153,23 @@ public class WolfSSLEngineTest {
             ByteBuffer.allocateDirect(appBufSize);
         result = client.unwrap(fakeHeader, cliAppBuf);
 
-        if (result.getStatus() !=
-                SSLEngineResult.Status.BUFFER_UNDERFLOW) {
-            error("\t... failed");
+        if (result.getStatus() != SSLEngineResult.Status.BUFFER_UNDERFLOW) {
             fail("expected BUFFER_UNDERFLOW for oversized partial " +
                  "record, got: " + result.getStatus());
         }
 
         if (result.bytesConsumed() != 0) {
-            error("\t... failed");
-            fail("BUFFER_UNDERFLOW must consume 0 bytes, " +
-                 "consumed: " + result.bytesConsumed());
+            fail("BUFFER_UNDERFLOW must consume 0 bytes, consume: " +
+                result.bytesConsumed());
         }
 
         /* Engine must remain in NEED_UNWRAP after underflow. */
         if (result.getHandshakeStatus() !=
                 SSLEngineResult.HandshakeStatus.NEED_UNWRAP) {
-            error("\t... failed");
             fail("expected NEED_UNWRAP after underflow, got: " +
                  result.getHandshakeStatus());
         }
 
-        pass("\t... passed");
     }
 
     @Test
@@ -3432,7 +3180,6 @@ public class WolfSSLEngineTest {
 
         /* Test BUFFER_OVERFLOW with small output, then retry
          * with larger buffer. */
-        System.out.print("\tOverflow small output");
 
         this.ctx = tf.createSSLContext("TLS", engineProvider);
         SSLEngine server = this.ctx.createSSLEngine();
@@ -3448,7 +3195,6 @@ public class WolfSSLEngineTest {
         int ret = tf.testConnection(server, client, null, null,
             "overflow test");
         if (ret != 0) {
-            error("\t... failed");
             fail("failed to create connection");
         }
 
@@ -3462,7 +3208,6 @@ public class WolfSSLEngineTest {
 
         SSLEngineResult result = client.wrap(appBuf, netBuf);
         if (result.getStatus() != SSLEngineResult.Status.OK) {
-            error("\t... failed");
             fail("wrap failed: " + result.getStatus());
         }
         netBuf.flip();
@@ -3475,9 +3220,8 @@ public class WolfSSLEngineTest {
         result = server.unwrap(netCopy, tinyOut);
 
         if (result.getStatus() != SSLEngineResult.Status.BUFFER_OVERFLOW) {
-            error("\t... failed");
-            fail("expected BUFFER_OVERFLOW for small output buffer, " +
-                 "got " + result.getStatus());
+            fail("expected BUFFER_OVERFLOW for small output buffer, got: " +
+                result.getStatus());
         }
 
         /* Now retry with a properly-sized buffer */
@@ -3487,15 +3231,13 @@ public class WolfSSLEngineTest {
         result = server.unwrap(netBuf, properOut);
 
         if (result.getStatus() != SSLEngineResult.Status.OK) {
-            error("\t... failed");
             fail("unwrap with proper buffer should succeed, got " +
-                 result.getStatus());
+                result.getStatus());
         }
 
         /* Verify we got the data */
         properOut.flip();
         if (properOut.remaining() != bigData.length) {
-            error("\t... failed");
             fail("expected " + bigData.length + " bytes, got " +
                  properOut.remaining());
         }
@@ -3503,11 +3245,9 @@ public class WolfSSLEngineTest {
         byte[] received = new byte[properOut.remaining()];
         properOut.get(received);
         if (!java.util.Arrays.equals(received, bigData)) {
-            error("\t... failed");
             fail("received data does not match sent data");
         }
 
-        pass("\t\t... passed");
     }
 
     @Test
@@ -3520,8 +3260,6 @@ public class WolfSSLEngineTest {
 
         /* CopyOutPacket() must decrement internalIOSendBufOffset after a
          * partial drain, otherwise stale ciphertext gets re-emitted. */
-        System.out.print("\tTesting wrap() partial drain offset");
-
         this.ctx = tf.createSSLContext("TLS", engineProvider);
         SSLEngine server = this.ctx.createSSLEngine();
         SSLEngine client = this.ctx.createSSLEngine("wolfSSL test", 11111);
@@ -3536,7 +3274,6 @@ public class WolfSSLEngineTest {
         int ret = tf.testConnection(server, client, null, null,
             "partial drain test");
         if (ret != 0) {
-            error("\t... failed");
             fail("failed to create connection");
         }
 
@@ -3554,8 +3291,7 @@ public class WolfSSLEngineTest {
         Field bufSzField =
             WolfSSLEngine.class.getDeclaredField("internalIOSendBufSz");
         Field offField =
-            WolfSSLEngine.class.getDeclaredField(
-                "internalIOSendBufOffset");
+            WolfSSLEngine.class.getDeclaredField("internalIOSendBufOffset");
         bufField.setAccessible(true);
         bufSzField.setAccessible(true);
         offField.setAccessible(true);
@@ -3571,15 +3307,13 @@ public class WolfSSLEngineTest {
         SSLEngineResult result = client.wrap(empty, firstOut);
 
         if (result.bytesProduced() != packetSz) {
-            error("\t... failed");
-            fail("first wrap expected " + packetSz +
-                 " produced, got " + result.bytesProduced());
+            fail("first wrap expected " + packetSz + " produced, got " +
+                result.bytesProduced());
         }
 
         /* Fix-sensitive check: unfixed code leaves offset at queuedSz. */
         int offAfterFirst = offField.getInt(client);
         if (offAfterFirst != queuedSz - packetSz) {
-            error("\t... failed");
             fail("internalIOSendBufOffset not decremented after " +
                  "partial drain: expected " + (queuedSz - packetSz) +
                  ", got " + offAfterFirst);
@@ -3592,15 +3326,12 @@ public class WolfSSLEngineTest {
 
         int expectedRemainder = queuedSz - packetSz;
         if (result.bytesProduced() != expectedRemainder) {
-            error("\t... failed");
             fail("second wrap expected " + expectedRemainder +
-                 " produced (remainder only), got " +
-                 result.bytesProduced() +
+                 " produced (remainder only), got " + result.bytesProduced() +
                  " - stale bytes re-sent after partial drain");
         }
 
         if (offField.getInt(client) != 0) {
-            error("\t... failed");
             fail("internalIOSendBufOffset not reset to 0 after " +
                  "remainder drained");
         }
@@ -3613,11 +3344,8 @@ public class WolfSSLEngineTest {
         firstOut.get(drained, 0, packetSz);
         secondOut.get(drained, packetSz, expectedRemainder);
         if (!Arrays.equals(marker, drained)) {
-            error("\t... failed");
             fail("drained output does not match injected queue");
         }
-
-        pass("\t... passed");
     }
-
 }
+

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLKeyX509Test.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLKeyX509Test.java
@@ -42,12 +42,18 @@ import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509ExtendedKeyManager;
 
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import com.wolfssl.WolfSSLException;
 import com.wolfssl.provider.jsse.WolfSSLProvider;
+import com.wolfssl.test.TimedTestWatcher;
 
 public class WolfSSLKeyX509Test {
+
+    @Rule
+    public TestRule testWatcher = TimedTestWatcher.create();
 
     private static WolfSSLTestFactory tf;
     private String provider = "wolfJSSE";
@@ -83,26 +89,21 @@ public class WolfSSLKeyX509Test {
         X509Certificate[] chain;
         String[] alias;
 
-        System.out.print("\tTesting getClientAliases");
-
         list = tf.createKeyManager("SunX509", tf.allJKS, provider);
         km = (X509KeyManager) list[0];
         alias = km.getClientAliases("RSA", null);
         if (alias == null) {
-            error("\t... failed");
             fail("failed to get client aliases");
             return;
         }
 
         if (alias.length != 6) {
-            error("\t... failed");
             fail("unexpected number of alias found");
         }
 
         /* Try getting chain with null alias, should return null */
         chain = km.getCertificateChain(null);
         if (chain != null) {
-            error("\t... failed");
             fail("did not return null chain with null alias");
             return;
         }
@@ -110,7 +111,6 @@ public class WolfSSLKeyX509Test {
         /* Try getting chain with client alias */
         chain = km.getCertificateChain("client");
         if (chain == null || chain.length < 1) {
-            error("\t... failed");
             fail("failed to get client certificate");
             return;
         }
@@ -119,29 +119,23 @@ public class WolfSSLKeyX509Test {
             new Principal[] { chain[0].getIssuerDN() });
 
         if (alias == null || alias.length != 1) {
-            error("\t... failed");
             fail("failed to get client aliases");
             return;
         }
 
         if (!alias[0].equals("client")) {
-            error("\t... failed");
             fail("unexpected alias found");
         }
 
         alias = km.getClientAliases("EC", null);
         if (alias == null) {
-            error("\t... failed");
             fail("failed to get client aliases");
             return;
         }
 
         if (alias.length != 3) {
-            error("\t... failed");
             fail("unexpected number of alias found");
         }
-
-        pass("\t... passed");
     }
 
     @Test
@@ -154,29 +148,23 @@ public class WolfSSLKeyX509Test {
         X509KeyManager x509km = null;
         String alias = null;
 
-        System.out.print("\tTesting chooseClientAlias");
-
         km = tf.createKeyManager("SunX509", tf.allJKS, provider);
         if (km == null) {
-            error("\t... failed");
             fail("failed to create KeyManager[]");
         }
 
         if (!(km[0] instanceof X509KeyManager)) {
-            error("\t... failed");
             fail("KeyManager[0] is not of type X509KeyManager");
         }
 
         x509km = (X509KeyManager) km[0];
         if (x509km == null) {
-            error("\t... failed");
             fail("failed to get X509KeyManager");
         }
 
         /* All null args, expect null return */
         alias = x509km.chooseClientAlias(null, null, null);
         if (alias != null) {
-            error("\t... failed");
             fail("expected null alias with all null args, got: " + alias);
         }
 
@@ -188,8 +176,8 @@ public class WolfSSLKeyX509Test {
              * all.jks. If that file is re-generated or changed, this test may
              * need to be updated */
             if (!alias.equals("client") && !alias.equals("ca")) {
-                error("\t... failed");
-                fail("expected 'client' alias for RSA type from allJKS, got: " + alias);
+                fail("expected 'client' alias for RSA type from " +
+                    "allJKS, got: " + alias);
             }
         }
 
@@ -201,12 +189,10 @@ public class WolfSSLKeyX509Test {
              * all.jks. If that file is re-generated or changed, this test may
              * need to be updated */
             if (!alias.equals("server-ecc") && !alias.equals("ca-ecc")) {
-                error("\t... failed");
-                fail("expected 'server-ecc' alias for EC type from allJKS, got: " + alias);
+                fail("expected 'server-ecc' alias for EC type from " +
+                    "allJKS, got: " + alias);
             }
         }
-
-        pass("\t... passed");
     }
 
     @Test
@@ -219,29 +205,23 @@ public class WolfSSLKeyX509Test {
         X509ExtendedKeyManager x509km = null;
         String alias = null;
 
-        System.out.print("\tTesting chooseEngineClientAlias");
-
         km = tf.createKeyManager("SunX509", tf.allJKS, provider);
         if (km == null) {
-            error("\t... failed");
             fail("failed to create KeyManager[]");
         }
 
         if (!(km[0] instanceof X509ExtendedKeyManager)) {
-            error("\t... failed");
             fail("KeyManager[0] is not of type X509ExtendedKeyManager");
         }
 
         x509km = (X509ExtendedKeyManager) km[0];
         if (x509km == null) {
-            error("\t... failed");
             fail("failed to get X509ExtendedKeyManager");
         }
 
         /* All null args, expect null return */
         alias = x509km.chooseEngineClientAlias(null, null, null);
         if (alias != null) {
-            error("\t... failed");
             fail("expected null alias with all null args, got: " + alias);
         }
 
@@ -253,8 +233,8 @@ public class WolfSSLKeyX509Test {
              * all.jks. If that file is re-generated or changed, this test may
              * need to be updated */
             if (!alias.equals("client") && !alias.equals("ca")) {
-                error("\t... failed");
-                fail("expected 'client' alias for RSA type from allJKS, got: " + alias);
+                fail("expected 'client' alias for RSA type from " +
+                    "allJKS, got: " + alias);
             }
         }
 
@@ -266,15 +246,13 @@ public class WolfSSLKeyX509Test {
              * all.jks. If that file is re-generated or changed, this test may
              * need to be updated */
             if (!alias.equals("server-ecc") && !alias.equals("ca-ecc")) {
-                error("\t... failed");
-                fail("expected 'server-ecc' alias for EC type from allJKS, got: " + alias);
+                fail("expected 'server-ecc' alias for EC type from " +
+                    "allJKS, got: " + alias);
             }
         }
 
         /* Currently SSLEngine argument is not used by wolfJSSE, if this
          * behavior changes, add tests here */
-
-        pass("\t... passed");
     }
 
     @Test
@@ -287,31 +265,25 @@ public class WolfSSLKeyX509Test {
         X509KeyManager km;
         String[] alias;
 
-        System.out.print("\tTesting getServerAliases");
-
         list = tf.createKeyManager("SunX509", tf.allJKS, provider);
         km = (X509KeyManager) list[0];
         alias = km.getServerAliases("RSA", null);
         if (alias == null) {
-            error("\t... failed");
             fail("failed to get server aliases");
             return;
         }
 
         if (alias.length != 6) {
-            error("\t... failed");
             fail("unexpected number of alias found");
         }
 
         alias = km.getServerAliases("EC", null);
         if (alias == null) {
-            error("\t... failed");
             fail("failed to get server aliases");
             return;
         }
 
         if (alias.length != 3) {
-            error("\t... failed");
             fail("unexpected number of alias found");
         }
 
@@ -320,11 +292,8 @@ public class WolfSSLKeyX509Test {
         km = (X509KeyManager) list[0];
         alias = km.getServerAliases("EC", null);
         if (alias != null) {
-            error("\t... failed");
             fail("failed to get server aliases");
         }
-
-        pass("\t... passed");
     }
 
     @Test
@@ -337,29 +306,23 @@ public class WolfSSLKeyX509Test {
         X509KeyManager x509km = null;
         String alias = null;
 
-        System.out.print("\tTesting chooseServerAlias");
-
         km = tf.createKeyManager("SunX509", tf.allJKS, provider);
         if (km == null) {
-            error("\t... failed");
             fail("failed to create KeyManager[]");
         }
 
         if (!(km[0] instanceof X509KeyManager)) {
-            error("\t... failed");
             fail("KeyManager[0] is not of type X509KeyManager");
         }
 
         x509km = (X509KeyManager) km[0];
         if (x509km == null) {
-            error("\t... failed");
             fail("failed to get X509KeyManager");
         }
 
         /* All null args, expect null return */
         alias = x509km.chooseServerAlias(null, null, null);
         if (alias != null) {
-            error("\t... failed");
             fail("expected null alias with all null args, got: " + alias);
         }
 
@@ -371,8 +334,8 @@ public class WolfSSLKeyX509Test {
              * all.jks. If that file is re-generated or changed, this test may
              * need to be updated */
             if (!alias.equals("client") && !alias.equals("ca")) {
-                error("\t... failed");
-                fail("expected 'client' alias for RSA type from allJKS, got: " + alias);
+                fail("expected 'client' alias for RSA type from " +
+                    "allJKS, got: " + alias);
             }
         }
 
@@ -384,12 +347,10 @@ public class WolfSSLKeyX509Test {
              * all.jks. If that file is re-generated or changed, this test may
              * need to be updated */
             if (!alias.equals("server-ecc") && !alias.equals("ca-ecc")) {
-                error("\t... failed");
-                fail("expected 'server-ecc' alias for EC type from allJKS, got: " + alias);
+                fail("expected 'server-ecc' alias for EC type from " +
+                    "allJKS, got: " + alias);
             }
         }
-
-        pass("\t... passed");
     }
 
     @Test
@@ -402,29 +363,23 @@ public class WolfSSLKeyX509Test {
         X509ExtendedKeyManager x509km = null;
         String alias = null;
 
-        System.out.print("\tTesting chooseEngineServerAlias");
-
         km = tf.createKeyManager("SunX509", tf.allJKS, provider);
         if (km == null) {
-            error("\t... failed");
             fail("failed to create KeyManager[]");
         }
 
         if (!(km[0] instanceof X509ExtendedKeyManager)) {
-            error("\t... failed");
             fail("KeyManager[0] is not of type X509ExtendedKeyManager");
         }
 
         x509km = (X509ExtendedKeyManager) km[0];
         if (x509km == null) {
-            error("\t... failed");
             fail("failed to get X509ExtendedKeyManager");
         }
 
         /* All null args, expect null return */
         alias = x509km.chooseEngineServerAlias(null, null, null);
         if (alias != null) {
-            error("\t... failed");
             fail("expected null alias with all null args, got: " + alias);
         }
 
@@ -436,8 +391,8 @@ public class WolfSSLKeyX509Test {
              * all.jks. If that file is re-generated or changed, this test may
              * need to be updated */
             if (!alias.equals("client") && !alias.equals("ca")) {
-                error("\t... failed");
-                fail("expected 'client' alias for RSA type from allJKS, got: " + alias);
+                fail("expected 'client' alias for RSA type from " +
+                    "allJKS, got: " + alias);
             }
         }
 
@@ -449,15 +404,13 @@ public class WolfSSLKeyX509Test {
              * all.jks. If that file is re-generated or changed, this test may
              * need to be updated */
             if (!alias.equals("server-ecc") && !alias.equals("ca-ecc")) {
-                error("\t... failed");
-                fail("expected 'server-ecc' alias for EC type from allJKS, got: " + alias);
+                fail("expected 'server-ecc' alias for EC type from " +
+                    "allJKS, got: " + alias);
             }
         }
 
         /* Currently SSLSocket argument is not used by wolfJSSE, if this
          * behavior changes, add tests here */
-
-        pass("\t... passed");
     }
 
     @Test
@@ -466,19 +419,14 @@ public class WolfSSLKeyX509Test {
                KeyManagementException, CertificateException, IOException,
                NoSuchProviderException, UnrecoverableKeyException {
 
-        System.out.print("\tTesting with invalid KeyStore");
-
         /* Test with null KeyStore - should not throw exception */
         try {
             com.wolfssl.provider.jsse.WolfSSLKeyX509 km =
                 new com.wolfssl.provider.jsse.WolfSSLKeyX509(null, null);
             /* Should succeed with empty cache */
         } catch (Exception e) {
-            error("\t... failed");
             fail("Constructor should handle null KeyStore gracefully: " + e);
         }
-
-        pass("\t... passed");
     }
 
     @Test
@@ -491,8 +439,6 @@ public class WolfSSLKeyX509Test {
         X509KeyManager km;
         String[] aliases;
 
-        System.out.print("\tTesting cache consistency");
-
         /* Create KeyManager with cached WolfSSLKeyX509 */
         list = tf.createKeyManager("SunX509", tf.allJKS, provider);
         km = (X509KeyManager) list[0];
@@ -500,7 +446,6 @@ public class WolfSSLKeyX509Test {
         /* Test that cached aliases match what we expect */
         aliases = km.getClientAliases("RSA", null);
         if (aliases == null || aliases.length == 0) {
-            error("\t... failed");
             fail("No RSA client aliases found in cache");
         }
 
@@ -509,8 +454,8 @@ public class WolfSSLKeyX509Test {
             if (alias != null) {
                 X509Certificate[] chain = km.getCertificateChain(alias);
                 if (chain == null) {
-                    error("\t... failed");
-                    fail("Certificate chain missing from cache for alias: " + alias);
+                    fail("Certificate chain missing from cache for alias: " +
+                        alias);
                 }
             }
         }
@@ -522,8 +467,6 @@ public class WolfSSLKeyX509Test {
                 km.getPrivateKey(alias);
             }
         }
-
-        pass("\t... passed");
     }
 
     @Test
@@ -531,8 +474,6 @@ public class WolfSSLKeyX509Test {
         throws NoSuchAlgorithmException, KeyStoreException,
                KeyManagementException, CertificateException, IOException,
                NoSuchProviderException, UnrecoverableKeyException {
-
-        System.out.print("\tTesting empty KeyStore cache");
 
         try {
             /* Create empty KeyStore */
@@ -546,34 +487,28 @@ public class WolfSSLKeyX509Test {
             /* Test methods with empty cache */
             String[] aliases = km.getClientAliases("RSA", null);
             if (aliases != null) {
-                error("\t... failed");
                 fail("Expected null aliases from empty KeyStore");
             }
 
             aliases = km.getServerAliases("RSA", null);
             if (aliases != null) {
-                error("\t... failed");
                 fail("Expected null server aliases from empty KeyStore");
             }
 
-            String alias = km.chooseClientAlias(new String[] {"RSA"}, null, null);
+            String alias = km.chooseClientAlias(
+                new String[] {"RSA"}, null, null);
             if (alias != null) {
-                error("\t... failed");
                 fail("Expected null client alias from empty KeyStore");
             }
 
             alias = km.chooseServerAlias("RSA", null, null);
             if (alias != null) {
-                error("\t... failed");
                 fail("Expected null server alias from empty KeyStore");
             }
 
         } catch (Exception e) {
-            error("\t... failed");
             fail("Empty KeyStore test failed: " + e);
         }
-
-        pass("\t... passed");
     }
 
     @Test
@@ -581,8 +516,6 @@ public class WolfSSLKeyX509Test {
         throws NoSuchAlgorithmException, KeyStoreException,
                KeyManagementException, CertificateException, IOException,
                NoSuchProviderException, UnrecoverableKeyException {
-
-        System.out.print("\tTesting null KeyStore cache");
 
         try {
             /* Create WolfSSLKeyX509 with null KeyStore */
@@ -592,46 +525,38 @@ public class WolfSSLKeyX509Test {
             /* Test methods with null KeyStore */
             String[] aliases = km.getClientAliases("RSA", null);
             if (aliases != null) {
-                error("\t... failed");
                 fail("Expected null aliases from null KeyStore");
             }
 
             aliases = km.getServerAliases("RSA", null);
             if (aliases != null) {
-                error("\t... failed");
                 fail("Expected null server aliases from null KeyStore");
             }
 
-            String alias = km.chooseClientAlias(new String[] {"RSA"}, null, null);
+            String alias = km.chooseClientAlias(
+                new String[] {"RSA"}, null, null);
             if (alias != null) {
-                error("\t... failed");
                 fail("Expected null client alias from null KeyStore");
             }
 
             alias = km.chooseServerAlias("RSA", null, null);
             if (alias != null) {
-                error("\t... failed");
                 fail("Expected null server alias from null KeyStore");
             }
 
             X509Certificate[] chain = km.getCertificateChain("nonexistent");
             if (chain != null) {
-                error("\t... failed");
                 fail("Expected null certificate chain from null KeyStore");
             }
 
             java.security.PrivateKey key = km.getPrivateKey("nonexistent");
             if (key != null) {
-                error("\t... failed");
                 fail("Expected null private key from null KeyStore");
             }
 
         } catch (Exception e) {
-            error("\t... failed");
             fail("Null KeyStore test failed: " + e);
         }
-
-        pass("\t... passed");
     }
 
     @Test
@@ -644,8 +569,6 @@ public class WolfSSLKeyX509Test {
         X509KeyManager km;
         X509Certificate[] chain1, chain2;
 
-        System.out.print("\tTesting cert chain caching");
-
         list = tf.createKeyManager("SunX509", tf.allJKS, provider);
         km = (X509KeyManager) list[0];
 
@@ -654,36 +577,29 @@ public class WolfSSLKeyX509Test {
         chain2 = km.getCertificateChain("client");
 
         if (chain1 == null) {
-            error("\t... failed");
             fail("Certificate chain should not be null for 'client' alias");
         }
 
         if (chain2 == null) {
-            error("\t... failed");
             fail("Second certificate chain retrieval should not be null");
         }
 
         /* Test that both retrievals return the same cached object */
         if (chain1 != chain2) {
-            error("\t... failed");
-            fail("Certificate chain caching failed - different objects returned");
+            fail("Certificate chain caching failed, different objs returned");
         }
 
         /* Test with non-existent alias */
         X509Certificate[] nullChain = km.getCertificateChain("nonexistent");
         if (nullChain != null) {
-            error("\t... failed");
             fail("Expected null certificate chain for non-existent alias");
         }
 
         /* Test with null alias */
         nullChain = km.getCertificateChain(null);
         if (nullChain != null) {
-            error("\t... failed");
             fail("Expected null certificate chain for null alias");
         }
-
-        pass("\t... passed");
     }
 
     @Test
@@ -696,8 +612,6 @@ public class WolfSSLKeyX509Test {
         X509KeyManager km;
         java.security.PrivateKey key1, key2;
 
-        System.out.print("\tTesting private key caching");
-
         list = tf.createKeyManager("SunX509", tf.allJKS, provider);
         km = (X509KeyManager) list[0];
 
@@ -706,36 +620,29 @@ public class WolfSSLKeyX509Test {
         key2 = km.getPrivateKey("client");
 
         if (key1 == null) {
-            error("\t... failed");
             fail("Private key should not be null for 'client' alias");
         }
 
         if (key2 == null) {
-            error("\t... failed");
             fail("Second private key retrieval should not be null");
         }
 
         /* Test that both retrievals return the same cached object */
         if (key1 != key2) {
-            error("\t... failed");
             fail("Private key caching failed - different objects returned");
         }
 
         /* Test with non-existent alias */
         java.security.PrivateKey nullKey = km.getPrivateKey("nonexistent");
         if (nullKey != null) {
-            error("\t... failed");
             fail("Expected null private key for non-existent alias");
         }
 
         /* Test with null alias */
         nullKey = km.getPrivateKey(null);
         if (nullKey != null) {
-            error("\t... failed");
             fail("Expected null private key for null alias");
         }
-
-        pass("\t... passed");
     }
 
     @Test
@@ -743,8 +650,6 @@ public class WolfSSLKeyX509Test {
         throws NoSuchAlgorithmException, KeyStoreException,
                KeyManagementException, CertificateException, IOException,
                NoSuchProviderException, UnrecoverableKeyException {
-
-        System.out.print("\tTesting cache disabled");
 
         /* Save original property value */
         String originalValue =
@@ -769,14 +674,12 @@ public class WolfSSLKeyX509Test {
             /* Test that operations work with caching disabled */
             String[] aliases = km.getClientAliases("RSA", null);
             if (aliases == null || aliases.length == 0) {
-                error("\t\t... failed");
                 fail("No RSA client aliases found with caching disabled");
             }
 
             /* Test certificate chain retrieval */
             X509Certificate[] chain = km.getCertificateChain("client");
             if (chain == null) {
-                error("\t\t... failed");
                 fail("Certificate chain should not be null with " +
                      "caching disabled");
             }
@@ -784,7 +687,6 @@ public class WolfSSLKeyX509Test {
             /* Test private key retrieval */
             java.security.PrivateKey key = km.getPrivateKey("client");
             if (key == null) {
-                error("\t\t... failed");
                 fail("Private key should not be null with caching disabled");
             }
 
@@ -792,7 +694,6 @@ public class WolfSSLKeyX509Test {
             String selectedAlias =
                 km.chooseClientAlias(new String[] {"RSA"}, null, null);
             if (selectedAlias == null) {
-                error("\t\t... failed");
                 fail("Should be able to choose client alias with " +
                      "caching disabled");
             }
@@ -808,8 +709,6 @@ public class WolfSSLKeyX509Test {
                     "wolfjsse.X509KeyManager.disableCache", "");
             }
         }
-
-        pass("\t\t... passed");
     }
 
     @Test
@@ -817,8 +716,6 @@ public class WolfSSLKeyX509Test {
         throws NoSuchAlgorithmException, KeyStoreException,
                KeyManagementException, CertificateException, IOException,
                NoSuchProviderException, UnrecoverableKeyException {
-
-        System.out.print("\tTesting cache enabled");
 
         /* Save original property value */
         String originalValue =
@@ -843,7 +740,6 @@ public class WolfSSLKeyX509Test {
             /* Test that operations work with caching enabled */
             String[] aliases = km.getClientAliases("RSA", null);
             if (aliases == null || aliases.length == 0) {
-                error("\t\t... failed");
                 fail("No RSA client aliases found with caching enabled");
             }
 
@@ -851,14 +747,12 @@ public class WolfSSLKeyX509Test {
             X509Certificate[] chain1 = km.getCertificateChain("client");
             X509Certificate[] chain2 = km.getCertificateChain("client");
             if (chain1 == null || chain2 == null) {
-                error("\t\t... failed");
                 fail("Certificate chains should not be null " +
                      "with caching enabled");
             }
 
             /* With caching enabled, should return same cached object */
             if (chain1 != chain2) {
-                error("\t\t... failed");
                 fail("Certificate chain caching failed - different " +
                      "objects returned");
             }
@@ -867,13 +761,11 @@ public class WolfSSLKeyX509Test {
             java.security.PrivateKey key1 = km.getPrivateKey("client");
             java.security.PrivateKey key2 = km.getPrivateKey("client");
             if (key1 == null || key2 == null) {
-                error("\t\t... failed");
                 fail("Private keys should not be null with caching enabled");
             }
 
             /* With caching enabled, should return same cached object */
             if (key1 != key2) {
-                error("\t\t... failed");
                 fail("Private key caching failed - different objects returned");
             }
 
@@ -888,8 +780,6 @@ public class WolfSSLKeyX509Test {
                     "wolfjsse.X509KeyManager.disableCache", "");
             }
         }
-
-        pass("\t\t... passed");
     }
 
     @Test
@@ -897,8 +787,6 @@ public class WolfSSLKeyX509Test {
         throws NoSuchAlgorithmException, KeyStoreException,
                KeyManagementException, CertificateException, IOException,
                NoSuchProviderException, UnrecoverableKeyException {
-
-        System.out.print("\tTesting default cache behavior");
 
         /* Save original property value */
         String originalValue = Security.getProperty(
@@ -923,7 +811,6 @@ public class WolfSSLKeyX509Test {
             /* Test that operations work with default behavior */
             String[] aliases = km.getClientAliases("RSA", null);
             if (aliases == null || aliases.length == 0) {
-                error("\t... failed");
                 fail("No RSA client aliases found with default behavior");
             }
 
@@ -931,14 +818,12 @@ public class WolfSSLKeyX509Test {
             X509Certificate[] chain1 = km.getCertificateChain("client");
             X509Certificate[] chain2 = km.getCertificateChain("client");
             if (chain1 == null || chain2 == null) {
-                error("\t... failed");
                 fail("Certificate chains should not be null " +
                      "with default behavior");
             }
 
             /* Default behavior should be caching enabled */
             if (chain1 != chain2) {
-                error("\t... failed");
                 fail("Default behavior should enable caching - " +
                      "different objects returned");
             }
@@ -954,8 +839,6 @@ public class WolfSSLKeyX509Test {
                     "wolfjsse.X509KeyManager.disableCache", "");
             }
         }
-
-        pass("\t... passed");
     }
 
     @Test
@@ -963,8 +846,6 @@ public class WolfSSLKeyX509Test {
         throws NoSuchAlgorithmException, KeyStoreException,
                KeyManagementException, CertificateException, IOException,
                NoSuchProviderException, UnrecoverableKeyException {
-
-        System.out.print("\tCase insensitive cache disable");
 
         /* Save original property value */
         String originalValue = Security.getProperty(
@@ -991,7 +872,6 @@ public class WolfSSLKeyX509Test {
                 /* Should work with any case variation of "true" */
                 String[] aliases = km.getClientAliases("RSA", null);
                 if (aliases == null || aliases.length == 0) {
-                    error("\t... failed");
                     fail("No RSA client aliases found with '" +
                          trueValue + "'");
                 }
@@ -1019,15 +899,13 @@ public class WolfSSLKeyX509Test {
                 X509Certificate[] chain1 = km.getCertificateChain("client");
                 X509Certificate[] chain2 = km.getCertificateChain("client");
                 if (chain1 == null || chain2 == null) {
-                    error("\t... failed");
                     fail("Certificate chains should not be null with '" +
-                         falseValue + "'");
+                        falseValue + "'");
                 }
 
                 if (chain1 != chain2) {
-                    error("\t... failed");
                     fail("Caching should be enabled with '" +
-                         falseValue + "' - different objects returned");
+                        falseValue + "' - different objects returned");
                 }
             }
 
@@ -1042,8 +920,6 @@ public class WolfSSLKeyX509Test {
                     "wolfjsse.X509KeyManager.disableCache", "");
             }
         }
-
-        pass("\t... passed");
     }
 
     @Test
@@ -1051,8 +927,6 @@ public class WolfSSLKeyX509Test {
         throws NoSuchAlgorithmException, KeyStoreException,
                KeyManagementException, CertificateException, IOException,
                NoSuchProviderException, UnrecoverableKeyException {
-
-        System.out.print("\tnull KeyStore with no caching");
 
         /* Save original property value */
         String originalValue = Security.getProperty(
@@ -1069,21 +943,18 @@ public class WolfSSLKeyX509Test {
             /* Test that all operations return null gracefully */
             String[] aliases = km.getClientAliases("RSA", null);
             if (aliases != null) {
-                error("\t... failed");
                 fail("Expected null aliases with null KeyStore and " +
                      "caching disabled");
             }
 
             X509Certificate[] chain = km.getCertificateChain("client");
             if (chain != null) {
-                error("\t... failed");
                 fail("Expected null certificate chain with null " +
                      "KeyStore and caching disabled");
             }
 
             java.security.PrivateKey key = km.getPrivateKey("client");
             if (key != null) {
-                error("\t... failed");
                 fail("Expected null private key with null KeyStore " +
                      "and caching disabled");
             }
@@ -1091,7 +962,6 @@ public class WolfSSLKeyX509Test {
             String alias = km.chooseClientAlias(new String[] {"RSA"},
                 null, null);
             if (alias != null) {
-                error("\t... failed");
                 fail("Expected null alias with null KeyStore and " +
                      "caching disabled");
             }
@@ -1107,8 +977,6 @@ public class WolfSSLKeyX509Test {
                     "wolfjsse.X509KeyManager.disableCache", "");
             }
         }
-
-        pass("\t... passed");
     }
 
     /* Test that chooseAlias methods return aliases with private keys */
@@ -1117,8 +985,6 @@ public class WolfSSLKeyX509Test {
         throws NoSuchAlgorithmException, KeyStoreException,
                KeyManagementException, CertificateException, IOException,
                NoSuchProviderException, UnrecoverableKeyException {
-
-        System.out.print("\tchooseAlias skips cert-only");
 
         KeyManager[] km = tf.createKeyManager("SunX509", tf.allJKS, provider);
         X509ExtendedKeyManager x509km = (X509ExtendedKeyManager) km[0];
@@ -1134,15 +1000,5 @@ public class WolfSSLKeyX509Test {
         if (alias != null && x509km.getPrivateKey(alias) == null) {
             fail("chooseEngineClientAlias returned alias without private key");
         }
-
-        pass("\t... passed");
-    }
-
-    private void pass(String msg) {
-        WolfSSLTestFactory.pass(msg);
-    }
-
-    private void error(String msg) {
-        WolfSSLTestFactory.fail(msg);
     }
 }

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLParametersPskTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLParametersPskTest.java
@@ -28,6 +28,7 @@ import com.wolfssl.WolfSSLPskClientCallback;
 import com.wolfssl.WolfSSLPskServerCallback;
 import com.wolfssl.provider.jsse.WolfSSLProvider;
 import com.wolfssl.provider.jsse.WolfSSLParameters;
+import com.wolfssl.test.TimedTestWatcher;
 
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -57,6 +58,7 @@ import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
 
 /**
@@ -66,12 +68,14 @@ import org.junit.rules.Timeout;
  */
 public class WolfSSLParametersPskTest {
 
+    @Rule
+    public TestRule testWatcher = TimedTestWatcher.create();
+
     private static final String engineProvider = "wolfJSSE";
     private static String pskCipher = null;
 
     @Rule
-    public Timeout globalTimeout =
-        new Timeout(60, TimeUnit.SECONDS);
+    public Timeout globalTimeout = new Timeout(60, TimeUnit.SECONDS);
 
     private static WolfSSLPskClientCallback testClientCb =
         new WolfSSLPskClientCallback() {
@@ -174,18 +178,12 @@ public class WolfSSLParametersPskTest {
 
     @Test
     public void testExtendsSSLParameters() {
-        System.out.print("\tExtends SSLParameters\t\t... ");
-
         WolfSSLParameters wp = new WolfSSLParameters();
         assertTrue(wp instanceof SSLParameters);
-
-        System.out.println("passed");
     }
 
     @Test
     public void testGetSetPskClientCb() {
-        System.out.print("\tGet/Set PSK client cb\t\t... ");
-
         WolfSSLParameters wp = new WolfSSLParameters();
         assertNull(wp.getPskClientCb());
 
@@ -194,14 +192,10 @@ public class WolfSSLParametersPskTest {
 
         wp.setPskClientCb(null);
         assertNull(wp.getPskClientCb());
-
-        System.out.println("passed");
     }
 
     @Test
     public void testGetSetPskServerCb() {
-        System.out.print("\tGet/Set PSK server cb\t\t... ");
-
         WolfSSLParameters wp = new WolfSSLParameters();
         assertNull(wp.getPskServerCb());
 
@@ -210,14 +204,10 @@ public class WolfSSLParametersPskTest {
 
         wp.setPskServerCb(null);
         assertNull(wp.getPskServerCb());
-
-        System.out.println("passed");
     }
 
     @Test
     public void testGetSetPskIdentityHint() {
-        System.out.print("\tGet/Set PSK identity hint\t... ");
-
         WolfSSLParameters wp = new WolfSSLParameters();
         assertNull(wp.getPskIdentityHint());
 
@@ -226,14 +216,10 @@ public class WolfSSLParametersPskTest {
 
         wp.setPskIdentityHint(null);
         assertNull(wp.getPskIdentityHint());
-
-        System.out.println("passed");
     }
 
     @Test
     public void testGetSetKeepArrays() {
-        System.out.print("\tGet/Set keepArrays\t\t... ");
-
         WolfSSLParameters wp = new WolfSSLParameters();
         assertFalse(wp.getKeepArrays());
 
@@ -242,25 +228,17 @@ public class WolfSSLParametersPskTest {
 
         wp.setKeepArrays(false);
         assertFalse(wp.getKeepArrays());
-
-        System.out.println("passed");
     }
 
     @Test
     public void testUseCipherSuitesOrderDefault() {
-        System.out.print("\tCipher suite order default\t... ");
-
         WolfSSLParameters wp = new WolfSSLParameters();
         assertTrue("useCipherSuitesOrder should default to true",
             wp.getUseCipherSuitesOrder());
-
-        System.out.println("passed");
     }
 
     @Test
     public void testUseCipherSuitesOrderGetSet() {
-        System.out.print("\tGet/Set useCipherSuitesOrder\t... ");
-
         WolfSSLParameters wp = new WolfSSLParameters();
 
         wp.setUseCipherSuitesOrder(false);
@@ -268,15 +246,11 @@ public class WolfSSLParametersPskTest {
 
         wp.setUseCipherSuitesOrder(true);
         assertTrue(wp.getUseCipherSuitesOrder());
-
-        System.out.println("passed");
     }
 
     @Test
     public void testPskFieldsNotLeakedViaGetSSLParameters()
         throws Exception {
-
-        System.out.print("\tPSK fields not in getSSLParams\t... ");
 
         SSLContext ctx = SSLContext.getInstance("TLSv1.2", engineProvider);
         ctx.init(null, null, null);
@@ -293,15 +267,11 @@ public class WolfSSLParametersPskTest {
             assertNull(wp.getPskIdentityHint());
             assertFalse(wp.getKeepArrays());
         }
-
-        System.out.println("passed");
     }
 
     @Test
     public void testPskClearedOnPlainSSLParamsImport()
         throws Exception {
-
-        System.out.print("\tPSK cleared by plain SSLParams\t... ");
 
         SSLContext ctx = SSLContext.getInstance("TLSv1.2", engineProvider);
         ctx.init(null, null, null);
@@ -347,14 +317,10 @@ public class WolfSSLParametersPskTest {
 
         clientEngine.closeOutbound();
         serverEngine.closeOutbound();
-
-        System.out.println("passed");
     }
 
     @Test
     public void testPskEngineHandshake() throws Exception {
-
-        System.out.print("\tPSK SSLEngine handshake\t\t... ");
 
         SSLContext ctx = SSLContext.getInstance("TLSv1.2", engineProvider);
         ctx.init(null, null, null);
@@ -389,14 +355,10 @@ public class WolfSSLParametersPskTest {
 
         clientEngine.closeOutbound();
         serverEngine.closeOutbound();
-
-        System.out.println("passed");
     }
 
     @Test
     public void testPskEngineKeepArrays() throws Exception {
-
-        System.out.print("\tPSK SSLEngine keepArrays\t... ");
 
         SSLContext ctx = SSLContext.getInstance("TLSv1.2", engineProvider);
         ctx.init(null, null, null);
@@ -408,8 +370,7 @@ public class WolfSSLParametersPskTest {
         serverParams.setPskServerCb(testServerCb);
         serverParams.setPskIdentityHint("wolfssl hint");
         serverParams.setKeepArrays(true);
-        serverParams.setCipherSuites(
-            new String[]{pskCipher});
+        serverParams.setCipherSuites(new String[]{pskCipher});
         serverEngine.setSSLParameters(serverParams);
 
         SSLEngine clientEngine = ctx.createSSLEngine("localhost", 0);
@@ -418,8 +379,7 @@ public class WolfSSLParametersPskTest {
         WolfSSLParameters clientParams = new WolfSSLParameters();
         clientParams.setPskClientCb(testClientCb);
         clientParams.setKeepArrays(true);
-        clientParams.setCipherSuites(
-            new String[]{pskCipher});
+        clientParams.setCipherSuites(new String[]{pskCipher});
         clientEngine.setSSLParameters(clientParams);
 
         doInMemoryHandshake(clientEngine, serverEngine);
@@ -429,14 +389,10 @@ public class WolfSSLParametersPskTest {
 
         clientEngine.closeOutbound();
         serverEngine.closeOutbound();
-
-        System.out.println("passed");
     }
 
     @Test
     public void testPskSocketHandshake() throws Exception {
-
-        System.out.print("\tPSK SSLSocket handshake\t\t... ");
 
         SSLContext ctx = SSLContext.getInstance("TLSv1.2", engineProvider);
         ctx.init(null, null, null);
@@ -456,8 +412,7 @@ public class WolfSSLParametersPskTest {
                 WolfSSLParameters sp = new WolfSSLParameters();
                 sp.setPskServerCb(testServerCb);
                 sp.setPskIdentityHint("wolfssl hint");
-                sp.setCipherSuites(
-                    new String[]{pskCipher});
+                sp.setCipherSuites(new String[]{pskCipher});
                 serverSock.setSSLParameters(sp);
 
                 serverSock.startHandshake();
@@ -486,8 +441,7 @@ public class WolfSSLParametersPskTest {
 
             WolfSSLParameters cp = new WolfSSLParameters();
             cp.setPskClientCb(testClientCb);
-            cp.setCipherSuites(
-                new String[]{pskCipher});
+            cp.setCipherSuites(new String[]{pskCipher});
             clientSock.setSSLParameters(cp);
 
             clientSock.startHandshake();
@@ -510,17 +464,12 @@ public class WolfSSLParametersPskTest {
             latch.await(10, TimeUnit.SECONDS));
 
         if (serverEx[0] != null) {
-            fail("Server thread failed: " +
-                serverEx[0].getMessage());
+            fail("Server thread failed: " + serverEx[0].getMessage());
         }
-
-        System.out.println("passed");
     }
 
     @Test
     public void testPskSocketKeepArrays() throws Exception {
-
-        System.out.print("\tPSK SSLSocket keepArrays\t... ");
 
         SSLContext ctx = SSLContext.getInstance("TLSv1.2", engineProvider);
         ctx.init(null, null, null);
@@ -540,8 +489,7 @@ public class WolfSSLParametersPskTest {
                 sp.setPskServerCb(testServerCb);
                 sp.setPskIdentityHint("wolfssl hint");
                 sp.setKeepArrays(true);
-                sp.setCipherSuites(
-                    new String[]{pskCipher});
+                sp.setCipherSuites(new String[]{pskCipher});
                 serverSock.setSSLParameters(sp);
 
                 serverSock.startHandshake();
@@ -570,8 +518,7 @@ public class WolfSSLParametersPskTest {
             WolfSSLParameters cp = new WolfSSLParameters();
             cp.setPskClientCb(testClientCb);
             cp.setKeepArrays(true);
-            cp.setCipherSuites(
-                new String[]{pskCipher});
+            cp.setCipherSuites(new String[]{pskCipher});
             clientSock.setSSLParameters(cp);
 
             clientSock.startHandshake();
@@ -595,8 +542,6 @@ public class WolfSSLParametersPskTest {
         if (serverEx[0] != null) {
             fail("Server thread failed: " + serverEx[0].getMessage());
         }
-
-        System.out.println("passed");
     }
 
     /**

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLServerSocketFactoryTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLServerSocketFactoryTest.java
@@ -23,6 +23,9 @@ package com.wolfssl.provider.jsse.test;
 
 import org.junit.Test;
 import org.junit.BeforeClass;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.rules.TestRule;
 import static org.junit.Assert.*;
 
 import java.util.Arrays;
@@ -33,7 +36,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.FileNotFoundException;
 import java.net.InetAddress;
-import java.net.SocketException;
 import java.net.UnknownHostException;
 import javax.net.ssl.SSLServerSocketFactory;
 import javax.net.ssl.SSLContext;
@@ -51,8 +53,12 @@ import java.security.KeyStoreException;
 import com.wolfssl.WolfSSL;
 import com.wolfssl.WolfSSLException;
 import com.wolfssl.provider.jsse.WolfSSLProvider;
+import com.wolfssl.test.TimedTestWatcher;
 
 public class WolfSSLServerSocketFactoryTest {
+
+    @Rule
+    public TestRule testWatcher = TimedTestWatcher.create();
 
     private final static char[] jksPass = "wolfSSL test".toCharArray();
     private static WolfSSLTestFactory tf;
@@ -108,7 +114,7 @@ public class WolfSSLServerSocketFactoryTest {
 
         try {
             /* set up KeyStore */
-                InputStream stream = new FileInputStream(tf.serverJKS);
+            InputStream stream = new FileInputStream(tf.serverJKS);
             pKey = KeyStore.getInstance(tf.keyStoreType);
             pKey.load(stream, jksPass);
             stream.close();
@@ -148,47 +154,35 @@ public class WolfSSLServerSocketFactoryTest {
     public void testGetDefaultCipherSuites()
         throws NoSuchProviderException, NoSuchAlgorithmException {
 
-        System.out.print("\tgetDefaultCipherSuites()");
-
         for (int i = 0; i < sockFactories.size(); i++) {
             SSLServerSocketFactory sf = sockFactories.get(i);
             String[] cipherSuites = sf.getDefaultCipherSuites();
 
             if (cipherSuites == null) {
-                System.out.println("\t... failed");
                 fail("SSLServerSocketFactory.getDefaultCipherSuites() failed");
             }
         }
-
-        System.out.println("\t... passed");
     }
 
     @Test
     public void testGetSupportedCipherSuites()
         throws NoSuchProviderException, NoSuchAlgorithmException {
 
-        System.out.print("\tgetSupportedCipherSuites()");
-
         for (int i = 0; i < sockFactories.size(); i++) {
             SSLServerSocketFactory sf = sockFactories.get(i);
             String[] cipherSuites = sf.getSupportedCipherSuites();
 
             if (cipherSuites == null) {
-                System.out.println("\t... failed");
                 fail("SSLServerSocketFactory.getSupportedCipherSuites() " +
                      "failed");
             }
         }
-
-        System.out.println("\t... passed");
     }
 
     @Test
     public void testCreateSocket()
         throws NoSuchProviderException, NoSuchAlgorithmException,
                IOException {
-
-        System.out.print("\tcreateSocket()");
 
         for (int i = 0; i < sockFactories.size(); i++) {
             int port = 11118;
@@ -200,62 +194,47 @@ public class WolfSSLServerSocketFactoryTest {
                 InetAddress.getByName("www.example.com");
             } catch (UnknownHostException e) {
                 /* skip test if no Internet connection available */
-                System.out.println("\t\t\t... skipped");
+                Assume.assumeNoException("No Internet connection", e);
                 return;
             }
 
-            try {
-
-                /* no arguments */
-                s = (SSLServerSocket)sf.createServerSocket();
-                if (s == null) {
-                    System.out.println("\t\t\t... failed");
-                    fail("SSLServerSocketFactory.createSocket() failed");
-                    return;
-                }
-                s.close();
-
-                /* int */
-                s = (SSLServerSocket)sf.createServerSocket(port);
-                if (s == null) {
-                    System.out.println("\t\t\t... failed");
-                    fail("SSLServerSocketFactory.createSocket(i) failed");
-                    return;
-                }
-                s.close();
-
-                /* int, int */
-                s = (SSLServerSocket)sf.createServerSocket(port, backlog);
-                if (s == null) {
-                    System.out.println("\t\t\t... failed");
-                    fail("SSLServerSocketFactory.createSocket(Si) failed");
-                    return;
-                }
-                s.close();
-
-                /* int, int, InetAddress */
-                s = (SSLServerSocket)sf.createServerSocket(port, backlog, null);
-                if (s == null) {
-                    System.out.println("\t\t\t... failed");
-                    fail("SSLServerSocketFactory.createSocket(SiI) failed");
-                    return;
-                }
-                s.close();
-
-            } catch (SocketException e) {
-                System.out.println("\t\t\t... failed");
-                throw e;
+            /* no arguments */
+            s = (SSLServerSocket)sf.createServerSocket();
+            if (s == null) {
+                fail("SSLServerSocketFactory.createSocket() failed");
+                return;
             }
-        }
+            s.close();
 
-        System.out.println("\t\t\t... passed");
+            /* int */
+            s = (SSLServerSocket)sf.createServerSocket(port);
+            if (s == null) {
+                fail("SSLServerSocketFactory.createSocket(i) failed");
+                return;
+            }
+            s.close();
+
+            /* int, int */
+            s = (SSLServerSocket)sf.createServerSocket(port, backlog);
+            if (s == null) {
+                fail("SSLServerSocketFactory.createSocket(Si) failed");
+                return;
+            }
+            s.close();
+
+            /* int, int, InetAddress */
+            s = (SSLServerSocket)sf.createServerSocket(port, backlog, null);
+            if (s == null) {
+                fail("SSLServerSocketFactory.createSocket(SiI) failed");
+                return;
+            }
+            s.close();
+        }
     }
 
     @Test
     public void testServerFactoryAnonCipherSuiteFiltering()
         throws Exception {
-
-        System.out.print("\tanon filtering");
 
         String[] allCiphers = WolfSSL.getCiphersIana();
         boolean haveAnon = false;
@@ -266,10 +245,7 @@ public class WolfSSLServerSocketFactoryTest {
             }
         }
 
-        if (!haveAnon) {
-            System.out.println("\t\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue("No anon cipher suites compiled in", haveAnon);
 
         Security.setProperty("wolfjsse.enabledCipherSuites", "");
         SSLContext ctx = SSLContext.getInstance("TLS", "wolfJSSE");
@@ -303,7 +279,5 @@ public class WolfSSLServerSocketFactoryTest {
             assertTrue("Default suite not in supported: " + s,
                 suppList.contains(s));
         }
-
-        System.out.println("\t\t\t... passed");
     }
 }

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLServerSocketTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLServerSocketTest.java
@@ -21,9 +21,14 @@
 
 package com.wolfssl.provider.jsse.test;
 
+import org.junit.Assume;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.BeforeClass;
+import org.junit.rules.TestRule;
 import static org.junit.Assert.*;
+
+import com.wolfssl.test.TimedTestWatcher;
 
 import java.util.Arrays;
 import java.util.ArrayList;
@@ -65,6 +70,9 @@ import com.wolfssl.WolfSSLException;
 import com.wolfssl.provider.jsse.WolfSSLProvider;
 
 public class WolfSSLServerSocketTest {
+
+    @Rule
+    public TestRule testWatcher = TimedTestWatcher.create();
 
     private final static char[] jksPass = "wolfSSL test".toCharArray();
     private final static String ctxProvider = "wolfJSSE";
@@ -170,8 +178,6 @@ public class WolfSSLServerSocketTest {
 
     @Test
     public void testGetSSLParameters() throws Exception {
-        System.out.print("\tget/setSSLParameters()");
-
         /* create new context, SSLServerSocket */
         this.ctx = tf.createSSLContext("TLS", "wolfJSSE");
         SSLServerSocket ss = (SSLServerSocket)
@@ -212,7 +218,7 @@ public class WolfSSLServerSocketTest {
 
         /* test getting and setting Application Protocols */
         assertArrayEquals(new String[] {},
-                p.getApplicationProtocols());             /* default: empty */
+            p.getApplicationProtocols());             /* default: empty */
         String[] alpnProtos = new String[] {"h2", "http/1.1"};
         p.setApplicationProtocols(alpnProtos);
         assertArrayEquals(alpnProtos, p.getApplicationProtocols());
@@ -246,16 +252,12 @@ public class WolfSSLServerSocketTest {
         server.close();
         cs.close();
         ss.close();
-
-        System.out.println("\t\t... passed");
     }
 
     @Test
     public void testGetSupportedCipherSuites()
         throws NoSuchProviderException, NoSuchAlgorithmException,
                IOException {
-
-        System.out.print("\tgetSupportedCipherSuites()");
 
         for (int i = 0; i < sockFactories.size(); i++) {
             SSLServerSocketFactory sf = sockFactories.get(i);
@@ -264,20 +266,15 @@ public class WolfSSLServerSocketTest {
             s.close();
 
             if (cipherSuites == null) {
-                System.out.println("\t... failed");
                 fail("SSLServerSocket.getSupportedCipherSuites() failed");
             }
         }
-
-        System.out.println("\t... passed");
     }
 
     @Test
     public void testGetEnabledCipherSuites()
         throws NoSuchProviderException, NoSuchAlgorithmException,
                IOException {
-
-        System.out.print("\tgetEnabledCipherSuites()");
 
         for (int i = 0; i < sockFactories.size(); i++) {
             SSLServerSocketFactory sf = sockFactories.get(i);
@@ -287,12 +284,9 @@ public class WolfSSLServerSocketTest {
 
             /* should be null since we haven't set them */
             if (cipherSuites == null) {
-                System.out.println("\t... failed");
                 fail("SSLServerSocket.getEnabledCipherSuites() failed");
             }
         }
-
-        System.out.println("\t... passed");
     }
 
     @Test
@@ -300,15 +294,12 @@ public class WolfSSLServerSocketTest {
         throws NoSuchProviderException, NoSuchAlgorithmException,
                IOException {
 
-        System.out.print("\tget/setEnabledCipherSuites()");
-
         for (int i = 0; i < sockFactories.size(); i++) {
             SSLServerSocketFactory sf = sockFactories.get(i);
             SSLServerSocket s = (SSLServerSocket)sf.createServerSocket(0);
             String[] cipherSuites = s.getEnabledCipherSuites();
 
             if (cipherSuites == null) {
-                System.out.println("\t... failed");
                 fail("getEnabledCipherSuites() failed");
             }
 
@@ -318,7 +309,6 @@ public class WolfSSLServerSocketTest {
             /* test failure, null input */
             try {
                 s.setEnabledCipherSuites(null);
-                System.out.println("\t... failed");
                 fail("setEnabledCipherSuites() failed");
             } catch (IllegalArgumentException e) {
                 /* expected */
@@ -328,7 +318,6 @@ public class WolfSSLServerSocketTest {
             try {
                 String[] empty = {};
                 s.setEnabledCipherSuites(empty);
-                System.out.println("\t... failed");
                 fail("setEnabledCipherSuites() failed");
             } catch (IllegalArgumentException e) {
                 /* expected */
@@ -338,7 +327,6 @@ public class WolfSSLServerSocketTest {
             try {
                 String[] badvalue = { "badvalue" };
                 s.setEnabledCipherSuites(badvalue);
-                System.out.println("\t... failed");
                 fail("setEnabledCipherSuites() failed");
             } catch (IllegalArgumentException e) {
                 /* expected */
@@ -357,12 +345,9 @@ public class WolfSSLServerSocketTest {
             s.setEnabledCipherSuites(oneSuite);
             String[] after = s.getEnabledCipherSuites();
             if (after.length != 1 || !after[0].equals(oneSuite[0])) {
-                System.out.println("\t... failed");
                 fail("setEnabledCipherSuites() failed");
             }
         }
-
-        System.out.println("\t... passed");
     }
 
     @Test
@@ -370,23 +355,18 @@ public class WolfSSLServerSocketTest {
         throws NoSuchProviderException, NoSuchAlgorithmException,
                IOException {
 
-        System.out.print("\tgetSupportedProtocols()");
-
         for (int i = 0; i < sockFactories.size(); i++) {
             SSLServerSocketFactory sf = sockFactories.get(i);
             SSLServerSocket s = (SSLServerSocket)sf.createServerSocket(0);
             String[] protocols = s.getSupportedProtocols();
 
             if (protocols == null) {
-                System.out.println("\t\t... failed");
                 fail("getSupportedProtocols() failed");
             }
 
             /* verify we return a copy */
             assertNotSame(protocols, s.getSupportedProtocols());
         }
-
-        System.out.println("\t\t... passed");
     }
 
     @Test
@@ -394,15 +374,12 @@ public class WolfSSLServerSocketTest {
         throws NoSuchProviderException, NoSuchAlgorithmException,
                IOException {
 
-        System.out.print("\tget/setEnabledProtocols()");
-
         for (int i = 0; i < sockFactories.size(); i++) {
             SSLServerSocketFactory sf = sockFactories.get(i);
             SSLServerSocket s = (SSLServerSocket)sf.createServerSocket(0);
             String[] protocols = s.getEnabledProtocols();
 
             if (protocols == null) {
-                System.out.println("\t... failed");
                 fail("getEnabledProtocols() failed");
             }
 
@@ -412,7 +389,6 @@ public class WolfSSLServerSocketTest {
             /* test failure, null input */
             try {
                 s.setEnabledProtocols(null);
-                System.out.println("\t... failed");
                 fail("setEnabledProtocols() failed");
             } catch (IllegalArgumentException e) {
                 /* expected */
@@ -425,7 +401,6 @@ public class WolfSSLServerSocketTest {
                 String[] empty = {};
                 s.setEnabledProtocols(empty);
             } catch (IllegalArgumentException e) {
-                System.out.println("\t... failed");
                 fail("setEnabledProtocols() should accept empty");
             }
 
@@ -435,7 +410,6 @@ public class WolfSSLServerSocketTest {
             try {
                 String[] badvalue = { "badvalue" };
                 s.setEnabledProtocols(badvalue);
-                System.out.println("\t... failed");
                 fail("setEnabledProtocols() failed");
             } catch (IllegalArgumentException e) {
                 /* expected */
@@ -454,18 +428,13 @@ public class WolfSSLServerSocketTest {
             s.setEnabledProtocols(oneProto);
             String[] after = s.getEnabledProtocols();
             if (after.length != 1 || !after[0].equals(oneProto[0])) {
-                System.out.println("\t... failed");
                 fail("setEnabledProtocols() failed");
             }
         }
-
-        System.out.println("\t... passed");
     }
 
     @Test
     public void testEnableSessionCreation() throws Exception {
-
-        System.out.print("\tget/setEnableSessionCreation()");
 
         /* create new CTX */
         this.ctx = tf.createSSLContext("TLS", ctxProvider);
@@ -501,7 +470,6 @@ public class WolfSSLServerSocketTest {
             public Void call() throws Exception {
                 try {
                     server.startHandshake();
-                    System.out.println("\t... failed");
                     fail();
                 } catch (SSLException e) {
                     /* expected, SSLSocket not allowed to make new sessions */
@@ -512,7 +480,6 @@ public class WolfSSLServerSocketTest {
 
         try {
             cs.startHandshake();
-            System.out.println("\t... failed");
             fail();
 
         } catch (SSLHandshakeException e) {
@@ -524,14 +491,10 @@ public class WolfSSLServerSocketTest {
         cs.close();
         server.close();
         ss.close();
-
-        System.out.println("\t... passed");
     }
 
     @Test
     public void testSetNeedClientAuth() throws Exception {
-
-        System.out.print("\tsetNeedClientAuth()");
 
         /* create ctx, uses client keystore (cert/key) and truststore (cert) */
         this.ctx = tf.createSSLContext("TLS", ctxProvider);
@@ -561,7 +524,6 @@ public class WolfSSLServerSocketTest {
                     server.close();
 
                 } catch (SSLException e) {
-                    System.out.println("\t... failed");
                     fail();
                 }
                 return null;
@@ -573,7 +535,6 @@ public class WolfSSLServerSocketTest {
             cs.close();
 
         } catch (SSLHandshakeException e) {
-            System.out.println("\t... failed");
             fail();
         }
 
@@ -605,7 +566,6 @@ public class WolfSSLServerSocketTest {
             public Void call() throws Exception {
                 try {
                     server2.startHandshake();
-                    System.out.println("\t\t... failed");
                     fail();
 
                 } catch (SSLException e) {
@@ -618,7 +578,6 @@ public class WolfSSLServerSocketTest {
 
         try {
             cs.startHandshake();
-            System.out.println("\t\t... failed");
             fail();
 
         } catch (SSLHandshakeException e) {
@@ -627,7 +586,6 @@ public class WolfSSLServerSocketTest {
             if (!e.toString().contains("ASN no signer") &&
                 !e.toString().contains("certificate verify failed") &&
                 !e.toString().contains("ASN self-signed certificate error")) {
-                System.out.println("\t\t... failed");
                 fail();
             }
             cs.close();
@@ -670,7 +628,6 @@ public class WolfSSLServerSocketTest {
                     server3.close();
 
                 } catch (SSLException e) {
-                    System.out.println("\t\t... failed");
                     fail();
                 }
                 return null;
@@ -682,21 +639,16 @@ public class WolfSSLServerSocketTest {
             cs.close();
 
         } catch (SSLHandshakeException e) {
-            System.out.println("\t\t... failed");
             fail();
         }
 
         es.shutdown();
         serverFuture.get();
         ss.close();
-
-        System.out.println("\t\t... passed");
     }
 
     @Test
     public void testSetUseClientMode() throws Exception {
-
-        System.out.print("\tget/setUseClientMode()");
 
         /* create new CTX */
         this.ctx = tf.createSSLContext("TLS", "wolfJSSE");
@@ -732,7 +684,6 @@ public class WolfSSLServerSocketTest {
             public Void call() throws Exception {
                 try {
                     server.startHandshake();
-                    System.out.println("\t\t... failed");
                     fail();
                 } catch (SSLHandshakeException e) {
                     /* expected: Out of order message, fatal */
@@ -743,7 +694,6 @@ public class WolfSSLServerSocketTest {
 
         try {
             cs.startHandshake();
-            System.out.println("\t\t... failed");
             fail();
 
         } catch (SSLHandshakeException e) {
@@ -755,14 +705,10 @@ public class WolfSSLServerSocketTest {
         cs.close();
         server.close();
         ss.close();
-
-        System.out.println("\t\t... passed");
     }
 
     @Test
     public void testCustomTrustManager() throws Exception {
-
-        System.out.print("\tCustom TrustManager - ALL");
 
         /* TrustManager that trusts all certificates */
         TrustManager[] trustAllCerts = {
@@ -804,7 +750,6 @@ public class WolfSSLServerSocketTest {
                 } catch (SSLHandshakeException e) {
                     e.printStackTrace();
                     /* should not fail, trust all certs */
-                    System.out.println("\t... failed");
                     fail();
                 }
                 return null;
@@ -815,7 +760,6 @@ public class WolfSSLServerSocketTest {
             cs.startHandshake();
         } catch (SSLHandshakeException e) {
             e.printStackTrace();
-            System.out.println("\t... failed");
             fail();
         }
 
@@ -824,14 +768,10 @@ public class WolfSSLServerSocketTest {
         cs.close();
         server.close();
         ss.close();
-
-        System.out.println("\t... passed");
     }
 
     @Test
     public void testCustomTrustManagerNone() throws Exception {
-
-        System.out.print("\tCustom TrustManager - NONE");
 
         /* TrustManager that trusts no certificates */
         TrustManager[] trustNoCerts = {
@@ -840,11 +780,11 @@ public class WolfSSLServerSocketTest {
                     return null;
                 }
                 public void checkClientTrusted(X509Certificate[] xc,
-                                       String type) throws CertificateException{
+                    String type) throws CertificateException {
                     throw new CertificateException();
                 }
                 public void checkServerTrusted(X509Certificate[] xc,
-                                       String type) throws CertificateException{
+                    String type) throws CertificateException {
                     throw new CertificateException();
                 }
             }
@@ -872,7 +812,6 @@ public class WolfSSLServerSocketTest {
             public Void call() throws Exception {
                 try {
                     server.startHandshake();
-                    System.out.println("\t... failed");
                     fail();
                 } catch (SSLHandshakeException e) {
                     /* should fail, trust no certs */
@@ -883,7 +822,6 @@ public class WolfSSLServerSocketTest {
 
         try {
             cs.startHandshake();
-            System.out.println("\t... failed");
             fail();
         } catch (SSLHandshakeException e) {
             /* should fail, trust no certs */
@@ -894,15 +832,11 @@ public class WolfSSLServerSocketTest {
         cs.close();
         server.close();
         ss.close();
-
-        System.out.println("\t... passed");
     }
 
     @Test
     public void testServerSocketAnonCipherSuiteFiltering()
         throws Exception {
-
-        System.out.print("\tanon cipher filtering");
 
         String[] allCiphers = WolfSSL.getCiphersIana();
         String anonSuite = null;
@@ -917,10 +851,7 @@ public class WolfSSLServerSocketTest {
             }
         }
 
-        if (anonSuite == null) {
-            System.out.println("\t\t... skipped");
-            return;
-        }
+        Assume.assumeNotNull(anonSuite);
 
         Security.setProperty("wolfjsse.enabledCipherSuites", "");
         this.ctx = tf.createSSLContext("TLS", "wolfJSSE");
@@ -970,8 +901,6 @@ public class WolfSSLServerSocketTest {
         assertEquals(2, enabled.length);
 
         ss.close();
-
-        System.out.println("\t\t... passed");
     }
 }
 

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLServiceLoaderTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLServiceLoaderTest.java
@@ -24,6 +24,8 @@ package com.wolfssl.provider.jsse.test;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.TestRule;
 
 import java.security.Provider;
 import java.security.Security;
@@ -32,6 +34,7 @@ import java.util.ServiceLoader;
 import javax.net.ssl.SSLContext;
 
 import com.wolfssl.provider.jsse.WolfSSLProvider;
+import com.wolfssl.test.TimedTestWatcher;
 import org.junit.Assume;
 
 /**
@@ -46,6 +49,9 @@ import org.junit.Assume;
  * Android apps register providers directly.
  */
 public class WolfSSLServiceLoaderTest {
+
+    @Rule
+    public TestRule testWatcher = TimedTestWatcher.create();
 
     @BeforeClass
     public static void setUpClass() {
@@ -75,8 +81,7 @@ public class WolfSSLServiceLoaderTest {
             String className = provider.getClass().getName();
 
             /* Check if we found WolfSSLProvider */
-            if (className.equals(
-                "com.wolfssl.provider.jsse.WolfSSLProvider")) {
+            if (className.equals("com.wolfssl.provider.jsse.WolfSSLProvider")) {
                 foundWolfSSL = true;
 
                 /* Verify provider name is correct */
@@ -84,16 +89,15 @@ public class WolfSSLServiceLoaderTest {
                     "wolfJSSE", provider.getName());
 
                 /* Verify it's the right class */
-                assertTrue("Provider should be instance of " +
-                    "WolfSSLProvider",
+                assertTrue("Provider should be instance of WolfSSLProvider",
                     provider instanceof WolfSSLProvider);
 
                 break;
             }
         }
 
-        assertTrue("WolfSSLProvider should be discoverable via " +
-            "ServiceLoader", foundWolfSSL);
+        assertTrue("WolfSSLProvider should be discoverable via ServiceLoader",
+            foundWolfSSL);
     }
 
     /**

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSessionContextTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSessionContextTest.java
@@ -21,8 +21,12 @@
 
 package com.wolfssl.provider.jsse.test;
 
+import org.junit.Assume;
+import org.junit.AssumptionViolatedException;
 import org.junit.Test;
 import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.TestRule;
 import static org.junit.Assert.*;
 
 import java.util.Arrays;
@@ -44,9 +48,14 @@ import java.security.cert.CertificateException;
 
 import com.wolfssl.WolfSSLException;
 import com.wolfssl.provider.jsse.WolfSSLProvider;
+import com.wolfssl.test.TimedTestWatcher;
 
 
 public class WolfSSLSessionContextTest {
+
+    @Rule
+    public TestRule testWatcher = TimedTestWatcher.create();
+
     public final static char[] jksPass = "wolfSSL test".toCharArray();
     public final static String engineProvider = "wolfJSSE";
     private static WolfSSLTestFactory tf;
@@ -79,18 +88,13 @@ public class WolfSSLSessionContextTest {
         int ret;
         SSLSessionContext sesCtx;
 
-        /* create new SSLEngine */
-        System.out.print("\tTesting getSessionTimeout");
-
         this.ctx = tf.createSSLContext("TLS", engineProvider);
         if (this.ctx == null) {
-            error("\t... failed");
             fail("unable to make a context");
         }
 
         server = this.ctx.createSSLEngine();
         if (server == null)     {
-            error("\t... failed");
             fail("failed to create an engine");
         }
 
@@ -98,35 +102,32 @@ public class WolfSSLSessionContextTest {
         server.setNeedClientAuth(false);
         sesCtx = server.getSession().getSessionContext();
         if (sesCtx != null)     {
-            error("\t... failed");
             fail("session context should be null before connection is made");
         }
 
-        client = this.ctx.createSSLEngine("wolfSSL begin handshake test", 11111);
+        client = this.ctx.createSSLEngine(
+            "wolfSSL begin handshake test", 11111);
         client.setUseClientMode(true);
 
         try {
             server.beginHandshake();
             client.beginHandshake();
         } catch (SSLException e) {
-            error("\t... failed");
             fail("failed to begin handshake");
         }
 
-        ret = tf.testConnection(server, client, null, null, "Test in/out bound");
+        ret = tf.testConnection(server, client, null, null,
+            "Test in/out bound");
         if (ret != 0) {
-            error("\t... failed");
             fail("failed to create engine");
         }
         sesCtx = server.getSession().getSessionContext();
         if (sesCtx == null)     {
-            error("\t... failed");
             fail("session context was null after connection");
         }
 
         /* default should be default of 86400 */
         if (sesCtx.getSessionTimeout() != 86400) {
-            error("\t... failed");
             fail("failed to get session timeout");
         }
 
@@ -134,11 +135,8 @@ public class WolfSSLSessionContextTest {
             tf.CloseConnection(server, client, false);
         } catch (SSLException e1) {
             e1.printStackTrace();
-            error("\t\t... failed");
             fail("session close failed");
         }
-
-        pass("\t... passed");
     }
 
 
@@ -154,9 +152,6 @@ public class WolfSSLSessionContextTest {
         SSLSessionContext sesCtx;
         SSLSession ses;
 
-        /* create new SSLEngine */
-        System.out.print("\tTesting setSessionTimeout");
-
         this.ctx = tf.createSSLContext("TLS", engineProvider);
         server = this.ctx.createSSLEngine();
         client =
@@ -169,7 +164,6 @@ public class WolfSSLSessionContextTest {
         /* get a copy of session before connection */
         ses = server.getSession();
         if (ses == null) {
-            error("\t... failed");
             fail("failed get session from created engine");
         }
 
@@ -177,26 +171,22 @@ public class WolfSSLSessionContextTest {
             server.beginHandshake();
             client.beginHandshake();
         } catch (SSLException e) {
-            error("\t... failed");
             fail("failed to begin handshake");
         }
 
         ret = tf.testConnection(server, client, null, null,
             "Test in/out bound");
         if (ret != 0) {
-            error("\t... failed");
             fail("failed to create engine");
         }
 
         /* check old session copy is not valid */
         if (ses.isValid() != false) {
-            error("\t... failed");
             fail("old session not valid");
         }
 
         ses = server.getSession(); /* get a new copy of session */
         if (ses.isValid() == false) {
-            error("\t... failed");
             fail("session not valid");
         }
 
@@ -214,7 +204,6 @@ public class WolfSSLSessionContextTest {
         /* client timeout should still be default */
         if (client.getSession().getSessionContext()
                 .getSessionTimeout() != 86400) {
-            error("\t... failed");
             fail("client session timout should still be default value");
         }
 
@@ -222,45 +211,34 @@ public class WolfSSLSessionContextTest {
             tf.CloseConnection(server, client, false);
         } catch (SSLException e1) {
             e1.printStackTrace();
-            error("\t... failed");
             fail("session close failed");
         }
-
-        pass("\t... passed");
     }
 
     private void testSetCacheSize(SSLSession ses) {
-        System.out.print("\tTesting SettingCache");
         /* these are wolfJSSE default values,
          * make sure wolfJSSE is the provider */
-        if (ctx.getProvider() == Security.getProvider("wolfJSSE")) {
-            SSLSessionContext sesCtx = ses.getSessionContext();
+        assertSame("ctx provider must be wolfJSSE",
+            Security.getProvider("wolfJSSE"), ctx.getProvider());
 
-            if (sesCtx.getSessionCacheSize() != 33) {
-                error("\t\t... failed");
-                fail("session default cache size wrong");
-            }
+        SSLSessionContext sesCtx = ses.getSessionContext();
 
-            sesCtx.setSessionCacheSize(1000);
-            if (sesCtx.getSessionCacheSize() != 1000) {
-                error("\t\t... failed");
-                fail("session set cache size failed");
-            }
+        if (sesCtx.getSessionCacheSize() != 33) {
+            fail("session default cache size wrong");
         }
-        pass("\t\t... passed");
+
+        sesCtx.setSessionCacheSize(1000);
+        if (sesCtx.getSessionCacheSize() != 1000) {
+            fail("session set cache size failed");
+        }
     }
 
     private void testResizeCache(SSLSession ses) {
-        System.out.print("\tTesting ResizeCache");
-
-        if (ctx.getProvider() != Security.getProvider("wolfJSSE")) {
-            pass("\t\t... skipped");
-            return;
-        }
+        assertSame("ctx provider must be wolfJSSE",
+            Security.getProvider("wolfJSSE"), ctx.getProvider());
 
         SSLSessionContext sesCtx = ses.getSessionContext();
         if (sesCtx == null) {
-            error("\t\t... failed");
             fail("session context was null");
         }
 
@@ -279,7 +257,6 @@ public class WolfSSLSessionContextTest {
         }
 
         if (countBefore == 0 || firstId == null) {
-            error("\t\t... failed");
             fail("no sessions in cache before resize");
         }
 
@@ -298,20 +275,16 @@ public class WolfSSLSessionContextTest {
         }
 
         if (countAfter != countBefore) {
-            error("\t\t... failed");
             fail("resize-up lost sessions: before=" +
                 countBefore + " after=" + countAfter);
         }
 
         if (!found) {
-            error("\t\t... failed");
             fail("original session ID not found after resize");
         }
 
         /* restore original cache size */
         sesCtx.setSessionCacheSize(originalSize);
-
-        pass("\t\t... passed");
     }
 
     @Test
@@ -328,9 +301,6 @@ public class WolfSSLSessionContextTest {
         boolean found;
         byte id[];
         Enumeration<byte[]> allIds;
-
-        /* create new SSLEngine */
-        System.out.print("\tTesting SessionIDs with TLSv1.3");
 
         /* wolfjsse.clientSessionCache.disabled could be set in users
          * java.security file which would cause this test to not work
@@ -352,42 +322,38 @@ public class WolfSSLSessionContextTest {
 
             try {
                 String s[] = server.getEnabledProtocols();
-                if (Arrays.asList(s).contains("TLSv1.3") == false) {
-                    pass("\t... skipped");
-                    return;
-                }
+                Assume.assumeTrue("TLSv1.3 not enabled",
+                    Arrays.asList(s).contains("TLSv1.3"));
 
                 server.setEnabledProtocols(proto);
                 client.setEnabledProtocols(proto);
+            } catch (AssumptionViolatedException ave) {
+                throw ave;
             } catch (Exception e) {
                 e.printStackTrace();
-                error("\t... failed");
+                fail("failed to check or set enabled protocols: " + e);
             }
 
             try {
                 server.beginHandshake();
                 client.beginHandshake();
             } catch (SSLException e) {
-                error("\t... failed");
                 fail("failed to begin handshake");
             }
 
             ret = tf.testConnection(
                 server, client, null, null, "Test in/out bound");
             if (ret != 0) {
-                error("\t... failed");
                 fail("failed to create engine");
             }
 
             ses = server.getSession(); /* get a new copy of session */
             if (ses == null) {
-                error("\t... failed");
                 fail("unable to get session after handshake");
             }
 
             id = ses.getId();
             if (id == null) {
-                error("\t... failed");
                 fail("session had no id....");
             }
             found = false;
@@ -402,25 +368,21 @@ public class WolfSSLSessionContextTest {
             }
 
             if (!found) {
-                error("\t... failed");
                 fail("did not find session id in global context list");
             }
 
             if (ses.isValid() == false) {
-                error("\t... failed");
                 fail("session not valid");
             }
 
             /* now test finding client session by ID */
             ses = client.getSession(); /* get a new copy of session */
             if (ses == null) {
-                error("\t... failed");
                 fail("unable to get session after handshake");
             }
 
             id = ses.getId();
             if (id == null) {
-                error("\t... failed");
                 fail("client session had no id....");
             }
             found = false;
@@ -435,7 +397,6 @@ public class WolfSSLSessionContextTest {
             }
 
             if (!found) {
-                error("\t... failed");
                 fail("did not find client session id in global context list");
             }
 
@@ -443,10 +404,8 @@ public class WolfSSLSessionContextTest {
                 tf.CloseConnection(server, client, false);
             } catch (SSLException e1) {
                 e1.printStackTrace();
-                error("\t... failed");
                 fail("session close failed");
             }
-            pass("\t... passed");
 
         } finally {
             restoreClientSessionCacheProperty(originalProp);
@@ -468,9 +427,6 @@ public class WolfSSLSessionContextTest {
         byte id[];
         Enumeration<byte[]> allIds;
 
-        /* create new SSLEngine */
-        System.out.print("\tTesting SessionIDs with TLSv1.2");
-
         /* wolfjsse.clientSessionCache.disabled could be set in users
          * java.security file which would cause this test to not work
          * properly. Save their setting here, and re-enable session
@@ -491,42 +447,38 @@ public class WolfSSLSessionContextTest {
 
             try {
                 String s[] = server.getEnabledProtocols();
-                if (Arrays.asList(s).contains("TLSv1.2") == false) {
-                    pass("\t... skipped");
-                    return;
-                }
+                Assume.assumeTrue("TLSv1.2 not enabled",
+                    Arrays.asList(s).contains("TLSv1.2"));
 
                 server.setEnabledProtocols(proto);
                 client.setEnabledProtocols(proto);
+            } catch (AssumptionViolatedException ave) {
+                throw ave;
             } catch (Exception e) {
                 e.printStackTrace();
-                error("\t... failed");
+                fail("failed to check or set enabled protocols: " + e);
             }
 
             try {
                 server.beginHandshake();
                 client.beginHandshake();
             } catch (SSLException e) {
-                error("\t... failed");
                 fail("failed to begin handshake");
             }
 
             ret = tf.testConnection(
                 server, client, null, null, "Test in/out bound");
             if (ret != 0) {
-                error("\t... failed");
                 fail("failed to create engine");
             }
 
             ses = server.getSession(); /* get a new copy of session */
             if (ses == null) {
-                error("\t... failed");
                 fail("unable to get session after handshake");
             }
 
             id = ses.getId();
             if (id == null) {
-                error("\t... failed");
                 fail("session had no id....");
             }
             found = false;
@@ -541,25 +493,21 @@ public class WolfSSLSessionContextTest {
             }
 
             if (!found) {
-                error("\t... failed");
                 fail("did not find session id in global context list");
             }
 
             if (ses.isValid() == false) {
-                error("\t... failed");
                 fail("session not valid");
             }
 
             /* now test finding client session by ID */
             ses = client.getSession(); /* get a new copy of session */
             if (ses == null) {
-                error("\t... failed");
                 fail("unable to get session after handshake");
             }
 
             id = ses.getId();
             if (id == null) {
-                error("\t... failed");
                 fail("client session had no id....");
             }
             found = false;
@@ -574,11 +522,8 @@ public class WolfSSLSessionContextTest {
             }
 
             if (!found) {
-                error("\t... failed");
                 fail("did not find client session id in global context list");
             }
-
-            pass("\t... passed");
 
             /* additional tests on the engines and sessions while open */
             testSetCacheSize(ses);
@@ -589,7 +534,6 @@ public class WolfSSLSessionContextTest {
                 tf.CloseConnection(server, client, false);
             } catch (SSLException e1) {
                 e1.printStackTrace();
-                error("\t\t... failed");
                 fail("session close failed");
             }
 
@@ -612,7 +556,6 @@ public class WolfSSLSessionContextTest {
 
         /* Regression: session must expire at exactly the
          * timeout boundary (diff >= timeout, not diff > timeout) */
-        System.out.print("\tSession timeout boundary");
 
         String originalProp = Security.getProperty(
             "wolfjsse.clientSessionCache.disabled");
@@ -631,20 +574,17 @@ public class WolfSSLSessionContextTest {
                 server.beginHandshake();
                 client.beginHandshake();
             } catch (SSLException e) {
-                error("\t... failed");
                 fail("failed to begin handshake");
             }
 
             ret = tf.testConnection(server, client, null, null,
                 "timeout boundary test");
             if (ret != 0) {
-                error("\t... failed");
                 fail("failed to create connection");
             }
 
             ses = server.getSession();
             if (ses == null || !ses.isValid()) {
-                error("\t... failed");
                 fail("session should be valid after handshake");
             }
 
@@ -677,14 +617,12 @@ public class WolfSSLSessionContextTest {
                 }
             }
             if (found) {
-                error("\t... failed");
                 fail("expired session should not appear in getIds()");
             }
 
             /* After updateTimeouts ran via getIds(), session should
              * also report as invalid */
             if (ses.isValid()) {
-                error("\t... failed");
                 fail("session should be invalid after timeout");
             }
 
@@ -692,11 +630,8 @@ public class WolfSSLSessionContextTest {
                 tf.CloseConnection(server, client, false);
             } catch (SSLException e1) {
                 e1.printStackTrace();
-                error("\t... failed");
                 fail("session close failed");
             }
-
-            pass("\t... passed");
 
         } finally {
             restoreClientSessionCacheProperty(originalProp);
@@ -717,7 +652,6 @@ public class WolfSSLSessionContextTest {
 
         /* Regression: invalidated sessions must be filtered
          * from getIds() and getSession(). */
-        System.out.print("\tInvalidation filtered getIds");
 
         String originalProp = Security.getProperty(
             "wolfjsse.clientSessionCache.disabled");
@@ -737,20 +671,17 @@ public class WolfSSLSessionContextTest {
                 server.beginHandshake();
                 client.beginHandshake();
             } catch (SSLException e) {
-                error("\t... failed");
                 fail("failed to begin handshake");
             }
 
             ret = tf.testConnection(server, client, null, null,
                 "invalidation test");
             if (ret != 0) {
-                error("\t... failed");
                 fail("failed to create connection");
             }
 
             ses = server.getSession();
             if (ses == null || !ses.isValid()) {
-                error("\t... failed");
                 fail("session should be valid after handshake");
             }
 
@@ -768,7 +699,6 @@ public class WolfSSLSessionContextTest {
                 }
             }
             if (!foundBefore) {
-                error("\t... failed");
                 fail("session should be in getIds() before invalidation");
             }
 
@@ -776,7 +706,6 @@ public class WolfSSLSessionContextTest {
             ses.invalidate();
 
             if (ses.isValid()) {
-                error("\t... failed");
                 fail("session should not be valid after invalidation");
             }
 
@@ -791,7 +720,6 @@ public class WolfSSLSessionContextTest {
                 }
             }
             if (foundAfter) {
-                error("\t... failed");
                 fail("invalidated session should not appear in getIds()");
             }
 
@@ -799,7 +727,6 @@ public class WolfSSLSessionContextTest {
              * invalidated session */
             SSLSession retrieved = sesCtx.getSession(sessionId);
             if (retrieved != null && retrieved.isValid()) {
-                error("\t... failed");
                 fail("getSession() should not return valid " +
                      "invalidated session");
             }
@@ -808,11 +735,8 @@ public class WolfSSLSessionContextTest {
                 tf.CloseConnection(server, client, false);
             } catch (SSLException e1) {
                 e1.printStackTrace();
-                error("\t... failed");
                 fail("session close failed");
             }
-
-            pass("\t... passed");
 
         } finally {
             restoreClientSessionCacheProperty(originalProp);
@@ -830,13 +754,5 @@ public class WolfSSLSessionContextTest {
             Security.setProperty("wolfjsse.clientSessionCache.disabled", "");
         }
     }
-
-    private void pass(String msg) {
-        WolfSSLTestFactory.pass(msg);
-    }
-
-    private void error(String msg) {
-        WolfSSLTestFactory.fail(msg);
-    }
-
 }
+

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSessionTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSessionTest.java
@@ -54,14 +54,22 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLHandshakeException;
 
+import org.junit.Assume;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import com.wolfssl.WolfSSL;
 import com.wolfssl.WolfSSLException;
 import com.wolfssl.provider.jsse.WolfSSLProvider;
+import com.wolfssl.test.TimedTestWatcher;
 
 public class WolfSSLSessionTest {
+
+    @Rule
+    public TestRule testWatcher = TimedTestWatcher.create();
+
     public final static char[] jksPass = "wolfSSL test".toCharArray();
     public final static String engineProvider = "wolfJSSE";
     private static WolfSSLTestFactory tf;
@@ -92,14 +100,10 @@ public class WolfSSLSessionTest {
         int ret;
         SSLSession session;
 
-        /* create new SSLEngine */
-        System.out.print("\tTesting session time");
-
         SSLContext ctx = tf.createSSLContext("TLS", engineProvider);
         SSLEngine client = ctx.createSSLEngine("server", 12345);
         SSLEngine server = ctx.createSSLEngine();
         if (client == null || server == null) {
-            error("\t\t... failed");
             fail("failed to create engine");
             return;
         }
@@ -109,31 +113,23 @@ public class WolfSSLSessionTest {
         client.setUseClientMode(true);
         ret = tf.testConnection(server, client, null, null, "Test reuse");
         if (ret != 0) {
-            error("\t... failed");
             fail("failed to connect");
         }
 
         session = client.getSession();
         if (session.getCreationTime() <= 0) {
-            error("\t... failed");
             fail("failed to get creation time");
         }
 
         if (session.getCreationTime() > session.getLastAccessedTime() ||
                 session.getLastAccessedTime() <= 0) {
-            error("\t... failed");
             fail("failed creation time does not equal accessed time");
         }
 
-        pass("\t\t... passed");
-
-
         /* test certificates */
-        System.out.print("\tTesting session cert");
         session = client.getSession();
         /* TODO changes back to != null once we can check for client auth */
         if (session.getLocalPrincipal() == null) {
-            error("\t... failed");
             fail("Principal is null when it should not be");
         }
 
@@ -141,18 +137,14 @@ public class WolfSSLSessionTest {
             /* @TODO make match SunJSSE better */
             session.getPeerPrincipal().getName();
         } catch (SSLPeerUnverifiedException e) {
-            error("\t... failed");
             fail("failed to find peer principal");
         }
 
         try {
             session.getPeerCertificateChain();
         } catch (SSLPeerUnverifiedException e) {
-            error("\t... failed");
             fail("failed to get peer certificate chain");
         }
-
-        pass("\t\t... passed");
     }
 
     @Test
@@ -164,60 +156,50 @@ public class WolfSSLSessionTest {
         int ret;
         SSLSession session;
 
-        /* create new SSLEngine */
-        System.out.print("\tTesting null session");
-
         SSLContext ctx = tf.createSSLContext("TLS", engineProvider);
         SSLEngine client = ctx.createSSLEngine("server", 12345);
         SSLEngine server = ctx.createSSLEngine();
         if (client == null || server == null) {
-            error("\t\t... failed");
             fail("failed to create engine");
             return;
         }
-        session = client.getSession(); /* get null session since handshake not done */
+        /* get null session since handshake not done */
+        session = client.getSession();
 
         server.setUseClientMode(false);
         server.setNeedClientAuth(false);
         client.setUseClientMode(true);
         ret = tf.testConnection(server, client, null, null, "Test reuse");
         if (ret != 0) {
-            error("\t... failed");
             fail("failed to create engine");
         }
 
         /* session stored before handshake should still be null */
         if (session.getId() == null) {
-            error("\t... failed");
             fail("failed to get ID");
         }
 
         if (session.getId().length != 0) {
-            error("\t... failed");
             fail("ID longer than expected");
         }
 
         try {
             session.getPeerCertificates();
-            error("\t... failed");
             fail("Unexpected peer certificates found");
         } catch (SSLPeerUnverifiedException e) {
             /* expected to fail with unverified exception */
         }
 
         if (!session.getCipherSuite().equals("SSL_NULL_WITH_NULL_NULL")) {
-            error("\t... failed");
             fail("Unexpected cipher suite found");
         }
 
         if (!session.getProtocol().equals("NONE")) {
-            error("\t... failed");
             fail("Unexpected protocol found");
         }
 
         try {
             session.getPeerPrincipal();
-            error("\t... failed");
             fail("Unexpected peer principal found");
         } catch (SSLPeerUnverifiedException e) {
             /* expected to fail here */
@@ -225,13 +207,10 @@ public class WolfSSLSessionTest {
 
         try {
             session.getPeerCertificateChain();
-            error("\t... failed");
             fail("Unexpected peer certificate chain found");
         } catch (SSLPeerUnverifiedException e) {
             /* expected to fail here */
         }
-
-        pass("\t\t... passed");
     }
 
 
@@ -246,14 +225,10 @@ public class WolfSSLSessionTest {
         listner bound  = new listner();
         listner bound2 = new listner();
 
-        /* create new SSLEngine */
-        System.out.print("\tTesting binding session");
-
         SSLContext ctx = tf.createSSLContext("TLS", engineProvider);
         SSLEngine client = ctx.createSSLEngine("server", 12345);
         SSLEngine server = ctx.createSSLEngine();
         if (client == null || server == null) {
-            error("\t\t... failed");
             fail("failed to create engine");
             return;
         }
@@ -266,7 +241,6 @@ public class WolfSSLSessionTest {
         client.setUseClientMode(true);
         ret = tf.testConnection(server, client, null, null, "Test reuse");
         if (ret != 0) {
-            error("\t\t... failed");
             fail("failed to create engine");
         }
 
@@ -274,12 +248,10 @@ public class WolfSSLSessionTest {
         session = client.getSession();
         session.putValue("testing", bound);
         if (!bound.checkID(session.getId())) {
-            error("\t\t... failed");
             fail("test of ID failed");
         }
 
         if (!bound.checkPeer("server", 12345)) {
-            error("\t\t... failed");
             fail("test of port and host fail");
 
         }
@@ -289,12 +261,10 @@ public class WolfSSLSessionTest {
                 Certificate[] certs = session.getPeerCertificates();
 
                 if (certs.length != 1) {
-                    error("\t\t... failed");
                     fail("unexpected number of peer certs found");
                 }
 
                 if (!certs[0].getType().equals("X.509")) {
-                    error("\t\t... failed");
                     fail("unexpected cert type found");
                 }
 
@@ -306,74 +276,61 @@ public class WolfSSLSessionTest {
                     X509Certificate[] xCerts = (X509Certificate[])certs;
                     assertNotNull(xCerts);
                 } catch (ClassCastException e) {
-                    error("\t\t... failed");
                     fail("getPeerCertificates() did not return array of type " +
                          "X509Certificate[]");
                 }
             }
         } catch (SSLPeerUnverifiedException e) {
-            error("\t\t... failed");
             fail("failed to get peer certificate");
         }
 
         if (!bound.checkCipher(server.getSession().getCipherSuite())) {
-            error("\t\t... failed");
             fail("unexpected cipher suite");
         }
 
         session.removeValue("testing");
         if (bound.isBound) {
-            error("\t\t... failed");
             fail("bound when should not be");
         }
         session.putValue("testing", bound);
         if (!bound.isBound) {
-            error("\t\t... failed");
             fail("not bound when should be");
         }
         session.putValue("testing", bound2);
         if (!bound2.isBound || bound.isBound) {
-            error("\t\t... failed");
             fail("override failed");
         }
 
         if (!bound2.checkPeer("server", 12345)) {
-            error("\t\t... failed");
             fail("test of port and host fail");
         }
 
         if (!session.getValue("testing").equals(bound2)) {
-            error("\t\t... failed");
             fail("failed to get value");
         }
 
         if (session.getValue("bad") != null) {
-            error("\t\t... failed");
             fail("able to get bogus value");
         }
 
         session.putValue("testing 2", bound);
         values = session.getValueNames();
         if (values.length != 2) {
-            error("\t\t... failed");
             fail("unexpected number of values");
         }
 
         if (!values[0].equals("testing 2") || !values[1].equals("testing")) {
-            error("\t\t... failed");
             fail("unexpected value names");
         }
 
         try {
             session.removeValue("bad");
         } catch (IllegalArgumentException ex) {
-            error("\t\t... failed");
             fail("could not remove a bogus value");
         }
 
         try {
             session.removeValue(null);
-            error("\t\t... failed");
             fail("null sanity check failed");
         } catch (IllegalArgumentException ex) {
             /* expected to throw exception */
@@ -381,10 +338,8 @@ public class WolfSSLSessionTest {
 
         if (!server.getSession().getProtocol().equals(
                 client.getSession().getProtocol())) {
-            error("\t... failed");
             fail("protocols do not match");
         }
-        pass("\t\t... passed");
     }
 
     @Test
@@ -397,14 +352,10 @@ public class WolfSSLSessionTest {
         SSLSession session;
         SSLSessionContext context;
 
-        /* create new SSLEngine */
-        System.out.print("\tTesting session context");
-
         SSLContext ctx = tf.createSSLContext("TLS", engineProvider);
         SSLEngine client = ctx.createSSLEngine("server", 12345);
         SSLEngine server = ctx.createSSLEngine();
         if (client == null || server == null) {
-            error("\t\t... failed");
             fail("failed to create engine");
             return;
         }
@@ -414,7 +365,6 @@ public class WolfSSLSessionTest {
         client.setUseClientMode(true);
         ret = tf.testConnection(server, client, null, null, "Test reuse");
         if (ret != 0) {
-            error("\t\t... failed");
             fail("failed to create engine");
         }
         session = client.getSession();
@@ -424,7 +374,6 @@ public class WolfSSLSessionTest {
             /* TLSv1.3 uses session tickets */
             context.setSessionTimeout(100);
             if (context.getSessionTimeout() != 100) {
-                error("\t\t... failed");
                 fail("failed to set session timeout");
             }
         }
@@ -434,7 +383,6 @@ public class WolfSSLSessionTest {
 
         /* @TODO additional tests around setting session cache size */
         context.setSessionCacheSize(2);
-        pass("\t\t... passed");
     }
 
     @Test
@@ -443,18 +391,15 @@ public class WolfSSLSessionTest {
         String protocol = null;
         SSLContext ctx = null;
 
-        System.out.print("\tTesting SSLSocket.getSession");
-
         if (WolfSSL.TLSv12Enabled()) {
             protocol = "TLSv1.2";
         } else if (WolfSSL.TLSv11Enabled()) {
             protocol = "TLSv1.1";
         } else if (WolfSSL.TLSv1Enabled()) {
             protocol = "TLSv1.0";
-        } else {
-            System.out.println("\t... skipped");
-            return;
         }
+
+        Assume.assumeNotNull(protocol);
 
         /* create new CTX */
         ctx = tf.createSSLContext(protocol, engineProvider);
@@ -478,7 +423,6 @@ public class WolfSSLSessionTest {
                     testSSLSession(server, true);
 
                 } catch (SSLException e) {
-                    error("\t... failed");
                     fail();
                 }
                 return null;
@@ -491,7 +435,6 @@ public class WolfSSLSessionTest {
             testSSLSession(cs, true);
 
         } catch (SSLHandshakeException e) {
-            error("\t... failed");
             fail();
         }
 
@@ -504,8 +447,6 @@ public class WolfSSLSessionTest {
         server.close();
         testSSLSession(server, true);
         ss.close();
-
-        pass("\t... passed");
     }
 
     /* Tests that setting/restricting TLS Signature Schemes with the
@@ -524,8 +465,6 @@ public class WolfSSLSessionTest {
         String origClient = System.getProperty(cSigSchemes);
         String origServer = System.getProperty(sSigSchemes);
 
-        System.out.print("\tTesting Signature Schemes");
-
         try {
             /* Case 1: Mismatching schemes - Should Fail */
             /* Client: ECDSA only */
@@ -538,7 +477,6 @@ public class WolfSSLSessionTest {
             SSLEngine server = ctx1.createSSLEngine();
 
             if (client == null || server == null) {
-                error("\t... failed");
                 fail("failed to create engine");
                 return;
             }
@@ -552,7 +490,6 @@ public class WolfSSLSessionTest {
                 "Test sig mismatch");
 
             if (ret == 0) {
-                error("\t... failed");
                 fail("Handshake succeeded with mismatching signature schemes");
             }
 
@@ -572,7 +509,6 @@ public class WolfSSLSessionTest {
             server = ctx2.createSSLEngine();
 
             if (client == null || server == null) {
-                error("\t... failed");
                 fail("failed to create engine");
                 return;
             }
@@ -584,11 +520,8 @@ public class WolfSSLSessionTest {
             ret = tf.testConnection(server, client, null, null,
                 "Test sig match");
             if (ret != 0) {
-                error("\t... failed");
                 fail("Handshake failed with matching signature schemes");
             }
-
-            pass("\t... passed");
 
         } finally {
             /* Restore properties */
@@ -622,14 +555,11 @@ public class WolfSSLSessionTest {
         int ret;
         SSLSession session;
 
-        System.out.print("\tTesting hashCode()");
-
         SSLContext ctx = tf.createSSLContext("TLS", engineProvider);
         SSLEngine client = ctx.createSSLEngine("localhost", 12345);
         SSLEngine server = ctx.createSSLEngine();
 
         if (client == null || server == null) {
-            error("\t\t... failed");
             fail("failed to create engine");
             return;
         }
@@ -640,14 +570,12 @@ public class WolfSSLSessionTest {
 
         ret = tf.testConnection(server, client, null, null, "Test hashCode");
         if (ret != 0) {
-            error("\t\t... failed");
             fail("failed to create connection");
             return;
         }
 
         session = client.getSession();
         if (session == null) {
-            error("\t\t... failed");
             fail("SSLEngine.getSession() returned null");
             return;
         }
@@ -657,7 +585,6 @@ public class WolfSSLSessionTest {
         try {
             session.getClass().getDeclaredMethod("hashCode", new Class<?>[0]);
         } catch (NoSuchMethodException e) {
-            error("\t\t... failed");
             fail("SSLSession class does not declare hashCode() method");
             return;
         }
@@ -666,7 +593,6 @@ public class WolfSSLSessionTest {
         int hash1 = session.hashCode();
         int hash2 = session.hashCode();
         if (hash1 != hash2) {
-            error("\t\t... failed");
             fail("SSLSession.hashCode() not consistent: " +
                  hash1 + " != " + hash2);
             return;
@@ -685,14 +611,12 @@ public class WolfSSLSessionTest {
         ret = tf.testConnection(server2, client2, null, null,
             "Test hashCode 2");
         if (ret != 0) {
-            error("\t\t... failed");
             fail("failed to create second connection");
             return;
         }
 
         SSLSession session2 = client2.getSession();
         if (session2 == null) {
-            error("\t\t... failed");
             fail("Second SSLEngine.getSession() returned null");
             return;
         }
@@ -704,8 +628,6 @@ public class WolfSSLSessionTest {
              * are technically allowed */
             System.out.println(" (warning: hash collision)");
         }
-
-        pass("\t\t... passed");
     }
 
     @Test
@@ -717,14 +639,11 @@ public class WolfSSLSessionTest {
         int ret;
         SSLSession session;
 
-        System.out.print("\tTesting equals()");
-
         SSLContext ctx = tf.createSSLContext("TLS", engineProvider);
         SSLEngine client = ctx.createSSLEngine("localhost", 12345);
         SSLEngine server = ctx.createSSLEngine();
 
         if (client == null || server == null) {
-            error("\t\t... failed");
             fail("failed to create engine");
             return;
         }
@@ -735,14 +654,12 @@ public class WolfSSLSessionTest {
 
         ret = tf.testConnection(server, client, null, null, "Test equals");
         if (ret != 0) {
-            error("\t\t... failed");
             fail("failed to create connection");
             return;
         }
 
         session = client.getSession();
         if (session == null) {
-            error("\t\t... failed");
             fail("SSLEngine.getSession() returned null");
             return;
         }
@@ -753,21 +670,18 @@ public class WolfSSLSessionTest {
             session.getClass().getDeclaredMethod("equals",
                 new Class<?>[] { Object.class });
         } catch (NoSuchMethodException e) {
-            error("\t\t... failed");
             fail("SSLSession class does not declare equals() method");
             return;
         }
 
         /* Test reflexivity: session.equals(session) should be true */
         if (!session.equals(session)) {
-            error("\t\t... failed");
             fail("SSLSession.equals() reflexivity failed");
             return;
         }
 
         /* Test null: session.equals(null) should be false */
         if (session.equals(null)) {
-            error("\t\t... failed");
             fail("SSLSession.equals(null) should return false");
             return;
         }
@@ -777,7 +691,6 @@ public class WolfSSLSessionTest {
          * the equals() implementation handles type mismatches correctly. */
         Object differentType = "not a session";
         if (session.equals(differentType)) {
-            error("\t\t... failed");
             fail("SSLSession.equals(Object) should return false for " +
                  "incompatible type");
             return;
@@ -786,12 +699,9 @@ public class WolfSSLSessionTest {
         /* Test hashCode/equals contract: equal objects must have same hash */
         if (session.equals(session) &&
             session.hashCode() != session.hashCode()) {
-            error("\t\t... failed");
             fail("Equal sessions have different hashCodes");
             return;
         }
-
-        pass("\t\t... passed");
     }
 
     @Test
@@ -800,13 +710,10 @@ public class WolfSSLSessionTest {
                KeyStoreException, CertificateException, IOException,
                NoSuchProviderException, UnrecoverableKeyException {
 
-        System.out.print("\tTesting hashCode() before HS");
-
         SSLContext ctx = tf.createSSLContext("TLS", engineProvider);
         SSLEngine engine = ctx.createSSLEngine("localhost", 12345);
 
         if (engine == null) {
-            error("\t... failed");
             fail("failed to create engine");
             return;
         }
@@ -817,7 +724,6 @@ public class WolfSSLSessionTest {
         SSLSession session = engine.getSession();
         if (session == null) {
             /* Some implementations return null before handshake */
-            pass("\t... passed (null session)");
             return;
         }
 
@@ -827,7 +733,6 @@ public class WolfSSLSessionTest {
             int hash = session.hashCode();
             /* hashCode should work without throwing */
         } catch (Exception e) {
-            error("\t... failed");
             fail("hashCode() threw exception before handshake: " +
                  e.getMessage());
             return;
@@ -837,13 +742,10 @@ public class WolfSSLSessionTest {
         try {
             boolean eq = session.equals(session);
         } catch (Exception e) {
-            error("\t... failed");
             fail("equals() threw exception before handshake: " +
                  e.getMessage());
             return;
         }
-
-        pass("\t... passed");
     }
 
     /**
@@ -932,14 +834,6 @@ public class WolfSSLSessionTest {
     }
 
 
-    private void pass(String msg) {
-        WolfSSLTestFactory.pass(msg);
-    }
-
-    private void error(String msg) {
-        WolfSSLTestFactory.fail(msg);
-    }
-
     private class listner implements SSLSessionBindingListener {
         private SSLSession ses;
         private boolean isBound = false;
@@ -994,6 +888,6 @@ public class WolfSSLSessionTest {
         public void valueUnbound(SSLSessionBindingEvent event) {
             isBound = false;
         }
-
     }
 }
+

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketFactoryTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketFactoryTest.java
@@ -21,13 +21,17 @@
 
 package com.wolfssl.provider.jsse.test;
 
+import org.junit.Assume;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.BeforeClass;
+import org.junit.rules.TestRule;
 import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 
 import com.wolfssl.provider.jsse.WolfSSLSocketFactory;
+import com.wolfssl.test.TimedTestWatcher;
 
 import java.util.Arrays;
 import java.util.List;
@@ -59,6 +63,9 @@ import com.wolfssl.WolfSSLException;
 import com.wolfssl.provider.jsse.WolfSSLProvider;
 
 public class WolfSSLSocketFactoryTest {
+
+    @Rule
+    public TestRule testWatcher = TimedTestWatcher.create();
 
     public final static char[] jksPass = "wolfSSL test".toCharArray();
     private final static String ctxProvider = "wolfJSSE";
@@ -160,51 +167,37 @@ public class WolfSSLSocketFactoryTest {
     public void testUseDefaultSSLSocketFactory()
         throws NoSuchProviderException, NoSuchAlgorithmException {
 
-        System.out.print("\tgetDefault()");
-
         SSLSocketFactory sf =
             new com.wolfssl.provider.jsse.WolfSSLSocketFactory();
         assertNotNull(sf);
-
-        System.out.println("\t\t\t... passed");
     }
 
     @Test
     public void testGetDefaultCipherSuites()
         throws NoSuchProviderException, NoSuchAlgorithmException {
 
-        System.out.print("\tgetDefaultCipherSuites()");
-
         for (int i = 0; i < sockFactories.size(); i++) {
             SSLSocketFactory sf = sockFactories.get(i);
             String[] cipherSuites = sf.getDefaultCipherSuites();
 
             if (cipherSuites == null) {
-                System.out.println("\t... failed");
                 fail("SSLSocketFactory.getDefaultCipherSuites() failed");
             }
         }
-
-        System.out.println("\t... passed");
     }
 
     @Test
     public void testGetSupportedCipherSuites()
         throws NoSuchProviderException, NoSuchAlgorithmException {
 
-        System.out.print("\tgetSupportedCipherSuites()");
-
         for (int i = 0; i < sockFactories.size(); i++) {
             SSLSocketFactory sf = sockFactories.get(i);
             String[] cipherSuites = sf.getSupportedCipherSuites();
 
             if (cipherSuites == null) {
-                System.out.println("\t... failed");
                 fail("SSLSocketFactory.getSupportedCipherSuites() failed");
             }
         }
-
-        System.out.println("\t... passed");
     }
 
     @Test
@@ -212,11 +205,9 @@ public class WolfSSLSocketFactoryTest {
         throws NoSuchProviderException, NoSuchAlgorithmException,
                IOException {
 
-        System.out.print("\tcreateSocket()");
-
         for (int i = 0; i < sockFactories.size(); i++) {
             String addrStr = "www.example.com";
-            InetAddress addr;
+            InetAddress addr = null;
             int port = 443;
             SSLSocketFactory sf = sockFactories.get(i);
             SSLSocket ss = null;
@@ -230,8 +221,7 @@ public class WolfSSLSocketFactoryTest {
                 testConn.close();
             } catch (Exception e) {
                 /* unable to connect, skip test */
-                System.out.println("\t\t\t... skipped");
-                return;
+                Assume.assumeNoException(e);
             }
 
             /* set up InetAddress for www.example.com */
@@ -239,8 +229,7 @@ public class WolfSSLSocketFactoryTest {
                 addr = InetAddress.getByName("www.example.com");
             } catch (UnknownHostException e) {
                 /* skip test if no Internet connection available */
-                System.out.println("\t\t\t... skipped");
-                return;
+                Assume.assumeNoException(e);
             }
 
             /* good arguments */
@@ -249,7 +238,6 @@ public class WolfSSLSocketFactoryTest {
                 /* no arguments */
                 ss = (SSLSocket)sf.createSocket();
                 if (ss == null) {
-                    System.out.println("\t\t\t... failed");
                     fail("SSLSocketFactory.createSocket() failed");
                     return;
                 }
@@ -258,7 +246,6 @@ public class WolfSSLSocketFactoryTest {
                 /* InetAddress, int */
                 ss = (SSLSocket)sf.createSocket(addr, port);
                 if (ss == null) {
-                    System.out.println("\t\t\t... failed");
                     fail("SSLSocketFactory.createSocket(Ii) failed");
                     return;
                 }
@@ -267,7 +254,6 @@ public class WolfSSLSocketFactoryTest {
                 /* String, int */
                 ss = (SSLSocket)sf.createSocket(addrStr, port);
                 if (ss == null) {
-                    System.out.println("\t\t\t... failed");
                     fail("SSLSocketFactory.createSocket(Si) failed");
                     return;
                 }
@@ -282,14 +268,12 @@ public class WolfSSLSocketFactoryTest {
 
                 ss = (SSLSocket)sf.createSocket(s, addrStr, port, true);
                 if (ss == null) {
-                    System.out.println("\t\t\t... failed");
                     fail("SSLSocketFactory.createSocket(SkSib) failed");
                     return;
                 }
 
                 /* verify getSoTimeout matches set value */
                 if (ss.getSoTimeout() != tmpTimeout) {
-                    System.out.println("\t\t\t... failed");
                     fail("SSLSocketFactory.createSocket(SkSib) failed " +
                          "setSoTimeout check");
                     return;
@@ -301,9 +285,9 @@ public class WolfSSLSocketFactoryTest {
                 /* Socket, InputStream, boolean */
                 s = new Socket(addr, port);
                 in = s.getInputStream();
-                ss = (SSLSocket)((WolfSSLSocketFactory)sf).createSocket(s, in, true);
+                ss = (SSLSocket)((WolfSSLSocketFactory)sf)
+                    .createSocket(s, in, true);
                 if (ss == null) {
-                    System.out.println("\t\t\t... failed");
                     fail("SSLSocketFactory.createSocket(SkSib) failed");
                     return;
                 }
@@ -315,28 +299,23 @@ public class WolfSSLSocketFactoryTest {
                 ss = (SSLSocket)sf.createSocket(addrStr, port,
                     null, 0);
                 if (ss == null) {
-                    System.out.println("\t\t\t... failed");
                     fail("SSLSocketFactory.createSocket(SiIi) failed");
                     return;
                 }
                 ss.close();
 
                 /* InetAddress, int, InetAddress, int */
-                ss = (SSLSocket)sf.createSocket(addr, port,
-                    null, 0);
+                ss = (SSLSocket)sf.createSocket(addr, port, null, 0);
                 if (ss == null) {
-                    System.out.println("\t\t\t... failed");
                     fail("SSLSocketFactory.createSocket(IiIi) failed");
                     return;
                 }
                 ss.close();
 
             } catch (SocketException e) {
-                System.out.println("\t\t\t... failed");
                 throw e;
             }
             catch (Exception e) {
-                System.out.println("\t\t\t... failed");
                 throw e;
             }
 
@@ -344,33 +323,28 @@ public class WolfSSLSocketFactoryTest {
             try {
                 /* InetAddress, int - null host */
                 ss = (SSLSocket)sf.createSocket((InetAddress)null, port);
-                System.out.println("\t\t\t... failed");
                 fail("createSocket() should return NullPointerException");
             } catch (NullPointerException ne) {
                 /* expected */
             }
             catch (Exception e) {
-                System.out.println("\t\t\t... failed");
                 fail("createSocket() should return NullPointerException");
             }
 
             try {
                 /* InetAddress, int - port out of range {0:65535} */
                 ss = (SSLSocket)sf.createSocket(addr, 65536);
-                System.out.println("\t\t\t... failed");
                 fail("createSocket() should return IllegalArgumentException");
             } catch (IllegalArgumentException ie) {
                 /* expected */
             }
             catch (Exception e) {
-                System.out.println("\t\t\t... failed");
                 fail("createSocket() should return IllegalArgumentException");
             }
 
             try {
                 /* String, int - bad host */
                 ss = (SSLSocket)sf.createSocket("badhost", port);
-                System.out.println("\t\t\t... failed");
                 fail("createSocket() should return UnknownHostException");
             } catch (UnknownHostException ne) {
                 /* expected */
@@ -382,13 +356,11 @@ public class WolfSSLSocketFactoryTest {
             try {
                 /* String, int - port out of range {0:65535} */
                 ss = (SSLSocket)sf.createSocket(addrStr, 65536);
-                System.out.println("\t\t\t... failed");
                 fail("createSocket() should return IllegalArgumentException");
             } catch (IllegalArgumentException ie) {
                 /* expected */
             }
             catch (Exception e) {
-                System.out.println("\t\t\t... failed");
                 fail("createSocket() should return IllegalArgumentException");
             }
 
@@ -396,28 +368,23 @@ public class WolfSSLSocketFactoryTest {
                 /* Socket, String, int, boolean - null Socket */
                 ss = (SSLSocket)sf.createSocket((Socket)null, addrStr, port,
                     true);
-                System.out.println("\t\t\t... failed");
                 fail("createSocket() should return NullPointerException");
             } catch (NullPointerException ne) {
                 /* expected */
             }
             catch (Exception e) {
-                System.out.println("\t\t\t... failed");
                 fail("createSocket() should return NullPointerException");
             }
 
             try {
                 /* Socket, String, int, boolean - Socket not connected */
                 s = new Socket();
-                ss = (SSLSocket)sf.createSocket(s, addrStr, port,
-                    true);
-                System.out.println("\t\t\t... failed");
+                ss = (SSLSocket)sf.createSocket(s, addrStr, port, true);
                 fail("createSocket() should return IOException");
             } catch (IOException ne) {
                 /* expected */
             }
             catch (Exception e) {
-                System.out.println("\t\t\t... failed");
                 fail("createSocket() should return IOException");
             }
             s.close();
@@ -426,27 +393,22 @@ public class WolfSSLSocketFactoryTest {
                 /* Socket, InputStream, boolean - null Socket */
                 s = new Socket(addr, port);
                 in = s.getInputStream();
-                ss = (SSLSocket)((WolfSSLSocketFactory)sf).createSocket((Socket)null, in, true);
-                System.out.println("\t\t\t... failed");
+                ss = (SSLSocket)((WolfSSLSocketFactory)sf)
+                    .createSocket((Socket)null, in, true);
                 fail("createSocket() should throw exception");
             } catch (NullPointerException e) {
                 /* expected */
             }
             catch (Exception e) {
-                System.out.println("\t\t\t... failed");
                 fail("createSocket() should throw exception");
             }
             in.close();
         }
-
-        System.out.println("\t\t\t... passed");
     }
 
     @Test
     public void testFactoryAnonCipherSuiteFiltering()
         throws Exception {
-
-        System.out.print("\tanon cipher filtering");
 
         String[] allCiphers = WolfSSL.getCiphersIana();
         boolean haveAnon = false;
@@ -457,10 +419,7 @@ public class WolfSSLSocketFactoryTest {
             }
         }
 
-        if (!haveAnon) {
-            System.out.println("\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(haveAnon);
 
         Security.setProperty("wolfjsse.enabledCipherSuites", "");
         SSLContext ctx = SSLContext.getInstance("TLS", ctxProvider);
@@ -494,7 +453,5 @@ public class WolfSSLSocketFactoryTest {
             assertTrue("Default suite not in supported: " + s,
                 suppList.contains(s));
         }
-
-        System.out.println("\t\t... passed");
     }
 }

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
@@ -21,9 +21,14 @@
 
 package com.wolfssl.provider.jsse.test;
 
+import org.junit.Assume;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.BeforeClass;
+import org.junit.rules.TestRule;
 import static org.junit.Assert.*;
+
+import com.wolfssl.test.TimedTestWatcher;
 
 import java.util.List;
 import java.util.Arrays;
@@ -128,6 +133,9 @@ import com.wolfssl.WolfSSLException;
     public void testSSLHandshakeExceptionCauseChain();
  */
 public class WolfSSLSocketTest {
+
+    @Rule
+    public TestRule testWatcher = TimedTestWatcher.create();
 
     public final static char[] jksPass = "wolfSSL test".toCharArray();
     private final static String ctxProvider = "wolfJSSE";
@@ -246,14 +254,11 @@ public class WolfSSLSocketTest {
     public void testGetSupportedCipherSuites()
         throws NoSuchProviderException, NoSuchAlgorithmException {
 
-        System.out.print("\tgetSupportedCipherSuites()");
-
         for (int i = 0; i < socks.size(); i++) {
             SSLSocket s = socks.get(i);
             String[] cipherSuites = s.getSupportedCipherSuites();
 
             if (cipherSuites == null) {
-                System.out.println("\t... failed");
                 fail("SSLSocket.getSupportedCipherSuites() failed");
             }
 
@@ -261,21 +266,17 @@ public class WolfSSLSocketTest {
             assertNotSame(cipherSuites, s.getSupportedCipherSuites());
         }
 
-        System.out.println("\t... passed");
     }
 
     @Test
     public void testGetSetEnabledCipherSuites()
         throws NoSuchProviderException, NoSuchAlgorithmException {
 
-        System.out.print("\tget/setEnabledCipherSuites()");
-
         for (int i = 0; i < socks.size(); i++) {
             SSLSocket s = socks.get(i);
             String[] cipherSuites = s.getEnabledCipherSuites();
 
             if (cipherSuites == null) {
-                System.out.println("\t... failed");
                 fail("SSLSocket.getEnabledCipherSuites() failed");
             }
 
@@ -285,7 +286,6 @@ public class WolfSSLSocketTest {
             /* test failure, null input */
             try {
                 s.setEnabledCipherSuites(null);
-                System.out.println("\t... failed");
                 fail("SSLSocket.setEnabledCipherSuites() failed");
             } catch (IllegalArgumentException e) {
                 /* expected */
@@ -295,7 +295,6 @@ public class WolfSSLSocketTest {
             try {
                 String[] empty = {};
                 s.setEnabledCipherSuites(empty);
-                System.out.println("\t... failed");
                 fail("SSLSocket.setEnabledCipherSuites() failed");
             } catch (IllegalArgumentException e) {
                 /* expected */
@@ -305,7 +304,6 @@ public class WolfSSLSocketTest {
             try {
                 String[] badvalue = { "badvalue" };
                 s.setEnabledCipherSuites(badvalue);
-                System.out.println("\t... failed");
                 fail("SSLSocket.setEnabledCipherSuites() failed");
             } catch (IllegalArgumentException e) {
                 /* expected */
@@ -324,18 +322,14 @@ public class WolfSSLSocketTest {
             s.setEnabledCipherSuites(oneSuite);
             String[] after = s.getEnabledCipherSuites();
             if (after.length != 1 || !after[0].equals(oneSuite[0])) {
-                System.out.println("\t... failed");
                 fail("SSLSocket.setEnabledCipherSuites() failed");
             }
         }
 
-        System.out.println("\t... passed");
     }
 
     @Test
     public void testServerUsesClientCipherSuitePreference() throws Exception {
-
-        System.out.print("\tTesting client suite preference");
 
         this.ctx = tf.createSSLContext("TLS", "wolfJSSE");
 
@@ -374,9 +368,7 @@ public class WolfSSLSocketTest {
          * alias depending on wolfSSL configuration. */
         if (!"TLS_AES_256_GCM_SHA384".equals(chosen1) &&
             !"TLS13-AES256-GCM-SHA384".equals(chosen1)) {
-            System.out.println("\t... failed");
-            fail("Expected server preference cipher (AES_256), got "
-                  + chosen1);
+            fail("Expected server preference cipher (AES_256), got " + chosen1);
         }
 
         cs1.close();
@@ -412,9 +404,7 @@ public class WolfSSLSocketTest {
          * alias depending on wolfSSL configuration. */
         if (!"TLS_AES_128_GCM_SHA256".equals(chosen2) &&
             !"TLS13-AES128-GCM-SHA256".equals(chosen2)) {
-            System.out.println("\t... failed");
-            fail("Expected client preference cipher (AES_128), got "
-                 + chosen2);
+            fail("Expected client preference cipher (AES_128), got " + chosen2);
         }
 
         cs2.close();
@@ -422,21 +412,17 @@ public class WolfSSLSocketTest {
         ss2.close();
         es.shutdown();
 
-        System.out.println("\t... passed");
     }
 
     @Test
     public void testGetSupportedProtocols()
         throws NoSuchProviderException, NoSuchAlgorithmException {
 
-        System.out.print("\tgetSupportedProtocols()");
-
         for (int i = 0; i < socks.size(); i++) {
             SSLSocket s = socks.get(i);
             String[] protocols = s.getSupportedProtocols();
 
             if (protocols == null) {
-                System.out.println("\t\t... failed");
                 fail("SSLSocket.getSupportedProtocols() failed");
             }
 
@@ -444,21 +430,17 @@ public class WolfSSLSocketTest {
             assertNotSame(protocols, s.getSupportedProtocols());
         }
 
-        System.out.println("\t\t... passed");
     }
 
     @Test
     public void testGetSetEnabledProtocols()
         throws NoSuchProviderException, NoSuchAlgorithmException {
 
-        System.out.print("\tget/setEnabledProtocols()");
-
         for (int i = 0; i < socks.size(); i++) {
             SSLSocket s = socks.get(i);
             String[] protocols = s.getEnabledProtocols();
 
             if (protocols == null) {
-                System.out.println("\t... failed");
                 fail("SSLSocket.getEnabledProtocols() failed");
             }
 
@@ -468,7 +450,6 @@ public class WolfSSLSocketTest {
             /* test failure, null input */
             try {
                 s.setEnabledProtocols(null);
-                System.out.println("\t\t... failed");
                 fail("SSLSocket.setEnabledProtocols() failed");
             } catch (IllegalArgumentException e) {
                 /* expected */
@@ -481,7 +462,6 @@ public class WolfSSLSocketTest {
                 String[] empty = {};
                 s.setEnabledProtocols(empty);
             } catch (IllegalArgumentException e) {
-                System.out.println("\t\t... failed");
                 fail("SSLSocket.setEnabledProtocols() should accept empty");
             }
 
@@ -491,7 +471,6 @@ public class WolfSSLSocketTest {
             try {
                 String[] badvalue = { "badvalue" };
                 s.setEnabledProtocols(badvalue);
-                System.out.println("\t\t... failed");
                 fail("SSLSocket.setEnabledProtocols() failed");
             } catch (IllegalArgumentException e) {
                 /* expected */
@@ -510,7 +489,6 @@ public class WolfSSLSocketTest {
             s.setEnabledProtocols(oneProto);
             String[] after = s.getEnabledProtocols();
             if (after.length != 1 || !after[0].equals(oneProto[0])) {
-                System.out.println("\t... failed");
                 fail("SSLSocket.setEnabledProtocols() failed");
             }
 
@@ -524,7 +502,6 @@ public class WolfSSLSocketTest {
                     Security.setProperty(
                         "jdk.tls.disabledAlgorithms", "TLSv1");
                     s.setEnabledProtocols(new String[] {"TLSv1"});
-                    System.out.println("\t\t... failed");
                     fail("SSLSocket.setEnabledProtocols() failed");
                 } catch (IllegalArgumentException e) {
                     /* expected */
@@ -534,7 +511,6 @@ public class WolfSSLSocketTest {
                     Security.setProperty(
                         "jdk.tls.disabledAlgorithms", "TLSv1.1");
                     s.setEnabledProtocols(new String[] {"TLSv1.1"});
-                    System.out.println("\t\t... failed");
                     fail("SSLSocket.setEnabledProtocols() failed");
                 } catch (IllegalArgumentException e) {
                     /* expected */
@@ -544,7 +520,6 @@ public class WolfSSLSocketTest {
                     Security.setProperty(
                         "jdk.tls.disabledAlgorithms", "TLSv1.2");
                     s.setEnabledProtocols(new String[] {"TLSv1.2"});
-                    System.out.println("\t\t... failed");
                     fail("SSLSocket.setEnabledProtocols() failed");
                 } catch (IllegalArgumentException e) {
                     /* expected */
@@ -554,7 +529,6 @@ public class WolfSSLSocketTest {
                     Security.setProperty(
                         "jdk.tls.disabledAlgorithms", "TLSv1.3");
                     s.setEnabledProtocols(new String[] {"TLSv1.3"});
-                    System.out.println("\t\t... failed");
                     fail("SSLSocket.setEnabledProtocols() failed");
                 } catch (IllegalArgumentException e) {
                     /* expected */
@@ -566,7 +540,6 @@ public class WolfSSLSocketTest {
             }
         }
 
-        System.out.println("\t... passed");
     }
 
     @Test
@@ -579,8 +552,6 @@ public class WolfSSLSocketTest {
         Exception cliException = null;
         CountDownLatch sDoneLatch = null;
         CountDownLatch cDoneLatch = null;
-
-        System.out.print("\twolfjsse.enabledSupportedCurves");
 
         /* create new CTX */
         this.ctx = tf.createSSLContext("TLS", ctxProvider);
@@ -776,7 +747,6 @@ public class WolfSSLSocketTest {
             }
         }
 
-
         /* restore original property value */
         if (originalProperty == null) {
             /* set property to empty if original was not set */
@@ -786,7 +756,6 @@ public class WolfSSLSocketTest {
                 originalProperty);
         }
 
-        System.out.println("\t... passed");
     }
 
     @Test
@@ -794,8 +763,6 @@ public class WolfSSLSocketTest {
 
         CountDownLatch sDoneLatch = null;
         CountDownLatch cDoneLatch = null;
-
-        System.out.print("\tTesting basic client/server");
 
         /* create new CTX */
         this.ctx = tf.createSSLContext("TLS", ctxProvider);
@@ -839,7 +806,6 @@ public class WolfSSLSocketTest {
             fail("Threaded client/server test failed");
         }
 
-        System.out.println("\t... passed");
     }
 
     public void alpnClientServerRunner(TestArgs sArgs, TestArgs cArgs,
@@ -908,13 +874,8 @@ public class WolfSSLSocketTest {
         TestArgs sArgs = null;
         TestArgs cArgs = null;
 
-        System.out.print("\tTesting ALPN select callback");
-
         /* wolfSSL_set_alpn_select_cb() added in wolfSSL 5.6.6 */
-        if (WolfSSL.getLibVersionHex() < 0x05006006) {
-            System.out.println("\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.getLibVersionHex() >= 0x05006006);
 
         /* Successful test:
          * Sanity check, no ALPN */
@@ -992,7 +953,6 @@ public class WolfSSLSocketTest {
         cArgs.setExpectedAlpn(greaseString);
         alpnClientServerRunner(sArgs, cArgs, false);
 
-        System.out.println("\t... passed");
     }
 
     /**
@@ -1171,15 +1131,10 @@ public class WolfSSLSocketTest {
         failures.set(0, 0);
         success.set(0, 0);
 
-        System.out.print("\tTesting ExtendedThreadingUse");
-
         /* This test hangs on Android, marking TODO for later investigation.
          * Seems to be something specific to the test code, not library
          * proper. */
-        if (WolfSSLTestFactory.isAndroid()) {
-            System.out.println("\t... skipped");
-            return;
-        }
+        Assume.assumeFalse(WolfSSLTestFactory.isAndroid());
 
         /* Start up simple TLS test server */
         CountDownLatch serverOpenLatch = new CountDownLatch(1);
@@ -1224,9 +1179,7 @@ public class WolfSSLSocketTest {
         server.join(1000);
 
         /* check failure count and success count against thread count */
-        if (failures.get(0) == 0 && success.get(0) == numThreads) {
-            System.out.println("\t... passed");
-        } else {
+        if (failures.get(0) != 0 || success.get(0) != numThreads) {
             if (returnWithoutTimeout == true) {
                 fail("SSLSocket threading error: " +
                      failures.get(0) + " failures, " +
@@ -1240,8 +1193,6 @@ public class WolfSSLSocketTest {
 
     @Test
     public void testPreConsumedSocket() throws Exception {
-
-        System.out.print("\tTesting consumed InputStream");
 
         /* create new CTX */
         this.ctx = tf.createSSLContext("TLS", ctxProvider);
@@ -1288,13 +1239,10 @@ public class WolfSSLSocketTest {
                     server.close();
 
                     if (!Arrays.equals(outBytes, inBytes)) {
-                        System.out.println("\t... failed");
                         fail();
                     }
 
-
                 } catch (SSLException e) {
-                    System.out.println("\t... failed");
                     fail();
                 }
                 return null;
@@ -1314,12 +1262,10 @@ public class WolfSSLSocketTest {
             cs.close();
 
             if (!Arrays.equals(outBytes2, inBytes2)) {
-                System.out.println("\t... failed");
                 fail();
             }
 
         } catch (SSLHandshakeException e) {
-            System.out.println("\t... failed");
             fail();
         }
 
@@ -1327,13 +1273,10 @@ public class WolfSSLSocketTest {
         serverFuture.get();
         serverSock.close();
 
-        System.out.println("\t... passed");
     }
 
     @Test
     public void testCreateSocketNullHost() throws Exception {
-
-        System.out.print("\tcreateSocket(null host)");
 
         /* create new CTX */
         this.ctx = tf.createSSLContext("TLS", ctxProvider);
@@ -1351,20 +1294,17 @@ public class WolfSSLSocketTest {
         /* Try to convert client Socket to SSLSocket, with null hostname.
          * This should not throw any Exceptions, null host is ok. */
         SSLSocket ssc = (SSLSocket)ctx.getSocketFactory().createSocket(
-                cs, null, cs.getPort(), false);
+            cs, null, cs.getPort(), false);
 
         ssc.close();
         cs.close();
         socket.close();
         ss.close();
 
-        System.out.println("\t\t... passed");
     }
 
     @Test
     public void testEnableSessionCreation() throws Exception {
-
-        System.out.print("\tget/setEnableSessionCreation()");
 
         /* create new CTX */
         this.ctx = tf.createSSLContext("TLS", ctxProvider);
@@ -1399,7 +1339,6 @@ public class WolfSSLSocketTest {
             public Void call() throws Exception {
                 try {
                     server.startHandshake();
-                    System.out.println("\t... failed");
                     fail();
                 } catch (SSLException e) {
                     /* expected, SSLSocket not allowed to make new sessions */
@@ -1410,7 +1349,6 @@ public class WolfSSLSocketTest {
 
         try {
             cs.startHandshake();
-            System.out.println("\t... failed");
             fail();
 
         } catch (SSLHandshakeException e) {
@@ -1423,13 +1361,10 @@ public class WolfSSLSocketTest {
         server.close();
         ss.close();
 
-        System.out.println("\t... passed");
     }
 
     @Test
     public void testSetUseClientMode() throws Exception {
-
-        System.out.print("\tget/setUseClientMode()");
 
         /* create new CTX */
         this.ctx = tf.createSSLContext("TLS", "wolfJSSE");
@@ -1464,7 +1399,6 @@ public class WolfSSLSocketTest {
             public Void call() throws Exception {
                 try {
                     server.startHandshake();
-                    System.out.println("\t\t... failed");
                     fail();
                 } catch (SSLHandshakeException e) {
                     /* expected: Out of order message, fatal */
@@ -1475,7 +1409,6 @@ public class WolfSSLSocketTest {
 
         try {
             cs.startHandshake();
-            System.out.println("\t\t... failed");
             fail();
 
         } catch (SSLHandshakeException e) {
@@ -1504,7 +1437,6 @@ public class WolfSSLSocketTest {
                 try {
                     server2.startHandshake();
                     server2.setUseClientMode(true);
-                    System.out.println("\t\t... failed");
                     fail();
                 } catch (IllegalArgumentException e) {
                     /* expected */
@@ -1517,7 +1449,6 @@ public class WolfSSLSocketTest {
             cs.startHandshake();
 
         } catch (SSLHandshakeException e) {
-            System.out.println("\t\t... failed");
             fail();
         }
 
@@ -1527,13 +1458,10 @@ public class WolfSSLSocketTest {
         server2.close();
         ss.close();
 
-        System.out.println("\t\t... passed");
     }
 
     @Test
     public void testGetSSLParameters() throws Exception {
-
-        System.out.print("\tget/setSSLParameters()");
 
         /* create new CTX, SSLSocket */
         this.ctx = tf.createSSLContext("TLS", "wolfJSSE");
@@ -1582,13 +1510,10 @@ public class WolfSSLSocketTest {
 
         s.close();
 
-        System.out.println("\t\t... passed");
     }
 
     @Test
     public void testAddHandshakeCompletedListener() throws Exception {
-
-        System.out.print("\taddHandshakeCompletedListener()");
 
         /* create new CTX */
         this.ctx = tf.createSSLContext("TLS", ctxProvider);
@@ -1614,7 +1539,6 @@ public class WolfSSLSocketTest {
         /* test failure on null argument */
         try {
             cs.addHandshakeCompletedListener(null);
-            System.out.println("\t... failed");
             fail();
         } catch (IllegalArgumentException e) {
             /* expected */
@@ -1624,7 +1548,6 @@ public class WolfSSLSocketTest {
         try {
             cs.addHandshakeCompletedListener(clientListener);
         } catch (IllegalArgumentException e) {
-            System.out.println("\t... failed");
             fail();
         }
 
@@ -1642,7 +1565,6 @@ public class WolfSSLSocketTest {
         /* test failure on null argument */
         try {
             server.addHandshakeCompletedListener(null);
-            System.out.println("\t... failed");
             fail();
         } catch (IllegalArgumentException e) {
             /* expected */
@@ -1652,7 +1574,6 @@ public class WolfSSLSocketTest {
         try {
             server.addHandshakeCompletedListener(serverListener);
         } catch (IllegalArgumentException e) {
-            System.out.println("\t... failed");
             fail();
         }
 
@@ -1662,9 +1583,7 @@ public class WolfSSLSocketTest {
             public Void call() throws Exception {
                 try {
                     server.startHandshake();
-
                 } catch (SSLException e) {
-                    System.out.println("\t... failed");
                     fail();
                 }
                 return null;
@@ -1675,7 +1594,6 @@ public class WolfSSLSocketTest {
             cs.startHandshake();
 
         } catch (SSLHandshakeException e) {
-            System.out.println("\t... failed");
             fail();
         }
 
@@ -1687,7 +1605,6 @@ public class WolfSSLSocketTest {
 
         /* verify that handshake listeners were called */
         if (clientFlag != true || serverFlag != true) {
-            System.out.println("\t... failed");
             fail();
         }
 
@@ -1695,21 +1612,18 @@ public class WolfSSLSocketTest {
         try {
             server.removeHandshakeCompletedListener(serverListener);
         } catch (IllegalArgumentException e) {
-            System.out.println("\t... failed");
             fail();
         }
 
         try {
             cs.removeHandshakeCompletedListener(clientListener);
         } catch (IllegalArgumentException e) {
-            System.out.println("\t... failed");
             fail();
         }
 
         /* should throw exception if we remove one not registered */
         try {
             server.removeHandshakeCompletedListener(serverListener);
-            System.out.println("\t... failed");
             fail();
         } catch (IllegalArgumentException e) {
             /* expected */
@@ -1718,19 +1632,15 @@ public class WolfSSLSocketTest {
         /* should throw exception if we use null argument */
         try {
             server.removeHandshakeCompletedListener(null);
-            System.out.println("\t... failed");
             fail();
         } catch (IllegalArgumentException e) {
             /* expected */
         }
 
-        System.out.println("\t... passed");
     }
 
     @Test
     public void testGetSession() throws Exception {
-
-        System.out.print("\tgetSession()");
 
         /* create new CTX */
         this.ctx = tf.createSSLContext("TLS", ctxProvider);
@@ -1758,7 +1668,6 @@ public class WolfSSLSocketTest {
                     server.close();
 
                 } catch (SSLException e) {
-                    System.out.println("\t\t\t... failed");
                     fail();
                 }
                 return null;
@@ -1775,7 +1684,6 @@ public class WolfSSLSocketTest {
             cs.close();
 
         } catch (SSLHandshakeException e) {
-            System.out.println("\t\t\t... failed");
             fail();
         }
 
@@ -1813,7 +1721,6 @@ public class WolfSSLSocketTest {
                     server2.close();
 
                 } catch (SSLException e) {
-                    System.out.println("\t\t\t... failed");
                     fail();
                 }
                 return null;
@@ -1829,14 +1736,12 @@ public class WolfSSLSocketTest {
             Certificate[] certs = cliSess.getPeerCertificates();
             assertNotNull(certs);
             if (certs.length == 0) {
-                System.out.println("\t\t\t... failed");
                 fail();
             }
 
             cs.close();
 
         } catch (SSLHandshakeException e) {
-            System.out.println("\t\t\t... failed");
             fail();
         }
 
@@ -1844,13 +1749,10 @@ public class WolfSSLSocketTest {
         serverFuture.get();
         ss.close();
 
-        System.out.println("\t\t\t... passed");
     }
 
     @Test
     public void testSetNeedClientAuth() throws Exception {
-
-        System.out.print("\tsetNeedClientAuth()");
 
         /* create ctx, uses client keystore (cert/key) and truststore (cert) */
         this.ctx = tf.createSSLContext("TLSv1.2", ctxProvider);
@@ -1876,7 +1778,6 @@ public class WolfSSLSocketTest {
                     server.close();
 
                 } catch (SSLException e) {
-                    System.out.println("\t... failed");
                     fail();
                 }
                 return null;
@@ -1888,7 +1789,6 @@ public class WolfSSLSocketTest {
             cs.close();
 
         } catch (SSLHandshakeException e) {
-            System.out.println("\t... failed");
             fail();
         }
 
@@ -1919,7 +1819,6 @@ public class WolfSSLSocketTest {
             public Void call() throws Exception {
                 try {
                     server2.startHandshake();
-                    System.out.println("\t\t... failed");
                     fail();
 
                 } catch (SSLException e) {
@@ -1932,7 +1831,6 @@ public class WolfSSLSocketTest {
 
         try {
             cs.startHandshake();
-            System.out.println("\t\t... failed");
             fail();
 
         } catch (SSLHandshakeException e) {
@@ -1976,7 +1874,6 @@ public class WolfSSLSocketTest {
                     server3.close();
 
                 } catch (SSLException e) {
-                    System.out.println("\t\t... failed");
                     fail();
                 }
                 return null;
@@ -1988,7 +1885,6 @@ public class WolfSSLSocketTest {
             cs.close();
 
         } catch (SSLHandshakeException e) {
-            System.out.println("\t\t... failed");
             fail();
         }
 
@@ -1996,19 +1892,13 @@ public class WolfSSLSocketTest {
         serverFuture.get();
         ss.close();
 
-        System.out.println("\t\t... passed");
     }
 
     @Test
     public void testProtocolTLSv10() throws Exception {
 
-        System.out.print("\tTLS 1.0 connection test");
-
         /* skip if TLS 1.0 is not compiled in at native level */
-        if (WolfSSL.TLSv1Enabled() == false) {
-            System.out.println("\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.TLSv1Enabled());
 
         /* reset disabledAlgorithms property to test TLS 1.0 which is
          * disabled by default */
@@ -2019,7 +1909,6 @@ public class WolfSSLSocketTest {
 
             protocolConnectionTest("TLSv1");
 
-            System.out.print("\tTLS 1.0 extended Socket test");
             protocolConnectionTestExtendedSocket("TLSv1");
 
             /* restore system property if it was originally set */
@@ -2033,13 +1922,8 @@ public class WolfSSLSocketTest {
     @Test
     public void testProtocolTLSv11() throws Exception {
 
-        System.out.print("\tTLS 1.1 connection test");
-
         /* skip if TLS 1.1 is not compiled in at native level */
-        if (WolfSSL.TLSv11Enabled() == false) {
-            System.out.println("\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.TLSv11Enabled());
 
         /* reset disabledAlgorithms property to test TLS 1.1 which is
          * disabled by default */
@@ -2050,7 +1934,6 @@ public class WolfSSLSocketTest {
 
             protocolConnectionTest("TLSv1.1");
 
-            System.out.print("\tTLS 1.1 extended Socket test");
             protocolConnectionTestExtendedSocket("TLSv1.1");
 
             /* restore system property if it was originally set */
@@ -2064,20 +1947,14 @@ public class WolfSSLSocketTest {
     @Test
     public void testProtocolTLSv12() throws Exception {
 
-        System.out.print("\tTLS 1.2 connection test");
-
         /* skip if TLS 1.2 is not compiled in at native level */
         synchronized (WolfSSLTestFactory.jdkTlsDisabledAlgorithmsLock) {
-            if (WolfSSL.TLSv12Enabled() == false ||
-                WolfSSLTestFactory.securityPropContains(
-                    "jdk.tls.disabledAlgorithms", "TLSv1.2")) {
-                System.out.println("\t\t... skipped");
-                return;
-            }
+            Assume.assumeTrue(WolfSSL.TLSv12Enabled());
+            Assume.assumeFalse(WolfSSLTestFactory.securityPropContains(
+                "jdk.tls.disabledAlgorithms", "TLSv1.2"));
 
             protocolConnectionTest("TLSv1.2");
 
-            System.out.print("\tTLS 1.2 extended Socket test");
             protocolConnectionTestExtendedSocket("TLSv1.2");
         }
     }
@@ -2085,20 +1962,14 @@ public class WolfSSLSocketTest {
     @Test
     public void testProtocolTLSv13() throws Exception {
 
-        System.out.print("\tTLS 1.3 connection test");
-
         /* skip if TLS 1.3 is not compiled in at native level */
         synchronized (WolfSSLTestFactory.jdkTlsDisabledAlgorithmsLock) {
-            if (WolfSSL.TLSv13Enabled() == false ||
-                WolfSSLTestFactory.securityPropContains(
-                    "jdk.tls.disabledAlgorithms", "TLSv1.3")) {
-                System.out.println("\t\t... skipped");
-                return;
-            }
+            Assume.assumeTrue(WolfSSL.TLSv13Enabled());
+            Assume.assumeFalse(WolfSSLTestFactory.securityPropContains(
+                "jdk.tls.disabledAlgorithms", "TLSv1.3"));
 
             protocolConnectionTest("TLSv1.3");
 
-            System.out.print("\tTLS 1.3 extended Socket test");
             protocolConnectionTestExtendedSocket("TLSv1.3");
         }
     }
@@ -2122,9 +1993,7 @@ public class WolfSSLSocketTest {
             public Void call() throws Exception {
                 try {
                     server.startHandshake();
-
                 } catch (SSLException e) {
-                    System.out.println("\t\t... failed");
                     fail();
                 }
                 return null;
@@ -2135,7 +2004,6 @@ public class WolfSSLSocketTest {
             cs.startHandshake();
 
         } catch (SSLHandshakeException e) {
-            System.out.println("\t\t... failed");
             fail();
         }
 
@@ -2145,7 +2013,6 @@ public class WolfSSLSocketTest {
         server.close();
         ss.close();
 
-        System.out.println("\t\t... passed");
     }
 
     /**
@@ -2256,7 +2123,6 @@ public class WolfSSLSocketTest {
                     server.close();
 
                 } catch (SSLException e) {
-                    System.out.println("\t... failed");
                     fail();
                 }
                 return null;
@@ -2268,7 +2134,6 @@ public class WolfSSLSocketTest {
             cs.close();
 
         } catch (SSLHandshakeException e) {
-            System.out.println("\t... failed");
             fail();
         }
 
@@ -2276,13 +2141,10 @@ public class WolfSSLSocketTest {
         serverFuture.get();
         ss.close();
 
-        System.out.println("\t... passed");
     }
 
     @Test
     public void testConnectionWithDisabledAlgorithms() throws Exception {
-
-        System.out.print("\tConnect with disabled algos");
 
         /* create new CTX */
         this.ctx = tf.createSSLContext("TLS", ctxProvider);
@@ -2310,14 +2172,13 @@ public class WolfSSLSocketTest {
 
                 /* disable protocol after socket setup, should fail conn */
                 Security.setProperty("jdk.tls.disabledAlgorithms",
-                        enabledProtocols.get(i));
+                    enabledProtocols.get(i));
 
                 /* don't need server since should throw exception before */
                 cs.connect(new InetSocketAddress(ss.getLocalPort()));
 
                 try {
                     cs.startHandshake();
-                    System.out.println("\t... failed");
                     fail();
 
                 } catch (SSLException e) {
@@ -2334,7 +2195,6 @@ public class WolfSSLSocketTest {
                 "jdk.tls.disabledAlgorithms", originalProperty);
         }
 
-        System.out.println("\t... passed");
     }
 
     @Test
@@ -2343,8 +2203,6 @@ public class WolfSSLSocketTest {
         byte[] sessionID1 = null;
         byte[] sessionID2 = null;
         String protocol = null;
-
-        System.out.print("\tTesting session resumption");
 
         /* use TLS 1.2, else 1.1, else 1.0, else skip */
         /* TODO: TLS 1.3 handles session resumption differently */
@@ -2355,10 +2213,8 @@ public class WolfSSLSocketTest {
             protocol = "TLSv1.1";
         } else if (WolfSSL.TLSv1Enabled()) {
             protocol = "TLSv1.0";
-        } else {
-            System.out.println("\t\t... skipped");
-            return;
         }
+        Assume.assumeNotNull(protocol);
 
         /* wolfjsse.clientSessionCache.disabled could be set in users
          * java.security file which would cause this test to not work
@@ -2396,7 +2252,6 @@ public class WolfSSLSocketTest {
                         }
 
                     } catch (SSLException e) {
-                        System.out.println("\t... failed");
                         fail();
                     }
                     return null;
@@ -2419,21 +2274,16 @@ public class WolfSSLSocketTest {
 
                 if (!Arrays.equals(sessionID1, sessionID2)) {
                     /* session not resumed */
-                    System.out.println("\t... failed");
                     fail();
                 }
 
             } catch (SSLHandshakeException e) {
-                System.out.println("\t... failed");
                 fail();
             }
-
 
             es.shutdown();
             serverFuture.get();
             ss.close();
-
-            System.out.println("\t... passed");
 
         } finally {
             if (originalProp != null && !originalProp.isEmpty()) {
@@ -2450,8 +2300,6 @@ public class WolfSSLSocketTest {
         byte[] sessionID2 = null;
         String protocol = null;
 
-        System.out.print("\tDisabling client session cache");
-
         /* Use TLS 1.2, else 1.1, else 1.0, else skip */
         if (WolfSSL.TLSv12Enabled()) {
             protocol = "TLSv1.2";
@@ -2459,10 +2307,8 @@ public class WolfSSLSocketTest {
             protocol = "TLSv1.1";
         } else if (WolfSSL.TLSv1Enabled()) {
             protocol = "TLSv1.0";
-        } else {
-            System.out.println("\t\t... skipped");
-            return;
         }
+        Assume.assumeNotNull(protocol);
 
         /* Save original Security property value */
         String originalProp = Security.getProperty(
@@ -2499,7 +2345,6 @@ public class WolfSSLSocketTest {
                         }
 
                     } catch (SSLException e) {
-                        System.out.println("\t... failed");
                         fail();
                     }
                     return null;
@@ -2522,21 +2367,16 @@ public class WolfSSLSocketTest {
 
                 if (Arrays.equals(sessionID1, sessionID2)) {
                     /* session resumed, but should not */
-                    System.out.println("\t... failed");
                     fail();
                 }
 
             } catch (SSLHandshakeException e) {
-                System.out.println("\t... failed");
                 fail();
             }
-
 
             es.shutdown();
             serverFuture.get();
             ss.close();
-
-            System.out.println("\t... passed");
 
         } finally {
             if (originalProp != null && !originalProp.isEmpty()) {
@@ -2560,8 +2400,6 @@ public class WolfSSLSocketTest {
         byte[] sessionID2 = null;
         String protocol = null;
 
-        System.out.print("\tresumption with tickets enabled");
-
         /* use TLS 1.2, else 1.1, else 1.0, else skip */
         /* TODO: TLS 1.3 handles session resumption differently */
 
@@ -2571,10 +2409,8 @@ public class WolfSSLSocketTest {
             protocol = "TLSv1.1";
         } else if (WolfSSL.TLSv1Enabled()) {
             protocol = "TLSv1.0";
-        } else {
-            System.out.println("\t\t... skipped");
-            return;
         }
+        Assume.assumeNotNull(protocol);
 
         /* wolfjsse.clientSessionCache.disabled could be set in users
          * java.security file which would cause this test to not work
@@ -2613,7 +2449,6 @@ public class WolfSSLSocketTest {
                         }
 
                     } catch (SSLException e) {
-                        System.out.println("\t... failed");
                         fail();
                     }
                     return null;
@@ -2637,21 +2472,16 @@ public class WolfSSLSocketTest {
 
                 if (!Arrays.equals(sessionID1, sessionID2)) {
                     /* session not resumed */
-                    System.out.println("\t... failed");
                     fail();
                 }
 
             } catch (SSLHandshakeException e) {
-                System.out.println("\t... failed");
                 fail();
             }
-
 
             es.shutdown();
             serverFuture.get();
             ss.close();
-
-            System.out.println("\t... passed");
 
         } finally {
             if (originalProp != null && !originalProp.isEmpty()) {
@@ -2666,18 +2496,14 @@ public class WolfSSLSocketTest {
 
         String protocol = null;
 
-        System.out.print("\tTesting duplicate close");
-
         if (WolfSSL.TLSv12Enabled()) {
             protocol = "TLSv1.2";
         } else if (WolfSSL.TLSv11Enabled()) {
             protocol = "TLSv1.1";
         } else if (WolfSSL.TLSv1Enabled()) {
             protocol = "TLSv1.0";
-        } else {
-            System.out.println("\t\t... skipped");
-            return;
         }
+        Assume.assumeNotNull(protocol);
 
         /* create new CTX */
         this.ctx = tf.createSSLContext(protocol, ctxProvider);
@@ -2698,7 +2524,6 @@ public class WolfSSLSocketTest {
                     server.startHandshake();
 
                 } catch (SSLException e) {
-                    System.out.println("\t\t... failed");
                     fail();
                 }
                 return null;
@@ -2709,7 +2534,6 @@ public class WolfSSLSocketTest {
             cs.startHandshake();
 
         } catch (SSLHandshakeException e) {
-            System.out.println("\t\t... failed");
             fail();
         }
 
@@ -2720,13 +2544,10 @@ public class WolfSSLSocketTest {
         ss.close();
         cs.close();
 
-        System.out.println("\t\t... passed");
     }
 
     @Test
     public void testSocketConnectException() throws Exception {
-
-        System.out.print("\tTesting for ConnectException");
 
         this.ctx = tf.createSSLContext("TLS", ctxProvider);
         SocketFactory sf = this.ctx.getSocketFactory();
@@ -2740,19 +2561,14 @@ public class WolfSSLSocketTest {
             /* expected */
         } catch (Exception e) {
             /* other Exceptions (ie NullPointerException) are unexpected */
-            System.out.println("\t... failed");
             e.printStackTrace();
             fail();
         }
 
-        System.out.println("\t... passed");
     }
-
 
     @Test
     public void testClientServerUsingSystemProperties() throws Exception {
-
-        System.out.print("\tSystem Property Store Support");
 
         System.setProperty("javax.net.ssl.trustStore", tf.clientJKS);
         System.setProperty("javax.net.ssl.trustStoreType", tf.keyStoreType);
@@ -2786,7 +2602,6 @@ public class WolfSSLSocketTest {
                     server.startHandshake();
 
                 } catch (SSLException e) {
-                    System.out.println("\t... failed");
                     fail();
                 }
                 return null;
@@ -2797,7 +2612,6 @@ public class WolfSSLSocketTest {
             cs.startHandshake();
 
         } catch (SSLHandshakeException e) {
-            System.out.println("\t... failed");
             fail();
         }
 
@@ -2825,7 +2639,6 @@ public class WolfSSLSocketTest {
             /* not specifying TrustStore and KeyStore, expect to load from
              * system properties set above */
             ctx.init(null, null, null);
-            System.out.println("\t... failed");
             fail();
         } catch (KeyManagementException e) {
             /* expected: java.io.IOException: keystore password was incorrect */
@@ -2850,7 +2663,6 @@ public class WolfSSLSocketTest {
             /* not specifying TrustStore and KeyStore, expect to load from
              * system properties set above */
             ctx.init(null, null, null);
-            System.out.println("\t... failed");
             fail();
         } catch (KeyManagementException e) {
             /* expected: java.io.IOException: keystore password was incorrect */
@@ -2875,7 +2687,6 @@ public class WolfSSLSocketTest {
             /* not specifying TrustStore and KeyStore, expect to load from
              * system properties set above */
             ctx.init(null, null, null);
-            System.out.println("\t... failed");
             fail();
         } catch (KeyManagementException e) {
             /* expected: java.io.IOException: keystore password was incorrect */
@@ -2899,7 +2710,6 @@ public class WolfSSLSocketTest {
             /* not specifying TrustStore and KeyStore, expect to load from
              * system properties set above */
             ctx.init(null, null, null);
-            System.out.println("\t... failed");
             fail();
         } catch (KeyManagementException e) {
             /* expected: java.io.IOException: keystore password was incorrect */
@@ -2924,7 +2734,6 @@ public class WolfSSLSocketTest {
             /* not specifying TrustStore and KeyStore, expect to load from
              * system properties set above */
             ctx.init(null, null, null);
-            System.out.println("\t... failed");
             fail();
         } catch (KeyManagementException e) {
             /* expected: java.io.IOException: keystore password was incorrect */
@@ -2949,7 +2758,6 @@ public class WolfSSLSocketTest {
             /* not specifying TrustStore and KeyStore, expect to load from
              * system properties set above */
             ctx.init(null, null, null);
-            System.out.println("\t... failed");
             fail();
         } catch (KeyManagementException e) {
             /* expected: java.io.IOException: keystore password was incorrect */
@@ -2963,7 +2771,6 @@ public class WolfSSLSocketTest {
         System.clearProperty("javax.net.ssl.keyStoreType");
         System.clearProperty("javax.net.ssl.keyStorePassword");
 
-        System.out.println("\t... passed");
     }
 
     /* Test timeout set to 10000 ms (10 sec) in case inerrupt code is not
@@ -2976,15 +2783,10 @@ public class WolfSSLSocketTest {
         SSLServerSocket ss = null;
         boolean passed = false;
 
-        System.out.print("\tTesting close/write interrupt");
-
         /* pipe() interrupt mechamism not implemented for Windows yet since
          * Windows does not support Unix/Linux pipe(). Re-enable this test
          * for Windows when that support has been added */
-        if (WolfSSLTestFactory.isWindows()) {
-            System.out.println("\t... skipped");
-            return;
-        }
+        Assume.assumeFalse(WolfSSLTestFactory.isWindows());
 
         if (WolfSSL.TLSv12Enabled()) {
             protocol = "TLSv1.2";
@@ -2992,10 +2794,8 @@ public class WolfSSLSocketTest {
             protocol = "TLSv1.1";
         } else if (WolfSSL.TLSv1Enabled()) {
             protocol = "TLSv1.0";
-        } else {
-            System.out.println("\t... skipped");
-            return;
         }
+        Assume.assumeNotNull(protocol);
 
         /* create new CTX */
         this.ctx = tf.createSSLContext(protocol, ctxProvider);
@@ -3031,7 +2831,6 @@ public class WolfSSLSocketTest {
                     cs.close();
 
                 } catch (SSLException e) {
-                    System.out.println("\t... failed");
                     e.printStackTrace();
                     fail("Server thread got SSLException when not expected");
                 }
@@ -3049,7 +2848,6 @@ public class WolfSSLSocketTest {
                 out.write(tmpArr);
             }
             catch (Exception e) {
-                System.out.println("\t... failed");
                 e.printStackTrace();
                 fail("Exception from first out.write() when not expected");
             }
@@ -3066,8 +2864,9 @@ public class WolfSSLSocketTest {
             } catch (SocketException e) {
                 /* We expect SocketException with this message, error if
                  * different than expected */
-                if (!e.getMessage().contains("Socket fd closed during poll")) {
-                    System.out.println("\t... failed");
+                String msg = e.getMessage();
+                if (msg == null ||
+                    !msg.contains("Socket fd closed during poll")) {
                     e.printStackTrace();
                     fail("Incorrect SocketException thrown by client");
                     throw e;
@@ -3089,10 +2888,6 @@ public class WolfSSLSocketTest {
                 ss.close();
             }
         }
-
-        if (passed) {
-            System.out.println("\t... passed");
-        }
     }
 
     /* Test timeout set to 10000 ms (10 sec) in case inerrupt code is not
@@ -3106,15 +2901,10 @@ public class WolfSSLSocketTest {
         SSLServerSocket ss = null;
         boolean passed = false;
 
-        System.out.print("\tTesting close/read interrupt");
-
         /* pipe() interrupt mechamism not implemented for Windows yet since
          * Windows does not support Unix/Linux pipe(). Re-enable this test
          * for Windows when that support has been added */
-        if (WolfSSLTestFactory.isWindows()) {
-            System.out.println("\t... skipped");
-            return;
-        }
+        Assume.assumeFalse(WolfSSLTestFactory.isWindows());
 
         if (WolfSSL.TLSv12Enabled()) {
             protocol = "TLSv1.2";
@@ -3122,10 +2912,8 @@ public class WolfSSLSocketTest {
             protocol = "TLSv1.1";
         } else if (WolfSSL.TLSv1Enabled()) {
             protocol = "TLSv1.0";
-        } else {
-            System.out.println("\t... skipped");
-            return;
         }
+        Assume.assumeNotNull(protocol);
 
         /* create new CTX */
         this.ctx = tf.createSSLContext(protocol, ctxProvider);
@@ -3160,7 +2948,6 @@ public class WolfSSLSocketTest {
                     cs.close();
 
                 } catch (SSLException e) {
-                    System.out.println("\t... failed");
                     e.printStackTrace();
                     fail("Server thread got SSLException when not expected");
                 }
@@ -3176,7 +2963,6 @@ public class WolfSSLSocketTest {
                 cs.startHandshake();
             }
             catch (Exception e) {
-                System.out.println("\t... failed");
                 e.printStackTrace();
                 fail("Exception from startHandshake() when not expected");
             }
@@ -3196,10 +2982,11 @@ public class WolfSSLSocketTest {
             } catch (SocketException e) {
                 /* We expect SocketException with this message, error if
                  * different than expected */
-                if (!e.getMessage().contains("Socket is closed") &&
-                    !e.getMessage().contains("Connection already shutdown") &&
-                    !e.getMessage().contains("object has been freed")) {
-                    System.out.println("\t... failed");
+                String msg = e.getMessage();
+                if (msg == null ||
+                    (!msg.contains("Socket is closed") &&
+                     !msg.contains("Connection already shutdown") &&
+                     !msg.contains("object has been freed"))) {
                     e.printStackTrace();
                     fail("Incorrect SocketException thrown by client");
                     throw e;
@@ -3221,10 +3008,6 @@ public class WolfSSLSocketTest {
                 ss.close();
             }
         }
-
-        if (passed) {
-            System.out.println("\t... passed");
-        }
     }
 
     @Test
@@ -3232,18 +3015,14 @@ public class WolfSSLSocketTest {
 
         String protocol = null;
 
-        System.out.print("\tTesting methods after close");
-
         if (WolfSSL.TLSv12Enabled()) {
             protocol = "TLSv1.2";
         } else if (WolfSSL.TLSv11Enabled()) {
             protocol = "TLSv1.1";
         } else if (WolfSSL.TLSv1Enabled()) {
             protocol = "TLSv1.0";
-        } else {
-            System.out.println("\t... skipped");
-            return;
         }
+        Assume.assumeNotNull(protocol);
 
         /* create new CTX */
         this.ctx = tf.createSSLContext(protocol, ctxProvider);
@@ -3262,9 +3041,7 @@ public class WolfSSLSocketTest {
             public Void call() throws Exception {
                 try {
                     server.startHandshake();
-
                 } catch (SSLException e) {
-                    System.out.println("\t... failed");
                     fail();
                 }
                 return null;
@@ -3275,7 +3052,6 @@ public class WolfSSLSocketTest {
             cs.startHandshake();
 
         } catch (SSLHandshakeException e) {
-            System.out.println("\t... failed");
             fail();
         }
 
@@ -3292,7 +3068,6 @@ public class WolfSSLSocketTest {
             cs.getApplicationProtocol();
         } catch (Exception e) {
             /* should not throw exception */
-            System.out.println("\t... failed");
             fail("getApplicationProtocol() exception after close()");
         }
 
@@ -3300,7 +3075,6 @@ public class WolfSSLSocketTest {
             cs.getEnableSessionCreation();
         } catch (Exception e) {
             /* should not throw exception */
-            System.out.println("\t... failed");
             fail("getEnableSessionCreation() exception after close()");
         }
 
@@ -3308,18 +3082,15 @@ public class WolfSSLSocketTest {
             cs.setEnableSessionCreation(true);
         } catch (Exception e) {
             /* should not throw exception */
-            System.out.println("\t... failed");
             fail("setEnableSessionCreation() exception after close()");
         }
 
         try {
             if (cs.getWantClientAuth() != false) {
-                System.out.println("\t... failed");
                 fail("getWantClientAuth() not false after close()");
             }
         } catch (Exception e) {
             /* should not throw exception */
-            System.out.println("\t... failed");
             fail("getWantClientAuth() exception after close()");
         }
 
@@ -3327,18 +3098,15 @@ public class WolfSSLSocketTest {
             cs.setWantClientAuth(true);
         } catch (Exception e) {
             /* should not throw exception */
-            System.out.println("\t... failed");
             fail("setWantClientAuth() exception after close()");
         }
 
         try {
             if (cs.getNeedClientAuth() != false) {
-                System.out.println("\t... failed");
                 fail("getNeedClientAuth() not false after close()");
             }
         } catch (Exception e) {
             /* should not throw exception */
-            System.out.println("\t... failed");
             fail("getNeedClientAuth() exception after close()");
         }
 
@@ -3346,18 +3114,15 @@ public class WolfSSLSocketTest {
             cs.setNeedClientAuth(true);
         } catch (Exception e) {
             /* should not throw exception */
-            System.out.println("\t... failed");
             fail("setNeedClientAuth() exception after close()");
         }
 
         try {
             if (cs.getUseClientMode() != true) {
-                System.out.println("\t... failed");
                 fail("getUseClientMode() on client not true after close()");
             }
         } catch (Exception e) {
             /* should not throw exception */
-            System.out.println("\t... failed");
             fail("getUseClientMode() exception after close()");
         }
 
@@ -3365,18 +3130,15 @@ public class WolfSSLSocketTest {
             cs.setUseClientMode(true);
         } catch (Exception e) {
             /* should not throw exception */
-            System.out.println("\t... failed");
             fail("setUseClientMode() exception after close()");
         }
 
         try {
             if (cs.getHandshakeSession() != null) {
-                System.out.println("\t... failed");
                 fail("getHandshakeSession() not null after close()");
             }
         } catch (Exception e) {
             /* should not throw exception */
-            System.out.println("\t... failed");
             fail("getHandshakeSession() exception after close()");
         }
 
@@ -3384,23 +3146,19 @@ public class WolfSSLSocketTest {
             SSLSession closeSess = cs.getSession();
             if (closeSess == null ||
                 !closeSess.getCipherSuite().equals("SSL_NULL_WITH_NULL_NULL")) {
-                System.out.println("\t... failed");
                 fail("getSession() null or wrong cipher suite after close()");
             }
         } catch (Exception e) {
             /* should not throw exception */
-            System.out.println("\t... failed");
             fail("getSession() exception after close()");
         }
 
         try {
             if (cs.getEnabledProtocols() != null) {
-                System.out.println("\t... failed");
                 fail("getEnabledProtocols() not null after close()");
             }
         } catch (Exception e) {
             /* should not throw exception */
-            System.out.println("\t... failed");
             fail("getEnabledProtocols() exception after close()");
         }
 
@@ -3408,7 +3166,6 @@ public class WolfSSLSocketTest {
             cs.setEnabledProtocols(new String[] {"INVALID"});
         } catch (Exception e) {
             /* should not throw exception */
-            System.out.println("\t... failed");
             fail("setEnabledProtocols() exception after close()");
         }
 
@@ -3416,50 +3173,41 @@ public class WolfSSLSocketTest {
             cs.setEnabledCipherSuites(new String[] {"INVALID"});
         } catch (Exception e) {
             /* should not throw exception */
-            System.out.println("\t... failed");
             fail("setEnabledCipherSuites() exception after close()");
         }
 
         try {
             String[] suppProtos = cs.getSupportedProtocols();
             if (suppProtos == null || suppProtos.length == 0) {
-                System.out.println("\t... failed");
                 fail("getSupportedProtocols() null or empty after close()");
             }
         } catch (Exception e) {
             /* should not throw exception */
-            System.out.println("\t... failed");
             fail("getSupportedProtocols() exception after close()");
         }
 
         try {
             String[] suppSuites = cs.getSupportedCipherSuites();
             if (suppSuites == null || suppSuites.length == 0) {
-                System.out.println("\t... failed");
                 fail("getSupportedCipherSuites() null or empty after close()");
             }
         } catch (Exception e) {
             /* should not throw exception */
-            System.out.println("\t... failed");
             fail("getSupportedCipherSuites() exception after close()");
         }
 
         try {
             if (cs.getEnabledCipherSuites() != null) {
-                System.out.println("\t... failed");
                 fail("getEnabledCipherSuites() not null after close()");
             }
         } catch (Exception e) {
             /* should not throw exception */
-            System.out.println("\t... failed");
             fail("getEnabledCipherSuites() exception after close()");
         }
 
-        System.out.println("\t... passed");
     }
     @Test
     public void testAutoSNIProperty() throws Exception {
-        System.out.print("\tTesting autoSNI property");
 
         /* Save original System property value */
         String originalProp = System.getProperty("wolfjsse.autoSNI");
@@ -3523,8 +3271,7 @@ public class WolfSSLSocketTest {
             sDoneLatch = new CountDownLatch(1);
             cDoneLatch = new CountDownLatch(1);
 
-            server = new TestServer(this.ctx, ss, sArgs,
-                            1, sDoneLatch);
+            server = new TestServer(this.ctx, ss, sArgs, 1, sDoneLatch);
             server.start();
 
             client = new TestClient(this.ctx, ss.getLocalPort(), cArgs,
@@ -3544,8 +3291,6 @@ public class WolfSSLSocketTest {
                 throw cliException;
             }
 
-            System.out.println("\t... passed");
-
         } finally {
             /* Restore original property value */
             if (originalProp != null) {
@@ -3559,8 +3304,6 @@ public class WolfSSLSocketTest {
     @Test
     public void testSNIMatchers() throws Exception {
 
-        System.out.print("\tTesting SNI Matchers");
-
         /* SNI matcher functionality requires wolfSSL 5.7.6 or later.
          * Older versions have a limitation where wolfSSL_SNI_GetRequest()
          * only returns SNI data if native wolfSSL already matched it, but
@@ -3570,18 +3313,14 @@ public class WolfSSLSocketTest {
          * WOLFSSL_ALWAYS_KEEP_SNI by default with --enable-jni (PR 8283),
          * which is required for full SNI matcher rejection behavior. */
         long libVerHex = WolfSSL.getLibVersionHex();
-        if (libVerHex < 0x05007006L) {
-            System.out.println("\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(libVerHex >= 0x05007006L);
 
         /* create new CTX */
         this.ctx = tf.createSSLContext("TLS", ctxProvider);
 
         /* create SSLServerSocket first to get ephemeral port */
-        final SSLServerSocket ss =
-            (SSLServerSocket)ctx.getServerSocketFactory()
-                .createServerSocket(0);
+        final SSLServerSocket ss = (SSLServerSocket)ctx.getServerSocketFactory()
+            .createServerSocket(0);
 
         /* Configure SNI matcher for server*/
         SNIMatcher matcher =
@@ -3619,7 +3358,6 @@ public class WolfSSLSocketTest {
                         serverMatched.startHandshake();
                         serverMatched.close();
                     } catch (SSLException e) {
-                        System.out.println("\t... failed");
                         fail();
                     }
                     return null;
@@ -3670,11 +3408,10 @@ public class WolfSSLSocketTest {
             serverFuture.get();
             cs.close();
 
-            System.out.println("\t\t... passed");
         } catch (Exception e) {
-            System.out.println("\t\t... failed");
             e.printStackTrace();
             fail("SNI Matcher test failed: " + e.getMessage());
+
         } finally {
             ss.close();
         }
@@ -3802,7 +3539,6 @@ public class WolfSSLSocketTest {
             this.numConnections = numConnections;
             this.doneLatch = doneLatch;
         }
-
 
         @Override
         public void run() {
@@ -3996,8 +3732,6 @@ public class WolfSSLSocketTest {
         throws NoSuchProviderException, NoSuchAlgorithmException,
                IOException {
 
-        System.out.print("\tdouble close() regression test");
-
         /* Test that calling close() when ssl field is null does not cause
          * NullPointerException. This is a regression test for the fix where
          * this.ssl could be null during close() operations. */
@@ -4015,9 +3749,8 @@ public class WolfSSLSocketTest {
                  * race conditions) */
                 if (sock instanceof com.wolfssl.provider.jsse.WolfSSLSocket) {
                     try {
-                        Field sslField =
-                            com.wolfssl.provider.jsse
-                                .WolfSSLSocket.class.getDeclaredField("ssl");
+                        Field sslField = com.wolfssl.provider.jsse
+                            .WolfSSLSocket.class.getDeclaredField("ssl");
                         sslField.setAccessible(true);
                         sslField.set(sock, null);
 
@@ -4031,10 +3764,9 @@ public class WolfSSLSocketTest {
                          * skip this specific test but don't fail */
                         System.out.print(" (reflection skipped)");
                     } catch (NullPointerException e) {
-                        System.out.println("\t... failed");
                         fail("close() call with null ssl field threw " +
-                             "NullPointerException: " + e.getMessage() +
-                             ". This indicates the NPE fix is not working.");
+                            "NullPointerException: " + e.getMessage() +
+                            ". This indicates the NPE fix is not working.");
                     }
                 }
 
@@ -4043,14 +3775,11 @@ public class WolfSSLSocketTest {
             }
         }
 
-        System.out.println("\t... passed");
     }
 
     @Test
     public void testCloseWithNullEngineHelper()
         throws NoSuchFieldException, IllegalAccessException {
-
-        System.out.print("\tclose() with null EngineHelper");
 
         /* Create a normal WolfSSLSocket first using the factory */
         SSLSocketFactory factory = null;
@@ -4094,7 +3823,6 @@ public class WolfSSLSocketTest {
             /* IOException from close() is acceptable */
         }
 
-        System.out.println("\t... passed");
     }
 
     /**
@@ -4107,8 +3835,6 @@ public class WolfSSLSocketTest {
     @Test
     public void testCertificateChainOrderingFromStoreCtx()
         throws Exception {
-
-        System.out.print("\tProper chain ordering");
 
         /* Custom TrustManager that checks certificate order */
         final boolean[] wasCalled = {false};
@@ -4344,13 +4070,10 @@ public class WolfSSLSocketTest {
                 "first cert was not peer/leaf cert"),
             orderCorrect[0]);
 
-        System.out.println("\t\t... passed");
     }
 
     @Test
     public void testSocketAnonCipherSuiteFiltering() throws Exception {
-
-        System.out.print("\tanon cipher suite filtering");
 
         String[] allCiphers = WolfSSL.getCiphersIana();
         String anonSuite = null;
@@ -4365,10 +4088,7 @@ public class WolfSSLSocketTest {
             }
         }
 
-        if (anonSuite == null) {
-            System.out.println("\t... skipped");
-            return;
-        }
+        Assume.assumeNotNull(anonSuite);
 
         Security.setProperty("wolfjsse.enabledCipherSuites", "");
         SSLContext ctx = tf.createSSLContext("TLS", "wolfJSSE");
@@ -4415,7 +4135,6 @@ public class WolfSSLSocketTest {
         assertEquals(2, enabled.length);
 
         sock.close();
-        System.out.println("\t... passed");
     }
 
     @Test
@@ -4425,8 +4144,6 @@ public class WolfSSLSocketTest {
                CertificateException, IOException,
                UnrecoverableKeyException, InterruptedException,
                java.util.concurrent.ExecutionException {
-
-        System.out.print("\tSSLHandshakeException cause");
 
         /* Create server context with valid certs */
         SSLContext srvCtx = tf.createSSLContext("TLS", ctxProvider);
@@ -4480,7 +4197,6 @@ public class WolfSSLSocketTest {
 
         try {
             cs.startHandshake();
-            System.out.println("\t... failed");
             fail("Expected SSLHandshakeException from rejecting " +
                  "TrustManager");
         } catch (SSLHandshakeException e) {
@@ -4504,6 +4220,5 @@ public class WolfSSLSocketTest {
         server.close();
         ss.close();
 
-        System.out.println("\t... passed");
     }
 }

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLTestFactory.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLTestFactory.java
@@ -555,42 +555,6 @@ class WolfSSLTestFactory {
     }
 
     /**
-     * Red coloring to fail message
-     * @param msg
-     */
-    static void fail(String msg) {
-        System.out.println(msg);
-        /* commented out because of portability concerns
-        if (System.getProperty("os.name").contains("Windows")) {
-            System.out.println(msg);
-        }
-        else {
-            String red = "\u001B[31m";
-            String reset = "\u001B[0m";
-            System.out.println(red + msg + reset);
-        }
-        */
-    }
-
-    /**
-     * Green coloring to pass message
-     * @param msg
-     */
-    static void pass(String msg) {
-        System.out.println(msg);
-        /* commented out because of portability concerns
-        if (System.getProperty("os.name").contains("Windows")) {
-            System.out.println(msg);
-        }
-        else {
-            String green = "\u001B[32m";
-            String reset = "\u001B[0m";
-            System.out.println(green + msg + reset);
-        }
-        */
-    }
-
-    /**
      * Run SSLEngine delegated tasks.
      *
      * wolfJSSE doesn't use delegated tasks, but we use this for

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLTrustX509Test.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLTrustX509Test.java
@@ -79,14 +79,23 @@ import javax.net.ssl.KeyStoreBuilderParameters;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import static org.junit.Assert.*;
+import org.junit.Assume;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import com.wolfssl.test.TimedTestWatcher;
 
 /**
  *
  * @author wolfSSL
  */
 public class WolfSSLTrustX509Test {
+
+    @Rule
+    public TestRule testWatcher = TimedTestWatcher.create();
+
     private static WolfSSLTestFactory tf;
     private String provider = "wolfJSSE";
 
@@ -128,13 +137,8 @@ public class WolfSSLTrustX509Test {
         int i = 0;
         int expected = OU.length;
 
-        System.out.print("\tTesting parse all.jks");
-
-        if (WolfSSLTestFactory.isAndroid()) {
-            /* @TODO finding that BKS has different order of certs */
-            pass("\t... skipped");
-            return;
-        }
+        /* @TODO finding that BKS has different order of certs */
+        Assume.assumeFalse(WolfSSLTestFactory.isAndroid());
 
         /* wolfSSL only returns a list of CA's, server-ecc basic constraint is
          * set to false so it is not added as a CA */
@@ -146,27 +150,24 @@ public class WolfSSLTrustX509Test {
 
         tm = tf.createTrustManager("SunX509", tf.allJKS, provider);
         if (tm == null) {
-            error("\t\t... failed");
             fail("failed to create trustmanager");
             return;
         }
         x509tm = (X509TrustManager) tm[0];
         cas = x509tm.getAcceptedIssuers();
         if (cas == null) {
-            error("\t\t... failed");
             fail("no CAs where found");
             return;
         }
 
         if (cas.length != expected) {
-            error("\t\t... failed");
             fail("wrong number of CAs found: found " + cas.length +
                  ", expected " + expected);
         }
 
         for (String x: OU) {
             if (this.provider != null &&
-                    provider.equals("wolfJSSE") && x.equals("OU=ECC")) {
+                provider.equals("wolfJSSE") && x.equals("OU=ECC")) {
                 /* skip checking ECC certs, since not all Java versions
                  * support them */
                 if (WolfSSL.trustPeerCertEnabled()) {
@@ -176,13 +177,11 @@ public class WolfSSLTrustX509Test {
             }
 
             if (!cas[i].getSubjectDN().getName().contains(x)) {
-                error("\t\t... failed");
                 fail("wrong CA found");
             }
             i++;
 
         }
-        pass("\t\t... passed");
     }
 
     @Test
@@ -191,24 +190,17 @@ public class WolfSSLTrustX509Test {
         TrustManagerFactory tmf;
         KeyManagerFactory kmf;
 
-        System.out.print("\tTesting use before init()");
-
-        if (WolfSSLTestFactory.isAndroid()) {
-            /* @TODO finding that BKS has different order of certs */
-            pass("\t... skipped");
-            return;
-        }
+        /* @TODO finding that BKS has different order of certs */
+        Assume.assumeFalse(WolfSSLTestFactory.isAndroid());
 
         tmf = TrustManagerFactory.getInstance("SunX509", provider);
         if (tmf == null) {
-            error("\t... failed");
             fail("failed to get instance of trustmanager factory");
             return;
         }
 
         try {
             tmf.getTrustManagers();
-            error("\t... failed");
             fail("getTrustManagers() before init() did not throw an error");
         } catch (IllegalStateException e) {
             /* Expected, TrustManagerFactory not yet initialized */
@@ -216,20 +208,17 @@ public class WolfSSLTrustX509Test {
 
         kmf = KeyManagerFactory.getInstance("SunX509", provider);
         if (kmf == null) {
-            error("\t... failed");
             fail("failed to get instance of keymanager factory");
             return;
         }
 
         try {
             kmf.getKeyManagers();
-            error("\t... failed");
             fail("getKeyManagers() before init() did not throw an error");
         } catch (IllegalStateException e) {
             /* Expected, KeyManagerFactory not yet initialized */
         }
 
-        pass("\t... passed");
     }
 
     /* Testing WolfSSLTrustX509.getAcceptedIssuers() with server.jks */
@@ -247,13 +236,8 @@ public class WolfSSLTrustX509Test {
         int i = 0;
         int expected = OU.length;
 
-        System.out.print("\tTesting parsing server.jks");
-
-        if (WolfSSLTestFactory.isAndroid()) {
-            /* @TODO finding that BKS has different order of certs */
-            pass("\t... skipped");
-            return;
-        }
+        /* @TODO finding that BKS has different order of certs */
+        Assume.assumeFalse(WolfSSLTestFactory.isAndroid());
 
         /* wolfSSL only returns a list of CA's, server-ecc basic constraint is
          * set to false so it is not added as a CA */
@@ -265,40 +249,34 @@ public class WolfSSLTrustX509Test {
 
         tm = tf.createTrustManager("SunX509", tf.serverJKS, provider);
         if (tm == null) {
-            error("\t... failed");
             fail("failed to create trustmanager");
             return;
         }
         x509tm = (X509TrustManager) tm[0];
         cas = x509tm.getAcceptedIssuers();
         if (cas == null) {
-            error("\t... failed");
             fail("no CAs were found");
             return;
         }
 
         if (cas.length != expected) {
-            error("\t... failed");
             fail("wrong number of CAs found: found " + cas.length +
                  ", expected " + expected);
         }
 
         for (String x : OU) {
             if (this.provider != null &&
-                    provider.equals("wolfJSSE") && x.equals("OU=ECC")) {
+                provider.equals("wolfJSSE") && x.equals("OU=ECC")) {
                 continue;
             }
 
             if (!cas[i].getSubjectDN().getName().contains(x)) {
-                error("\t... failed");
                 fail("wrong CA found");
             }
             i++;
 
         }
-        pass("\t... passed");
     }
-
 
     /* Testing WolfSSLTrustX509.getAcceptedIssuers() with all_mixed.jks */
     @Test
@@ -317,13 +295,8 @@ public class WolfSSLTrustX509Test {
         int i = 0, j;
         int expected = OU.length;
 
-        System.out.print("\tTesting parse all_mixed.jks");
-
-        if (WolfSSLTestFactory.isAndroid()) {
-            /* @TODO finding that BKS has different order of certs */
-            pass("\t... skipped");
-            return;
-        }
+        /* @TODO finding that BKS has different order of certs */
+        Assume.assumeFalse(WolfSSLTestFactory.isAndroid());
         /* wolfSSL only returns a list of CA's, server-ecc basic constraint is
          * set to false so it is not added as a CA */
         if (this.provider != null && this.provider.equals("wolfJSSE") &&
@@ -334,20 +307,17 @@ public class WolfSSLTrustX509Test {
 
         tm = tf.createTrustManager("SunX509", tf.allMixedJKS, provider);
         if (tm == null) {
-            error("\t... failed");
             fail("failed to create trustmanager");
             return;
         }
         x509tm = (X509TrustManager) tm[0];
         cas = x509tm.getAcceptedIssuers();
         if (cas == null) {
-            error("\t... failed");
             fail("no CAs where found");
             return;
         }
 
         if (cas.length != expected) {
-            error("\t... failed");
             fail("wrong number of CAs found: found " + cas.length +
                  ", expected " + expected);
         }
@@ -364,13 +334,11 @@ public class WolfSSLTrustX509Test {
             }
 
             if (!cas[i].getSubjectDN().getName().contains(OU[j])) {
-                error("\t... failed");
                 fail("wrong CA found");
             }
             i++;
 
         }
-        pass("\t... passed");
     }
 
     @Test
@@ -381,32 +349,26 @@ public class WolfSSLTrustX509Test {
         String file = System.getProperty("javax.net.ssl.trustStore");
         TrustManager[] tm;
 
-        System.out.print("\tTesting loading default certs");
-
         if (file == null) {
             String home = System.getenv("JAVA_HOME");
             if (home != null) {
                 File f = new File(home.concat("lib/security/jssecacerts"));
                 if (f.exists()) {
                     tm = tf.createTrustManager(
-                            "SunX509", (String)null, provider);
+                        "SunX509", (String)null, provider);
                     if (tm == null) {
-                        error("\t... failed");
                         fail("failed to create trustmanager with default");
                     }
-                    pass("\t... passed");
                     return;
                 }
                 else {
                     f = new File(home.concat("lib/security/cacerts"));
                     if (f.exists()) {
                         tm = tf.createTrustManager(
-                                "SunX509", (String)null, provider);
+                            "SunX509", (String)null, provider);
                         if (tm == null) {
-                            error("\t... failed");
                             fail("failed to create trustmanager with default");
                         }
-                        pass("\t... passed");
                         return;
                     }
                 }
@@ -415,17 +377,13 @@ public class WolfSSLTrustX509Test {
         else {
             tm = tf.createTrustManager("SunX509", (String)null, provider);
             if (tm == null) {
-                error("\t... failed");
                 fail("failed to create trustmanager with default");
             }
-            pass("\t... passed");
             return;
         }
 
         /* case of no default found */
-        pass("\t... skipped");
     }
-
 
     @Test
     public void testVerify()
@@ -439,19 +397,15 @@ public class WolfSSLTrustX509Test {
         InputStream stream;
         KeyStore ks;
 
-        System.out.print("\tTesting verify");
-
         /* success case */
         tm = tf.createTrustManager("SunX509", tf.caJKS, provider);
         if (tm == null) {
-            error("\t\t\t... failed");
             fail("failed to create trustmanager");
             return;
         }
         x509tm = (X509TrustManager) tm[0];
         cas = x509tm.getAcceptedIssuers();
         if (cas == null) {
-            error("\t\t\t... failed");
             fail("no CAs where found");
             return;
         }
@@ -465,22 +419,18 @@ public class WolfSSLTrustX509Test {
             (X509Certificate)ks.getCertificate("server") }, "RSA");
         }
         catch (Exception e) {
-            error("\t\t\t... failed");
             fail("failed to verify");
         }
-
 
         /* fail case */
         tm = tf.createTrustManager("SunX509", tf.serverJKS, provider);
         if (tm == null) {
-            error("\t\t\t... failed");
             fail("failed to create trustmanager");
             return;
         }
         x509tm = (X509TrustManager) tm[0];
         cas = x509tm.getAcceptedIssuers();
         if (cas == null) {
-            error("\t\t\t... failed");
             fail("no CAs where found");
         }
 
@@ -491,13 +441,11 @@ public class WolfSSLTrustX509Test {
         try {
             x509tm.checkServerTrusted(new X509Certificate[] {
             (X509Certificate)ks.getCertificate("ca-ecc-cert") }, "ECC");
-            error("\t\t\t... failed");
             fail("able to verify when should not have");
         }
         catch (Exception e) {
             /* expected to error out */
         }
-        pass("\t\t\t... passed");
     }
 
     @Test
@@ -507,9 +455,7 @@ public class WolfSSLTrustX509Test {
             CertificateException {
 
         /* skip if RSA_PSS is not compiled in at native level */
-        if (WolfSSL.RsaPssEnabled() == false) {
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.RsaPssEnabled());
 
         TrustManager[] tm;
         X509TrustManager x509tm;
@@ -517,11 +463,8 @@ public class WolfSSLTrustX509Test {
         InputStream stream;
         KeyStore ks;
 
-        System.out.print("\tTesting verify rsa_pss");
-
         tm = tf.createTrustManager("SunX509", tf.caServerJKS, provider);
         if (tm == null) {
-            error("\t\t\t... failed");
             fail("failed to create trustmanager");
             return;
         }
@@ -529,7 +472,6 @@ public class WolfSSLTrustX509Test {
         x509tm = (X509TrustManager) tm[0];
         cas = x509tm.getAcceptedIssuers();
         if (cas == null) {
-            error("\t\t\t... failed");
             fail("no CAs where found");
             return;
         }
@@ -545,11 +487,9 @@ public class WolfSSLTrustX509Test {
         }
         catch (Exception e) {
             e.printStackTrace();
-            error("\t\t... failed");
             fail("failed to verify");
         }
 
-        pass("\t\t... passed");
     }
 
     @Test
@@ -565,8 +505,6 @@ public class WolfSSLTrustX509Test {
         FileInputStream fis = null;
         BufferedInputStream bis = null;
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
-
-        System.out.print("\tcheckServerTrusted() chain");
 
         String rsaServerCert =
             "examples/certs/intermediate/server-int-cert.pem";
@@ -590,7 +528,6 @@ public class WolfSSLTrustX509Test {
 
         tm = tf.createTrustManager("SunX509", tf.caJKS, provider);
         if (tm == null) {
-            error("\t... failed");
             fail("failed to create trustmanager");
             return;
         }
@@ -630,7 +567,6 @@ public class WolfSSLTrustX509Test {
         try {
             x509tm.checkServerTrusted(certArray, "RSA");
         } catch (CertificateException e) {
-            error("\t... failed");
             fail("Failed verify of RSA chain with intermediates");
         }
 
@@ -667,11 +603,9 @@ public class WolfSSLTrustX509Test {
         try {
             x509tm.checkServerTrusted(certArray, "ECC");
         } catch (CertificateException e) {
-            error("\t... failed");
             fail("Failed verify of ECC chain with intermediates");
         }
 
-        pass("\t... passed");
     }
 
     @Test
@@ -687,8 +621,6 @@ public class WolfSSLTrustX509Test {
         FileInputStream fis = null;
         BufferedInputStream bis = null;
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
-
-        System.out.print("\tcheckServerTrusted() bad int");
 
         String rsaServerCert =
             "examples/certs/intermediate/server-int-cert.pem";
@@ -720,7 +652,6 @@ public class WolfSSLTrustX509Test {
 
         tm = tf.createTrustManager("SunX509", tf.caJKS, provider);
         if (tm == null) {
-            error("\t... failed");
             fail("failed to create trustmanager");
             return;
         }
@@ -759,7 +690,6 @@ public class WolfSSLTrustX509Test {
         /* verify chain, root (certs/ca-cert.pem) should be in caJKS */
         try {
             x509tm.checkServerTrusted(certArray, "RSA");
-            error("\t... failed");
             fail("Verified RSA chain with bad CA, but shouldn't have");
         } catch (CertificateException e) {
             /* expected, should fail with wrong intermediate chain CA */
@@ -797,13 +727,11 @@ public class WolfSSLTrustX509Test {
         /* verify chain, root (certs/ca-ecc-cert.pem) should be in caJKS */
         try {
             x509tm.checkServerTrusted(certArray, "ECC");
-            error("\t... failed");
             fail("Verified RSA chain with bad CA, but shouldn't have");
         } catch (CertificateException e) {
             /* expected, should fail with wrong intermediate chain CA */
         }
 
-        pass("\t... passed");
     }
 
     @Test
@@ -819,8 +747,6 @@ public class WolfSSLTrustX509Test {
         FileInputStream fis = null;
         BufferedInputStream bis = null;
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
-
-        System.out.print("\tcheckServerTrusted() bad chain");
 
         /* server/peer cert is ECC, but is using RSA example chain. Should
          * not verify correctly */
@@ -848,7 +774,6 @@ public class WolfSSLTrustX509Test {
 
         tm = tf.createTrustManager("SunX509", tf.caJKS, provider);
         if (tm == null) {
-            error("\t... failed");
             fail("failed to create trustmanager");
             return;
         }
@@ -887,7 +812,6 @@ public class WolfSSLTrustX509Test {
         /* verify chain, root (certs/ca-ecc-cert.pem) should be in caJKS */
         try {
             x509tm.checkServerTrusted(certArray, "ECC");
-            error("\t... failed");
             fail("Verified cert with wrong chain, should not happen");
         } catch (CertificateException e) {
             /* expected, should fail with wrong intermediate chain CA */
@@ -925,13 +849,11 @@ public class WolfSSLTrustX509Test {
         /* verify chain, root (certs/ca-cert.pem) should be in caJKS */
         try {
             x509tm.checkServerTrusted(certArray, "RSA");
-            error("\t... failed");
             fail("Verified cert with wrong chain, should not happen");
         } catch (CertificateException e) {
             /* expected, should fail with wrong intermediate chain CA */
         }
 
-        pass("\t... passed");
     }
 
     @Test
@@ -947,8 +869,6 @@ public class WolfSSLTrustX509Test {
         FileInputStream fis = null;
         BufferedInputStream bis = null;
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
-
-        System.out.print("\tcheckServerTrusted() miss chain");
 
         /* RSA chain, missing intermediate CA 1 */
         String rsaServerCert =
@@ -972,7 +892,6 @@ public class WolfSSLTrustX509Test {
 
         tm = tf.createTrustManager("SunX509", tf.caJKS, provider);
         if (tm == null) {
-            error("\t... failed");
             fail("failed to create trustmanager");
             return;
         }
@@ -1003,7 +922,6 @@ public class WolfSSLTrustX509Test {
         /* try to verify chain, root (certs/ca-cert.pem) should be in caJKS */
         try {
             x509tm.checkServerTrusted(certArray, "RSA");
-            error("\t... failed");
             fail("Did not fail verify like expected when missing intermediate");
         } catch (CertificateException e) {
             /* Expected, missing intermediate 1 from chain */
@@ -1033,13 +951,11 @@ public class WolfSSLTrustX509Test {
         /* try to verify chain, root (certs/ca-cert.pem) should be in caJKS */
         try {
             x509tm.checkServerTrusted(certArray, "ECC");
-            error("\t... failed");
             fail("Did not fail verify like expected when missing intermediate");
         } catch (CertificateException e) {
             /* Expected, missing intermediate 1 from chain */
         }
 
-        pass("\t... passed");
     }
 
     @Test
@@ -1055,8 +971,6 @@ public class WolfSSLTrustX509Test {
         FileInputStream fis = null;
         BufferedInputStream bis = null;
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
-
-        System.out.print("\tcheckServerTrusted() ooo chain");
 
         /* RSA chain, out of order intermediate CAs */
         String rsaServerCert =
@@ -1086,7 +1000,6 @@ public class WolfSSLTrustX509Test {
 
         tm = tf.createTrustManager("SunX509", tf.caJKS, provider);
         if (tm == null) {
-            error("\t... failed");
             fail("failed to create trustmanager");
             return;
         }
@@ -1126,7 +1039,6 @@ public class WolfSSLTrustX509Test {
         try {
             x509tm.checkServerTrusted(certArray, "RSA");
         } catch (CertificateException e) {
-            error("\t... failed");
             fail("Failed verify of RSA chain with intermediates");
         }
 
@@ -1163,13 +1075,10 @@ public class WolfSSLTrustX509Test {
         try {
             x509tm.checkServerTrusted(certArray, "ECC");
         } catch (CertificateException e) {
-            error("\t... failed");
             fail("Failed verify of ECC chain with intermediates");
         }
 
-        pass("\t... passed");
     }
-
 
     @Test
     public void testCheckServerTrustedWithChainReturnsChain()
@@ -1186,8 +1095,6 @@ public class WolfSSLTrustX509Test {
         BufferedInputStream bis = null;
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
         List<X509Certificate> retChain = null;
-
-        System.out.print("\tcheckServerTrusted() ret chain");
 
         /* RSA chain */
         String rsaServerCert =
@@ -1213,7 +1120,6 @@ public class WolfSSLTrustX509Test {
 
         tm = tf.createTrustManager("SunX509", tf.caJKS, provider);
         if (tm == null) {
-            error("\t... failed");
             fail("failed to create trustmanager");
             return;
         }
@@ -1260,18 +1166,15 @@ public class WolfSSLTrustX509Test {
             retChain = wolfX509tm.checkServerTrusted(certArray,
                                                      "RSA", "localhost");
         } catch (CertificateException e) {
-            error("\t... failed");
             fail("Failed verify of RSA chain with intermediates");
         }
 
         if (retChain == null) {
-            error("\t... failed");
             fail("checkServerTrusted() did not return expected List of certs");
         }
 
         /* cert chain returned should include peer, ints, and root */
         if (retChain.size() != 4) {
-            error("\t... failed");
             fail("checkServerTrusted() didn't return expected number of certs");
         }
 
@@ -1310,22 +1213,18 @@ public class WolfSSLTrustX509Test {
             retChain = wolfX509tm.checkServerTrusted(certArray,
                                                      "ECC", "localhost");
         } catch (CertificateException e) {
-            error("\t... failed");
             fail("Failed verify of ECC chain with intermediates");
         }
 
         if (retChain == null) {
-            error("\t... failed");
             fail("checkServerTrusted() did not return expected List of certs");
         }
 
         /* cert chain returned should include peer, ints, and root */
         if (retChain.size() != 4) {
-            error("\t... failed");
             fail("checkServerTrusted() didn't return expected number of certs");
         }
 
-        pass("\t... passed");
     }
 
     @Test
@@ -1344,8 +1243,6 @@ public class WolfSSLTrustX509Test {
         BufferedInputStream bis = null;
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
         List<X509Certificate> retChain = null;
-
-        System.out.print("\tcheckServerTrusted() dup root");
 
         /* RSA chain, including root (which is already in caJKS) */
         String rsaServerCert =
@@ -1375,7 +1272,6 @@ public class WolfSSLTrustX509Test {
 
         tm = tf.createTrustManager("SunX509", tf.caJKS, provider);
         if (tm == null) {
-            error("\t... failed");
             fail("failed to create trustmanager");
             return;
         }
@@ -1430,19 +1326,16 @@ public class WolfSSLTrustX509Test {
             retChain = wolfX509tm.checkServerTrusted(certArray,
                                                      "RSA", "localhost");
         } catch (CertificateException e) {
-            error("\t... failed");
             fail("Failed verify of RSA chain with intermediates");
         }
 
         if (retChain == null) {
-            error("\t... failed");
             fail("checkServerTrusted() did not return expected List of certs");
         }
 
         /* cert chain returned should include peer, ints, and root, but
          * not a duplicate of root if in both TrustStore and chain */
         if (retChain.size() != 4) {
-            error("\t... failed");
             fail("checkServerTrusted() didn't return expected number of certs");
         }
 
@@ -1454,7 +1347,6 @@ public class WolfSSLTrustX509Test {
             }
         }
         if (rootCount != 1) {
-            error("\t... failed");
             fail("checkServerTrusted() contained more than one copy of root");
         }
 
@@ -1501,19 +1393,16 @@ public class WolfSSLTrustX509Test {
             retChain = wolfX509tm.checkServerTrusted(certArray,
                                                      "ECC", "localhost");
         } catch (CertificateException e) {
-            error("\t... failed");
             fail("Failed verify of ECC chain with intermediates");
         }
 
         if (retChain == null) {
-            error("\t... failed");
             fail("checkServerTrusted() did not return expected List of certs");
         }
 
         /* cert chain returned should include peer, ints, and root, but
          * not a duplicate of root if in both TrustStore and chain */
         if (retChain.size() != 4) {
-            error("\t... failed");
             fail("checkServerTrusted() didn't return expected number of certs");
         }
 
@@ -1525,11 +1414,9 @@ public class WolfSSLTrustX509Test {
             }
         }
         if (rootCount != 1) {
-            error("\t... failed");
             fail("checkServerTrusted() contained more than one copy of root");
         }
 
-        pass("\t... passed");
     }
 
     /**
@@ -1561,8 +1448,6 @@ public class WolfSSLTrustX509Test {
             intCACert1 = "/data/local/tmp/" + intCACert1;
             intCACert2 = "/data/local/tmp/" + intCACert2;
         }
-
-        System.out.print("\tcheckServerTrusted() Android");
 
         try {
             X509Certificate serverCert;
@@ -1597,7 +1482,6 @@ public class WolfSSLTrustX509Test {
             tm = tmf.getTrustManagers();
 
             if (tm.length != 1) {
-                error("\t... failed");
                 fail("TrustManagerFactory did not return single TrustManager");
             }
 
@@ -1609,21 +1493,18 @@ public class WolfSSLTrustX509Test {
                 retChain = wolfX509tm.checkServerTrusted(certArray,
                     null, null, "RSA", "localhost");
             } catch (CertificateException e) {
-                error("\t... failed");
                 fail("checkServerTrusted failed: " + e.getMessage());
             }
 
             if (retChain == null) {
-                error("\t... failed");
                 fail("checkServerTrusted() did not return expected " +
-                     "List of certs");
+                    "List of certs");
             }
 
             /* cert chain returned should include peer, ints, and root */
             if (retChain.size() != 4) {
-                error("\t... failed");
                 fail("checkServerTrusted() didn't return expected " +
-                     "number of certs, got: " + retChain.size());
+                    "number of certs, got: " + retChain.size());
             }
 
             /* Test with invalid OCSP data, should fail, SCT data is currently
@@ -1632,9 +1513,8 @@ public class WolfSSLTrustX509Test {
                 retChain = wolfX509tm.checkServerTrusted(certArray,
                     dummyOcspData, dummySctData, "RSA", "localhost");
 
-                error("\t... failed");
                 fail("checkServerTrusted with invalid OCSP data " +
-                     "should have thrown CertificateException");
+                    "should have thrown CertificateException");
 
             } catch (CertificateException e) {
                 /* Expected */
@@ -1646,53 +1526,39 @@ public class WolfSSLTrustX509Test {
                     null, dummySctData, "RSA", "localhost");
 
             } catch (CertificateException e) {
-                error("\t... failed");
                 fail("checkServerTrusted with null OCSP failed: " +
-                     e.getMessage());
+                    e.getMessage());
             }
 
             if (retChain == null) {
-                error("\t... failed");
                 fail("checkServerTrusted() with null OCSP did not " +
-                     "return expected List of certs");
+                    "return expected List of certs");
             }
 
             if (retChain.size() != 4) {
-                error("\t... failed");
                 fail("checkServerTrusted() with null OCSP didn't " +
-                     "return expected number of certs, got: " +
-                     retChain.size());
+                    "return expected number of certs, got: " +
+                    retChain.size());
             }
 
         } catch (Exception e) {
-            error("\t... failed");
-            fail("checkServerTrusted test failed with: " +
-                 e.getMessage());
+            fail("checkServerTrusted test failed with: " + e.getMessage());
         }
 
-        pass("\t... passed");
     }
 
     @Test
     public void testUsingRsaPssCert()
         throws Exception {
 
-        System.out.print("\tTest using rsa_pss certs");
-
         /* skip if RSA_PSS or TLS 1.3 are not compiled in at native level */
-        if ((WolfSSL.RsaPssEnabled() == false) ||
-            (WolfSSL.TLSv13Enabled() == false)) {
-            System.out.println("\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.RsaPssEnabled());
+        Assume.assumeTrue(WolfSSL.TLSv13Enabled());
 
         /* Skip on Android: Android's BKS KeyStore implementation cannot
          * extract RSA-PSS private keys. When calling store.getKey() for an
          * RSA-PSS key, it returns null. */
-        if (WolfSSLTestFactory.isAndroid()) {
-            System.out.println("\t... skipped");
-            return;
-        }
+        Assume.assumeFalse(WolfSSLTestFactory.isAndroid());
 
         SSLContext srvCtx = tf.createSSLContext("TLSv1.3", provider,
             tf.createTrustManager("SunX509", tf.caClientJKS, provider),
@@ -1740,14 +1606,11 @@ public class WolfSSLTrustX509Test {
             throw new Exception(traceString);
         }
 
-        pass("\t... passed");
     }
 
     @Test
     public void testX509ExtTrustMgrInternal()
         throws CertificateException, IOException, Exception {
-
-        System.out.print("\tX509ExtendedTrustManager int");
 
         /* Basic SSLSocket success case, SNI matches server cert CN */
         testX509ExtTrustMgrSSLSocketBasicSuccess();
@@ -1792,19 +1655,18 @@ public class WolfSSLTrustX509Test {
         /* SSLEngine should fail if trying to use bad endoint alg */
         testX509ExtTrustMgrSSLEngineEndpointAlgFail();
 
-        pass("\t... passed");
     }
 
     private void testX509ExtTrustMgrSSLSocketBasicSuccess()
         throws CertificateException, IOException, Exception {
 
         SSLContext srvCtx = tf.createSSLContext("TLSv1.2", provider,
-                tf.createTrustManager("SunX509", tf.caClientJKS, provider),
-                tf.createKeyManager("SunX509", tf.serverJKS, provider));
+            tf.createTrustManager("SunX509", tf.caClientJKS, provider),
+            tf.createKeyManager("SunX509", tf.serverJKS, provider));
 
         SSLContext cliCtx = tf.createSSLContext("TLSv1.2", provider,
-                tf.createTrustManager("SunX509", tf.caServerJKS, provider),
-                tf.createKeyManager("SunX509", tf.clientJKS, provider));
+            tf.createTrustManager("SunX509", tf.caServerJKS, provider),
+            tf.createKeyManager("SunX509", tf.clientJKS, provider));
 
         /* create SSLServerSocket first to get ephemeral port */
         SSLServerSocket ss = (SSLServerSocket)srvCtx.getServerSocketFactory()
@@ -1851,12 +1713,12 @@ public class WolfSSLTrustX509Test {
         throws CertificateException, IOException, Exception {
 
         SSLContext srvCtx = tf.createSSLContext("TLSv1.2", provider,
-                tf.createTrustManager("SunX509", tf.caClientJKS, provider),
-                tf.createKeyManager("SunX509", tf.serverJKS, provider));
+            tf.createTrustManager("SunX509", tf.caClientJKS, provider),
+            tf.createKeyManager("SunX509", tf.serverJKS, provider));
 
         SSLContext cliCtx = tf.createSSLContext("TLSv1.2", provider,
-                tf.createTrustManager("SunX509", tf.caServerJKS, provider),
-                tf.createKeyManager("SunX509", tf.clientJKS, provider));
+            tf.createTrustManager("SunX509", tf.caServerJKS, provider),
+            tf.createKeyManager("SunX509", tf.clientJKS, provider));
 
         /* create SSLServerSocket first to get ephemeral port */
         SSLServerSocket ss = (SSLServerSocket)srvCtx.getServerSocketFactory()
@@ -1903,12 +1765,12 @@ public class WolfSSLTrustX509Test {
         throws CertificateException, IOException, Exception {
 
         SSLContext srvCtx = tf.createSSLContext("TLSv1.2", provider,
-                tf.createTrustManager("SunX509", tf.caClientJKS, provider),
-                tf.createKeyManager("SunX509", tf.serverJKS, provider));
+            tf.createTrustManager("SunX509", tf.caClientJKS, provider),
+            tf.createKeyManager("SunX509", tf.serverJKS, provider));
 
         SSLContext cliCtx = tf.createSSLContext("TLSv1.2", provider,
-                tf.createTrustManager("SunX509", tf.caServerJKS, provider),
-                tf.createKeyManager("SunX509", tf.clientJKS, provider));
+            tf.createTrustManager("SunX509", tf.caServerJKS, provider),
+            tf.createKeyManager("SunX509", tf.clientJKS, provider));
 
         /* create SSLServerSocket first to get ephemeral port */
         SSLServerSocket ss = (SSLServerSocket)srvCtx.getServerSocketFactory()
@@ -1955,12 +1817,12 @@ public class WolfSSLTrustX509Test {
         throws CertificateException, IOException, Exception {
 
         SSLContext srvCtx = tf.createSSLContext("TLSv1.2", provider,
-                tf.createTrustManager("SunX509", tf.caClientJKS, provider),
-                tf.createKeyManager("SunX509", tf.serverJKS, provider));
+            tf.createTrustManager("SunX509", tf.caClientJKS, provider),
+            tf.createKeyManager("SunX509", tf.serverJKS, provider));
 
         SSLContext cliCtx = tf.createSSLContext("TLSv1.2", provider,
-                tf.createTrustManager("SunX509", tf.caServerJKS, provider),
-                tf.createKeyManager("SunX509", tf.clientJKS, provider));
+            tf.createTrustManager("SunX509", tf.caServerJKS, provider),
+            tf.createKeyManager("SunX509", tf.clientJKS, provider));
 
         /* create SSLServerSocket first to get ephemeral port */
         SSLServerSocket ss = (SSLServerSocket)srvCtx.getServerSocketFactory()
@@ -2007,12 +1869,12 @@ public class WolfSSLTrustX509Test {
         throws CertificateException, IOException, Exception {
 
         SSLContext srvCtx = tf.createSSLContext("TLSv1.2", provider,
-                tf.createTrustManager("SunX509", tf.caClientJKS, provider),
-                tf.createKeyManager("SunX509", tf.serverJKS, provider));
+            tf.createTrustManager("SunX509", tf.caClientJKS, provider),
+            tf.createKeyManager("SunX509", tf.serverJKS, provider));
 
         SSLContext cliCtx = tf.createSSLContext("TLSv1.2", provider,
-                tf.createTrustManager("SunX509", tf.caServerJKS, provider),
-                tf.createKeyManager("SunX509", tf.clientJKS, provider));
+            tf.createTrustManager("SunX509", tf.caServerJKS, provider),
+            tf.createKeyManager("SunX509", tf.clientJKS, provider));
 
         /* create SSLServerSocket first to get ephemeral port */
         SSLServerSocket ss = (SSLServerSocket)srvCtx.getServerSocketFactory()
@@ -2051,12 +1913,12 @@ public class WolfSSLTrustX509Test {
         throws CertificateException, IOException, Exception {
 
         SSLContext srvCtx = tf.createSSLContext("TLSv1.2", provider,
-                tf.createTrustManager("SunX509", tf.caClientJKS, provider),
-                tf.createKeyManager("SunX509", tf.serverJKS, provider));
+            tf.createTrustManager("SunX509", tf.caClientJKS, provider),
+            tf.createKeyManager("SunX509", tf.serverJKS, provider));
 
         SSLContext cliCtx = tf.createSSLContext("TLSv1.2", provider,
-                tf.createTrustManager("SunX509", tf.caServerJKS, provider),
-                tf.createKeyManager("SunX509", tf.clientJKS, provider));
+            tf.createTrustManager("SunX509", tf.caServerJKS, provider),
+            tf.createKeyManager("SunX509", tf.clientJKS, provider));
 
         /* create SSLServerSocket first to get ephemeral port */
         SSLServerSocket ss = (SSLServerSocket)srvCtx.getServerSocketFactory()
@@ -2293,7 +2155,6 @@ public class WolfSSLTrustX509Test {
         client.setUseClientMode(true);
         server.setUseClientMode(false);
 
-
         /* Enable Endpoint Identification for hostname verification on client.
          * Not setting SNI, since LDAPS hostname verification requires server
          * name to come directly from when connection was made. Peer cert
@@ -2320,7 +2181,6 @@ public class WolfSSLTrustX509Test {
         server.setNeedClientAuth(true);
         client.setUseClientMode(true);
         server.setUseClientMode(false);
-
 
         /* Enable Endpoint Identification for hostname verification on client.
          * Not setting SNI, since LDAPS hostname verification requires server
@@ -2506,14 +2366,14 @@ public class WolfSSLTrustX509Test {
                 "wolfSSL test");
 
         SSLContext srvCtx = tf.createSSLContext("TLSv1.2", provider,
-                tf.createTrustManager("SunX509", tf.caClientJKS, provider),
-                tf.createKeyManager("SunX509", tf.serverJKS, provider));
+            tf.createTrustManager("SunX509", tf.caClientJKS, provider),
+            tf.createKeyManager("SunX509", tf.serverJKS, provider));
 
         /* Loading caJKS so client SSLContext can verify server both
          * before and after cert changes */
         SSLContext cliCtx = tf.createSSLContext("TLSv1.2", provider,
-                tf.createTrustManager("SunX509", tf.caJKS, provider),
-                tf.createKeyManager("SunX509", tf.clientJKS, provider));
+            tf.createTrustManager("SunX509", tf.caJKS, provider),
+            tf.createKeyManager("SunX509", tf.clientJKS, provider));
 
         /* create SSLServerSocket first to get ephemeral port */
         SSLServerSocket ss = (SSLServerSocket)srvCtx.getServerSocketFactory()
@@ -2645,8 +2505,6 @@ public class WolfSSLTrustX509Test {
     public void testX509ExtTrustMgrExternal()
         throws CertificateException, IOException, Exception {
 
-        System.out.print("\tX509ExtendedTrustManager ext");
-
         /* Basic SSLSocket success case, SNI matches server cert CN */
         testX509ExtTrustMgrSSLSocketBasicExtSuccess();
 
@@ -2661,13 +2519,10 @@ public class WolfSSLTrustX509Test {
         testX509ExtTrustMgrSSLSocketExtNoClientStartHandshakeSuccess();
         testX509ExtTrustMgrSSLSocketExtNoServerStartHandshakeSuccess();
 
-        pass("\t... passed");
     }
 
     @Test
     public void testExtendedKeyUsageWithLeafNotFirst() throws Exception {
-
-        System.out.print("\tEKU validation leaf not first");
 
         /* This test reproduces the case where a certificate chain arrives
          * with CA before leaf cert and helps verify the peer chain sorting
@@ -2771,8 +2626,6 @@ public class WolfSSLTrustX509Test {
                  "Peer cert: " + peerCert.getSubjectX500Principal() +
                 ", EKU list: " + ekuOids);
         }
-
-        System.out.println("\t... passed");
     }
 
     /**
@@ -2791,8 +2644,6 @@ public class WolfSSLTrustX509Test {
         KeyStore caJKS;
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
         List<X509Certificate> retChain = null;
-
-        System.out.print("\tcheckServerTrusted() OCSP data");
 
         String rsaServerCert =
             "examples/certs/intermediate/server-int-cert.pem";
@@ -2835,8 +2686,7 @@ public class WolfSSLTrustX509Test {
 
             /* Load cacerts.jks into KeyStore */
             caJKS = KeyStore.getInstance(tf.keyStoreType);
-            try (FileInputStream stream =
-                    new FileInputStream(caJKSPath)) {
+            try (FileInputStream stream = new FileInputStream(caJKSPath)) {
                 caJKS.load(stream, "wolfSSL test".toCharArray());
             }
 
@@ -2851,13 +2701,11 @@ public class WolfSSLTrustX509Test {
                 retChain = wolfX509tm.checkServerTrusted(certArray,
                     null, null, "RSA", "localhost");
                 if (retChain == null || retChain.size() == 0) {
-                    error("\t... failed");
                     fail("checkServerTrusted with null OCSP failed");
                 }
             } catch (CertificateException e) {
-                error("\t... failed");
                 fail("checkServerTrusted with null OCSP failed: " +
-                     e.getMessage());
+                    e.getMessage());
             }
 
             /* Test invalid OCSP data */
@@ -2876,12 +2724,9 @@ public class WolfSSLTrustX509Test {
             }
 
         } catch (Exception e) {
-            error("\t... failed");
             fail("checkServerTrusted with OCSP test failed: " +
                 e.getMessage());
         }
-
-        pass("\t... passed");
     }
 
     /**
@@ -2897,8 +2742,6 @@ public class WolfSSLTrustX509Test {
     @Test
     public void testCheckServerTrustedWithValidOCSPData()
         throws Exception {
-
-        System.out.print("\tcheckServerTrusted() valid OCSP");
 
         String caJKSPath =
             "examples/provider/cacerts.jks";
@@ -2916,8 +2759,7 @@ public class WolfSSLTrustX509Test {
         try {
             /* Load basic cacerts trust store */
             KeyStore caJKS = KeyStore.getInstance(tf.keyStoreType);
-            try (FileInputStream stream =
-                    new FileInputStream(caJKSPath)) {
+            try (FileInputStream stream = new FileInputStream(caJKSPath)) {
                 caJKS.load(stream, "wolfSSL test".toCharArray());
             }
 
@@ -2957,25 +2799,21 @@ public class WolfSSLTrustX509Test {
 
             /* Verify return value is valid */
             if (retChain == null || retChain.size() == 0) {
-                error("\t... failed");
                 fail("checkServerTrusted with valid OCSP returned null or " +
-                     "empty chain");
+                    "empty chain");
             }
 
             /* Should return at least the certs we passed in */
             if (retChain.size() < certArray.length) {
-                error("\t... failed");
                 fail("checkServerTrusted with valid OCSP returned fewer " +
-                     "certs than expected, got: " + retChain.size());
+                    "certs than expected, got: " + retChain.size());
             }
 
         } catch (Exception e) {
-            error("\t... failed");
             fail("checkServerTrusted with valid OCSP test failed: " +
-                 e.getMessage());
+                e.getMessage());
         }
 
-        pass("\t... passed");
     }
 
     /**
@@ -2994,8 +2832,6 @@ public class WolfSSLTrustX509Test {
         TrustManager[] tm = null;
         WolfSSLTrustX509 wolfX509tm = null;
 
-        System.out.print("\tmismatched OCSP response");
-
         String caJKSPath = "examples/provider/cacerts.jks";
         String ocspRootCaPath = "examples/certs/ocsp-root-ca-cert.pem";
         String serverCertPath = "examples/certs/server-cert.pem";
@@ -3009,8 +2845,7 @@ public class WolfSSLTrustX509Test {
         try {
             /* Load basic cacerts trust store */
             caJKS = KeyStore.getInstance(tf.keyStoreType);
-            try (FileInputStream stream =
-                    new FileInputStream(caJKSPath)) {
+            try (FileInputStream stream = new FileInputStream(caJKSPath)) {
                 caJKS.load(stream, "wolfSSL test".toCharArray());
             }
 
@@ -3043,7 +2878,6 @@ public class WolfSSLTrustX509Test {
                     WolfSSLCertManagerTest.validOcspResponse,
                     null, "RSA", "localhost");
 
-                error("\t... failed");
                 fail("checkServerTrusted should have thrown " +
                     "CertificateException for mismatched OCSP response");
 
@@ -3053,18 +2887,13 @@ public class WolfSSLTrustX509Test {
 
         } catch (Exception e) {
             /* Check if OCSP is not compiled in */
-            if (e.getMessage() != null &&
-                e.getMessage().contains("not compiled")) {
-                System.out.println("\t... skipped (OCSP not compiled in)");
-                return;
-            }
+            Assume.assumeFalse(e.getMessage() != null &&
+                e.getMessage().contains("not compiled"));
 
-            error("\t... failed");
             fail("checkServerTrusted with mismatched OCSP test failed: " +
-                 e.getMessage());
+                e.getMessage());
         }
 
-        pass("\t... passed");
     }
 
     /**
@@ -3082,8 +2911,6 @@ public class WolfSSLTrustX509Test {
     @Test
     public void testCheckServerTrustedOCSPWithChainCAs()
         throws Exception {
-
-        System.out.print("\tOCSP with chain CAs");
 
         String ocspRootCaPath =
             "examples/certs/ocsp-root-ca-cert.pem";
@@ -3137,36 +2964,28 @@ public class WolfSSLTrustX509Test {
 
             /* Verify return value is valid */
             if (retChain == null || retChain.size() == 0) {
-                error("\t\t... failed");
                 fail("checkServerTrusted with OCSP and chain CAs " +
-                     "returned null or empty chain");
+                    "returned null or empty chain");
             }
 
             /* Should return at least the certs we passed in */
             if (retChain.size() < certArray.length) {
-                error("\t\t... failed");
                 fail("checkServerTrusted with OCSP and chain CAs " +
-                     "returned fewer certs than expected");
+                    "returned fewer certs than expected");
             }
 
         } catch (CertificateException e) {
             /* Check if OCSP is not compiled in */
             String msg = e.getMessage();
-            if (msg != null && msg.contains("not compiled")) {
-                System.out.println("\t... skipped (OCSP not compiled in)");
-                return;
-            }
-            error("\t\t... failed");
+            Assume.assumeFalse(msg != null && msg.contains("not compiled"));
             fail("checkServerTrusted with OCSP and chain CAs failed: " +
-                 e.getMessage());
+                e.getMessage());
 
         } catch (Exception e) {
-            error("\t\t... failed");
             fail("checkServerTrusted with OCSP and chain CAs test " +
-                 "failed: " + e.getMessage());
+                "failed: " + e.getMessage());
         }
 
-        pass("\t\t... passed");
     }
 
     /* TrustManager that trusts all certificates */
@@ -3233,12 +3052,12 @@ public class WolfSSLTrustX509Test {
         throws CertificateException, IOException, Exception {
 
         SSLContext srvCtx = tf.createSSLContext("TLSv1.2", provider,
-                trustAllCerts,
-                tf.createKeyManager("SunX509", tf.serverJKS, provider));
+            trustAllCerts,
+            tf.createKeyManager("SunX509", tf.serverJKS, provider));
 
         SSLContext cliCtx = tf.createSSLContext("TLSv1.2", provider,
-                trustAllCerts,
-                tf.createKeyManager("SunX509", tf.clientJKS, provider));
+            trustAllCerts,
+            tf.createKeyManager("SunX509", tf.clientJKS, provider));
 
         /* create SSLServerSocket first to get ephemeral port */
         SSLServerSocket ss = (SSLServerSocket)srvCtx.getServerSocketFactory()
@@ -3285,12 +3104,12 @@ public class WolfSSLTrustX509Test {
         throws CertificateException, IOException, Exception {
 
         SSLContext srvCtx = tf.createSSLContext("TLSv1.2", provider,
-                trustNoCerts,
-                tf.createKeyManager("SunX509", tf.serverJKS, provider));
+            trustNoCerts,
+            tf.createKeyManager("SunX509", tf.serverJKS, provider));
 
         SSLContext cliCtx = tf.createSSLContext("TLSv1.2", provider,
-                trustNoCerts,
-                tf.createKeyManager("SunX509", tf.clientJKS, provider));
+            trustNoCerts,
+            tf.createKeyManager("SunX509", tf.clientJKS, provider));
 
         /* create SSLServerSocket first to get ephemeral port */
         SSLServerSocket ss = (SSLServerSocket)srvCtx.getServerSocketFactory()
@@ -3328,12 +3147,12 @@ public class WolfSSLTrustX509Test {
         throws CertificateException, IOException, Exception {
 
         SSLContext srvCtx = tf.createSSLContext("TLSv1.2", provider,
-                trustAllCerts,
-                tf.createKeyManager("SunX509", tf.serverJKS, provider));
+            trustAllCerts,
+            tf.createKeyManager("SunX509", tf.serverJKS, provider));
 
         SSLContext cliCtx = tf.createSSLContext("TLSv1.2", provider,
-                trustAllCerts,
-                tf.createKeyManager("SunX509", tf.clientJKS, provider));
+            trustAllCerts,
+            tf.createKeyManager("SunX509", tf.clientJKS, provider));
 
         /* create SSLServerSocket first to get ephemeral port */
         SSLServerSocket ss = (SSLServerSocket)srvCtx.getServerSocketFactory()
@@ -3381,12 +3200,12 @@ public class WolfSSLTrustX509Test {
         throws CertificateException, IOException, Exception {
 
         SSLContext srvCtx = tf.createSSLContext("TLSv1.2", provider,
-                trustAllCerts,
-                tf.createKeyManager("SunX509", tf.serverJKS, provider));
+            trustAllCerts,
+            tf.createKeyManager("SunX509", tf.serverJKS, provider));
 
         SSLContext cliCtx = tf.createSSLContext("TLSv1.2", provider,
-                trustAllCerts,
-                tf.createKeyManager("SunX509", tf.clientJKS, provider));
+            trustAllCerts,
+            tf.createKeyManager("SunX509", tf.clientJKS, provider));
 
         /* create SSLServerSocket first to get ephemeral port */
         SSLServerSocket ss = (SSLServerSocket)srvCtx.getServerSocketFactory()
@@ -3434,12 +3253,12 @@ public class WolfSSLTrustX509Test {
         throws CertificateException, IOException, Exception {
 
         SSLContext srvCtx = tf.createSSLContext("TLSv1.2", provider,
-                trustAllCerts,
-                tf.createKeyManager("SunX509", tf.serverJKS, provider));
+            trustAllCerts,
+            tf.createKeyManager("SunX509", tf.serverJKS, provider));
 
         SSLContext cliCtx = tf.createSSLContext("TLSv1.2", provider,
-                trustAllCerts,
-                tf.createKeyManager("SunX509", tf.clientJKS, provider));
+            trustAllCerts,
+            tf.createKeyManager("SunX509", tf.clientJKS, provider));
 
         /* create SSLServerSocket first to get ephemeral port */
         SSLServerSocket ss = (SSLServerSocket)srvCtx.getServerSocketFactory()
@@ -3490,8 +3309,6 @@ public class WolfSSLTrustX509Test {
                KeyStoreException, IOException, CertificateException,
                InvalidAlgorithmParameterException {
 
-        System.out.print("\tinit(CPTrustManagerParameters)");
-
         /* Load CA certs and create TrustAnchors manually */
         KeyStore caStore = KeyStore.getInstance(
             WolfSSLTestFactory.isAndroid() ? "BKS" : "JKS");
@@ -3509,10 +3326,7 @@ public class WolfSSLTrustX509Test {
             }
         }
 
-        if (anchors.isEmpty()) {
-            pass("\t... skipped (no certs)");
-            return;
-        }
+        Assume.assumeFalse(anchors.isEmpty());
 
         PKIXParameters pkixParams = new PKIXParameters(anchors);
         CertPathTrustManagerParameters certPathParams =
@@ -3533,7 +3347,6 @@ public class WolfSSLTrustX509Test {
             fail("No accepted issuers after CertPathParams init");
         }
 
-        pass("\t... passed");
     }
 
     /* Test TrustManagerFactory.init(KeyStoreBuilderParameters) */
@@ -3542,8 +3355,6 @@ public class WolfSSLTrustX509Test {
         throws NoSuchProviderException, NoSuchAlgorithmException,
                KeyStoreException, IOException, CertificateException,
                InvalidAlgorithmParameterException {
-
-        System.out.print("\tinit(KeyStoreBuilderParameters)");
 
         KeyStore.Builder ksBuilder = KeyStore.Builder.newInstance(
             WolfSSLTestFactory.isAndroid() ? "BKS" : "JKS",
@@ -3569,15 +3380,6 @@ public class WolfSSLTrustX509Test {
             fail("No accepted issuers after KeyStoreBuilder init");
         }
 
-        pass("\t... passed");
-    }
-
-    private void pass(String msg) {
-        WolfSSLTestFactory.pass(msg);
-    }
-
-    private void error(String msg) {
-        WolfSSLTestFactory.fail(msg);
     }
 
     /**
@@ -3827,8 +3629,6 @@ public class WolfSSLTrustX509Test {
         X509Certificate[] certArray = null;
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
 
-        System.out.print("\talt chain: unverifiable CA");
-
         /* Build a chain where the root CA is included but in cross-signed
          * form that cannot verify against our trust store. The trust store
          * contains the self-signed version of the same root CA.
@@ -3852,7 +3652,6 @@ public class WolfSSLTrustX509Test {
         /* Create TrustManager with caJKS which contains ca-cert.pem */
         tm = tf.createTrustManager("SunX509", tf.caJKS, provider);
         if (tm == null) {
-            error("\t... failed");
             fail("failed to create trustmanager");
             return;
         }
@@ -3888,12 +3687,10 @@ public class WolfSSLTrustX509Test {
         try {
             x509tm.checkServerTrusted(certArray, "RSA");
         } catch (CertificateException e) {
-            error("\t... failed");
             fail("Failed to verify chain with alternate path: " +
-                 e.getMessage());
+                e.getMessage());
         }
 
-        pass("\t... passed");
     }
 
     /**
@@ -3914,8 +3711,6 @@ public class WolfSSLTrustX509Test {
         X509Certificate[] certArray = null;
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
 
-        System.out.print("\talt chain: multiple CA skip");
-
         /* Build valid chain with extra wrong CAs appended at end */
 
         String serverCert = "examples/certs/intermediate/server-int-cert.pem";
@@ -3933,7 +3728,6 @@ public class WolfSSLTrustX509Test {
 
         tm = tf.createTrustManager("SunX509", tf.caJKS, provider);
         if (tm == null) {
-            error("\t... failed");
             fail("failed to create trustmanager");
             return;
         }
@@ -3975,12 +3769,10 @@ public class WolfSSLTrustX509Test {
         try {
             x509tm.checkServerTrusted(certArray, "RSA");
         } catch (CertificateException e) {
-            error("\t... failed");
             fail("Failed to verify chain with extra wrong CA: " +
-                 e.getMessage());
+                e.getMessage());
         }
 
-        pass("\t... passed");
     }
 
     /**
@@ -3998,8 +3790,6 @@ public class WolfSSLTrustX509Test {
         X509Certificate[] certArray = null;
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
 
-        System.out.print("\talt chain: non-CA must verify");
-
         /* Build invalid chain with unverifiable server cert.
          * This should FAIL because non-CA certs must verify. */
 
@@ -4016,7 +3806,6 @@ public class WolfSSLTrustX509Test {
         /* Create TrustManager with RSA CA certs */
         tm = tf.createTrustManager("SunX509", tf.caJKS, provider);
         if (tm == null) {
-            error("\t... failed");
             fail("failed to create trustmanager");
             return;
         }
@@ -4043,13 +3832,11 @@ public class WolfSSLTrustX509Test {
          * verified and non-CA certs must always verify. */
         try {
             x509tm.checkServerTrusted(certArray, "ECC");
-            error("\t... failed");
             fail("Verified invalid server cert, should have failed");
         } catch (CertificateException e) {
             /* Expected - non-CA certificate must verify */
         }
 
-        pass("\t... passed");
     }
 
     /**
@@ -4066,8 +3853,6 @@ public class WolfSSLTrustX509Test {
         Certificate cert = null;
         X509Certificate[] certArray = null;
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
-
-        System.out.print("\talt chain: invalid still fails");
 
         /* Build invalid chain where no path to trust anchor exists, should
          * fail. Use server cert from one chain with CAs from different
@@ -4086,7 +3871,6 @@ public class WolfSSLTrustX509Test {
         /* Create TrustManager with ECC CAs only */
         tm = tf.createTrustManager("SunX509", tf.caJKS, provider);
         if (tm == null) {
-            error("\t... failed");
             fail("failed to create trustmanager");
             return;
         }
@@ -4097,21 +3881,21 @@ public class WolfSSLTrustX509Test {
 
         /* certArray[0]: RSA server cert */
         try (FileInputStream fis = new FileInputStream(serverCert);
-             BufferedInputStream bis = new BufferedInputStream(fis)) {
+            BufferedInputStream bis = new BufferedInputStream(fis)) {
             cert = cf.generateCertificate(bis);
             certArray[0] = (X509Certificate)cert;
         }
 
         /* certArray[1]: ECC CA (wrong chain) */
         try (FileInputStream fis = new FileInputStream(wrongCA1);
-             BufferedInputStream bis = new BufferedInputStream(fis)) {
+            BufferedInputStream bis = new BufferedInputStream(fis)) {
             cert = cf.generateCertificate(bis);
             certArray[1] = (X509Certificate)cert;
         }
 
         /* certArray[2]: ECC CA 2 (wrong chain) */
         try (FileInputStream fis = new FileInputStream(wrongCA2);
-             BufferedInputStream bis = new BufferedInputStream(fis)) {
+            BufferedInputStream bis = new BufferedInputStream(fis)) {
             cert = cf.generateCertificate(bis);
             certArray[2] = (X509Certificate)cert;
         }
@@ -4119,13 +3903,11 @@ public class WolfSSLTrustX509Test {
         /* Verify chain, should fail. No valid path to trust anchor exists */
         try {
             x509tm.checkServerTrusted(certArray, "RSA");
-            error("\t... failed");
             fail("Verified invalid chain, should have failed");
         } catch (CertificateException e) {
             /* Expected - no valid path to trust anchor */
         }
 
-        pass("\t... passed");
     }
 
     /**
@@ -4145,8 +3927,6 @@ public class WolfSSLTrustX509Test {
         X509Certificate[] certArray = null;
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
 
-        System.out.print("\talt chain: cross-sign");
-
         String serverCert = "examples/certs/intermediate/server-int-cert.pem";
         String int1Cert = "examples/certs/intermediate/ca-int-cert.pem";
         String int2Cert = "examples/certs/intermediate/ca-int2-cert.pem";
@@ -4159,7 +3939,6 @@ public class WolfSSLTrustX509Test {
 
         tm = tf.createTrustManager("SunX509", tf.caJKS, provider);
         if (tm == null) {
-            error("\t\t... failed");
             fail("failed to create trustmanager");
             return;
         }
@@ -4169,19 +3948,19 @@ public class WolfSSLTrustX509Test {
         certArray = new X509Certificate[3];
 
         try (FileInputStream fis = new FileInputStream(serverCert);
-             BufferedInputStream bis = new BufferedInputStream(fis)) {
+            BufferedInputStream bis = new BufferedInputStream(fis)) {
             cert = cf.generateCertificate(bis);
             certArray[0] = (X509Certificate)cert;
         }
 
         try (FileInputStream fis = new FileInputStream(int1Cert);
-             BufferedInputStream bis = new BufferedInputStream(fis)) {
+            BufferedInputStream bis = new BufferedInputStream(fis)) {
             cert = cf.generateCertificate(bis);
             certArray[1] = (X509Certificate)cert;
         }
 
         try (FileInputStream fis = new FileInputStream(int2Cert);
-             BufferedInputStream bis = new BufferedInputStream(fis)) {
+            BufferedInputStream bis = new BufferedInputStream(fis)) {
             cert = cf.generateCertificate(bis);
             certArray[2] = (X509Certificate)cert;
         }
@@ -4189,12 +3968,10 @@ public class WolfSSLTrustX509Test {
         try {
             x509tm.checkServerTrusted(certArray, "RSA");
         } catch (CertificateException e) {
-            error("\t\t... failed");
             fail("Cross-signed root test failed: " +
                  e.getMessage());
         }
 
-        pass("\t\t... passed");
     }
 
     /**
@@ -4216,8 +3993,6 @@ public class WolfSSLTrustX509Test {
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
         List<X509Certificate> retChain = null;
 
-        System.out.print("\tret chain excludes skipped CAs");
-
         /* Build valid RSA chain with extra wrong CA appended at end */
         String serverCert =
             "examples/certs/intermediate/server-int-cert.pem";
@@ -4235,7 +4010,6 @@ public class WolfSSLTrustX509Test {
 
         tm = tf.createTrustManager("SunX509", tf.caJKS, provider);
         if (tm == null) {
-            error("\t... failed");
             fail("failed to create trustmanager");
             return;
         }
@@ -4251,21 +4025,21 @@ public class WolfSSLTrustX509Test {
 
         /* certArray[0]: RSA server cert */
         try (FileInputStream fis = new FileInputStream(serverCert);
-             BufferedInputStream bis = new BufferedInputStream(fis)) {
+            BufferedInputStream bis = new BufferedInputStream(fis)) {
             cert = cf.generateCertificate(bis);
             certArray[0] = (X509Certificate)cert;
         }
 
         /* certArray[1]: RSA intermediate CA 1 */
         try (FileInputStream fis = new FileInputStream(int1Cert);
-             BufferedInputStream bis = new BufferedInputStream(fis)) {
+            BufferedInputStream bis = new BufferedInputStream(fis)) {
             cert = cf.generateCertificate(bis);
             certArray[1] = (X509Certificate)cert;
         }
 
         /* certArray[2]: RSA intermediate CA 2 */
         try (FileInputStream fis = new FileInputStream(int2Cert);
-             BufferedInputStream bis = new BufferedInputStream(fis)) {
+            BufferedInputStream bis = new BufferedInputStream(fis)) {
             cert = cf.generateCertificate(bis);
             certArray[2] = (X509Certificate)cert;
         }
@@ -4273,7 +4047,7 @@ public class WolfSSLTrustX509Test {
         /* certArray[3]: ECC CA (wrong, should be skipped) */
         X509Certificate skippedCA = null;
         try (FileInputStream fis = new FileInputStream(wrongCA);
-             BufferedInputStream bis = new BufferedInputStream(fis)) {
+            BufferedInputStream bis = new BufferedInputStream(fis)) {
             cert = cf.generateCertificate(bis);
             certArray[3] = (X509Certificate)cert;
             skippedCA = (X509Certificate)cert;
@@ -4285,27 +4059,23 @@ public class WolfSSLTrustX509Test {
             retChain = wolfX509tm.checkServerTrusted(certArray,
                 "RSA", "localhost");
         } catch (CertificateException e) {
-            error("\t... failed");
             fail("Failed to verify chain with extra wrong CA: " +
-                 e.getMessage());
+                e.getMessage());
         }
 
         if (retChain == null) {
-            error("\t... failed");
             fail("checkServerTrusted() did not return expected List of certs");
         }
 
         /* Returned chain should include peer + 2 intermediates + root = 4.
          * It should not include the skipped ECC CA cert. */
         if (retChain.size() != 4) {
-            error("\t... failed");
             fail("Expected 4 certs in chain (peer + 2 ints + root), got: " +
-                 retChain.size());
+                retChain.size());
         }
 
         /* Verify skipped CA is NOT in returned chain */
         if (retChain.contains(skippedCA)) {
-            error("\t... failed");
             fail("Returned chain should not contain skipped CA certificate");
         }
 
@@ -4314,28 +4084,23 @@ public class WolfSSLTrustX509Test {
          * - Chain must contain both intermediates (int1 and int2)
          * - Chain must not contain the skipped ECC CA */
         if (!retChain.get(0).equals(certArray[0])) {
-            error("\t... failed");
             fail("Expected peer cert at position 0 in returned chain");
         }
 
         /* Verify both valid intermediates are present in the chain */
         if (!retChain.contains(certArray[1])) {
-            error("\t... failed");
             fail("Returned chain missing intermediate 1 (ca-int-cert.pem)");
         }
 
         if (!retChain.contains(certArray[2])) {
-            error("\t... failed");
             fail("Returned chain missing intermediate 2 (ca-int2-cert.pem)");
         }
 
         /* Verify skipped CA is definitely NOT in the chain */
         if (retChain.contains(certArray[3])) {
-            error("\t... failed");
             fail("Returned chain should NOT contain skipped ECC CA");
         }
 
-        pass("\t... passed");
     }
 
     /**
@@ -4347,12 +4112,9 @@ public class WolfSSLTrustX509Test {
         throws NoSuchProviderException, NoSuchAlgorithmException,
                KeyStoreException {
 
-        System.out.print("\tTesting cacerts via java.home");
-
         /* Verify java.home system property is set (should always be by JVM) */
         String javaHome = System.getProperty("java.home");
         if (javaHome == null || javaHome.isEmpty()) {
-            error("\t... failed");
             fail("java.home system property not set");
             return;
         }
@@ -4362,18 +4124,14 @@ public class WolfSSLTrustX509Test {
             File.separator + "security" + File.separator + "cacerts";
         File cacertsFile = new File(cacertsPath);
 
-        if (!cacertsFile.exists()) {
-            /* cacerts may not exist on all systems, skip test */
-            pass("\t... skipped (no cacerts)");
-            return;
-        }
+        /* cacerts may not exist on all systems, skip test */
+        Assume.assumeTrue(cacertsFile.exists());
 
         /* Create TrustManagerFactory and init with null KeyStore.
          * This triggers loading of system CA certs from cacerts file. */
         TrustManagerFactory tmf =
             TrustManagerFactory.getInstance("PKIX", provider);
         if (tmf == null) {
-            error("\t... failed");
             fail("failed to get TrustManagerFactory instance");
             return;
         }
@@ -4381,7 +4139,6 @@ public class WolfSSLTrustX509Test {
         try {
             tmf.init((KeyStore)null);
         } catch (Exception e) {
-            error("\t... failed");
             fail("TrustManagerFactory.init(null) failed: " + e.getMessage());
             return;
         }
@@ -4389,7 +4146,6 @@ public class WolfSSLTrustX509Test {
         /* Verify TrustManagers were created */
         TrustManager[] tms = tmf.getTrustManagers();
         if (tms == null || tms.length == 0) {
-            error("\t... failed");
             fail("No TrustManagers returned after init with null KeyStore");
             return;
         }
@@ -4409,13 +4165,9 @@ public class WolfSSLTrustX509Test {
         }
 
         if (!foundX509TM) {
-            error("\t... failed");
             fail("No X509TrustManager with accepted issuers found, " +
                  "system cacerts may not have been loaded");
             return;
         }
-
-        pass("\t... passed");
     }
 }
-

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLX509Test.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLX509Test.java
@@ -59,17 +59,25 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLPeerUnverifiedException;
 
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import com.wolfssl.WolfSSL;
 import com.wolfssl.WolfSSLException;
 import com.wolfssl.provider.jsse.WolfSSLProvider;
 import com.wolfssl.provider.jsse.WolfSSLX509;
 import com.wolfssl.provider.jsse.WolfSSLX509X;
+import com.wolfssl.test.TimedTestWatcher;
 
 public class WolfSSLX509Test {
+
+    @Rule
+    public TestRule testWatcher = TimedTestWatcher.create();
+
     private static WolfSSLTestFactory tf;
     private String provider = "wolfJSSE";
     private javax.security.cert.X509Certificate[] certs;
@@ -85,7 +93,7 @@ public class WolfSSLX509Test {
 
         System.out.println("WolfSSLX509 Class");
 
-                /* install wolfJSSE provider at runtime */
+        /* install wolfJSSE provider at runtime */
         Security.insertProviderAt(new WolfSSLProvider(), 1);
 
 
@@ -109,7 +117,6 @@ public class WolfSSLX509Test {
 
     @Test
     public void testServerParsing() {
-        System.out.print("\tTesting server cert");
         try {
             X509Certificate x509, ca;
             byte[] der;
@@ -119,13 +126,11 @@ public class WolfSSLX509Test {
                 x509.checkValidity();
             } catch (CertificateExpiredException |
                     CertificateNotYetValidException e) {
-                error("\t\t... failed");
-                fail("certificae not valid");
+                fail("certificate not valid");
             }
 
             if (x509.getBasicConstraints() <=0) {
-                error("\t\t... failed");
-                fail("certificae does not have basic constraint set to true");
+                fail("certificate does not have basic constraint set to true");
             }
 
             der = tf.getCert("ca");
@@ -137,15 +142,12 @@ public class WolfSSLX509Test {
                 x509x.verify(pkey);
             } catch (InvalidKeyException | NoSuchProviderException |
                     SignatureException | javax.security.cert.CertificateException e) {
-                error("\t\t... failed");
-                fail("certificae not valid");
+                fail("certificate not valid");
             }
         } catch (KeyStoreException | WolfSSLException | NoSuchAlgorithmException |
                 CertificateException | IOException e) {
-            error("\t\t... failed");
             fail("general parsing failure");
         }
-        pass("\t\t... passed");
     }
 
 
@@ -164,26 +166,19 @@ public class WolfSSLX509Test {
         String[] expectCrit = {"2.5.29.15" , "2.5.29.19"};
         String[] expectNonCrit = {"2.5.29.14"};
 
-        System.out.print("\tTesting x509 ext");
-
         /* skip if wolfSSL compiled with NO_FILESYSTEM */
-        if (WolfSSL.FileSystemEnabled() == false) {
-            pass("\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.FileSystemEnabled());
 
         try {
             x509 = new WolfSSLX509(tf.googleCACert);
 
             keyUsage = x509.getKeyUsage();
             if (keyUsage.length != expected.length) {
-                error("\t... failed");
                 fail("unexpected key usage found");
             }
 
             for (i = 0; i < expected.length; i++) {
                 if (keyUsage[i] != expected[i])  {
-                    error("\t... failed");
                     fail("unexpected key usage found");
                 }
             }
@@ -191,12 +186,10 @@ public class WolfSSLX509Test {
             oids = x509.getCriticalExtensionOIDs();
             o = oids.toArray(new String[oids.size()]);
             if (o.length != expectCrit.length) {
-                error("\t... failed");
                 fail("unexpected crit extension length");
             }
             for (i = 0; i < o.length; i++) {
                 if (!o[i].equals(expectCrit[i])) {
-                    error("\t... failed");
                     fail("unexpected crit extension found");
                 }
             }
@@ -204,55 +197,42 @@ public class WolfSSLX509Test {
             oids = x509.getNonCriticalExtensionOIDs();
             o = oids.toArray(new String[oids.size()]);
             if (o.length != expectNonCrit.length) {
-                error("\t... failed");
                 fail("unexpected non crit extension length");
             }
             for (i = 0; i < o.length; i++) {
                 if (!o[i].equals(expectNonCrit[i])) {
-                    error("\t... failed");
                     fail("unexpected non crit extension found");
                 }
             }
 
             if (x509.hasUnsupportedCriticalExtension()) {
-                error("\t... failed");
                 fail("unexpected crit extension found");
             }
 
             /* @TODO testing for correctness of return value */
             if (x509.getExtensionValue("2.5.29.19") == null) {
-                error("\t... failed");
                 fail("failed to find basic constraint extension");
             }
 
              if (!x509.getSigAlgOID().equals("1.2.840.113549.1.1.12")) {
-                 error("\t... failed");
                  fail("unexpected sig alg OID found");
              }
 
              x509X = new WolfSSLX509X(x509.getEncoded());
              if (!x509X.getSigAlgOID().equals("1.2.840.113549.1.1.12")) {
-                 error("\t... failed");
                  fail("unexpected sig alg OID found");
              }
         } catch (Exception ex) {
-            error("\t... failed");
             fail("unexpected exception found");
         }
-        pass("\t\t... passed");
     }
 
     @Test
     public void testX509XValidity() {
         WolfSSLX509X x509;
 
-        System.out.print("\tTesting X509X validity");
-
         /* skip if wolfSSL compiled with NO_FILESYSTEM */
-        if (WolfSSL.FileSystemEnabled() == false) {
-            pass("\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.FileSystemEnabled());
 
         try {
             x509 = new WolfSSLX509X(tf.googleCACert);
@@ -260,10 +240,8 @@ public class WolfSSLX509Test {
             x509.checkValidity(new Date());
         } catch (WolfSSLException | javax.security.cert.CertificateExpiredException |
                 javax.security.cert.CertificateNotYetValidException e) {
-            error("\t\t... failed");
             fail("failed date validity test");
         }
-        pass("\t\t... passed");
    }
 
     @Test
@@ -272,41 +250,30 @@ public class WolfSSLX509Test {
         int i;
         WolfSSLX509 x509;
 
-        System.out.print("\tTesting TBS");
-
         /* skip if wolfSSL compiled with NO_FILESYSTEM */
-        if (WolfSSL.FileSystemEnabled() == false) {
-            pass("\t\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.FileSystemEnabled());
 
         try {
             x509 = new WolfSSLX509(tf.googleCACert);
             tbs = x509.getTBSCertificate();
             if (tbs == null) {
-                error("\t\t\t... failed");
                 fail("failed to get TBS cert");
                 return;
             }
 
             if (tbs.length != expectedTbs.length) {
-                error("\t\t\t... failed");
                 fail("unexpected tbs length");
             }
 
             for (i = 0; i < tbs.length; i++) {
                 if (tbs[i] != expectedTbs[i]) {
-                    error("\t\t\t... failed");
                     fail("unexpected TBS cert");
                 }
             }
 
         } catch (CertificateEncodingException | WolfSSLException e) {
-            error("\t\t\t... failed");
             fail("unexpected TBS cert");
         }
-
-        pass("\t\t\t... passed");
     }
 
     @Test
@@ -318,7 +285,6 @@ public class WolfSSLX509Test {
         PublicKey pkey;
         byte[] key;
 
-        System.out.print("\tTesting public key");
         try {
             store = KeyStore.getInstance(tf.keyStoreType);
             stream = new FileInputStream(tf.allJKS);
@@ -329,37 +295,30 @@ public class WolfSSLX509Test {
             cax = new WolfSSLX509X(ca.getEncoded());
             pkey = cax.getPublicKey();
             if (pkey == null) {
-                error("\t\t... failed");
                 fail("failed to get public key");
             }
 
             pkey = ca.getPublicKey();
 
             if (!pkey.getFormat().equals("X.509")) {
-                error("\t\t... failed");
                 fail("unexpected public key format");
             }
 
             if (!pkey.getAlgorithm().equals("RSA")) {
-                error("\t\t... failed");
                 fail("unexpected public key algorithm found");
             }
 
             key = pkey.getEncoded();
             for (int i = 0; i < key.length; i++) {
                 if (key[i] != expectedPkey[i]) {
-                    error("\t\t... failed");
                     fail("unexpected public key found");
                 }
             }
         } catch (KeyStoreException | WolfSSLException |
                 NoSuchAlgorithmException | CertificateException |
                 IOException e) {
-            error("\t\t... failed");
             fail("failed");
         }
-
-        pass("\t\t... passed");
     }
 
     @Test
@@ -371,7 +330,6 @@ public class WolfSSLX509Test {
         Provider[] p;
         Provider sigProvider = null;
 
-        System.out.print("\tTesting verify");
         try {
             /* check if signature providers available */
             p = Security.getProviders();
@@ -381,10 +339,8 @@ public class WolfSSLX509Test {
                     break;
                 }
             }
-            if (sigProvider == null || WolfSSLTestFactory.isAndroid()) {
-                pass("\t\t\t... skipped");
-                return;
-            }
+            Assume.assumeFalse(
+                sigProvider == null || WolfSSLTestFactory.isAndroid());
 
             store = KeyStore.getInstance(tf.keyStoreType);
             stream = new FileInputStream(tf.allJKS);
@@ -399,7 +355,6 @@ public class WolfSSLX509Test {
                 serverx.verify(ca.getPublicKey(), sigProvider.getName());
             } catch (InvalidKeyException | SignatureException |
                     NoSuchProviderException | javax.security.cert.CertificateException e) {
-                error("\t... failed");
                 fail("failed to verify certificate");
             }
 
@@ -407,13 +362,11 @@ public class WolfSSLX509Test {
                 server.verify(ca.getPublicKey(), sigProvider.getName());
             } catch (InvalidKeyException | SignatureException |
                     NoSuchProviderException e) {
-                error("\t\t\t... failed");
                 fail("failed to verify certificate");
             }
 
             try {
                 server.verify(server.getPublicKey(), sigProvider);
-                error("\t\t\t... failed");
                 fail("able to verify when should not have been");
             } catch (InvalidKeyException | SignatureException e) {
                 /* expected fail case */
@@ -421,11 +374,9 @@ public class WolfSSLX509Test {
 
         } catch (KeyStoreException | NoSuchAlgorithmException |
                 CertificateException | IOException | WolfSSLException e) {
-            error("\t\t\t... failed");
             e.printStackTrace();
             fail("general failure");
         }
-        pass("\t\t\t... passed");
     }
 
 
@@ -440,7 +391,6 @@ public class WolfSSLX509Test {
         int ret;
         SSLContext ctxClient;
         SSLContext ctxServer;
-        System.out.print("\tTesting x509 getters");
 
         ctxClient = tf.createSSLContext("TLS", provider,
                     tf.createTrustManager("SunX509", tf.caServerJKS, provider),
@@ -457,9 +407,8 @@ public class WolfSSLX509Test {
         server.setNeedClientAuth(false);
         client.setUseClientMode(true);
         ret = tf.testConnection(server, client, null, null,
-                "Test cipher suite");
+            "Test cipher suite");
         if (ret != 0) {
-            error("\t\t... failed");
             fail("failed to create engine");
         }
 
@@ -471,7 +420,6 @@ public class WolfSSLX509Test {
             /* getPeerCertificateChain() returns array of javax.security.cert.X509Certificate */
             certs = client.getSession().getPeerCertificateChain();
             if (certs == null) {
-                error("\t\t... failed");
                 fail("failed to get peer certificate chain");
             }
             /* @TODO certs.length != 2 test */
@@ -481,7 +429,6 @@ public class WolfSSLX509Test {
             /* getLocalCertificates() returns array of java.security.cert.Certificate */
             local = (X509Certificate[]) server.getSession().getLocalCertificates();
             if (local == null) {
-                error("\t\t... failed");
                 fail("failed to get local certificate");
                 return;
             }
@@ -491,37 +438,31 @@ public class WolfSSLX509Test {
             if (local[0].getType().equals("X.509")) {
                 x509 = (X509Certificate)local[0];
             } else {
-                error("\t\t... failed");
                 fail("getLocalCertificates() did not return X509Certificate type");
             }
 
             if (x509.getVersion() != 3 || peer.getVersion() != 2) {
-                error("\t\t... failed");
                 fail("unexpected x509 version");
             }
 
             if (!x509.getSigAlgName().equals(peer.getSigAlgName())) {
-                error("\t\t... failed");
                 fail("failed to match sig alg name");
             }
 
             /* check serial numbers */
            if (x509.getSerialNumber().intValue() !=
                    peer.getSerialNumber().intValue()) {
-               error("\t\t... failed");
                fail("failed to match serial number");
            }
 
 
            if (!x509.getNotBefore().before(new Date()) ||
                    !peer.getNotBefore().before(new Date())) {
-               error("\t\t... failed");
                fail("failed date not before");
            }
 
            if (!x509.getNotAfter().after(new Date()) ||
                    !peer.getNotAfter().after(new Date())) {
-               error("\t\t... failed");
                fail("failed date not after");
            }
 
@@ -529,19 +470,16 @@ public class WolfSSLX509Test {
            if (!WolfSSLTestFactory.isAndroid()) {
                if (!x509.getSubjectDN().getName().equals(
                        peer.getSubjectDN().getName())) {
-                   error("\t\t... failed");
                    fail("subject DN does not match");
                }
 
                if (!x509.getIssuerDN().getName().equals(
                        peer.getIssuerDN().getName())) {
-                   error("\t\t... failed");
                    fail("issuer DN does not match");
                }
            }
 
            if (peer.toString() == null || x509.toString() == null) {
-               error("\t\t... failed");
                fail("failed to get cert string");
            }
 
@@ -555,13 +493,11 @@ public class WolfSSLX509Test {
            /* test getter for signature, correctness of return is tested in
             * WolfSSLCertificateTest */
            if (x509.getSignature() == null) {
-               error("\t\t... failed");
                fail("failed to get cert signature");
            }
 
            try {
                tmp.getIssuerUniqueID();
-               error("\t\t... failed: A test case for getIssuerUniqueID is needed");
                fail("getIssuerUniqueID implemented without test case");
            } catch (Exception ex) {
                /* @TODO not supported */
@@ -569,7 +505,6 @@ public class WolfSSLX509Test {
 
            try {
                tmp.getSubjectUniqueID();
-               error("\t\t... failed: A test case for getSubjectUniqueID is needed");
                fail("getSubjectUniqueID implemented without test case");
            } catch (Exception ex) {
                /* @TODO not supported */
@@ -577,7 +512,6 @@ public class WolfSSLX509Test {
 
            try {
                tmp.getSigAlgParams();
-               error("\t\t... failed: A test case for getSigAlgParams is needed");
                fail("getSigAlgParams implemented without test case");
            } catch (Exception ex) {
                /* @TODO not supported */
@@ -585,7 +519,6 @@ public class WolfSSLX509Test {
 
            try {
                peer.getSigAlgParams();
-               error("\t\t... failed: A test case for getSigAlgParams is needed");
                fail("getSigAlgParams implemented without test case");
            } catch (Exception ex) {
                /* @TODO not supported */
@@ -593,7 +526,6 @@ public class WolfSSLX509Test {
 
            try {
                peer.getSigAlgParams();
-               error("\t\t... failed: A test case for getSigAlgParams is needed");
                fail("getSigAlgParams implemented without test case");
            } catch (Exception ex) {
                /* @TODO not supported */
@@ -602,11 +534,8 @@ public class WolfSSLX509Test {
         } catch (SSLPeerUnverifiedException | WolfSSLException |
                 CertificateEncodingException |
                 javax.security.cert.CertificateEncodingException e) {
-            error("\t\t... failed");
             fail("failed to get peer certificate chain");
         }
-
-        pass("\t\t... passed");
     }
 
     @Test
@@ -615,13 +544,8 @@ public class WolfSSLX509Test {
         X509Certificate x509;
         int ALT_DNS_NAME = 2; /* dNSName type */
 
-        System.out.print("\tTesting getting alt names");
-
         /* skip if wolfSSL compiled with NO_FILESYSTEM */
-        if (WolfSSL.FileSystemEnabled() == false) {
-            pass("\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.FileSystemEnabled());
 
         /* populate known alt name list for example.com cert, for comparison */
         List<String> expected = new ArrayList<>();
@@ -642,35 +566,29 @@ public class WolfSSLX509Test {
 
             Collection<?> subjectAltNames = x509.getSubjectAlternativeNames();
             if (subjectAltNames == null) {
-                error("\t... failed");
                 fail("subjectAltNames Collection was null");
             }
 
             for (Object subjectAltName : subjectAltNames) {
                 List<?> entry = (List<?>)subjectAltName;
                 if (entry == null || entry.size() < 2) {
-                    error("\t... failed");
                     fail("subjectAltName List<?> null or length < 2");
                 }
                 Integer altNameType = (Integer)entry.get(0);
                 if (altNameType == null) {
-                    error("\t... failed");
                     fail("subjectAltName List[0] was null, should be Integer");
                 }
                 if (altNameType != ALT_DNS_NAME) {
-                    error("\t... failed");
                     fail("subjectAltName type is not ALT_DNS_NAME (2)");
                 }
                 String altName = (String)entry.get(1);
                 if (altName == null) {
-                    error("\t... failed");
                     fail("Individual altName was null, should not be");
                 }
                 found.add(altName);
             }
 
             if (found.size() != expected.size()) {
-                error("\r... failed");
                 fail("altName list size differs from expected size, " +
                      "found: " + found.size() + ", expected: " +
                      expected.size());
@@ -680,28 +598,22 @@ public class WolfSSLX509Test {
              * contents without depending on order */
             for (String expectedName : expected) {
                 if (!found.contains(expectedName)) {
-                    error("\r... failed");
                     fail("expected altName not found: " + expectedName);
                 }
             }
             for (String foundName : found) {
                 if (!expected.contains(foundName)) {
-                    error("\r... failed");
                     fail("unexpected altName found: " + foundName);
                 }
             }
 
         } catch (Exception ex) {
-            error("\t... failed");
             fail("unexpected exception found");
         }
-        pass("\t... passed");
     }
 
     @Test
     public void testWolfSSLPrincipalToString() {
-        System.out.print("\tWolfSSLPrincipal toString");
-
         try {
             assertNotNull("issuerDN should not be null", issuerDN);
             assertNotNull("subjectDN should not be null", subjectDN);
@@ -726,18 +638,13 @@ public class WolfSSLX509Test {
                         subjectDN.getName(), subjectString);
 
         } catch (Exception e) {
-            error("\t... failed");
             fail("Exception during WolfSSLPrincipal toString test: " +
-                 e.getMessage());
+                e.getMessage());
         }
-
-        pass("\t... passed");
     }
 
     @Test
     public void testWolfSSLPrincipalGetName() {
-        System.out.print("\tWolfSSLPrincipal getName");
-
         try {
             assertNotNull("issuerDN should not be null", issuerDN);
             assertNotNull("subjectDN should not be null", subjectDN);
@@ -764,18 +671,13 @@ public class WolfSSLX509Test {
                        !subjectName.startsWith("/"));
 
         } catch (Exception e) {
-            error("\t... failed");
             fail("Exception during WolfSSLPrincipal getName test: " +
-                 e.getMessage());
+                e.getMessage());
         }
-
-        pass("\t... passed");
     }
 
     @Test
     public void testWolfSSLPrincipalInterfaceImplementation() {
-        System.out.print("\tWolfSSLPrincipal interface");
-
         try {
             assertNotNull("issuerDN should not be null", issuerDN);
             assertNotNull("subjectDN should not be null", subjectDN);
@@ -805,12 +707,9 @@ public class WolfSSLX509Test {
                         subjectHash1, subjectHash2);
 
         } catch (Exception e) {
-            error("\t... failed");
             fail("Exception during WolfSSLPrincipal interface test: " +
                  e.getMessage());
         }
-
-        pass("\t... passed");
     }
 
     @Test
@@ -818,13 +717,8 @@ public class WolfSSLX509Test {
         X509Certificate x509;
         List<String> eku;
 
-        System.out.print("\tTesting getExtendedKeyUsage");
-
         /* skip if wolfSSL compiled with NO_FILESYSTEM */
-        if (WolfSSL.FileSystemEnabled() == false) {
-            pass("\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.FileSystemEnabled());
 
         try {
             /* Test with server certificate which has Extended Key Usage
@@ -835,53 +729,42 @@ public class WolfSSLX509Test {
 
             /* Server cert should have EKU extension */
             if (eku == null) {
-                error("\t... failed");
                 fail("getExtendedKeyUsage() returned null for server cert");
             }
 
             /* Server cert should have serverAuth (1.3.6.1.5.5.7.3.1) and
              * clientAuth (1.3.6.1.5.5.7.3.2) */
             if (eku.size() != 2) {
-                error("\t... failed");
                 fail("Expected 2 EKU OIDs, got: " + eku.size());
             }
 
             if (!eku.contains("1.3.6.1.5.5.7.3.1")) {
-                error("\t... failed");
                 fail("Missing serverAuth OID 1.3.6.1.5.5.7.3.1");
             }
 
             if (!eku.contains("1.3.6.1.5.5.7.3.2")) {
-                error("\t... failed");
                 fail("Missing clientAuth OID 1.3.6.1.5.5.7.3.2");
             }
 
             /* Verify all OIDs are properly formatted */
             for (String oid : eku) {
                 if (oid == null || oid.isEmpty()) {
-                    error("\t... failed");
                     fail("EKU OID is null or empty");
                 }
                 if (!oid.matches("^[0-9]+(\\.[0-9]+)*$")) {
-                    error("\t... failed");
                     fail("Invalid OID format: " + oid);
                 }
             }
 
         } catch (Exception ex) {
-            error("\t... failed");
             ex.printStackTrace();
             fail("unexpected exception: " + ex.getMessage());
         }
-
-        pass("\t... passed");
     }
 
     @Test
     public void testWolfSSLPrincipalImplies() {
         Subject emptySubject, subjectWithPrincipals;
-
-        System.out.print("\tWolfSSLPrincipal implies");
 
         try {
             assertNotNull("issuerDN should not be null", issuerDN);
@@ -937,18 +820,13 @@ public class WolfSSLX509Test {
                 !issuerDN.implies(subjectWithSubjectOnly));
 
         } catch (Exception e) {
-            error("\t... failed");
             fail("Exception during WolfSSLPrincipal implies test: " +
-                 e.getMessage());
+                e.getMessage());
         }
-
-        pass("\t... passed");
     }
 
     @Test
     public void testX500Principal() {
-        System.out.print("\tTesting X500Principal methods");
-
         try {
             assertNotNull("x509 should not be null", x509);
 
@@ -1008,19 +886,8 @@ public class WolfSSLX509Test {
             caX509.free();
 
         } catch (Exception e) {
-            error("\t... failed");
             fail("Exception during X500Principal test: " + e.getMessage());
         }
-
-        pass("\t... passed");
-    }
-
-    private void pass(String msg) {
-        WolfSSLTestFactory.pass(msg);
-    }
-
-    private void error(String msg) {
-        WolfSSLTestFactory.fail(msg);
     }
 
     private byte[] expectedTbs = {
@@ -1236,79 +1103,79 @@ public class WolfSSLX509Test {
     };
 
     private byte[] expectedPkey = {
-            (byte)0x30, (byte)0x82, (byte)0x01, (byte)0x22,
-            (byte)0x30, (byte)0x0D, (byte)0x06, (byte)0x09,
-            (byte)0x2A, (byte)0x86, (byte)0x48, (byte)0x86,
-            (byte)0xF7, (byte)0x0D, (byte)0x01, (byte)0x01,
-            (byte)0x01, (byte)0x05, (byte)0x00, (byte)0x03,
-            (byte)0x82, (byte)0x01, (byte)0x0F, (byte)0x00,
-            (byte)0x30, (byte)0x82, (byte)0x01, (byte)0x0A,
-            (byte)0x02, (byte)0x82, (byte)0x01, (byte)0x01,
-            (byte)0x00, (byte)0xBF, (byte)0x0C, (byte)0xCA,
-            (byte)0x2D, (byte)0x14, (byte)0xB2, (byte)0x1E,
-            (byte)0x84, (byte)0x42, (byte)0x5B, (byte)0xCD,
-            (byte)0x38, (byte)0x1F, (byte)0x4A, (byte)0xF2,
-            (byte)0x4D, (byte)0x75, (byte)0x10, (byte)0xF1,
-            (byte)0xB6, (byte)0x35, (byte)0x9F, (byte)0xDF,
-            (byte)0xCA, (byte)0x7D, (byte)0x03, (byte)0x98,
-            (byte)0xD3, (byte)0xAC, (byte)0xDE, (byte)0x03,
-            (byte)0x66, (byte)0xEE, (byte)0x2A, (byte)0xF1,
-            (byte)0xD8, (byte)0xB0, (byte)0x7D, (byte)0x6E,
-            (byte)0x07, (byte)0x54, (byte)0x0B, (byte)0x10,
-            (byte)0x98, (byte)0x21, (byte)0x4D, (byte)0x80,
-            (byte)0xCB, (byte)0x12, (byte)0x20, (byte)0xE7,
-            (byte)0xCC, (byte)0x4F, (byte)0xDE, (byte)0x45,
-            (byte)0x7D, (byte)0xC9, (byte)0x72, (byte)0x77,
-            (byte)0x32, (byte)0xEA, (byte)0xCA, (byte)0x90,
-            (byte)0xBB, (byte)0x69, (byte)0x52, (byte)0x10,
-            (byte)0x03, (byte)0x2F, (byte)0xA8, (byte)0xF3,
-            (byte)0x95, (byte)0xC5, (byte)0xF1, (byte)0x8B,
-            (byte)0x62, (byte)0x56, (byte)0x1B, (byte)0xEF,
-            (byte)0x67, (byte)0x6F, (byte)0xA4, (byte)0x10,
-            (byte)0x41, (byte)0x95, (byte)0xAD, (byte)0x0A,
-            (byte)0x9B, (byte)0xE3, (byte)0xA5, (byte)0xC0,
-            (byte)0xB0, (byte)0xD2, (byte)0x70, (byte)0x76,
-            (byte)0x50, (byte)0x30, (byte)0x5B, (byte)0xA8,
-            (byte)0xE8, (byte)0x08, (byte)0x2C, (byte)0x7C,
-            (byte)0xED, (byte)0xA7, (byte)0xA2, (byte)0x7A,
-            (byte)0x8D, (byte)0x38, (byte)0x29, (byte)0x1C,
-            (byte)0xAC, (byte)0xC7, (byte)0xED, (byte)0xF2,
-            (byte)0x7C, (byte)0x95, (byte)0xB0, (byte)0x95,
-            (byte)0x82, (byte)0x7D, (byte)0x49, (byte)0x5C,
-            (byte)0x38, (byte)0xCD, (byte)0x77, (byte)0x25,
-            (byte)0xEF, (byte)0xBD, (byte)0x80, (byte)0x75,
-            (byte)0x53, (byte)0x94, (byte)0x3C, (byte)0x3D,
-            (byte)0xCA, (byte)0x63, (byte)0x5B, (byte)0x9F,
-            (byte)0x15, (byte)0xB5, (byte)0xD3, (byte)0x1D,
-            (byte)0x13, (byte)0x2F, (byte)0x19, (byte)0xD1,
-            (byte)0x3C, (byte)0xDB, (byte)0x76, (byte)0x3A,
-            (byte)0xCC, (byte)0xB8, (byte)0x7D, (byte)0xC9,
-            (byte)0xE5, (byte)0xC2, (byte)0xD7, (byte)0xDA,
-            (byte)0x40, (byte)0x6F, (byte)0xD8, (byte)0x21,
-            (byte)0xDC, (byte)0x73, (byte)0x1B, (byte)0x42,
-            (byte)0x2D, (byte)0x53, (byte)0x9C, (byte)0xFE,
-            (byte)0x1A, (byte)0xFC, (byte)0x7D, (byte)0xAB,
-            (byte)0x7A, (byte)0x36, (byte)0x3F, (byte)0x98,
-            (byte)0xDE, (byte)0x84, (byte)0x7C, (byte)0x05,
-            (byte)0x67, (byte)0xCE, (byte)0x6A, (byte)0x14,
-            (byte)0x38, (byte)0x87, (byte)0xA9, (byte)0xF1,
-            (byte)0x8C, (byte)0xB5, (byte)0x68, (byte)0xCB,
-            (byte)0x68, (byte)0x7F, (byte)0x71, (byte)0x20,
-            (byte)0x2B, (byte)0xF5, (byte)0xA0, (byte)0x63,
-            (byte)0xF5, (byte)0x56, (byte)0x2F, (byte)0xA3,
-            (byte)0x26, (byte)0xD2, (byte)0xB7, (byte)0x6F,
-            (byte)0xB1, (byte)0x5A, (byte)0x17, (byte)0xD7,
-            (byte)0x38, (byte)0x99, (byte)0x08, (byte)0xFE,
-            (byte)0x93, (byte)0x58, (byte)0x6F, (byte)0xFE,
-            (byte)0xC3, (byte)0x13, (byte)0x49, (byte)0x08,
-            (byte)0x16, (byte)0x0B, (byte)0xA7, (byte)0x4D,
-            (byte)0x67, (byte)0x00, (byte)0x52, (byte)0x31,
-            (byte)0x67, (byte)0x23, (byte)0x4E, (byte)0x98,
-            (byte)0xED, (byte)0x51, (byte)0x45, (byte)0x1D,
-            (byte)0xB9, (byte)0x04, (byte)0xD9, (byte)0x0B,
-            (byte)0xEC, (byte)0xD8, (byte)0x28, (byte)0xB3,
-            (byte)0x4B, (byte)0xBD, (byte)0xED, (byte)0x36,
-            (byte)0x79, (byte)0x02, (byte)0x03, (byte)0x01,
-            (byte)0x00, (byte)0x01
+        (byte)0x30, (byte)0x82, (byte)0x01, (byte)0x22,
+        (byte)0x30, (byte)0x0D, (byte)0x06, (byte)0x09,
+        (byte)0x2A, (byte)0x86, (byte)0x48, (byte)0x86,
+        (byte)0xF7, (byte)0x0D, (byte)0x01, (byte)0x01,
+        (byte)0x01, (byte)0x05, (byte)0x00, (byte)0x03,
+        (byte)0x82, (byte)0x01, (byte)0x0F, (byte)0x00,
+        (byte)0x30, (byte)0x82, (byte)0x01, (byte)0x0A,
+        (byte)0x02, (byte)0x82, (byte)0x01, (byte)0x01,
+        (byte)0x00, (byte)0xBF, (byte)0x0C, (byte)0xCA,
+        (byte)0x2D, (byte)0x14, (byte)0xB2, (byte)0x1E,
+        (byte)0x84, (byte)0x42, (byte)0x5B, (byte)0xCD,
+        (byte)0x38, (byte)0x1F, (byte)0x4A, (byte)0xF2,
+        (byte)0x4D, (byte)0x75, (byte)0x10, (byte)0xF1,
+        (byte)0xB6, (byte)0x35, (byte)0x9F, (byte)0xDF,
+        (byte)0xCA, (byte)0x7D, (byte)0x03, (byte)0x98,
+        (byte)0xD3, (byte)0xAC, (byte)0xDE, (byte)0x03,
+        (byte)0x66, (byte)0xEE, (byte)0x2A, (byte)0xF1,
+        (byte)0xD8, (byte)0xB0, (byte)0x7D, (byte)0x6E,
+        (byte)0x07, (byte)0x54, (byte)0x0B, (byte)0x10,
+        (byte)0x98, (byte)0x21, (byte)0x4D, (byte)0x80,
+        (byte)0xCB, (byte)0x12, (byte)0x20, (byte)0xE7,
+        (byte)0xCC, (byte)0x4F, (byte)0xDE, (byte)0x45,
+        (byte)0x7D, (byte)0xC9, (byte)0x72, (byte)0x77,
+        (byte)0x32, (byte)0xEA, (byte)0xCA, (byte)0x90,
+        (byte)0xBB, (byte)0x69, (byte)0x52, (byte)0x10,
+        (byte)0x03, (byte)0x2F, (byte)0xA8, (byte)0xF3,
+        (byte)0x95, (byte)0xC5, (byte)0xF1, (byte)0x8B,
+        (byte)0x62, (byte)0x56, (byte)0x1B, (byte)0xEF,
+        (byte)0x67, (byte)0x6F, (byte)0xA4, (byte)0x10,
+        (byte)0x41, (byte)0x95, (byte)0xAD, (byte)0x0A,
+        (byte)0x9B, (byte)0xE3, (byte)0xA5, (byte)0xC0,
+        (byte)0xB0, (byte)0xD2, (byte)0x70, (byte)0x76,
+        (byte)0x50, (byte)0x30, (byte)0x5B, (byte)0xA8,
+        (byte)0xE8, (byte)0x08, (byte)0x2C, (byte)0x7C,
+        (byte)0xED, (byte)0xA7, (byte)0xA2, (byte)0x7A,
+        (byte)0x8D, (byte)0x38, (byte)0x29, (byte)0x1C,
+        (byte)0xAC, (byte)0xC7, (byte)0xED, (byte)0xF2,
+        (byte)0x7C, (byte)0x95, (byte)0xB0, (byte)0x95,
+        (byte)0x82, (byte)0x7D, (byte)0x49, (byte)0x5C,
+        (byte)0x38, (byte)0xCD, (byte)0x77, (byte)0x25,
+        (byte)0xEF, (byte)0xBD, (byte)0x80, (byte)0x75,
+        (byte)0x53, (byte)0x94, (byte)0x3C, (byte)0x3D,
+        (byte)0xCA, (byte)0x63, (byte)0x5B, (byte)0x9F,
+        (byte)0x15, (byte)0xB5, (byte)0xD3, (byte)0x1D,
+        (byte)0x13, (byte)0x2F, (byte)0x19, (byte)0xD1,
+        (byte)0x3C, (byte)0xDB, (byte)0x76, (byte)0x3A,
+        (byte)0xCC, (byte)0xB8, (byte)0x7D, (byte)0xC9,
+        (byte)0xE5, (byte)0xC2, (byte)0xD7, (byte)0xDA,
+        (byte)0x40, (byte)0x6F, (byte)0xD8, (byte)0x21,
+        (byte)0xDC, (byte)0x73, (byte)0x1B, (byte)0x42,
+        (byte)0x2D, (byte)0x53, (byte)0x9C, (byte)0xFE,
+        (byte)0x1A, (byte)0xFC, (byte)0x7D, (byte)0xAB,
+        (byte)0x7A, (byte)0x36, (byte)0x3F, (byte)0x98,
+        (byte)0xDE, (byte)0x84, (byte)0x7C, (byte)0x05,
+        (byte)0x67, (byte)0xCE, (byte)0x6A, (byte)0x14,
+        (byte)0x38, (byte)0x87, (byte)0xA9, (byte)0xF1,
+        (byte)0x8C, (byte)0xB5, (byte)0x68, (byte)0xCB,
+        (byte)0x68, (byte)0x7F, (byte)0x71, (byte)0x20,
+        (byte)0x2B, (byte)0xF5, (byte)0xA0, (byte)0x63,
+        (byte)0xF5, (byte)0x56, (byte)0x2F, (byte)0xA3,
+        (byte)0x26, (byte)0xD2, (byte)0xB7, (byte)0x6F,
+        (byte)0xB1, (byte)0x5A, (byte)0x17, (byte)0xD7,
+        (byte)0x38, (byte)0x99, (byte)0x08, (byte)0xFE,
+        (byte)0x93, (byte)0x58, (byte)0x6F, (byte)0xFE,
+        (byte)0xC3, (byte)0x13, (byte)0x49, (byte)0x08,
+        (byte)0x16, (byte)0x0B, (byte)0xA7, (byte)0x4D,
+        (byte)0x67, (byte)0x00, (byte)0x52, (byte)0x31,
+        (byte)0x67, (byte)0x23, (byte)0x4E, (byte)0x98,
+        (byte)0xED, (byte)0x51, (byte)0x45, (byte)0x1D,
+        (byte)0xB9, (byte)0x04, (byte)0xD9, (byte)0x0B,
+        (byte)0xEC, (byte)0xD8, (byte)0x28, (byte)0xB3,
+        (byte)0x4B, (byte)0xBD, (byte)0xED, (byte)0x36,
+        (byte)0x79, (byte)0x02, (byte)0x03, (byte)0x01,
+        (byte)0x00, (byte)0x01
     };
 }

--- a/src/test/com/wolfssl/test/TimedTestWatcher.java
+++ b/src/test/com/wolfssl/test/TimedTestWatcher.java
@@ -1,0 +1,76 @@
+/* TimedTestWatcher.java
+ *
+ * Copyright (C) 2006-2026 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+package com.wolfssl.test;
+
+import org.junit.AssumptionViolatedException;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+/**
+ * Reusable JUnit TestWatcher that prints timing information for each test
+ * method. Displays elapsed time in milliseconds aligned in a column format.
+ * Tests skipped via Assume.assume*() are labeled "SKIP" instead of timed.
+ *
+ * Usage in test classes:
+ * <pre>
+ * {@literal @}Rule
+ * public TestRule testWatcher = TimedTestWatcher.create();
+ * </pre>
+ */
+public class TimedTestWatcher extends TestWatcher {
+    private volatile long startTime;
+    private volatile boolean skipped;
+
+    /**
+     * Factory method to create a new TimedTestWatcher instance.
+     * Recommended usage pattern for consistency across test classes.
+     *
+     * @return new TimedTestWatcher instance
+     */
+    public static TimedTestWatcher create() {
+        return new TimedTestWatcher();
+    }
+
+    @Override
+    protected void starting(Description description) {
+        startTime = System.nanoTime();
+        skipped = false;
+    }
+
+    @Override
+    protected void skipped(AssumptionViolatedException e,
+        Description description) {
+        skipped = true;
+        System.out.printf("\t       SKIP  %s%n", description.getMethodName());
+    }
+
+    @Override
+    protected void finished(Description description) {
+        if (skipped) {
+            return;
+        }
+        long elapsed = System.nanoTime() - startTime;
+        double elapsedMs = elapsed / 1_000_000.0;
+        System.out.printf("\t%8.2f ms  %s%n",
+            elapsedMs, description.getMethodName());
+    }
+}

--- a/src/test/com/wolfssl/test/WolfCryptECCTest.java
+++ b/src/test/com/wolfssl/test/WolfCryptECCTest.java
@@ -21,28 +21,27 @@
 
 package com.wolfssl.test;
 
+import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
+import static org.junit.Assert.assertNotNull;
 
 import com.wolfssl.WolfSSLException;
 import com.wolfssl.WolfCryptECC;
 
 public class WolfCryptECCTest {
 
-    WolfCryptECC ecc;
+    @Rule
+    public TestRule testWatcher = TimedTestWatcher.create();
+
+    @BeforeClass
+    public static void beforeClass() {
+        System.out.println("WolfCryptECC Class");
+    }
 
     @Test
-    public void testECC() throws WolfSSLException {
-
-        System.out.println("WolfCryptECC Class");
-
-        test_ECC_new();
-    }
-
-    public void test_ECC_new() {
-
-        System.out.print("\tWolfCryptECC()");
-        ecc = new WolfCryptECC();
-        System.out.println("\t\t\t... passed");
+    public void testECCNew() throws WolfSSLException {
+        assertNotNull(new WolfCryptECC());
     }
 }
-

--- a/src/test/com/wolfssl/test/WolfCryptRSATest.java
+++ b/src/test/com/wolfssl/test/WolfCryptRSATest.java
@@ -21,29 +21,27 @@
 
 package com.wolfssl.test;
 
+import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
+import static org.junit.Assert.assertNotNull;
 
 import com.wolfssl.WolfSSLException;
 import com.wolfssl.WolfCryptRSA;
 
 public class WolfCryptRSATest {
 
-    WolfCryptRSA rsa;
+    @Rule
+    public TestRule testWatcher = TimedTestWatcher.create();
+
+    @BeforeClass
+    public static void beforeClass() {
+        System.out.println("WolfCryptRSA Class");
+    }
 
     @Test
-    public void testRSA() throws WolfSSLException {
-
-        System.out.println("WolfCryptRSA Class");
-
-        test_RSA_new();
-    }
-
-    public void test_RSA_new() {
-
-        System.out.print("\tWolfCryptRSA()");
-        rsa = new WolfCryptRSA();
-        System.out.println("\t\t\t... passed");
+    public void testRSANew() throws WolfSSLException {
+        assertNotNull(new WolfCryptRSA());
     }
 }
-
-

--- a/src/test/com/wolfssl/test/WolfSSLCRLTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLCRLTest.java
@@ -21,8 +21,11 @@
 
 package com.wolfssl.test;
 
+import org.junit.Assume;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.BeforeClass;
+import org.junit.rules.TestRule;
 import static org.junit.Assert.*;
 
 import java.io.File;
@@ -51,6 +54,10 @@ import com.wolfssl.WolfSSLJNIException;
  * @author wolfSSL
  */
 public class WolfSSLCRLTest {
+
+    @Rule
+    public TestRule testWatcher = TimedTestWatcher.create();
+
     public final static int TEST_FAIL    = -1;
     public final static int TEST_SUCCESS =  0;
 
@@ -170,13 +177,7 @@ public class WolfSSLCRLTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException {
 
-        System.out.print("\tsetVersion()");
-
-        if (!WolfSSL.CrlGenerationEnabled()) {
-            /* CRL generation not enabled in wolfSSL */
-            System.out.println("\t\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.CrlGenerationEnabled());
 
         WolfSSLCRL crl = new WolfSSLCRL();
         assertNotNull(crl);
@@ -197,7 +198,6 @@ public class WolfSSLCRLTest {
         /* Native may or may not validate, so just check it doesn't crash */
 
         crl.free();
-        System.out.println("\t\t\t... passed");
     }
 
     @Test
@@ -205,13 +205,7 @@ public class WolfSSLCRLTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException {
 
-        System.out.print("\tsetIssuerName()");
-
-        if (!WolfSSL.CrlGenerationEnabled()) {
-            /* CRL generation not enabled in wolfSSL */
-            System.out.println("\t\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.CrlGenerationEnabled());
 
         WolfSSLCRL crl = new WolfSSLCRL();
         assertNotNull(crl);
@@ -225,7 +219,6 @@ public class WolfSSLCRLTest {
         /* Test null issuer name */
         try {
             crl.setIssuerName(null);
-            System.out.println("\t\t\t... failed");
             fail("null issuer name should throw exception");
         } catch (WolfSSLException e) {
             /* expected */
@@ -234,7 +227,6 @@ public class WolfSSLCRLTest {
         /* Free native memory */
         issuerName.free();
         crl.free();
-        System.out.println("\t\t\t... passed");
     }
 
     @Test
@@ -242,13 +234,7 @@ public class WolfSSLCRLTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException {
 
-        System.out.print("\tsetLastUpdate()");
-
-        if (!WolfSSL.CrlGenerationEnabled()) {
-            /* CRL generation not enabled in wolfSSL */
-            System.out.println("\t\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.CrlGenerationEnabled());
 
         WolfSSLCRL crl = new WolfSSLCRL();
         assertNotNull(crl);
@@ -268,14 +254,12 @@ public class WolfSSLCRLTest {
         /* Test null date */
         try {
             crl.setLastUpdate(null);
-            System.out.println("\t\t\t... failed");
             fail("null date should throw exception");
         } catch (IllegalArgumentException e) {
             /* expected */
         }
 
         crl.free();
-        System.out.println("\t\t\t... passed");
     }
 
     @Test
@@ -283,13 +267,7 @@ public class WolfSSLCRLTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException {
 
-        System.out.print("\tsetNextUpdate()");
-
-        if (!WolfSSL.CrlGenerationEnabled()) {
-            /* CRL generation not enabled in wolfSSL */
-            System.out.println("\t\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.CrlGenerationEnabled());
 
         WolfSSLCRL crl = new WolfSSLCRL();
         assertNotNull(crl);
@@ -311,14 +289,12 @@ public class WolfSSLCRLTest {
         /* Test null date */
         try {
             crl.setNextUpdate(null);
-            System.out.println("\t\t\t... failed");
             fail("null date should throw exception");
         } catch (IllegalArgumentException e) {
             /* expected */
         }
 
         crl.free();
-        System.out.println("\t\t\t... passed");
     }
 
     @Test
@@ -326,13 +302,7 @@ public class WolfSSLCRLTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException {
 
-        System.out.print("\taddRevoked()");
-
-        if (!WolfSSL.CrlGenerationEnabled()) {
-            /* CRL generation not enabled in wolfSSL */
-            System.out.println("\t\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.CrlGenerationEnabled());
 
         WolfSSLCRL crl = new WolfSSLCRL();
         assertNotNull(crl);
@@ -357,7 +327,6 @@ public class WolfSSLCRLTest {
         /* Test null serial number */
         try {
             crl.addRevoked(null, new Date());
-            System.out.println("\t\t\t... failed");
             fail("null serial number should throw exception");
         } catch (IllegalArgumentException e) {
             /* expected */
@@ -366,14 +335,12 @@ public class WolfSSLCRLTest {
         /* Test empty serial number */
         try {
             crl.addRevoked(new byte[0], new Date());
-            System.out.println("\t\t\t... failed");
             fail("empty serial number should throw exception");
         } catch (IllegalArgumentException e) {
             /* expected */
         }
 
         crl.free();
-        System.out.println("\t\t\t... passed");
     }
 
     @Test
@@ -381,13 +348,7 @@ public class WolfSSLCRLTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException {
 
-        System.out.print("\taddRevokedCert(byte[])");
-
-        if (!WolfSSL.CrlGenerationEnabled()) {
-            /* CRL generation not enabled in wolfSSL */
-            System.out.println("\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.CrlGenerationEnabled());
 
         WolfSSLCRL crl = new WolfSSLCRL();
         assertNotNull(crl);
@@ -412,7 +373,6 @@ public class WolfSSLCRLTest {
         /* Test null certificate DER */
         try {
             crl.addRevokedCert((byte[])null, new Date());
-            System.out.println("\t\t... failed");
             fail("null certificate DER should throw exception");
         } catch (IllegalArgumentException e) {
             /* expected */
@@ -421,14 +381,12 @@ public class WolfSSLCRLTest {
         /* Test empty certificate DER */
         try {
             crl.addRevokedCert(new byte[0], new Date());
-            System.out.println("\t\t... failed");
             fail("empty certificate DER should throw exception");
         } catch (IllegalArgumentException e) {
             /* expected */
         }
 
         crl.free();
-        System.out.println("\t\t... passed");
     }
 
     @Test
@@ -436,13 +394,7 @@ public class WolfSSLCRLTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException {
 
-        System.out.print("\taddRevokedCert(cert)");
-
-        if (!WolfSSL.CrlGenerationEnabled()) {
-            /* CRL generation not enabled in wolfSSL */
-            System.out.println("\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.CrlGenerationEnabled());
 
         WolfSSLCRL crl = new WolfSSLCRL();
         assertNotNull(crl);
@@ -466,7 +418,6 @@ public class WolfSSLCRLTest {
         /* Test null certificate */
         try {
             crl.addRevokedCert((WolfSSLCertificate)null, new Date());
-            System.out.println("\t\t... failed");
             fail("null certificate should throw exception");
         } catch (IllegalArgumentException e) {
             /* expected */
@@ -476,7 +427,6 @@ public class WolfSSLCRLTest {
         cert.free();
         cert2.free();
         crl.free();
-        System.out.println("\t\t... passed");
     }
 
     @Test
@@ -484,13 +434,7 @@ public class WolfSSLCRLTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException, NoSuchAlgorithmException {
 
-        System.out.print("\tsign(PrivateKey)");
-
-        if (!WolfSSL.CrlGenerationEnabled()) {
-            /* CRL generation not enabled in wolfSSL */
-            System.out.println("\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.CrlGenerationEnabled());
 
         WolfSSLCRL crl = new WolfSSLCRL();
         assertNotNull(crl);
@@ -530,7 +474,6 @@ public class WolfSSLCRLTest {
         /* Test null private key */
         try {
             crl.sign(null, "SHA256");
-            System.out.println("\t\t... failed");
             fail("null private key should throw exception");
         } catch (IllegalArgumentException e) {
             /* expected */
@@ -539,7 +482,6 @@ public class WolfSSLCRLTest {
         /* Free native memory */
         issuerName.free();
         crl.free();
-        System.out.println("\t\t... passed");
     }
 
     @Test
@@ -547,13 +489,7 @@ public class WolfSSLCRLTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException, ReflectiveOperationException {
 
-        System.out.print("\tsign(native PEM key bytes)");
-
-        if (!WolfSSL.CrlGenerationEnabled()) {
-            /* CRL generation not enabled in wolfSSL */
-            System.out.println("\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.CrlGenerationEnabled());
 
         WolfSSLCRL crl = new WolfSSLCRL();
         assertNotNull(crl);
@@ -601,8 +537,6 @@ public class WolfSSLCRLTest {
             }
             crl.free();
         }
-
-        System.out.println("\t... passed");
     }
 
     @Test
@@ -610,13 +544,7 @@ public class WolfSSLCRLTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException, NoSuchAlgorithmException {
 
-        System.out.print("\twriteToFile()");
-
-        if (!WolfSSL.CrlGenerationEnabled()) {
-            /* CRL generation not enabled in wolfSSL */
-            System.out.println("\t\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.CrlGenerationEnabled());
 
         WolfSSLCRL crl = new WolfSSLCRL();
         assertNotNull(crl);
@@ -663,7 +591,6 @@ public class WolfSSLCRLTest {
         /* Test null path */
         try {
             crl.writeToFile(null, WolfSSL.SSL_FILETYPE_PEM);
-            System.out.println("\t\t\t... failed");
             fail("null path should throw exception");
         } catch (IllegalArgumentException e) {
             /* expected */
@@ -672,7 +599,6 @@ public class WolfSSLCRLTest {
         /* Test empty path */
         try {
             crl.writeToFile("", WolfSSL.SSL_FILETYPE_PEM);
-            System.out.println("\t\t\t... failed");
             fail("empty path should throw exception");
         } catch (IllegalArgumentException e) {
             /* expected */
@@ -681,7 +607,6 @@ public class WolfSSLCRLTest {
         /* Test invalid format */
         try {
             crl.writeToFile("test.der", 12345);
-            System.out.println("\t\t\t... failed");
             fail("invalid format should throw exception");
         } catch (IllegalArgumentException e) {
             /* expected */
@@ -690,7 +615,6 @@ public class WolfSSLCRLTest {
         /* Free native memory */
         issuerName.free();
         crl.free();
-        System.out.println("\t\t\t... passed");
     }
 
     @Test
@@ -698,13 +622,7 @@ public class WolfSSLCRLTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException, NoSuchAlgorithmException {
 
-        System.out.print("\tgetDer()");
-
-        if (!WolfSSL.CrlGenerationEnabled()) {
-            /* CRL generation not enabled in wolfSSL */
-            System.out.println("\t\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.CrlGenerationEnabled());
 
         WolfSSLCRL crl = new WolfSSLCRL();
         assertNotNull(crl);
@@ -738,7 +656,6 @@ public class WolfSSLCRLTest {
         /* Free native memory */
         issuerName.free();
         crl.free();
-        System.out.println("\t\t\t... passed");
     }
 
     @Test
@@ -746,13 +663,7 @@ public class WolfSSLCRLTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException, NoSuchAlgorithmException {
 
-        System.out.print("\tgetPem()");
-
-        if (!WolfSSL.CrlGenerationEnabled()) {
-            /* CRL generation not enabled in wolfSSL */
-            System.out.println("\t\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.CrlGenerationEnabled());
 
         WolfSSLCRL crl = new WolfSSLCRL();
         assertNotNull(crl);
@@ -790,7 +701,6 @@ public class WolfSSLCRLTest {
         /* Free native memory */
         issuerName.free();
         crl.free();
-        System.out.println("\t\t\t... passed");
     }
 
     @Test
@@ -798,13 +708,7 @@ public class WolfSSLCRLTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException {
 
-        System.out.print("\tgetVersion()");
-
-        if (!WolfSSL.CrlGenerationEnabled()) {
-            /* CRL generation not enabled in wolfSSL */
-            System.out.println("\t\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.CrlGenerationEnabled());
 
         WolfSSLCRL crl = new WolfSSLCRL();
         assertNotNull(crl);
@@ -815,19 +719,16 @@ public class WolfSSLCRLTest {
         crl.setVersion(0);
         version = crl.getVersion();
         if (version != 1) {
-            System.out.println("\t\t\t... failed");
             fail("Version should be 1 for v1");
         }
 
         crl.setVersion(1);
         version = crl.getVersion();
         if (version != 2) {
-            System.out.println("\t\t\t... failed");
             fail("Version should be 2 for v2");
         }
 
         crl.free();
-        System.out.println("\t\t\t... passed");
     }
 
     @Test
@@ -835,13 +736,7 @@ public class WolfSSLCRLTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException, NoSuchAlgorithmException {
 
-        System.out.print("\tgen CRL using files");
-
-        if (!WolfSSL.CrlGenerationEnabled()) {
-            /* CRL generation not enabled in wolfSSL */
-            System.out.println("\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.CrlGenerationEnabled());
 
         WolfSSLCRL crl = new WolfSSLCRL();
         assertNotNull(crl);
@@ -900,8 +795,6 @@ public class WolfSSLCRLTest {
         /* Free native memory */
         issuerName.free();
         crl.free();
-
-        System.out.println("\t\t... passed");
     }
 
     @Test
@@ -909,13 +802,7 @@ public class WolfSSLCRLTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException, NoSuchAlgorithmException {
 
-        System.out.print("\tgen CRL using certificates");
-
-        if (!WolfSSL.CrlGenerationEnabled()) {
-            /* CRL generation not enabled in wolfSSL */
-            System.out.println("\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.CrlGenerationEnabled());
 
         WolfSSLCRL crl = new WolfSSLCRL();
         assertNotNull(crl);
@@ -962,8 +849,6 @@ public class WolfSSLCRLTest {
         cert1.free();
         issuerName.free();
         crl.free();
-
-        System.out.println("\t... passed");
     }
 
     @Test
@@ -971,18 +856,9 @@ public class WolfSSLCRLTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException, NoSuchAlgorithmException {
 
-        System.out.print("\tgen CRL with ECC key");
+        Assume.assumeTrue(WolfSSL.CrlGenerationEnabled());
 
-        if (!WolfSSL.CrlGenerationEnabled()) {
-            /* CRL generation not enabled in wolfSSL */
-            System.out.println("\t\t... skipped");
-            return;
-        }
-
-        if (!WolfSSL.EccEnabled()) {
-            System.out.println("\t\t... skipped (ECC not enabled)");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.EccEnabled());
 
         WolfSSLCRL crl = new WolfSSLCRL();
         assertNotNull(crl);
@@ -1027,8 +903,6 @@ public class WolfSSLCRLTest {
         /* Free native memory */
         issuerName.free();
         crl.free();
-
-        System.out.println("\t\t... passed");
     }
 
     @Test
@@ -1036,12 +910,7 @@ public class WolfSSLCRLTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException, NoSuchAlgorithmException {
 
-        System.out.print("\tload CRL from DER");
-
-        if (!WolfSSL.CrlDecodeEnabled()) {
-            System.out.println("\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.CrlDecodeEnabled());
 
         /* Load DER from pre-generated file */
         byte[] der = Files.readAllBytes(Paths.get(crlDecodeDer));
@@ -1082,7 +951,6 @@ public class WolfSSLCRLTest {
 
         loadedCrl2.free();
         loadedCrl.free();
-        System.out.println("\t\t... passed");
     }
 
     @Test
@@ -1090,12 +958,7 @@ public class WolfSSLCRLTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException, NoSuchAlgorithmException {
 
-        System.out.print("\tload CRL from PEM");
-
-        if (!WolfSSL.CrlDecodeEnabled()) {
-            System.out.println("\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.CrlDecodeEnabled());
 
         /* Load PEM from pre-generated file */
         byte[] pem = Files.readAllBytes(Paths.get(crlDecodePem));
@@ -1107,7 +970,6 @@ public class WolfSSLCRLTest {
         assertNotNull(loadedCrl);
 
         loadedCrl.free();
-        System.out.println("\t\t... passed");
     }
 
     @Test
@@ -1115,12 +977,7 @@ public class WolfSSLCRLTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException, NoSuchAlgorithmException {
 
-        System.out.print("\tload CRL from file");
-
-        if (!WolfSSL.CrlDecodeEnabled()) {
-            System.out.println("\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.CrlDecodeEnabled());
 
         /* Load pre-generated PEM CRL from file */
         WolfSSLCRL crl = loadTestCRLFromFile(WolfSSL.SSL_FILETYPE_PEM);
@@ -1157,8 +1014,6 @@ public class WolfSSLCRLTest {
             loadedCrl.free();
             genCrl.free();
         }
-
-        System.out.println("\t\t... passed");
     }
 
     @Test
@@ -1166,12 +1021,7 @@ public class WolfSSLCRLTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException, NoSuchAlgorithmException {
 
-        System.out.print("\tgetIssuerName()");
-
-        if (!WolfSSL.CrlDecodeEnabled()) {
-            System.out.println("\t\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.CrlDecodeEnabled());
 
         /* Test on CRL loaded from file */
         WolfSSLCRL fileCrl = loadTestCRLFromFile(WolfSSL.SSL_FILETYPE_PEM);
@@ -1193,8 +1043,6 @@ public class WolfSSLCRLTest {
             loadedCrl.free();
             genCrl.free();
         }
-
-        System.out.println("\t\t\t... passed");
     }
 
     @Test
@@ -1202,20 +1050,13 @@ public class WolfSSLCRLTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException, NoSuchAlgorithmException {
 
-        System.out.print("\tgetSignatureType()");
-
-        if (!WolfSSL.CrlDecodeEnabled()) {
-            System.out.println("\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.CrlDecodeEnabled());
 
         /* Test on CRL loaded from file */
         WolfSSLCRL fileCrl = loadTestCRLFromFile(WolfSSL.SSL_FILETYPE_PEM);
         int sigType = fileCrl.getSignatureType();
         assertTrue("Signature type should be > 0", sigType > 0);
         fileCrl.free();
-
-        System.out.println("\t\t... passed");
     }
 
     @Test
@@ -1223,20 +1064,13 @@ public class WolfSSLCRLTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException, NoSuchAlgorithmException {
 
-        System.out.print("\tgetSignatureNid()");
-
-        if (!WolfSSL.CrlDecodeEnabled()) {
-            System.out.println("\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.CrlDecodeEnabled());
 
         /* Test on CRL loaded from file */
         WolfSSLCRL fileCrl = loadTestCRLFromFile(WolfSSL.SSL_FILETYPE_PEM);
         int sigNid = fileCrl.getSignatureNid();
         assertTrue("Signature NID should be > 0", sigNid > 0);
         fileCrl.free();
-
-        System.out.println("\t\t... passed");
     }
 
     @Test
@@ -1244,12 +1078,7 @@ public class WolfSSLCRLTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException, NoSuchAlgorithmException {
 
-        System.out.print("\tverify()");
-
-        if (!WolfSSL.CrlDecodeEnabled()) {
-            System.out.println("\t\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.CrlDecodeEnabled());
 
         /* Load CRL from file, attempt verify.
          * wolfSSL_X509_CRL_verify is currently a stub and
@@ -1263,7 +1092,6 @@ public class WolfSSLCRLTest {
         assertFalse("Stub verify should return false", result);
 
         crl.free();
-        System.out.println("\t\t\t... passed");
     }
 
     @Test
@@ -1271,13 +1099,7 @@ public class WolfSSLCRLTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException {
 
-        System.out.print("\tfree()");
-
-        if (!WolfSSL.CrlGenerationEnabled()) {
-            /* CRL generation not enabled in wolfSSL */
-            System.out.println("\t\t\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.CrlGenerationEnabled());
 
         WolfSSLCRL crl = new WolfSSLCRL();
         assertNotNull(crl);
@@ -1288,7 +1110,6 @@ public class WolfSSLCRLTest {
         /* Operations after free should throw IllegalStateException */
         try {
             crl.setVersion(1);
-            System.out.println("\t\t\t\t... failed");
             fail("setVersion after free should throw exception");
         } catch (IllegalStateException e) {
             /* expected */
@@ -1296,7 +1117,6 @@ public class WolfSSLCRLTest {
 
         try {
             crl.getVersion();
-            System.out.println("\t\t\t\t... failed");
             fail("getVersion after free should throw exception");
         } catch (IllegalStateException e) {
             /* expected */
@@ -1304,7 +1124,5 @@ public class WolfSSLCRLTest {
 
         /* Multiple free() calls should be safe */
         crl.free();
-
-        System.out.println("\t\t\t\t... passed");
     }
 }

--- a/src/test/com/wolfssl/test/WolfSSLCertManagerTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLCertManagerTest.java
@@ -25,8 +25,11 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.TestRule;
 import static org.junit.Assert.*;
 
 import com.wolfssl.WolfSSL;
@@ -40,6 +43,9 @@ import com.wolfssl.WolfSSLException;
  * @author wolfSSL
  */
 public class WolfSSLCertManagerTest {
+
+    @Rule
+    public TestRule testWatcher = TimedTestWatcher.create();
 
     private static String ocspRootCaCert =
         "examples/certs/ocsp-root-ca-cert.pem";
@@ -530,15 +536,12 @@ public class WolfSSLCertManagerTest {
         int ret = 0;
         WolfSSLCertManager cm = null;
 
-        System.out.print("\tCertManagerLoadCA()");
-
         try {
             cm = new WolfSSLCertManager();
 
             /* Test loading CA cert by file only (null path) */
             ret = cm.CertManagerLoadCA(ocspRootCaCert, null);
             if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t\t... failed");
                 fail("CertManagerLoadCA(file, null) failed, ret = " + ret);
             }
 
@@ -546,13 +549,11 @@ public class WolfSSLCertManagerTest {
              * return error */
             ret = cm.CertManagerLoadCA(null, null);
             if (ret == WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t\t... failed");
                 fail("CertManagerLoadCA(null, null) should " +
                     "have failed but returned success");
             }
 
         } catch (WolfSSLException e) {
-            System.out.println("\t\t... failed");
             fail("CertManagerLoadCA test failed: " + e.getMessage());
 
         } finally {
@@ -561,8 +562,6 @@ public class WolfSSLCertManagerTest {
                 cm = null;
             }
         }
-
-        System.out.println("\t\t... passed");
     }
 
     @Test
@@ -577,8 +576,6 @@ public class WolfSSLCertManagerTest {
         WolfSSLCertManager cm = null;
         WolfSSLCertificate cert = null;
 
-        System.out.print("\tOCSP response cert validation");
-
         try {
             cm = new WolfSSLCertManager();
 
@@ -589,7 +586,6 @@ public class WolfSSLCertManagerTest {
                 caCertPem, caCertPem.length, WolfSSL.SSL_FILETYPE_PEM);
 
             if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t... failed");
                 fail("Failed to load OCSP root CA, ret = " + ret);
             }
 
@@ -611,7 +607,6 @@ public class WolfSSLCertManagerTest {
             ret = cm.CertManagerCheckOCSPResponse(
                 validOcspResponse, certToCheckDer, caCertDer);
             if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t... failed");
                 fail("CertManagerCheckOCSPResponse failed with valid " +
                     "OCSP and matching cert, ret = " + ret);
             }
@@ -628,7 +623,6 @@ public class WolfSSLCertManagerTest {
             ret = cm.CertManagerCheckOCSPResponse(
                 validOcspResponse, wrongCertDer, null);
             if (ret == WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t... failed");
                 fail("CertManagerCheckOCSPResponse should have failed " +
                     "with mismatched certificate, but returned success");
             }
@@ -638,7 +632,6 @@ public class WolfSSLCertManagerTest {
             try {
                 cm.CertManagerCheckOCSPResponse(
                     validOcspResponse, null, null);
-                System.out.println("\t... failed");
                 fail("Expected IllegalArgumentException for null cert");
             } catch (IllegalArgumentException e) {
                 /* Expected */
@@ -648,16 +641,14 @@ public class WolfSSLCertManagerTest {
             if (e.getMessage() != null &&
                 e.getMessage().contains("not compiled")) {
                 /* OCSP not compiled in, skip test */
-                System.out.println("\t... skipped (OCSP not compiled in)");
+                Assume.assumeNoException("OCSP not compiled in", e);
                 return;
             }
 
-            System.out.println("\t... failed");
             fail("CertManagerCheckOCSPResponse test failed: " +
                 e.getMessage());
 
         } catch (Exception e) {
-            System.out.println("\t... failed");
             fail("CertManagerCheckOCSPResponse test failed: " +
                 e.getMessage());
 
@@ -667,8 +658,6 @@ public class WolfSSLCertManagerTest {
                 cm = null;
             }
         }
-
-        System.out.println("\t... passed");
     }
 }
 

--- a/src/test/com/wolfssl/test/WolfSSLCertRequestTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLCertRequestTest.java
@@ -21,8 +21,11 @@
 
 package com.wolfssl.test;
 
+import org.junit.Assume;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.BeforeClass;
+import org.junit.rules.TestRule;
 import static org.junit.Assert.*;
 
 import java.io.File;
@@ -47,6 +50,10 @@ import com.wolfssl.WolfSSLJNIException;
  * @author wolfSSL
  */
 public class WolfSSLCertRequestTest {
+
+    @Rule
+    public TestRule testWatcher = TimedTestWatcher.create();
+
     public final static int TEST_FAIL    = -1;
     public final static int TEST_SUCCESS =  0;
 
@@ -108,13 +115,7 @@ public class WolfSSLCertRequestTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException {
 
-        System.out.print("\taddAttribute()");
-
-        if (!WolfSSL.certReqEnabled()) {
-            /* WOLFSSL_CERT_REQ / --enable-certreq not enabled in wolfSSL */
-            System.out.println("\t\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.certReqEnabled());
 
         WolfSSLCertRequest req = new WolfSSLCertRequest();
         assertNotNull(req);
@@ -139,16 +140,13 @@ public class WolfSSLCertRequestTest {
 
         /* Adding unsupported NID should throw exception */
         try {
-            req.addAttribute(123456,
-                "12345".getBytes());
-            System.out.println("\t\t\t... failed");
+            req.addAttribute(123456, "12345".getBytes());
             fail("Unsupported NID did not throw exception");
         } catch (WolfSSLException e) {
             /* expected */
         }
 
         req.free();
-        System.out.println("\t\t\t... passed");
     }
 
     @Test
@@ -156,13 +154,7 @@ public class WolfSSLCertRequestTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException {
 
-        System.out.print("\taddExtension()");
-
-        if (!WolfSSL.certReqEnabled()) {
-            /* WOLFSSL_CERT_REQ / --enable-certreq not enabled in wolfSSL */
-            System.out.println("\t\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.certReqEnabled());
 
         WolfSSLCertRequest req = new WolfSSLCertRequest();
         assertNotNull(req);
@@ -185,7 +177,6 @@ public class WolfSSLCertRequestTest {
         /* Adding unsupported NID should throw exception */
         try {
             req.addExtension(123456, "12345", false);
-            System.out.println("\t\t\t... failed");
             fail("Unsupported extension NID did not throw exception");
         } catch (WolfSSLException e) {
             /* expected */
@@ -195,28 +186,24 @@ public class WolfSSLCertRequestTest {
         req.addExtension(WolfSSL.NID_basic_constraints, true, true);
         req.addExtension(WolfSSL.NID_basic_constraints, false, true);
 
-        /* Test boolean extension with pathLen */
+        /* Test boolean extension with pathLen. If the basicConstraints
+         * pathLen overload isn't compiled in, skip the remaining pathLen
+         * assertions so they aren't interpreted as passing for the wrong
+         * reason (NOT_COMPILED_IN vs. actual input validation). */
         try {
             req.addExtension(WolfSSL.NID_basic_constraints, true, 0, true);
         } catch (WolfSSLException e) {
-            if (!isNotCompiledIn(e)) {
-                throw e;
+            if (isNotCompiledIn(e)) {
+                Assume.assumeNoException(
+                    "basicConstraints pathLen overload not compiled in", e);
             }
-            System.out.println("\t\t\t... skipped");
+            throw e;
         }
-        try {
-            req.addExtension(WolfSSL.NID_basic_constraints, true, 3, true);
-        } catch (WolfSSLException e) {
-            if (!isNotCompiledIn(e)) {
-                throw e;
-            }
-            System.out.println("\t\t\t... skipped");
-        }
+        req.addExtension(WolfSSL.NID_basic_constraints, true, 3, true);
 
         /* Invalid pathLen (< -1) should throw WolfSSLException */
         try {
             req.addExtension(WolfSSL.NID_basic_constraints, true, -2, true);
-            System.out.println("\t\t\t... failed");
             fail("Invalid pathLen did not throw exception");
         } catch (WolfSSLException e) {
             /* expected */
@@ -225,7 +212,6 @@ public class WolfSSLCertRequestTest {
         /* pathLen with isCA=false should throw (RFC 5280) */
         try {
             req.addExtension(WolfSSL.NID_basic_constraints, false, 0, true);
-            System.out.println("\t\t\t... failed");
             fail("pathLen with isCA=false did not throw");
         } catch (WolfSSLException e) {
             /* expected */
@@ -234,7 +220,6 @@ public class WolfSSLCertRequestTest {
         /* Unsupported NID with pathLen should throw exception */
         try {
             req.addExtension(123456, true, 0, true);
-            System.out.println("\t\t\t... failed");
             fail("Unsupported NID did not throw exception");
         } catch (WolfSSLException e) {
             /* expected */
@@ -243,14 +228,12 @@ public class WolfSSLCertRequestTest {
         /* Adding unsupported NID should throw exception */
         try {
             req.addExtension(123456, true, false);
-            System.out.println("\t\t\t... failed");
             fail("Unsupported extension NID did not throw exception");
         } catch (WolfSSLException e) {
             /* expected */
         }
 
         req.free();
-        System.out.println("\t\t\t... passed");
     }
 
     @Test
@@ -258,13 +241,7 @@ public class WolfSSLCertRequestTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException {
 
-        System.out.print("\tsetVersion()");
-
-        if (!WolfSSL.certReqEnabled()) {
-            /* WOLFSSL_CERT_REQ / --enable-certreq not enabled in wolfSSL */
-            System.out.println("\t\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.certReqEnabled());
 
         WolfSSLCertRequest req = new WolfSSLCertRequest();
         assertNotNull(req);
@@ -275,14 +252,12 @@ public class WolfSSLCertRequestTest {
         /* Negative versions should throw exception */
         try {
             req.setVersion(-100);
-            System.out.println("\t\t\t... failed");
             fail("Negative version should throw exception");
         } catch (WolfSSLException e) {
             /* expected */
         }
 
         req.free();
-        System.out.println("\t\t\t... passed");
     }
 
     @Test
@@ -290,13 +265,7 @@ public class WolfSSLCertRequestTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException {
 
-        System.out.print("\tsetPublicKey(file)");
-
-        if (!WolfSSL.certReqEnabled()) {
-            /* WOLFSSL_CERT_REQ / --enable-certreq not enabled in wolfSSL */
-            System.out.println("\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.certReqEnabled());
 
         WolfSSLCertRequest req = new WolfSSLCertRequest();
         assertNotNull(req);
@@ -309,7 +278,6 @@ public class WolfSSLCertRequestTest {
         try {
             req.setPublicKey(cliKeyPubDer, 12345,
                 WolfSSL.SSL_FILETYPE_ASN1);
-            System.out.println("\t\t... failed");
             fail("bad key type should throw exception");
         } catch (WolfSSLException e) {
             /* expected */
@@ -318,7 +286,6 @@ public class WolfSSLCertRequestTest {
         /* Test bad file type */
         try {
             req.setPublicKey(cliKeyPubDer, WolfSSL.RSAk, 12345);
-            System.out.println("\t\t... failed");
             fail("bad file type should throw exception");
         } catch (WolfSSLException e) {
             /* expected */
@@ -328,7 +295,6 @@ public class WolfSSLCertRequestTest {
         try {
             req.setPublicKey((String)null, WolfSSL.RSAk,
                 WolfSSL.SSL_FILETYPE_ASN1);
-            System.out.println("\t\t... failed");
             fail("null PublicKey should throw exception");
         } catch (WolfSSLException e) {
             /* expected */
@@ -338,14 +304,12 @@ public class WolfSSLCertRequestTest {
         try {
             req.setPublicKey("badfile", WolfSSL.RSAk,
                 WolfSSL.SSL_FILETYPE_ASN1);
-            System.out.println("\t\t... failed");
             fail("Bad path to PublicKey should throw exception");
         } catch (WolfSSLException e) {
             /* expected */
         }
 
         req.free();
-        System.out.println("\t\t... passed");
     }
 
     @Test
@@ -360,13 +324,7 @@ public class WolfSSLCertRequestTest {
         byte[] rsaPubKeyDer;
         byte[] eccPubKeyDer;
 
-        System.out.print("\tsetPublicKey(array)");
-
-        if (!WolfSSL.certReqEnabled()) {
-            /* WOLFSSL_CERT_REQ / --enable-certreq not enabled in wolfSSL */
-            System.out.println("\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.certReqEnabled());
 
         WolfSSLCertRequest req = new WolfSSLCertRequest();
         assertNotNull(req);
@@ -395,7 +353,6 @@ public class WolfSSLCertRequestTest {
         try {
             req.setPublicKey(rsaPubKeyDer, 12345,
                 WolfSSL.SSL_FILETYPE_ASN1);
-            System.out.println("\t\t... failed");
             fail("bad key type should throw exception");
         } catch (WolfSSLException e) {
             /* expected */
@@ -404,7 +361,6 @@ public class WolfSSLCertRequestTest {
         /* Test bad file type */
         try {
             req.setPublicKey(rsaPubKeyDer, WolfSSL.RSAk, 12345);
-            System.out.println("\t\t... failed");
             fail("bad file type should throw exception");
         } catch (WolfSSLException e) {
             /* expected */
@@ -414,7 +370,6 @@ public class WolfSSLCertRequestTest {
         try {
             req.setPublicKey((byte[])null, WolfSSL.RSAk,
                 WolfSSL.SSL_FILETYPE_ASN1);
-            System.out.println("\t\t... failed");
             fail("null key array should throw exception");
         } catch (WolfSSLException e) {
             /* expected */
@@ -425,14 +380,12 @@ public class WolfSSLCertRequestTest {
         try {
             req.setPublicKey(zeroArr, WolfSSL.RSAk,
                 WolfSSL.SSL_FILETYPE_ASN1);
-            System.out.println("\t\t... failed");
             fail("Zero length pub key array should throw exception");
         } catch (WolfSSLException e) {
             /* expected */
         }
 
         req.free();
-        System.out.println("\t\t... passed");
     }
 
     @Test
@@ -440,13 +393,7 @@ public class WolfSSLCertRequestTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException, NoSuchAlgorithmException {
 
-        System.out.print("\tsetPublicKey(PublicKey)");
-
-        if (!WolfSSL.certReqEnabled()) {
-            /* WOLFSSL_CERT_REQ / --enable-certreq not enabled in wolfSSL */
-            System.out.println("\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.certReqEnabled());
 
         WolfSSLCertRequest req = new WolfSSLCertRequest();
         assertNotNull(req);
@@ -468,14 +415,12 @@ public class WolfSSLCertRequestTest {
         /* Test null PublicKey object */
         try {
             req.setPublicKey((PublicKey)null);
-            System.out.println("\t\t... failed");
             fail("null PublicKey should throw exception");
         } catch (WolfSSLException e) {
             /* expected */
         }
 
         req.free();
-        System.out.println("\t\t... passed");
     }
 
     @Test
@@ -483,13 +428,7 @@ public class WolfSSLCertRequestTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException {
 
-        System.out.print("\tgen CSR using files");
-
-        if (!WolfSSL.certReqEnabled()) {
-            /* WOLFSSL_CERT_REQ / --enable-certreq not enabled in wolfSSL */
-            System.out.println("\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.certReqEnabled());
 
         WolfSSLCertRequest req = new WolfSSLCertRequest();
         assertNotNull(req);
@@ -533,8 +472,6 @@ public class WolfSSLCertRequestTest {
         /* Free native memory */
         subjectName.free();
         req.free();
-
-        System.out.println("\t\t... passed");
     }
 
     @Test
@@ -542,13 +479,7 @@ public class WolfSSLCertRequestTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException {
 
-        System.out.print("\tgen CSR using buffers");
-
-        if (!WolfSSL.certReqEnabled()) {
-            /* WOLFSSL_CERT_REQ / --enable-certreq not enabled in wolfSSL */
-            System.out.println("\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.certReqEnabled());
 
         WolfSSLCertRequest req = new WolfSSLCertRequest();
         assertNotNull(req);
@@ -592,8 +523,6 @@ public class WolfSSLCertRequestTest {
         /* Free native memory */
         subjectName.free();
         req.free();
-
-        System.out.println("\t\t... passed");
     }
 
     @Test
@@ -601,13 +530,7 @@ public class WolfSSLCertRequestTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException, NoSuchAlgorithmException {
 
-        System.out.print("\tgen CSR using Java classes");
-
-        if (!WolfSSL.certReqEnabled()) {
-            /* WOLFSSL_CERT_REQ / --enable-certreq not enabled in wolfSSL */
-            System.out.println("\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.certReqEnabled());
 
         WolfSSLCertRequest req = new WolfSSLCertRequest();
         assertNotNull(req);
@@ -653,8 +576,6 @@ public class WolfSSLCertRequestTest {
         /* Free native memory */
         subjectName.free();
         req.free();
-
-        System.out.println("\t... passed");
     }
 
     /* Utility method if needed for testing, print out CSR array to file */
@@ -663,4 +584,3 @@ public class WolfSSLCertRequestTest {
         Files.write(new File(path).toPath(), csr);
     }
 }
-

--- a/src/test/com/wolfssl/test/WolfSSLCertificateTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLCertificateTest.java
@@ -29,8 +29,6 @@ import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Date;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.time.Instant;
 import java.time.Duration;
 import java.security.cert.CertificateException;
@@ -48,8 +46,12 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Collection;
 import java.util.List;
 
+import org.junit.Assume;
+import org.junit.AssumptionViolatedException;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.BeforeClass;
+import org.junit.rules.TestRule;
 import static org.junit.Assert.*;
 
 import com.wolfssl.WolfSSL;
@@ -107,23 +109,26 @@ public class WolfSSLCertificateTest {
                msg.contains("NOT_COMPILED_IN");
     }
 
-    private void runOrAllowNotCompiled(ThrowingRunnable r, String label)
+    private void runOrAllowNotCompiled(ThrowingRunnable r)
         throws WolfSSLException, WolfSSLJNIException, IOException {
 
         try {
             r.run();
         } catch (WolfSSLException e) {
             if (isNotCompiledIn(e)) {
-                System.out.println("\t\t" + label +
-                    " ... NOT_COMPILED_IN (skipping)");
                 return;
             }
             throw e;
         }
     }
 
+    @Rule
+    public TestRule testWatcher = TimedTestWatcher.create();
+
     @BeforeClass
     public static void setCertPaths() throws WolfSSLException {
+
+        System.out.println("WolfSSLCertificate Class");
 
         try {
             WolfSSL.loadLibrary();
@@ -156,27 +161,29 @@ public class WolfSSLCertificateTest {
 
 
     @Test
-    public void testWolfSSLCertificate() throws WolfSSLException {
-
-        System.out.println("WolfSSLCertificate Class");
-
-        /* WolfSSLCertificate(byte[] der) */
+    public void testCertFromDerArray() throws WolfSSLException {
         test_WolfSSLCertificate_new_derArray();
         test_runCertTestsAfterConstructor();
+    }
 
-        /* WolfSSLCertificate(String der) */
+    @Test
+    public void testCertFromPemArray() throws WolfSSLException {
         test_WolfSSLCertificate_new_pemArray();
         test_runCertTestsAfterConstructor();
+    }
 
-        if (WolfSSL.FileSystemEnabled() == true) {
-            /* WolfSSLCertificate(byte[] pem) */
-            test_WolfSSLCertificate_new_derFile();
-            test_runCertTestsAfterConstructor();
+    @Test
+    public void testCertFromDerFile() throws WolfSSLException {
+        Assume.assumeTrue(WolfSSL.FileSystemEnabled());
+        test_WolfSSLCertificate_new_derFile();
+        test_runCertTestsAfterConstructor();
+    }
 
-            /* WolfSSLCertificate(String pem) */
-            test_WolfSSLCertificate_new_pemFile();
-            test_runCertTestsAfterConstructor();
-        }
+    @Test
+    public void testCertFromPemFile() throws WolfSSLException {
+        Assume.assumeTrue(WolfSSL.FileSystemEnabled());
+        test_WolfSSLCertificate_new_pemFile();
+        test_runCertTestsAfterConstructor();
     }
 
     public void test_runCertTestsAfterConstructor() {
@@ -200,8 +207,6 @@ public class WolfSSLCertificateTest {
             test_getKeyUsage();
             test_getExtendedKeyUsage();
         }
-        test_getAiaMulti();
-        test_getAiaOverflow();
         test_getExtensionSet();
         test_toString();
         test_free();
@@ -212,45 +217,30 @@ public class WolfSSLCertificateTest {
         File f = new File(cliCertDer);
         byte[] der = null;
 
-        System.out.print("\tnew(byte[] der)");
-
         try {
             InputStream stream = new FileInputStream(f);
             der = new byte[(int) f.length()];
             stream.read(der, 0, der.length);
             stream.close();
         } catch (IOException ex) {
-            System.out.println("\t\t\t... failed");
             fail("Unable to read file " + cliCertDer);
-            Logger.getLogger(WolfSSLCertificateTest.class.getName()).log(
-                                Level.SEVERE, null, ex);
         }
 
         try {
             this.cert = new WolfSSLCertificate(der);
         } catch (WolfSSLException ex) {
-            System.out.println("\t\t\t... failed");
             fail("Unable to initialize class");
-            Logger.getLogger(WolfSSLCertificateTest.class.getName()).log(
-                                Level.SEVERE, null, ex);
         }
-        System.out.println("\t\t\t... passed");
     }
 
 
     public void test_WolfSSLCertificate_new_derFile() {
-        System.out.print("\tnew(String der, int format)");
-
         try {
             this.cert = new WolfSSLCertificate(cliCertDer,
                                 WolfSSL.SSL_FILETYPE_ASN1);
         } catch (WolfSSLException ex) {
-            System.out.println("\t... failed");
             fail("Unable to initialize class");
-            Logger.getLogger(WolfSSLCertificateTest.class.getName()).log(
-                                Level.SEVERE, null, ex);
         }
-        System.out.println("\t... passed");
     }
 
 
@@ -258,45 +248,30 @@ public class WolfSSLCertificateTest {
         File f = new File(cliCertPem);
         byte[] pem = null;
 
-        System.out.print("\tnew(byte[] in, int format)");
-
         try {
             InputStream stream = new FileInputStream(f);
             pem = new byte[(int) f.length()];
             stream.read(pem, 0, pem.length);
             stream.close();
         } catch (IOException ex) {
-            System.out.println("\t... failed");
             fail("Unable to read file " + cliCertPem);
-            Logger.getLogger(WolfSSLCertificateTest.class.getName()).log(
-                                Level.SEVERE, null, ex);
         }
 
         try {
             this.cert = new WolfSSLCertificate(pem, WolfSSL.SSL_FILETYPE_PEM);
         } catch (WolfSSLException ex) {
-            System.out.println("\t... failed");
             fail("Unable to initialize class");
-            Logger.getLogger(WolfSSLCertificateTest.class.getName()).log(
-                                Level.SEVERE, null, ex);
         }
-        System.out.println("\t... passed");
     }
 
 
     public void test_WolfSSLCertificate_new_pemFile() {
-        System.out.print("\tnew(String pem, int format)");
-
         try {
             this.cert = new WolfSSLCertificate(cliCertPem,
                                 WolfSSL.SSL_FILETYPE_PEM);
         } catch (WolfSSLException ex) {
-            System.out.println("\t... failed");
             fail("Unable to initialize class");
-            Logger.getLogger(WolfSSLCertificateTest.class.getName()).log(
-                                Level.SEVERE, null, ex);
         }
-        System.out.println("\t... passed");
     }
 
     private byte[] fileToByteArray(String filePath)
@@ -324,27 +299,21 @@ public class WolfSSLCertificateTest {
         int i;
         BigInteger bigi = cert.getSerial();
 
-        System.out.print("\t\tgetSerial");
         serial = bigi.toByteArray();
         for (i = 0; i < serial.length && i < expected.length; i++) {
             if (serial[i] != expected[i]) {
-                System.out.println("\t\t... failed");
                 fail("Unexpected serial number");
             }
         }
-        System.out.println("\t\t... passed");
     }
 
     @SuppressWarnings("deprecation")
     public void test_notBefore() {
         Date date = cert.notBefore();
         Date expected = new Date("Dec 13 22:19:28 2023 GMT");
-        System.out.print("\t\tnotBefore");
         if (date.compareTo(expected) != 0) {
-            System.out.println("\t\t... failed");
             fail("Unexpected not before date");
         }
-        System.out.println("\t\t... passed");
     }
 
 
@@ -352,23 +321,17 @@ public class WolfSSLCertificateTest {
     public void test_notAfter() {
         Date date = cert.notAfter();
         Date expected = new Date("Sep  8 22:19:28 2026 GMT");
-        System.out.print("\t\tnotAfter");
         if (date.compareTo(expected) != 0) {
-            System.out.println("\t\t... failed");
             fail("Unexpected not after date");
         }
-        System.out.println("\t\t... passed");
     }
 
     public void test_getVersion() {
         int version = cert.getVersion();
 
-        System.out.print("\t\tgetVersion");
         if (version != 3) {
-            System.out.println("\t\t... failed");
             fail("Unexpected version number");
         }
-        System.out.println("\t\t... passed");
     }
 
     public void test_getSignature() {
@@ -428,45 +391,37 @@ public class WolfSSLCertificateTest {
             (byte)0x5c
         };
         int i;
-        System.out.print("\t\tgetSignature");
         for (i = 0; i < sig.length && i < expected.length; i++) {
             if (sig[i] != expected[i]) {
-                System.out.println("\t\t... failed");
                 fail("Unexpected signature");
             }
         }
-        System.out.println("\t\t... passed");
     }
 
     public void test_isCA() {
-        System.out.print("\t\tisCA");
         if (this.cert.isCA() != 1) {
-            System.out.println("\t\t\t... failed");
             fail("Expected isCA to be set");
         }
-        System.out.println("\t\t\t... passed");
     }
 
     public void test_getSubject() {
-        String expected = "/C=US/ST=Montana/L=Bozeman/O=wolfSSL_2048/OU=Programming-2048/CN=www.wolfssl.com/emailAddress=info@wolfssl.com";
+        String expected = "/C=US/ST=Montana/L=Bozeman/O=wolfSSL_2048" +
+            "/OU=Programming-2048/CN=www.wolfssl.com" +
+            "/emailAddress=info@wolfssl.com";
 
-        System.out.print("\t\tgetSubject");
         if (!cert.getSubject().equals(expected)) {
-            System.out.println("\t\t... failed");
             fail("Unexpected subject");
         }
-        System.out.println("\t\t... passed");
     }
 
     public void test_getIssuer() {
-        String expected = "/C=US/ST=Montana/L=Bozeman/O=wolfSSL_2048/OU=Programming-2048/CN=www.wolfssl.com/emailAddress=info@wolfssl.com";
+        String expected = "/C=US/ST=Montana/L=Bozeman/O=wolfSSL_2048" +
+            "/OU=Programming-2048/CN=www.wolfssl.com" +
+            "/emailAddress=info@wolfssl.com";
 
-        System.out.print("\t\tgetIssuer");
         if (!cert.getIssuer().equals(expected)) {
-            System.out.println("\t\t... failed");
             fail("Unexpected issuer");
         }
-        System.out.println("\t\t... passed");
     }
 
     public void test_getPubkey() {
@@ -543,75 +498,54 @@ public class WolfSSLCertificateTest {
         int i;
         byte[] pub;
 
-        System.out.print("\t\tgetPubkey");
         pub = cert.getPubkey();
         for (i = 0; i < pub.length && i < expected.length; i++) {
             if (pub[i] != expected[i]) {
-                System.out.println("\t\t... failed");
                 fail("Unexpected public key value");
             }
         }
-
-        System.out.println("\t\t... passed");
     }
 
     public void test_getPubkeyType() {
         String expected = "RSA";
-        System.out.print("\t\tgetPubkeyType");
         if (!expected.equals(this.cert.getPubkeyType())) {
-                System.out.println("\t\t... failed");
-                fail("Unexpected public key type value");
+            fail("Unexpected public key type value");
         }
-        System.out.println("\t\t... passed");
     }
 
     public void test_getPathLen() {
         int expected = -1;
-        System.out.print("\t\tgetPathLen");
         if (this.cert.getPathLen() != expected) {
-                System.out.println("\t\t... failed");
-                fail("Unexpected path length value");
+            fail("Unexpected path length value");
         }
-        System.out.println("\t\t... passed");
     }
 
     public void test_getSignatureType() {
         String expected = "SHA256withRSA";
-        System.out.print("\t\tgetSignatureType");
         if (!expected.equals(this.cert.getSignatureType())) {
-                System.out.println("\t... failed");
-                fail("Unexpected signature type");
+            fail("Unexpected signature type");
         }
-        System.out.println("\t... passed");
     }
 
     public void test_verify() {
         byte[] pubkey;
 
-        System.out.print("\t\tverify");
         pubkey = this.cert.getPubkey();
         if (pubkey == null) {
-            System.out.println("\t\t\t... failed");
             fail("Could not get public key");
             return;
         }
 
         if (this.cert.verify(pubkey, pubkey.length) != true) {
-            System.out.println("\t\t\t... failed");
             fail("Verify signature failed");
         }
-        System.out.println("\t\t\t... passed");
     }
 
     public void test_getSignatureOID() {
-        System.out.print("\t\tgetSignatureOID");
-
         /* make sure is sha256WithRSAEncryption OID */
         if (!this.cert.getSignatureOID().equals("1.2.840.113549.1.1.11")) {
-            System.out.println("\t\t... failed");
             fail("Could not get public key");
         }
-        System.out.println("\t\t... passed");
     }
 
     public void test_getKeyUsage() {
@@ -620,9 +554,7 @@ public class WolfSSLCertificateTest {
             true, false, false, false, false, true, true, false, false
         };
 
-        System.out.print("\t\tgetKeyUsage");
         if (this.cert.getKeyUsage() != null) {
-            System.out.println("\t\t... failed");
             fail("Found key usage extension when not expecting any");
         }
 
@@ -640,25 +572,19 @@ public class WolfSSLCertificateTest {
 
             kuse = ext.getKeyUsage();
             if (kuse == null) {
-                System.out.println("\t\t... failed");
                 fail("Did not find key usage extension");
                 return;
             }
 
             for (i = 0; i < kuse.length; i++) {
                 if (kuse[i] != expected[i]) {
-                    System.out.println("\t\t... failed");
                     fail("Found wrong key usage extension");
                 }
             }
             ext.free();
         } catch (Exception ex) {
-            Logger.getLogger(WolfSSLCertificateTest.class.getName()).log(
-                                Level.SEVERE, null, ex);
-            System.out.println("\t\t... failed");
             fail("Error loading external certificate");
         }
-        System.out.println("\t\t... passed");
     }
 
     public void test_getExtendedKeyUsage() {
@@ -669,18 +595,14 @@ public class WolfSSLCertificateTest {
             "1.3.6.1.5.5.7.3.2"   /* TLS Web Client Authentication */
         };
 
-        System.out.print("\t\tgetExtendedKeyUsage");
-
         /* Client cert has Extended Key Usage extension with serverAuth
          * and clientAuth */
         eku = this.cert.getExtendedKeyUsage();
         if (eku == null) {
-            System.out.println("\t... failed");
             fail("getExtendedKeyUsage() returned null for client cert");
         }
 
         if (eku.length != expected.length) {
-            System.out.println("\t... failed");
             fail("Expected " + expected.length + " EKU OIDs, got: " +
                  eku.length);
         }
@@ -695,7 +617,6 @@ public class WolfSSLCertificateTest {
                 }
             }
             if (!found) {
-                System.out.println("\t... failed");
                 fail("Missing expected OID: " + expected[i]);
             }
         }
@@ -703,18 +624,15 @@ public class WolfSSLCertificateTest {
         /* Verify all OIDs are properly formatted */
         for (i = 0; i < eku.length; i++) {
             if (eku[i] == null || eku[i].isEmpty()) {
-                System.out.println("\t... failed");
                 fail("Extended key usage OID is null or empty");
             }
             if (!eku[i].matches("^[0-9]+(\\.[0-9]+)*$")) {
-                System.out.println("\t... failed");
                 fail("Invalid OID format: " + eku[i]);
             }
         }
-
-        System.out.println("\t... passed");
     }
 
+    @Test
     public void test_getAiaMulti() {
         String[] ocsp;
         String[] ca;
@@ -723,8 +641,6 @@ public class WolfSSLCertificateTest {
         String ca1 = "http://www.wolfssl.com/ca.pem";
         String ca2 = "https://www.wolfssl.com/ca2.pem";
         WolfSSLCertificate tmp = null;
-
-        System.out.print("\t\tgetOcsp/getCaIssuerUris");
 
         try {
             if (WolfSSL.FileSystemEnabled() == true) {
@@ -738,53 +654,47 @@ public class WolfSSLCertificateTest {
 
             int overflow = tmp.getAiaOverflow();
             if (overflow == WolfSSL.NOT_COMPILED_IN) {
-                System.out.println("\t... skipped (AIA not compiled in)");
                 tmp.free();
-                return;
+                tmp = null;
+                Assume.assumeTrue("AIA not compiled in", false);
             }
 
             ocsp = tmp.getOcspUris();
             if (ocsp == null || ocsp.length != 2) {
-                System.out.println("\t... failed");
                 fail("Expected 2 OCSP URIs, got " +
-                     ((ocsp == null) ? "null" : ocsp.length));
+                    ((ocsp == null) ? "null" : ocsp.length));
             }
             assertTrue(arrayContains(ocsp, ocsp1));
             assertTrue(arrayContains(ocsp, ocsp2));
 
             ca = tmp.getCaIssuerUris();
             if (ca == null || ca.length != 2) {
-                System.out.println("\t... failed");
                 fail("Expected 2 CA Issuer URIs, got " +
-                     ((ca == null) ? "null" : ca.length));
+                    ((ca == null) ? "null" : ca.length));
             }
             assertTrue(arrayContains(ca, ca1));
             assertTrue(arrayContains(ca, ca2));
 
             if (overflow != 0) {
-                System.out.println("\t... failed");
                 fail("Expected no AIA overflow, got " + overflow);
             }
 
             tmp.free();
+        } catch (AssumptionViolatedException ave) {
+            /* Let JUnit handle the skip; do not wrap as failure. */
+            throw ave;
         } catch (Exception ex) {
             if (tmp != null) {
                 tmp.free();
             }
-            Logger.getLogger(WolfSSLCertificateTest.class.getName()).log(
-                                Level.SEVERE, null, ex);
-            System.out.println("\t... failed");
             fail("Error loading AIA multi certificate");
         }
-
-        System.out.println("\t... passed");
     }
 
+    @Test
     public void test_getAiaOverflow() {
         String[] ocsp;
         WolfSSLCertificate tmp = null;
-
-        System.out.print("\t\tgetOcspUris overflow");
 
         try {
             if (WolfSSL.FileSystemEnabled() == true) {
@@ -798,16 +708,15 @@ public class WolfSSLCertificateTest {
 
             int overflow = tmp.getAiaOverflow();
             if (overflow == WolfSSL.NOT_COMPILED_IN) {
-                System.out.println("\t... skipped (AIA not compiled in)");
                 tmp.free();
-                return;
+                tmp = null;
+                Assume.assumeTrue("AIA not compiled in", false);
             }
 
             ocsp = tmp.getOcspUris();
             if (ocsp == null || ocsp.length != 8) {
-                System.out.println("\t... failed");
                 fail("Expected 8 OCSP URIs (overflow), got " +
-                     ((ocsp == null) ? "null" : ocsp.length));
+                    ((ocsp == null) ? "null" : ocsp.length));
             }
             assertTrue(arrayContains(ocsp, "http://127.0.0.1:22220"));
             assertTrue(arrayContains(ocsp, "http://127.0.0.1:22221"));
@@ -820,22 +729,19 @@ public class WolfSSLCertificateTest {
             assertFalse(arrayContains(ocsp, "http://127.0.0.1:22228"));
 
             if (overflow != 1) {
-                System.out.println("\t... failed");
                 fail("Expected AIA overflow to be set, got " + overflow);
             }
 
             tmp.free();
+        } catch (AssumptionViolatedException ave) {
+            /* Let JUnit handle the skip; do not wrap as failure. */
+            throw ave;
         } catch (Exception ex) {
             if (tmp != null) {
                 tmp.free();
             }
-            Logger.getLogger(WolfSSLCertificateTest.class.getName()).log(
-                                Level.SEVERE, null, ex);
-            System.out.println("\t... failed");
             fail("Error loading AIA overflow certificate");
         }
-
-        System.out.println("\t... passed");
     }
 
     private boolean arrayContains(String[] list, String value) {
@@ -851,35 +757,25 @@ public class WolfSSLCertificateTest {
     }
 
     public void test_getExtensionSet() {
-        System.out.print("\t\tgetExtensionSet");
-
         if (this.cert.getExtensionSet("2.5.29.19") != 1) {
-            System.out.println("\t\t... failed");
             fail("Error with basic constraint extension");
         }
 
         if (this.cert.getExtensionSet("2.5.29.14") != 1) {
-            System.out.println("\t\t... failed");
             fail("Error with subject key ID extension");
         }
-        System.out.println("\t\t... passed");
     }
 
     public void test_toString() {
         String s;
-        System.out.print("\t\ttoString");
         s =  cert.toString();
         if (s == null) {
-            System.out.println("\t\t... failed");
             fail("Error getting certificate string");
         }
-        System.out.println("\t\t... passed");
     }
 
     public void test_free() {
-        System.out.print("\t\tfree");
         this.cert.free();
-        System.out.println("\t\t\t... passed");
     }
 
     @Test
@@ -887,8 +783,6 @@ public class WolfSSLCertificateTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException, NoSuchAlgorithmException,
                InvalidKeySpecException {
-
-        System.out.println("WolfSSLCertificate Generation");
 
         if (WolfSSL.FileSystemEnabled() == true) {
             testCertGen_SelfSigned_UsingFiles();
@@ -906,12 +800,7 @@ public class WolfSSLCertificateTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException {
 
-        System.out.print("\textension setters");
-
-        if (WolfSSL.FileSystemEnabled() == false) {
-            System.out.println("\tfilesystem disabled, skipping");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.FileSystemEnabled());
 
         WolfSSLCertificate x509 = new WolfSSLCertificate();
         assertNotNull(x509);
@@ -948,18 +837,10 @@ public class WolfSSLCertificateTest {
             0x1F, 0x20, 0x21, 0x22, 0x23
         };
 
-        runOrAllowNotCompiled(
-            () -> x509.setSubjectKeyId(skid),
-            "setSubjectKeyId");
-        runOrAllowNotCompiled(
-            () -> x509.setSubjectKeyIdEx(),
-            "setSubjectKeyIdEx");
-        runOrAllowNotCompiled(
-            () -> x509.setAuthorityKeyId(akid),
-            "setAuthorityKeyId");
-        runOrAllowNotCompiled(
-            () -> x509.setAuthorityKeyIdEx(issuer),
-            "setAuthorityKeyIdEx");
+        runOrAllowNotCompiled(() -> x509.setSubjectKeyId(skid));
+        runOrAllowNotCompiled(() -> x509.setSubjectKeyIdEx());
+        runOrAllowNotCompiled(() -> x509.setAuthorityKeyId(akid));
+        runOrAllowNotCompiled(() -> x509.setAuthorityKeyIdEx(issuer));
 
         /* Basic Constraints with pathLen */
         try {
@@ -968,7 +849,6 @@ public class WolfSSLCertificateTest {
             if (!isNotCompiledIn(e)) {
                 throw e;
             }
-            System.out.println("\t\t... skipped");
         }
         try {
             x509.addExtension(WolfSSL.NID_basic_constraints, true, 3, true);
@@ -976,7 +856,6 @@ public class WolfSSLCertificateTest {
             if (!isNotCompiledIn(e)) {
                 throw e;
             }
-            System.out.println("\t\t... skipped");
         }
 
         /* Invalid pathLen (< -1) should throw WolfSSLException */
@@ -1003,26 +882,19 @@ public class WolfSSLCertificateTest {
             /* expected */
         }
 
-        runOrAllowNotCompiled(
-            () -> x509.addCrlDistPoint("http://crl.example.com/ca.crl", false),
-            "addCrlDistPoint");
+        runOrAllowNotCompiled(() ->
+            x509.addCrlDistPoint("http://crl.example.com/ca.crl", false));
 
         byte[] crlDpDer = issuer.getExtension("2.5.29.31");
         if (crlDpDer != null && crlDpDer.length > 0) {
-            runOrAllowNotCompiled(
-                () -> x509.setCrlDistPoints(crlDpDer),
-                "setCrlDistPoints");
+            runOrAllowNotCompiled(() -> x509.setCrlDistPoints(crlDpDer));
         }
 
-        runOrAllowNotCompiled(
-            () -> x509.setNsCertType(0x80),
-            "setNsCertType");
+        runOrAllowNotCompiled(() -> x509.setNsCertType(0x80));
 
         subjectName.free();
         issuer.free();
         x509.free();
-
-        System.out.println("\t\t... passed");
     }
 
     /* Quick sanity check on certificate bytes. Loads cert into new
@@ -1141,8 +1013,6 @@ public class WolfSSLCertificateTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException {
 
-        System.out.print("\tself signed (files)");
-
         WolfSSLCertificate x509 = new WolfSSLCertificate();
         assertNotNull(x509);
 
@@ -1207,8 +1077,6 @@ public class WolfSSLCertificateTest {
         /* Free native memory */
         subjectName.free();
         x509.free();
-
-        System.out.println("\t\t... passed");
     }
 
     /* Test CA-signed certificate generation using files for public key,
@@ -1216,8 +1084,6 @@ public class WolfSSLCertificateTest {
     private void testCertGen_CASigned_UsingFiles()
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException {
-
-        System.out.print("\tCA signed (files)");
 
         WolfSSLCertificate x509 = new WolfSSLCertificate();
         assertNotNull(x509);
@@ -1285,8 +1151,6 @@ public class WolfSSLCertificateTest {
         /* Free native memory */
         subjectName.free();
         x509.free();
-
-        System.out.println("\t\t... passed");
     }
 
     /* Test self-signed certificate generation using buffers for public key,
@@ -1294,8 +1158,6 @@ public class WolfSSLCertificateTest {
     private void testCertGen_SelfSigned_UsingBuffers()
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException {
-
-        System.out.print("\tself signed (buffers)");
 
         WolfSSLCertificate x509 = new WolfSSLCertificate();
         assertNotNull(x509);
@@ -1361,8 +1223,6 @@ public class WolfSSLCertificateTest {
         /* Free native memory */
         subjectName.free();
         x509.free();
-
-        System.out.println("\t\t... passed");
     }
 
     /* Test CA-signed certificate generation using buffers for public key,
@@ -1370,8 +1230,6 @@ public class WolfSSLCertificateTest {
     private void testCertGen_CASigned_UsingBuffers()
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException {
-
-        System.out.print("\tCA signed (buffers)");
 
         WolfSSLCertificate x509 = new WolfSSLCertificate();
         assertNotNull(x509);
@@ -1441,8 +1299,6 @@ public class WolfSSLCertificateTest {
         /* Free native memory */
         subjectName.free();
         x509.free();
-
-        System.out.println("\t\t... passed");
     }
 
     /* Test self-signed certificate generation using higher-level Java classes
@@ -1450,8 +1306,6 @@ public class WolfSSLCertificateTest {
     private void testCertGen_SelfSigned_UsingJavaClasses()
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException, NoSuchAlgorithmException {
-
-        System.out.print("\tself signed (Java classes)");
 
         WolfSSLCertificate x509 = new WolfSSLCertificate();
         assertNotNull(x509);
@@ -1519,8 +1373,6 @@ public class WolfSSLCertificateTest {
         /* Free native memory */
         subjectName.free();
         x509.free();
-
-        System.out.println("\t... passed");
     }
 
     /* Test CA-signed certificate generation using higher-level Java classes
@@ -1529,8 +1381,6 @@ public class WolfSSLCertificateTest {
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException, NoSuchAlgorithmException,
                InvalidKeySpecException {
-
-        System.out.print("\tCA signed (Java classes)");
 
         WolfSSLCertificate x509 = new WolfSSLCertificate();
         assertNotNull(x509);
@@ -1608,8 +1458,6 @@ public class WolfSSLCertificateTest {
         /* Free native memory */
         subjectName.free();
         x509.free();
-
-        System.out.println("\t... passed");
     }
 
     /* Test self-signed CA certificate generation with Basic Constraints
@@ -1618,8 +1466,6 @@ public class WolfSSLCertificateTest {
     private void testCertGen_SelfSigned_WithPathLen()
         throws WolfSSLException, WolfSSLJNIException, IOException,
                CertificateException, NoSuchAlgorithmException {
-
-        System.out.print("\tSelf-signed CA (pathLen)");
 
         WolfSSLCertificate x509 = new WolfSSLCertificate();
         assertNotNull(x509);
@@ -1659,7 +1505,6 @@ public class WolfSSLCertificateTest {
             x509.addExtension(WolfSSL.NID_basic_constraints, true, 0, true);
         } catch (WolfSSLException e) {
             if (isNotCompiledIn(e)) {
-                System.out.println("\t... skipped");
                 subjectName.free();
                 x509.free();
                 return;
@@ -1689,8 +1534,6 @@ public class WolfSSLCertificateTest {
         reloaded.free();
         subjectName.free();
         x509.free();
-
-        System.out.println("\t... passed");
     }
 
     /* Utility method if needed for testing, print out cert array to file */
@@ -1709,8 +1552,6 @@ public class WolfSSLCertificateTest {
     public void testSubjectAltNames()
         throws WolfSSLException, WolfSSLJNIException, IOException {
 
-        System.out.println("Subject Alternative Names (SAN) Parsing");
-
         test_getSubjectAltNames_ServerCert();
         test_getSubjectAltNames_ExampleCert();
         test_getSubjectAltNamesExtended();
@@ -1727,8 +1568,6 @@ public class WolfSSLCertificateTest {
 
         boolean foundDNS = false;
         boolean foundIP = false;
-
-        System.out.print("\tgetSubjectAltNames (DNS + IP)");
 
         String serverCertPath = WolfSSLTestCommon.getPath(serverCertPem);
         WolfSSLCertificate serverCert = null;
@@ -1786,7 +1625,6 @@ public class WolfSSLCertificateTest {
         assertTrue("Did not find IP SAN '127.0.0.1'", foundIP);
 
         serverCert.free();
-        System.out.println("\t... passed");
     }
 
     /**
@@ -1795,8 +1633,6 @@ public class WolfSSLCertificateTest {
      */
     public void test_getSubjectAltNames_ExampleCert()
         throws WolfSSLException, IOException {
-
-        System.out.print("\tgetSubjectAltNames (multi DNS)");
 
         String exampleCertPath = WolfSSLTestCommon.getPath(external);
         /* external is ca-google-root.der, use example-com.der instead */
@@ -1817,7 +1653,6 @@ public class WolfSSLCertificateTest {
         }
         catch (WolfSSLException e) {
             /* Cert might not exist in test environment */
-            System.out.println("\t... skipped (cert not found)");
             return;
         }
 
@@ -1827,7 +1662,6 @@ public class WolfSSLCertificateTest {
         if (sans == null) {
             /* Native method may not be available */
             exampleCert.free();
-            System.out.println("\t... skipped (native not available)");
             return;
         }
 
@@ -1858,7 +1692,6 @@ public class WolfSSLCertificateTest {
             foundCount >= 1);
 
         exampleCert.free();
-        System.out.println("\t... passed");
     }
 
     /**
@@ -1867,8 +1700,6 @@ public class WolfSSLCertificateTest {
      */
     public void test_getSubjectAltNamesExtended()
         throws WolfSSLException, IOException {
-
-        System.out.print("\tgetSubjectAltNamesExtended");
 
         String serverCertPath = WolfSSLTestCommon.getPath(serverCertPem);
         WolfSSLCertificate serverCert = null;
@@ -1887,7 +1718,6 @@ public class WolfSSLCertificateTest {
         if (sans == null) {
             /* Native method may not be available in some builds */
             serverCert.free();
-            System.out.println("\t... skipped (native not available)");
             return;
         }
 
@@ -1918,7 +1748,6 @@ public class WolfSSLCertificateTest {
         }
 
         serverCert.free();
-        System.out.println("\t... passed");
     }
 
     /**
@@ -1927,8 +1756,6 @@ public class WolfSSLCertificateTest {
      */
     public void test_getSubjectAltNames_CertWithNoSANs()
         throws WolfSSLException, IOException {
-
-        System.out.print("\tgetSubjectAltNames (CA cert)");
 
         /* CA cert typically doesn't have SANs */
         String caCertPath = WolfSSLTestCommon.getPath(caCertPem);
@@ -1969,15 +1796,12 @@ public class WolfSSLCertificateTest {
         }
 
         caCert.free();
-        System.out.println("\t... passed");
     }
 
     /**
      * Test that SAN type constants match expected RFC 5280 values.
      */
     public void test_getSubjectAltNames_TypeConstants() {
-
-        System.out.print("\tSAN type constants");
 
         /* Verify constants match RFC 5280 GeneralName types */
         assertEquals("ASN_OTHER_TYPE should be 0", 0, WolfSSL.ASN_OTHER_TYPE);
@@ -1986,8 +1810,6 @@ public class WolfSSLCertificateTest {
         assertEquals("ASN_DIR_TYPE should be 4", 4, WolfSSL.ASN_DIR_TYPE);
         assertEquals("ASN_URI_TYPE should be 6", 6, WolfSSL.ASN_URI_TYPE);
         assertEquals("ASN_IP_TYPE should be 7", 7, WolfSSL.ASN_IP_TYPE);
-
-        System.out.println("\t\t... passed");
     }
 
     /**
@@ -2016,12 +1838,7 @@ public class WolfSSLCertificateTest {
         /* MS AD UPN OID */
         final String MS_UPN_OID = "1.3.6.1.4.1.311.20.2.3";
 
-        System.out.print("\tParsing otherName UPN");
-
-        if (WolfSSL.FileSystemEnabled() != true) {
-            System.out.println("\t... skipped (file system not enabled)");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.FileSystemEnabled());
 
         /* Test with server cert which has known SANs */
         String serverCertPath = WolfSSLTestCommon.getPath(serverCertPem);
@@ -2090,7 +1907,6 @@ public class WolfSSLCertificateTest {
         }
 
         serverCert.free();
-        System.out.println("\t\t... passed");
 
         /* Test with actual MS AD UPN certificate if available */
         test_MSADUPNMigrationPattern();
@@ -2108,15 +1924,11 @@ public class WolfSSLCertificateTest {
     private void test_MSADUPNMigrationPattern()
         throws WolfSSLException, IOException {
 
-        System.out.print("\tMS AD UPN parsing");
-
         /* Check if UPN test cert exists */
         String upnCertPath = sanTestUpnCert;
         File upnCertFile = new File(upnCertPath);
 
         if (!upnCertFile.exists()) {
-            System.out.println(
-                "\t... skipped (run generate-san-test-certs.sh)");
             return;
         }
 
@@ -2128,7 +1940,6 @@ public class WolfSSLCertificateTest {
             WolfSSLAltName[] sans = cert.getSubjectAltNamesArray();
 
             if (sans == null) {
-                System.out.println("\t... skipped (native not available)");
                 return;
             }
 
@@ -2214,8 +2025,6 @@ public class WolfSSLCertificateTest {
         } finally {
             cert.free();
         }
-
-        System.out.println("\t\t... passed");
     }
 
     /**
@@ -2228,8 +2037,6 @@ public class WolfSSLCertificateTest {
     @Test
     public void testSANParsingRegressionPrevention()
         throws WolfSSLException, WolfSSLJNIException, IOException {
-
-        System.out.println("SAN Parsing Regression Prevention Tests");
 
         test_SAN_OtherNameOID();
         test_SAN_OtherNameValue();
@@ -2244,13 +2051,10 @@ public class WolfSSLCertificateTest {
     private void test_SAN_OtherNameOID()
         throws WolfSSLException, IOException {
 
-        System.out.print("\totherName OID access");
-
         String certPath = sanTestUpnCert;
         File certFile = new File(certPath);
 
         if (!certFile.exists()) {
-            System.out.println("\t\t... skipped (cert not found)");
             return;
         }
 
@@ -2260,7 +2064,6 @@ public class WolfSSLCertificateTest {
         try {
             WolfSSLAltName[] sans = cert.getSubjectAltNamesArray();
             if (sans == null) {
-                System.out.println("\t\t... skipped (native not available)");
                 return;
             }
 
@@ -2279,8 +2082,6 @@ public class WolfSSLCertificateTest {
         } finally {
             cert.free();
         }
-
-        System.out.println("\t\t... passed");
     }
 
     /**
@@ -2289,13 +2090,10 @@ public class WolfSSLCertificateTest {
     private void test_SAN_OtherNameValue()
         throws WolfSSLException, IOException {
 
-        System.out.print("\totherName value bytes");
-
         String certPath = sanTestUpnCert;
         File certFile = new File(certPath);
 
         if (!certFile.exists()) {
-            System.out.println("\t\t... skipped (cert not found)");
             return;
         }
 
@@ -2305,7 +2103,6 @@ public class WolfSSLCertificateTest {
         try {
             WolfSSLAltName[] sans = cert.getSubjectAltNamesArray();
             if (sans == null) {
-                System.out.println("\t\t... skipped (native not available)");
                 return;
             }
 
@@ -2331,8 +2128,6 @@ public class WolfSSLCertificateTest {
         } finally {
             cert.free();
         }
-
-        System.out.println("\t\t... passed");
     }
 
     /**
@@ -2341,13 +2136,10 @@ public class WolfSSLCertificateTest {
     private void test_SAN_isMicrosoftUPN()
         throws WolfSSLException, IOException {
 
-        System.out.print("\tisMicrosoftUPN() detection");
-
         String certPath = sanTestUpnCert;
         File certFile = new File(certPath);
 
         if (!certFile.exists()) {
-            System.out.println("\t... skipped");
             return;
         }
 
@@ -2357,7 +2149,6 @@ public class WolfSSLCertificateTest {
         try {
             WolfSSLAltName[] sans = cert.getSubjectAltNamesArray();
             if (sans == null) {
-                System.out.println("\t... skipped");
                 return;
             }
 
@@ -2381,8 +2172,6 @@ public class WolfSSLCertificateTest {
         } finally {
             cert.free();
         }
-
-        System.out.println("\t... passed");
     }
 
     /**
@@ -2391,13 +2180,10 @@ public class WolfSSLCertificateTest {
     private void test_SAN_AllTypesSupported()
         throws WolfSSLException, IOException {
 
-        System.out.print("\tall SAN types supported");
-
         String certPath = sanTestAllTypesCert;
         File certFile = new File(certPath);
 
         if (!certFile.exists()) {
-            System.out.println("\t\t... skipped (cert not found)");
             return;
         }
 
@@ -2407,7 +2193,6 @@ public class WolfSSLCertificateTest {
         try {
             WolfSSLAltName[] sans = cert.getSubjectAltNamesArray();
             if (sans == null) {
-                System.out.println("\t\t... skipped (native not available)");
                 return;
             }
 
@@ -2469,8 +2254,6 @@ public class WolfSSLCertificateTest {
         } finally {
             cert.free();
         }
-
-        System.out.println("\t\t... passed");
     }
 
     /**
@@ -2480,13 +2263,10 @@ public class WolfSSLCertificateTest {
     private void test_SAN_DeprioritizedUsername()
         throws WolfSSLException, IOException {
 
-        System.out.print("\tdeprioritized username pattern");
-
         String certPath = sanTestUpnCert;
         File certFile = new File(certPath);
 
         if (!certFile.exists()) {
-            System.out.println("\t... skipped (cert not found)");
             return;
         }
 
@@ -2496,7 +2276,6 @@ public class WolfSSLCertificateTest {
         try {
             WolfSSLAltName[] sans = cert.getSubjectAltNamesArray();
             if (sans == null) {
-                System.out.println("\t... skipped (native not available)");
                 return;
             }
 
@@ -2538,8 +2317,6 @@ public class WolfSSLCertificateTest {
         } finally {
             cert.free();
         }
-
-        System.out.println("\t... passed");
     }
 
     /**
@@ -2550,8 +2327,6 @@ public class WolfSSLCertificateTest {
     @Test
     public void testWolfSSLAltNameClass()
         throws WolfSSLException, WolfSSLJNIException, IOException {
-
-        System.out.println("WolfSSLAltName Class Tests");
 
         test_getSubjectAltNamesArray_ServerCert();
         test_WolfSSLAltName_TypeConstants();
@@ -2569,10 +2344,7 @@ public class WolfSSLCertificateTest {
         boolean foundDNS = false;
         boolean foundIP = false;
 
-        System.out.print("\tgetSubjectAltNamesArray()");
-
         if (WolfSSL.FileSystemEnabled() != true) {
-            System.out.println("\t... skipped");
             return;
         }
 
@@ -2584,7 +2356,6 @@ public class WolfSSLCertificateTest {
         WolfSSLAltName[] sans = serverCert.getSubjectAltNamesArray();
         if (sans == null) {
             serverCert.free();
-            System.out.println("\t... skipped");
             return;
         }
 
@@ -2621,15 +2392,12 @@ public class WolfSSLCertificateTest {
         assertTrue("Did not find IP SAN '127.0.0.1'", foundIP);
 
         serverCert.free();
-        System.out.println("\t... passed");
     }
 
     /**
      * Test WolfSSLAltName type constants.
      */
     public void test_WolfSSLAltName_TypeConstants() {
-
-        System.out.print("\tWolfSSLAltName type constants");
 
         /* Verify constants match RFC 5280 GeneralName types */
         assertEquals("TYPE_OTHER_NAME should be 0",
@@ -2654,8 +2422,6 @@ public class WolfSSLCertificateTest {
         /* Verify MS UPN OID constant */
         assertEquals("OID_MS_UPN should be correct",
             "1.3.6.1.4.1.311.20.2.3", WolfSSLAltName.OID_MS_UPN);
-
-        System.out.println("\t... passed");
     }
 
     /**
@@ -2664,10 +2430,7 @@ public class WolfSSLCertificateTest {
     public void test_WolfSSLAltName_Methods()
         throws WolfSSLException, IOException {
 
-        System.out.print("\tWolfSSLAltName methods");
-
         if (WolfSSL.FileSystemEnabled() != true) {
-            System.out.println("\t\t... skipped (file system not enabled)");
             return;
         }
 
@@ -2679,7 +2442,6 @@ public class WolfSSLCertificateTest {
 
         if (sans == null || sans.length == 0) {
             serverCert.free();
-            System.out.println("\t\t... skipped (no SANs)");
             return;
         }
 
@@ -2740,7 +2502,6 @@ public class WolfSSLCertificateTest {
         }
 
         serverCert.free();
-        System.out.println("\t\t... passed");
     }
 
     /**
@@ -2749,10 +2510,7 @@ public class WolfSSLCertificateTest {
     public void test_WolfSSLAltName_EqualsHashCode()
         throws WolfSSLException, IOException {
 
-        System.out.print("\tequals() and hashCode()");
-
         if (WolfSSL.FileSystemEnabled() != true) {
-            System.out.println("\t\t... skipped (file system not enabled)");
             return;
         }
 
@@ -2769,7 +2527,6 @@ public class WolfSSLCertificateTest {
         if (sans1 == null || sans2 == null || sans1.length == 0) {
             cert1.free();
             cert2.free();
-            System.out.println("\t\t... skipped (no SANs)");
             return;
         }
 
@@ -2810,7 +2567,6 @@ public class WolfSSLCertificateTest {
 
         cert1.free();
         cert2.free();
-        System.out.println("\t\t... passed");
     }
 
     /**
@@ -2819,10 +2575,7 @@ public class WolfSSLCertificateTest {
     public void test_getSubjectAltNamesArray_DefensiveCopy()
         throws WolfSSLException, IOException {
 
-        System.out.print("\tdefensive copy test");
-
         if (WolfSSL.FileSystemEnabled() != true) {
-            System.out.println("\t\t... skipped");
             return;
         }
 
@@ -2860,7 +2613,6 @@ public class WolfSSLCertificateTest {
         assertEquals("Length should remain unchanged", origLen, sans3.length);
 
         cert.free();
-        System.out.println("\t\t... passed");
     }
 
     /**
@@ -2875,15 +2627,11 @@ public class WolfSSLCertificateTest {
     public void testSANTestCertificates()
         throws WolfSSLException, WolfSSLJNIException, IOException {
 
-        if (WolfSSL.FileSystemEnabled() != true) {
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.FileSystemEnabled());
 
         /* Check if test certs exist */
         File sanDir = new File(sanTestDir);
-        if (!sanDir.exists() || !sanDir.isDirectory()) {
-            return;
-        }
+        Assume.assumeTrue(sanDir.exists() && sanDir.isDirectory());
 
         test_SAN_DnsAndIp();
         test_SAN_EmailAndUri();
@@ -2902,12 +2650,9 @@ public class WolfSSLCertificateTest {
     private void test_SAN_DnsAndIp()
         throws WolfSSLException, IOException {
 
-        System.out.print("\tDNS and IP SANs");
-
         String certPath = sanTestDnsIpCert;
         File certFile = new File(certPath);
         if (!certFile.exists()) {
-            System.out.println("\t\t\t... skipped");
             return;
         }
 
@@ -2918,7 +2663,6 @@ public class WolfSSLCertificateTest {
         WolfSSLAltName[] sans = cert.getSubjectAltNamesArray();
         if (sans == null) {
             cert.free();
-            System.out.println("\t\t\t... skipped");
             return;
         }
 
@@ -2975,7 +2719,6 @@ public class WolfSSLCertificateTest {
         assertTrue("Did not find IPv6 link-local", foundIPv6_linklocal);
 
         cert.free();
-        System.out.println("\t\t\t... passed");
     }
 
     /**
@@ -2986,12 +2729,9 @@ public class WolfSSLCertificateTest {
     private void test_SAN_EmailAndUri()
         throws WolfSSLException, IOException {
 
-        System.out.print("\tEmail and URI SANs");
-
         String certPath = sanTestEmailUriCert;
         File certFile = new File(certPath);
         if (!certFile.exists()) {
-            System.out.println("\t\t... skipped (cert not found)");
             return;
         }
 
@@ -3002,7 +2742,6 @@ public class WolfSSLCertificateTest {
         WolfSSLAltName[] sans = cert.getSubjectAltNamesArray();
         if (sans == null) {
             cert.free();
-            System.out.println("\t\t... skipped (native not available)");
             return;
         }
 
@@ -3041,7 +2780,6 @@ public class WolfSSLCertificateTest {
         assertTrue("Did not find LDAP URI", foundUri2);
 
         cert.free();
-        System.out.println("\t\t... passed");
     }
 
     /**
@@ -3052,12 +2790,9 @@ public class WolfSSLCertificateTest {
     private void test_SAN_OtherNameUPN()
         throws WolfSSLException, IOException {
 
-        System.out.print("\totherName UPN SANs");
-
         String certPath = sanTestUpnCert;
         File certFile = new File(certPath);
         if (!certFile.exists()) {
-            System.out.println("\t\t... skipped (cert not found)");
             return;
         }
 
@@ -3068,7 +2803,6 @@ public class WolfSSLCertificateTest {
         WolfSSLAltName[] sans = cert.getSubjectAltNamesArray();
         if (sans == null) {
             cert.free();
-            System.out.println("\t\t... skipped (native not available)");
             return;
         }
 
@@ -3126,7 +2860,6 @@ public class WolfSSLCertificateTest {
         assertTrue("Did not find UPN 'admin@wolfssl.local'", foundUPN2);
 
         cert.free();
-        System.out.println("\t\t... passed");
     }
 
     /**
@@ -3136,12 +2869,9 @@ public class WolfSSLCertificateTest {
     private void test_SAN_DirName()
         throws WolfSSLException, IOException {
 
-        System.out.print("\tdirectoryName SANs");
-
         String certPath = sanTestDirNameRidCert;
         File certFile = new File(certPath);
         if (!certFile.exists()) {
-            System.out.println("\t\t... skipped (cert not found)");
             return;
         }
 
@@ -3152,7 +2882,6 @@ public class WolfSSLCertificateTest {
         WolfSSLAltName[] sans = cert.getSubjectAltNamesArray();
         if (sans == null) {
             cert.free();
-            System.out.println("\t\t... skipped (native not available)");
             return;
         }
 
@@ -3182,7 +2911,6 @@ public class WolfSSLCertificateTest {
             dirNameCount, dirNameCount >= 2);
 
         cert.free();
-        System.out.println("\t\t... passed");
     }
 
     /**
@@ -3196,12 +2924,9 @@ public class WolfSSLCertificateTest {
     private void test_SAN_AllTypes()
         throws WolfSSLException, IOException {
 
-        System.out.print("\tAll SAN types");
-
         String certPath = sanTestAllTypesCert;
         File certFile = new File(certPath);
         if (!certFile.exists()) {
-            System.out.println("\t\t\t... skipped (cert not found)");
             return;
         }
 
@@ -3212,7 +2937,6 @@ public class WolfSSLCertificateTest {
         WolfSSLAltName[] sans = cert.getSubjectAltNamesArray();
         if (sans == null) {
             cert.free();
-            System.out.println("\t\t\t... skipped (native not available)");
             return;
         }
 
@@ -3308,7 +3032,6 @@ public class WolfSSLCertificateTest {
             foundWolfSSLUri);
 
         cert.free();
-        System.out.println("\t\t\t... passed");
     }
 
     /**
@@ -3318,13 +3041,10 @@ public class WolfSSLCertificateTest {
     private void test_SAN_DerFormat()
         throws WolfSSLException, IOException {
 
-        System.out.print("\tDER format certificates");
-
         /* Test all-types cert in DER format */
         String derPath = sanTestAllTypesDer;
         File derFile = new File(derPath);
         if (!derFile.exists()) {
-            System.out.println("\t... skipped (DER not found)");
             return;
         }
 
@@ -3335,7 +3055,6 @@ public class WolfSSLCertificateTest {
         WolfSSLAltName[] sans = cert.getSubjectAltNamesArray();
         if (sans == null) {
             cert.free();
-            System.out.println("\t... skipped (native not available)");
             return;
         }
 
@@ -3377,7 +3096,6 @@ public class WolfSSLCertificateTest {
         }
 
         cert.free();
-        System.out.println("\t\t... passed");
     }
 
     /**
@@ -3388,12 +3106,9 @@ public class WolfSSLCertificateTest {
     private void test_SAN_CaCertVerification()
         throws WolfSSLException, IOException {
 
-        System.out.print("\tCA cert verification");
-
         String caCertPath = sanTestCaCert;
         File caCertFile = new File(caCertPath);
         if (!caCertFile.exists()) {
-            System.out.println("\t\t... skipped (CA cert not found)");
             return;
         }
 
@@ -3435,6 +3150,5 @@ public class WolfSSLCertificateTest {
         }
 
         caCert.free();
-        System.out.println("\t\t... passed");
     }
 }

--- a/src/test/com/wolfssl/test/WolfSSLContextTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLContextTest.java
@@ -21,8 +21,13 @@
 
 package com.wolfssl.test;
 
-import org.junit.Test;
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
@@ -64,21 +69,20 @@ public class WolfSSLContextTest {
     public static String dhParams   = "examples/certs/dh2048.pem";
     public final static String bogusFile = "/dev/null";
 
+    @Rule
+    public TestRule testWatcher = TimedTestWatcher.create();
+
     WolfSSLContext ctx;
 
     @BeforeClass
-    public static void loadLibrary() {
+    public static void loadLibrary() throws WolfSSLException {
+        System.out.println("WolfSSLContext Class");
+
         try {
             WolfSSL.loadLibrary();
         } catch (UnsatisfiedLinkError ule) {
             fail("failed to load native JNI library");
         }
-    }
-
-    @Test
-    public void testWolfSSLContext() throws WolfSSLException {
-
-        System.out.println("WolfSSLContext Class");
 
         cliCert = WolfSSLTestCommon.getPath(cliCert);
         cliKey = WolfSSLTestCommon.getPath(cliKey);
@@ -87,58 +91,38 @@ public class WolfSSLContextTest {
         svrCertEcc = WolfSSLTestCommon.getPath(svrCertEcc);
         caCert = WolfSSLTestCommon.getPath(caCert);
         dhParams = WolfSSLTestCommon.getPath(dhParams);
-
-        test_WolfSSLContext_new(WolfSSL.SSLv23_ServerMethod());
-        test_WolfSSLContext_useCertificateFile();
-        test_WolfSSLContext_usePrivateKeyFile();
-        test_WolfSSLContext_loadVerifyLocations();
-        test_WolfSSLContext_setPskClientCb();
-        test_WolfSSLContext_setPskServerCb();
-        test_WolfSSLContext_usePskIdentityHint();
-        test_WolfSSLContext_useSecureRenegotiation();
-        test_WolfSSLContext_useSupportedCurves();
-        test_WolfSSLContext_setGroups();
-        test_WolfSSLContext_set1SigAlgsList();
-        test_WolfSSLContext_setMinRSAKeySize();
-        test_WolfSSLContext_setMinECCKeySize();
-        test_WolfSSLContext_rsaCbHandshake();
-        test_WolfSSLContext_free();
     }
 
-    public void test_WolfSSLContext_new(long method) {
+    @Before
+    public void createCtx() throws WolfSSLException {
+        long method = WolfSSL.SSLv23_ServerMethod();
+        Assume.assumeTrue("SSLv23 server method not available",
+            method != 0 && method != WolfSSL.NOT_COMPILED_IN);
+        ctx = new WolfSSLContext(method);
+    }
 
-        if (method != 0)
-        {
-            System.out.print("\tWolfSSLContext()");
-
-            /* test failure case */
-            try {
-
-                ctx = new WolfSSLContext(0);
-
-            } catch (WolfSSLException e) {
-
-                /* now test success case */
-                try {
-                    ctx = new WolfSSLContext(method);
-                } catch (WolfSSLException we) {
-                    System.out.println("\t\t... failed");
-                    fail("failed to create WolfSSLContext object");
-                }
-
-                System.out.println("\t\t... passed");
-                return;
-            }
-
-            System.out.println("\t\t... failed");
-            fail("failure case improperly succeeded, WolfSSLContext()");
+    @After
+    public void freeCtx() {
+        if (ctx != null) {
+            ctx.free();
+            ctx = null;
         }
     }
 
+    @Test
+    public void test_WolfSSLContext_new() {
+        /* Freshly-created ctx from @Before covers the success path. Verify
+         * that constructor throws when passed an invalid method (0). */
+        try {
+            new WolfSSLContext(0);
+            fail("new WolfSSLContext(0) should have thrown");
+        } catch (WolfSSLException expected) {
+            /* expected */
+        }
+    }
+
+    @Test
     public void test_WolfSSLContext_useCertificateFile() {
-
-        System.out.print("\tuseCertificateFile()");
-
         test_ucf(null, null, 9999, WolfSSL.SSL_FAILURE,
                  "useCertificateFile(null, null, 9999)");
 
@@ -154,40 +138,31 @@ public class WolfSSLContextTest {
                      WolfSSL.SSL_SUCCESS,
                      "useCertificateFile(ctx, cliCert, SSL_FILETYPE_PEM)");
         }
-
-        System.out.println("\t\t... passed");
     }
 
     /* helper for testing WolfSSLContext.useCertificateFile() */
-    public void test_ucf(WolfSSLContext sslCtx, String filePath, int type,
+    private void test_ucf(WolfSSLContext sslCtx, String filePath, int type,
                         int cond, String name) {
 
         int result;
 
         try {
-
             result = sslCtx.useCertificateFile(filePath, type);
-            if (result != cond)
-            {
-                System.out.println("\t\t... failed");
+            if (result != cond) {
                 fail(name + " failed");
             }
-
         } catch (NullPointerException e) {
-
-            /* correctly handle NULL pointer */
-            if (sslCtx == null) {
-                return;
+            /* Native code throws NPE for null inputs (null ctx or null
+             * path) instead of returning SSL_FAILURE. Accept NPE only
+             * when the test was already expecting a failure. */
+            if (cond != WolfSSL.SSL_FAILURE) {
+                fail(name + " threw unexpected NullPointerException");
             }
         }
-
-        return;
     }
 
+    @Test
     public void test_WolfSSLContext_usePrivateKeyFile() {
-
-        System.out.print("\tusePrivateKeyFile()");
-
         test_upkf(null, null, 9999, WolfSSL.SSL_FAILURE,
                  "usePrivateKeyFile(null, null, 9999)");
 
@@ -203,40 +178,31 @@ public class WolfSSLContextTest {
                      WolfSSL.SSL_SUCCESS,
                      "usePrivateKeyFile(ctx, cliKey, SSL_FILETYPE_PEM)");
         }
-
-        System.out.println("\t\t... passed");
     }
 
     /* helper for testing WolfSSLContext.usePrivateKeyFile() */
-    public void test_upkf(WolfSSLContext sslCtx, String filePath, int type,
+    private void test_upkf(WolfSSLContext sslCtx, String filePath, int type,
                         int cond, String name) {
 
         int result;
 
         try {
-
             result = sslCtx.usePrivateKeyFile(filePath, type);
-            if (result != cond)
-            {
-                System.out.println("\t\t... failed");
+            if (result != cond) {
                 fail(name + " failed");
             }
-
         } catch (NullPointerException e) {
-
-            /* correctly handle NULL pointer */
-            if (sslCtx == null) {
-                return;
+            /* Native code throws NPE for null inputs (null ctx or null
+             * path) instead of returning SSL_FAILURE. Accept NPE only
+             * when the test was already expecting a failure. */
+            if (cond != WolfSSL.SSL_FAILURE) {
+                fail(name + " threw unexpected NullPointerException");
             }
         }
-
-        return;
     }
 
+    @Test
     public void test_WolfSSLContext_loadVerifyLocations() {
-
-        System.out.print("\tloadVerifyLocations()");
-
         test_lvl(null, null, null, WolfSSL.SSL_FAILURE,
                 "loadVerifyLocations(null, null, null)");
 
@@ -250,34 +216,27 @@ public class WolfSSLContextTest {
             test_lvl(ctx, caCert, null, WolfSSL.SSL_SUCCESS,
                     "loadVerifyLocations(ctx, caCert, 0)");
         }
-
-        System.out.println("\t\t... passed");
     }
 
     /* helper for testing WolfSSLContext.loadVerifyLocations() */
-    public void test_lvl(WolfSSLContext sslCtx, String filePath,
+    private void test_lvl(WolfSSLContext sslCtx, String filePath,
                          String dirPath, int cond, String name) {
 
         int result;
 
         try {
-
             result = sslCtx.loadVerifyLocations(filePath, dirPath);
-            if (result != cond)
-            {
-                System.out.println("\t\t... failed");
+            if (result != cond) {
                 fail(name + " failed");
             }
-
         } catch (NullPointerException e) {
-
-            /* correctly handle NULL pointer */
-            if (sslCtx == null) {
-                return;
+            /* Native code throws NPE for null inputs (null ctx or null
+             * path) instead of returning SSL_FAILURE. Accept NPE only
+             * when the test was already expecting a failure. */
+            if (cond != WolfSSL.SSL_FAILURE) {
+                fail(name + " threw unexpected NullPointerException");
             }
         }
-
-        return;
     }
 
     class TestPskClientCb implements WolfSSLPskClientCallback
@@ -287,8 +246,9 @@ public class WolfSSLContextTest {
                 long keyMaxLen) {
 
             /* set the client identity */
-            if (identity.length() != 0)
+            if (identity.length() != 0) {
                 return 0;
+            }
             identity.append("Client_identity");
 
             /* set the client key, max key size is key.length */
@@ -302,19 +262,21 @@ public class WolfSSLContextTest {
         }
     }
 
+    @Test
     public void test_WolfSSLContext_setPskClientCb() {
-        System.out.print("\tsetPskClientCb()");
         try {
             TestPskClientCb pskClientCb = new TestPskClientCb();
             ctx.setPskClientCb(pskClientCb);
+
         } catch (Exception e) {
-            if (!e.getMessage().equals("wolfSSL not compiled with PSK " +
-                        "support")) {
-                System.out.println("\t\t... failed");
-                e.printStackTrace();
+            String msg = e.getMessage();
+            if ("wolfSSL not compiled with PSK support".equals(msg)) {
+                Assume.assumeNoException("PSK not compiled in", e);
             }
+
+            e.printStackTrace();
+            fail("setPskClientCb threw unexpected: " + msg);
         }
-        System.out.println("\t\t... passed");
     }
 
     class TestPskServerCb implements WolfSSLPskServerCallback
@@ -323,8 +285,9 @@ public class WolfSSLContextTest {
                 byte[] key, long keyMaxLen) {
 
             /* check the client identity */
-            if (!identity.equals("Client_identity"))
+            if (!identity.equals("Client_identity")) {
                 return 0;
+            }
 
             /* set the server key, max key size is key.length */
             key[0] = 26;
@@ -337,53 +300,54 @@ public class WolfSSLContextTest {
         }
     }
 
+    @Test
     public void test_WolfSSLContext_setPskServerCb() {
-        System.out.print("\tsetPskServerCb()");
         try {
             TestPskServerCb pskServerCb = new TestPskServerCb();
             ctx.setPskServerCb(pskServerCb);
+
         } catch (Exception e) {
-            if (!e.getMessage().equals("wolfSSL not compiled with PSK " +
-                        "support")) {
-                System.out.println("\t\t... failed");
-                e.printStackTrace();
+            String msg = e.getMessage();
+            if ("wolfSSL not compiled with PSK support".equals(msg)) {
+                Assume.assumeNoException("PSK not compiled in", e);
             }
+
+            e.printStackTrace();
+            fail("setPskServerCb threw unexpected: " + msg);
         }
-        System.out.println("\t\t... passed");
     }
 
+    @Test
     public void test_WolfSSLContext_usePskIdentityHint() {
-        System.out.print("\tusePskIdentityHint()");
         try {
             int ret = ctx.usePskIdentityHint("wolfssl hint");
             if (ret != WolfSSL.SSL_SUCCESS &&
                 ret != WolfSSL.NOT_COMPILED_IN) {
-                System.out.println("\t\t... failed");
                 fail("usePskIdentityHint failed");
             }
+
         } catch (IllegalStateException e) {
-            System.out.println("\t\t... failed");
             e.printStackTrace();
+            fail("usePskIdentityHint threw: " + e.getMessage());
         }
-        System.out.println("\t\t... passed");
     }
 
+    @Test
     public void test_WolfSSLContext_useSecureRenegotiation() {
-        System.out.print("\tuseSecureRenegotiation()");
         try {
             int ret = ctx.useSecureRenegotiation();
             if (ret != WolfSSL.SSL_SUCCESS &&
                 ret != WolfSSL.NOT_COMPILED_IN) {
-                System.out.println("\t... failed");
                 fail("useSecureRenegotiation failed");
             }
+
         } catch (IllegalStateException e) {
-            System.out.println("\t... failed");
             e.printStackTrace();
+            fail("useSecureRenegotiation threw: " + e.getMessage());
         }
-        System.out.println("\t... passed");
     }
 
+    @Test
     public void test_WolfSSLContext_useSupportedCurves() {
 
         int ret;
@@ -396,25 +360,21 @@ public class WolfSSLContextTest {
         String[] x25519Curve = new String[] { "x25519" };
         String[] x448Curve = new String[] { "x448" };
 
-        System.out.print("\tuseSupportedCurves()");
         try {
             ret = ctx.useSupportedCurves(singleEccSecp256r1);
             if (ret != WolfSSL.SSL_SUCCESS &&
                 ret != WolfSSL.NOT_COMPILED_IN) {
-                System.out.println("\t\t... failed");
                 fail("useSupportedCurves(singleEccSecp256r1) failed");
             }
             ret = ctx.useSupportedCurves(allEccCurves);
             if (ret != WolfSSL.SSL_SUCCESS &&
                 ret != WolfSSL.NOT_COMPILED_IN) {
-                System.out.println("\t\t... failed");
                 fail("useSupportedCurves(allEccCurves) failed");
             }
             if (WolfSSL.Curve25519Enabled()) {
                 ret = ctx.useSupportedCurves(x25519Curve);
                 if (ret != WolfSSL.SSL_SUCCESS &&
                     ret != WolfSSL.NOT_COMPILED_IN) {
-                    System.out.println("\t\t... failed");
                     fail("useSupportedCurves(x25519Curve) failed");
                 }
             }
@@ -422,19 +382,16 @@ public class WolfSSLContextTest {
                 ret = ctx.useSupportedCurves(x448Curve);
                 if (ret != WolfSSL.SSL_SUCCESS &&
                     ret != WolfSSL.NOT_COMPILED_IN) {
-                    System.out.println("\t\t... failed");
                     fail("useSupportedCurves(x448Curve) failed");
                 }
             }
-            System.out.println("\t\t... passed");
-
         } catch (IllegalStateException e) {
-            System.out.println("\t\t... failed");
-            fail("useSupportedCurves failed");
             e.printStackTrace();
+            fail("useSupportedCurves failed");
         }
     }
 
+    @Test
     public void test_WolfSSLContext_setGroups() {
 
         int ret;
@@ -446,61 +403,50 @@ public class WolfSSLContextTest {
         int[] tooLong = new int[50];
         int[] badGroups = { 0xDEAD, 0xBEEF };
 
-        System.out.print("\tsetGroups()");
         try {
             ret = ctx.setGroups(null);
             if (ret != WolfSSL.NOT_COMPILED_IN &&
                 ret == WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t\t\t... failed");
                 fail("setGroups() should fail with null arg");
             }
             if (WolfSSL.EccEnabled()) {
                 ret = ctx.setGroups(singleItem);
                 if (ret != WolfSSL.NOT_COMPILED_IN &&
                     ret != WolfSSL.SSL_SUCCESS) {
-                    System.out.println("\t\t\t... failed");
                     fail("setGroups() failed with WOLFSSL_ECC_SECP256R1");
                 }
                 ret = ctx.setGroups(twoItems);
                 if (ret != WolfSSL.NOT_COMPILED_IN &&
                     ret != WolfSSL.SSL_SUCCESS) {
-                    System.out.println("\t\t\t... failed");
                     fail("setGroups() failed with two entries");
                 }
             }
             ret = ctx.setGroups(tooLong);
             if (ret != WolfSSL.NOT_COMPILED_IN &&
                 ret != WolfSSL.BAD_FUNC_ARG) {
-                System.out.println("\t\t\t... failed");
                 fail("setGroups() should fail with too long array");
             }
             ret = ctx.setGroups(badGroups);
             if (ret != WolfSSL.NOT_COMPILED_IN &&
                 ret != WolfSSL.BAD_FUNC_ARG) {
-                System.out.println("\t\t\t... failed");
                 fail("setGroups() should fail with bad/invalid values");
             }
-
-            System.out.println("\t\t\t... passed");
-
         } catch (IllegalStateException e) {
-            System.out.println("\t\t\t... failed");
             e.printStackTrace();
             fail("setGroups() failed");
         }
     }
 
+    @Test
     public void test_WolfSSLContext_set1SigAlgsList() {
 
         int ret;
 
-        System.out.print("\tset1SigAlgsList()");
         try {
             /* Expected failure, null list */
             ret = ctx.set1SigAlgsList(null);
             if (ret != WolfSSL.NOT_COMPILED_IN &&
                 ret != WolfSSL.SSL_FAILURE) {
-                System.out.println("\t\t... failed");
                 fail("set1SigAlgsList() should fail with null list");
             }
 
@@ -508,7 +454,6 @@ public class WolfSSLContextTest {
             ret = ctx.set1SigAlgsList("");
             if (ret != WolfSSL.NOT_COMPILED_IN &&
                 ret != WolfSSL.SSL_FAILURE) {
-                System.out.println("\t\t... failed");
                 fail("set1SigAlgsList() should fail with empty list");
             }
 
@@ -516,7 +461,6 @@ public class WolfSSLContextTest {
                 ret = ctx.set1SigAlgsList("RSA");
                 if (ret != WolfSSL.NOT_COMPILED_IN &&
                     ret != WolfSSL.SSL_FAILURE) {
-                    System.out.println("\t\t... failed");
                     fail("set1SigAlgsList() should fail without hash");
                 }
 
@@ -524,14 +468,12 @@ public class WolfSSLContextTest {
                     ret = ctx.set1SigAlgsList("RSA+SHA256");
                     if (ret != WolfSSL.NOT_COMPILED_IN &&
                         ret != WolfSSL.SSL_SUCCESS) {
-                        System.out.println("\t\t... failed");
                         fail("set1SigAlgsList() should pass with given list");
                     }
 
                     ret = ctx.set1SigAlgsList("RSA:RSA+SHA256");
                     if (ret != WolfSSL.NOT_COMPILED_IN &&
                         ret != WolfSSL.SSL_FAILURE) {
-                        System.out.println("\t\t... failed");
                         fail("set1SigAlgsList() should fail without hash");
                     }
 
@@ -539,7 +481,6 @@ public class WolfSSLContextTest {
                         ret = ctx.set1SigAlgsList("RSA+SHA256:RSA+SHA512");
                         if (ret != WolfSSL.NOT_COMPILED_IN &&
                             ret != WolfSSL.SSL_SUCCESS) {
-                            System.out.println("\t\t... failed");
                             fail("set1SigAlgsList() should pass");
                         }
                     }
@@ -550,7 +491,6 @@ public class WolfSSLContextTest {
                 ret = ctx.set1SigAlgsList("ECDSA");
                 if (ret != WolfSSL.NOT_COMPILED_IN &&
                     ret != WolfSSL.SSL_FAILURE) {
-                    System.out.println("\t\t... failed");
                     fail("set1SigAlgsList() should fail without hash");
                 }
 
@@ -558,14 +498,12 @@ public class WolfSSLContextTest {
                     ret = ctx.set1SigAlgsList("ECDSA+SHA256");
                     if (ret != WolfSSL.NOT_COMPILED_IN &&
                         ret != WolfSSL.SSL_SUCCESS) {
-                        System.out.println("\t\t... failed");
                         fail("set1SigAlgsList() should pass with given list");
                     }
 
                     ret = ctx.set1SigAlgsList("ECDSA:ECDSA+SHA256");
                     if (ret != WolfSSL.NOT_COMPILED_IN &&
                         ret != WolfSSL.SSL_FAILURE) {
-                        System.out.println("\t\t... failed");
                         fail("set1SigAlgsList() should fail without hash");
                     }
 
@@ -573,54 +511,44 @@ public class WolfSSLContextTest {
                         ret = ctx.set1SigAlgsList("ECDSA+SHA256:ECDSA+SHA512");
                         if (ret != WolfSSL.NOT_COMPILED_IN &&
                             ret != WolfSSL.SSL_SUCCESS) {
-                            System.out.println("\t\t... failed");
                             fail("set1SigAlgsList() should pass");
                         }
                     }
                 }
             }
-
-            System.out.println("\t\t... passed");
-
         } catch (IllegalStateException e) {
-            System.out.println("\t\t... failed");
             e.printStackTrace();
             fail("set1SigAlgsList() failed");
         }
     }
 
+    @Test
     public void test_WolfSSLContext_setMinRSAKeySize() {
 
         int ret = 0;
-
-        System.out.print("\tsetMinKeyRSASize()");
 
         try {
             /* negative size key length should fail */
             ret = ctx.setMinRSAKeySize(-1);
             if (ret != WolfSSL.BAD_FUNC_ARG) {
-                System.out.println("\t\t... failed");
                 fail("setMinRSAKeySize should fail with negative key size");
             }
 
             /* key length not % 8 should fail */
             ret = ctx.setMinRSAKeySize(1023);
             if (ret != WolfSSL.BAD_FUNC_ARG) {
-                System.out.println("\t\t... failed");
                 fail("setMinRSAKeySize should fail with non % 8 size");
             }
 
             /* valid key length should succeed */
             ret = ctx.setMinRSAKeySize(1024);
             if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t\t... failed");
                 fail("setMinRSAKeySize did not pass as expected");
             }
 
             /* loading of key larger than set size should pass */
             ret = ctx.useCertificateFile(cliCert, WolfSSL.SSL_FILETYPE_PEM);
             if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t\t... failed");
                 fail("setMinRSAKeySize did not pass as expected (1024 limit)");
             }
 
@@ -631,130 +559,116 @@ public class WolfSSLContextTest {
             ctx.setVerify(WolfSSL.SSL_VERIFY_PEER, null);
             ret = ctx.setMinRSAKeySize(8192);
             if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t\t... failed");
                 fail("setMinRSAKeySize did not pass as expected for 8192");
             }
 
             /* loading of key smaller than set size should fail */
             ret = ctx.useCertificateFile(cliCert, WolfSSL.SSL_FILETYPE_PEM);
             if (ret == WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t\t... failed");
                 fail("setMinRSAKeySize did not fail as expected with limit");
             }
 
         } catch (IllegalStateException e) {
-            System.out.println("\t\t... failed");
             e.printStackTrace();
+            fail("setMinRSAKeySize threw: " + e.getMessage());
         }
-
-        System.out.println("\t\t... passed");
     }
 
+    @Test
     public void test_WolfSSLContext_setMinECCKeySize() {
 
         int ret = 0;
-
-        System.out.print("\tsetMinECCKeySize()");
 
         try {
             /* negative size key length should fail */
             ret = ctx.setMinECCKeySize(-1);
             if (ret != WolfSSL.BAD_FUNC_ARG) {
-                System.out.println("\t\t... failed");
                 fail("setMinECCKeySize should fail with negative key size");
             }
 
             /* valid key length should succeed */
             ret = ctx.setMinECCKeySize(128);
             if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t\t... failed");
                 fail("setMinECCKeySize did not pass as expected");
             }
 
             /* loading of key larger than set size should pass */
             ret = ctx.useCertificateFile(svrCertEcc, WolfSSL.SSL_FILETYPE_PEM);
             if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t\t... failed");
                 fail("setMinECCKeySize did not pass as expected (128 limit)");
             }
+
+            /* Below we test ctx.useCertificateFile(), but that API will only
+             * fail based on key size limitations when peer verification is
+             * enabled, set SSL_VERIFY_PEER here. */
+            ctx.setVerify(WolfSSL.SSL_VERIFY_PEER, null);
 
             /* set min key size to something very large for next test */
             ret = ctx.setMinECCKeySize(512);
             if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t\t... failed");
                 fail("setMinECCKeySize did not pass as expected for 521");
             }
 
             /* loading of key smaller than set size should fail */
             ret = ctx.useCertificateFile(svrCertEcc, WolfSSL.SSL_FILETYPE_PEM);
             if (ret == WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t\t... failed");
                 fail("setMinECCKeySize did not fail as expected with limit");
             }
 
         } catch (IllegalStateException e) {
-            System.out.println("\t\t... failed");
             e.printStackTrace();
+            fail("setMinECCKeySize threw: " + e.getMessage());
         }
-
-        System.out.println("\t\t... passed");
     }
 
+    @Test
     public void test_WolfSSLContext_setMinDHKeySize() {
 
         int ret = 0;
 
-        System.out.print("\tsetMinDHKeySize()");
-
         try {
-            /* key length > 16000 fail */
+            /* key length > 16000 should fail */
             ret = ctx.setMinDHKeySize(17000);
             if (ret != WolfSSL.BAD_FUNC_ARG) {
-                System.out.println("\t\t... failed");
                 fail("setMinDHKeySize should fail with key size too large");
             }
 
             /* key length not % 8 should fail */
-            ret = ctx.setMinECCKeySize(1023);
+            ret = ctx.setMinDHKeySize(1023);
             if (ret != WolfSSL.BAD_FUNC_ARG) {
-                System.out.println("\t\t... failed");
                 fail("setMinDHKeySize should fail with non % 8 size");
             }
 
             /* valid key length should succeed */
             ret = ctx.setMinDHKeySize(1024);
             if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t\t... failed");
                 fail("setMinDHKeySize did not pass as expected");
             }
 
-            /* loading params larger than min size should pass */
+            Assume.assumeTrue(WolfSSL.FileSystemEnabled());
+
+            /* loading params larger than min size should pass (2048>1024) */
             ret = ctx.setTmpDHFile(dhParams, WolfSSL.SSL_FILETYPE_PEM);
             if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t\t... failed");
-                fail("setMinDHKeySize did not pass as expected (1024 limit)");
+                fail("setTmpDHFile did not pass as expected (1024 limit)");
             }
 
-            /* set min key size to something very large for next test */
-            ret = ctx.setMinECCKeySize(8192);
+            /* set min key size too large to accept dh2048 params */
+            ret = ctx.setMinDHKeySize(8192);
             if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t\t... failed");
                 fail("setMinDHKeySize did not pass as expected for 8192");
             }
 
-            /* loading of key smaller than set size should fail */
+            /* loading of params smaller than set size should fail */
             ret = ctx.setTmpDHFile(dhParams, WolfSSL.SSL_FILETYPE_PEM);
             if (ret == WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t\t... failed");
                 fail("setMinDHKeySize did not fail as expected with limit");
             }
 
         } catch (IllegalStateException | WolfSSLJNIException e) {
-            System.out.println("\t\t... failed");
             e.printStackTrace();
+            fail("setMinDHKeySize threw: " + e.getMessage());
         }
-
-        System.out.println("\t\t... passed");
     }
 
     /* Context object shared between RSA sign/verify callbacks, tracks whether
@@ -853,14 +767,9 @@ public class WolfSSLContextTest {
         return c;
     }
 
+    @Test
     public void test_WolfSSLContext_rsaCbHandshake() {
-
-        System.out.print("\trsaCbHandshake()");
-
-        if (!WolfSSL.RsaEnabled() || !WolfSSL.FileSystemEnabled()) {
-            System.out.println("\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.RsaEnabled() && WolfSSL.FileSystemEnabled());
 
         /* TLS 1.2 handshake with RSA PK callbacks */
         rsaCbHandshakeTls12();
@@ -869,8 +778,6 @@ public class WolfSSLContextTest {
         if (WolfSSL.TLSv13Enabled() && WolfSSL.RsaPssEnabled()) {
             rsaCbHandshakeTls13();
         }
-
-        System.out.println("\t\t... passed");
     }
 
     private void rsaCbHandshakeTls12() {
@@ -1011,15 +918,12 @@ public class WolfSSLContextTest {
                 e.getMessage().contains("PK Callback")) {
                 return;
             }
-            System.out.println("\t\t... failed");
             fail("TLS 1.2 RSA CB handshake: " + e.getMessage());
 
         } catch (ExecutionException e) {
-            System.out.println("\t\t... failed");
             fail("TLS 1.2 RSA CB server: " + e.getCause().getMessage());
 
         } catch (Exception e) {
-            System.out.println("\t\t... failed");
             fail("TLS 1.2 RSA CB handshake: " + e.getMessage());
 
         } finally {
@@ -1161,15 +1065,12 @@ public class WolfSSLContextTest {
                 e.getMessage().contains("PK Callback")) {
                 return;
             }
-            System.out.println("\t\t... failed");
             fail("TLS 1.3 PSS CB handshake: " + e.getMessage());
 
         } catch (ExecutionException e) {
-            System.out.println("\t\t... failed");
             fail("TLS 1.3 PSS CB server: " + e.getCause().getMessage());
 
         } catch (Exception e) {
-            System.out.println("\t\t... failed");
             fail("TLS 1.3 PSS CB handshake: " + e.getMessage());
 
         } finally {
@@ -1193,11 +1094,10 @@ public class WolfSSLContextTest {
         }
     }
 
+    @Test
     public void test_WolfSSLContext_free() {
-
-        System.out.print("\tfree()");
+        /* Free the ctx created in @Before, then null it so @After skips. */
         ctx.free();
-        System.out.println("\t\t\t\t... passed");
+        ctx = null;
     }
 }
-

--- a/src/test/com/wolfssl/test/WolfSSLNameConstraintsTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLNameConstraintsTest.java
@@ -23,8 +23,11 @@ package com.wolfssl.test;
 
 import java.util.List;
 
+import org.junit.Assume;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.BeforeClass;
+import org.junit.rules.TestRule;
 import static org.junit.Assert.*;
 
 import com.wolfssl.WolfSSL;
@@ -41,6 +44,9 @@ import com.wolfssl.WolfSSLGeneralName;
  * @author wolfSSL
  */
 public class WolfSSLNameConstraintsTest {
+
+    @Rule
+    public TestRule testWatcher = TimedTestWatcher.create();
 
     /* Test certificate with email name constraint (.wolfssl.com) */
     public static String certWithNC = "examples/certs/test/cert-ext-nc.pem";
@@ -85,12 +91,7 @@ public class WolfSSLNameConstraintsTest {
     @Test
     public void testGetNameConstraintsWithNC() throws WolfSSLException {
 
-        System.out.print("\tgetNameConstraints() with ext");
-
-        if (!WolfSSL.NameConstraintsEnabled()) {
-            System.out.println("\t... skipped (not compiled in)");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.NameConstraintsEnabled());
 
         WolfSSLCertificate cert = null;
         WolfSSLNameConstraints nc = null;
@@ -118,8 +119,6 @@ public class WolfSSLNameConstraintsTest {
             assertNotNull("Value should not be null", gn.getValue());
             assertTrue("Value should contain wolfssl.com",
                 gn.getValue().contains("wolfssl.com"));
-
-            System.out.println("\t... passed");
         } finally {
             if (nc != null) {
                 nc.free();
@@ -133,12 +132,7 @@ public class WolfSSLNameConstraintsTest {
     @Test
     public void testGetNameConstraintsWithoutNC() throws WolfSSLException {
 
-        System.out.print("\tgetNameConstraints() no ext");
-
-        if (!WolfSSL.NameConstraintsEnabled()) {
-            System.out.println("\t... skipped (not compiled in)");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.NameConstraintsEnabled());
 
         WolfSSLCertificate cert = null;
         try {
@@ -151,8 +145,6 @@ public class WolfSSLNameConstraintsTest {
             /* Should be null for cert without name constraints extension */
             assertNull("Name constraints should be null for cert without NC",
                 nc);
-
-            System.out.println("\t... passed");
         } finally {
             if (cert != null) {
                 cert.free();
@@ -163,12 +155,7 @@ public class WolfSSLNameConstraintsTest {
     @Test
     public void testGetNameConstraintsIPAddress() throws WolfSSLException {
 
-        System.out.print("\tgetNameConstraints() IP address");
-
-        if (!WolfSSL.NameConstraintsEnabled()) {
-            System.out.println("\t... skipped (not compiled in)");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.NameConstraintsEnabled());
 
         WolfSSLCertificate cert = null;
         WolfSSLNameConstraints nc = null;
@@ -195,8 +182,6 @@ public class WolfSSLNameConstraintsTest {
             String value = gn.getValue();
             assertTrue("IP constraint should contain network address",
                 value.contains("192.168.1.0") || value.contains(":"));
-
-            System.out.println("\t... passed");
         } finally {
             if (nc != null) {
                 nc.free();
@@ -210,8 +195,6 @@ public class WolfSSLNameConstraintsTest {
     @Test
     public void testGeneralNameTypes() throws WolfSSLException {
 
-        System.out.print("\tGeneralName type constants");
-
         /* Verify type constants match RFC 5280 */
         assertEquals("GEN_OTHERNAME", 0, WolfSSLGeneralName.GEN_OTHERNAME);
         assertEquals("GEN_EMAIL", 1, WolfSSLGeneralName.GEN_EMAIL);
@@ -222,14 +205,10 @@ public class WolfSSLNameConstraintsTest {
         assertEquals("GEN_URI", 6, WolfSSLGeneralName.GEN_URI);
         assertEquals("GEN_IPADD", 7, WolfSSLGeneralName.GEN_IPADD);
         assertEquals("GEN_RID", 8, WolfSSLGeneralName.GEN_RID);
-
-        System.out.println("\t... passed");
     }
 
     @Test
     public void testGeneralNameTypeName() {
-
-        System.out.print("\tGeneralName.getTypeName()");
 
         WolfSSLGeneralName gn = new WolfSSLGeneralName(
             WolfSSLGeneralName.GEN_DNS, "example.com");
@@ -238,19 +217,12 @@ public class WolfSSLNameConstraintsTest {
         assertEquals(WolfSSLGeneralName.GEN_DNS, gn.getType());
         assertEquals("example.com", gn.getValue());
         assertEquals("DNS:example.com", gn.toString());
-
-        System.out.println("\t... passed");
     }
 
     @Test
     public void testCheckDnsNamePermitted() throws WolfSSLException {
 
-        System.out.print("\tcheckDnsName() permitted");
-
-        if (!WolfSSL.NameConstraintsEnabled()) {
-            System.out.println("\t... skipped (not compiled in)");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.NameConstraintsEnabled());
 
         WolfSSLCertificate cert = null;
         WolfSSLNameConstraints nc = null;
@@ -264,8 +236,6 @@ public class WolfSSLNameConstraintsTest {
              * but no DNS constraints, so all DNS names should pass */
             assertTrue("DNS name should be permitted when no DNS constraint",
                 nc.checkDnsName("www.example.com"));
-
-            System.out.println("\t... passed");
         } finally {
             if (nc != null) {
                 nc.free();
@@ -279,12 +249,7 @@ public class WolfSSLNameConstraintsTest {
     @Test
     public void testCheckEmailPermitted() throws WolfSSLException {
 
-        System.out.print("\tcheckEmail() permitted");
-
-        if (!WolfSSL.NameConstraintsEnabled()) {
-            System.out.println("\t\t... skipped (not compiled in)");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.NameConstraintsEnabled());
 
         WolfSSLCertificate cert = null;
         WolfSSLNameConstraints nc = null;
@@ -303,8 +268,6 @@ public class WolfSSLNameConstraintsTest {
                 nc.checkEmail("user@sub.wolfssl.com"));
             assertTrue("Deeper subdomain should also be permitted",
                 nc.checkEmail("user@a.b.wolfssl.com"));
-
-            System.out.println("\t\t... passed");
         } finally {
             if (nc != null) {
                 nc.free();
@@ -318,12 +281,7 @@ public class WolfSSLNameConstraintsTest {
     @Test
     public void testCheckEmailNotPermitted() throws WolfSSLException {
 
-        System.out.print("\tcheckEmail() not permitted");
-
-        if (!WolfSSL.NameConstraintsEnabled()) {
-            System.out.println("\t... skipped (not compiled in)");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.NameConstraintsEnabled());
 
         WolfSSLCertificate cert = null;
         WolfSSLNameConstraints nc = null;
@@ -338,8 +296,6 @@ public class WolfSSLNameConstraintsTest {
                 nc.checkEmail("user@other.com"));
             assertFalse("Email @notwolfssl.com should not be permitted",
                 nc.checkEmail("user@notwolfssl.com"));
-
-            System.out.println("\t... passed");
         } finally {
             if (nc != null) {
                 nc.free();
@@ -353,12 +309,7 @@ public class WolfSSLNameConstraintsTest {
     @Test
     public void testCheckNameWithNullArgument() throws WolfSSLException {
 
-        System.out.print("\tcheckName() null argument");
-
-        if (!WolfSSL.NameConstraintsEnabled()) {
-            System.out.println("\t... skipped (not compiled in)");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.NameConstraintsEnabled());
 
         WolfSSLCertificate cert = null;
         WolfSSLNameConstraints nc = null;
@@ -374,8 +325,6 @@ public class WolfSSLNameConstraintsTest {
             } catch (IllegalArgumentException e) {
                 /* Expected */
             }
-
-            System.out.println("\t... passed");
         } finally {
             if (nc != null) {
                 nc.free();
@@ -389,12 +338,7 @@ public class WolfSSLNameConstraintsTest {
     @Test
     public void testNameConstraintsFree() throws WolfSSLException {
 
-        System.out.print("\tNameConstraints.free()");
-
-        if (!WolfSSL.NameConstraintsEnabled()) {
-            System.out.println("\t\t... skipped (not compiled in)");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.NameConstraintsEnabled());
 
         WolfSSLCertificate cert = null;
         WolfSSLNameConstraints nc = null;
@@ -417,8 +361,6 @@ public class WolfSSLNameConstraintsTest {
             } catch (IllegalStateException e) {
                 /* Expected */
             }
-
-            System.out.println("\t\t... passed");
         } finally {
             /* nc already freed in test, but safe due to double-free handling */
             if (cert != null) {
@@ -430,12 +372,7 @@ public class WolfSSLNameConstraintsTest {
     @Test
     public void testExcludedSubtrees() throws WolfSSLException {
 
-        System.out.print("\tgetExcludedSubtrees()");
-
-        if (!WolfSSL.NameConstraintsEnabled()) {
-            System.out.println("\t\t... skipped (not compiled in)");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.NameConstraintsEnabled());
 
         WolfSSLCertificate cert = null;
         WolfSSLNameConstraints nc = null;
@@ -457,8 +394,6 @@ public class WolfSSLNameConstraintsTest {
             } catch (UnsupportedOperationException e) {
                 /* Expected */
             }
-
-            System.out.println("\t\t... passed");
         } finally {
             if (nc != null) {
                 nc.free();
@@ -472,12 +407,7 @@ public class WolfSSLNameConstraintsTest {
     @Test
     public void testPermittedSubtreesUnmodifiable() throws WolfSSLException {
 
-        System.out.print("\tSubtrees unmodifiable");
-
-        if (!WolfSSL.NameConstraintsEnabled()) {
-            System.out.println("\t\t... skipped (not compiled in)");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.NameConstraintsEnabled());
 
         WolfSSLCertificate cert = null;
         WolfSSLNameConstraints nc = null;
@@ -497,8 +427,6 @@ public class WolfSSLNameConstraintsTest {
             } catch (UnsupportedOperationException e) {
                 /* Expected */
             }
-
-            System.out.println("\t\t... passed");
         } finally {
             if (nc != null) {
                 nc.free();
@@ -511,20 +439,12 @@ public class WolfSSLNameConstraintsTest {
 
     @Test
     public void testCheckIpAddressPermitted() throws WolfSSLException {
-        System.out.print("\tcheckIpAddress() permitted");
-
-        if (!WolfSSL.NameConstraintsEnabled()) {
-            System.out.println("\t... skipped (not compiled in)");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.NameConstraintsEnabled());
 
         /* Native wolfSSL XINET_PTON on Windows casts char* to
          * PCWSTR, causing IP address parsing to fail. Skip until
          * fixed in native wolfSSL (should use InetPtonA). */
-        if (WolfSSLTestCommon.isWindows()) {
-            System.out.println("\t... skipped (Windows)");
-            return;
-        }
+        Assume.assumeFalse(WolfSSLTestCommon.isWindows());
 
         WolfSSLCertificate cert = null;
         WolfSSLNameConstraints nc = null;
@@ -541,8 +461,6 @@ public class WolfSSLNameConstraintsTest {
                 nc.checkIpAddress("192.168.1.1"));
             assertTrue("IP 192.168.1.254 should be permitted",
                 nc.checkIpAddress("192.168.1.254"));
-
-            System.out.println("\t... passed");
         } finally {
             if (nc != null) {
                 nc.free();
@@ -555,12 +473,7 @@ public class WolfSSLNameConstraintsTest {
 
     @Test
     public void testCheckIpAddressNotPermitted() throws WolfSSLException {
-        System.out.print("\tcheckIpAddress() not permitted");
-
-        if (!WolfSSL.NameConstraintsEnabled()) {
-            System.out.println("\t... skipped (not compiled in)");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.NameConstraintsEnabled());
 
         WolfSSLCertificate cert = null;
         WolfSSLNameConstraints nc = null;
@@ -577,8 +490,6 @@ public class WolfSSLNameConstraintsTest {
                 nc.checkIpAddress("10.0.0.1"));
             assertFalse("IP 8.8.8.8 should not be permitted",
                 nc.checkIpAddress("8.8.8.8"));
-
-            System.out.println("\t... passed");
         } finally {
             if (nc != null) {
                 nc.free();
@@ -591,12 +502,7 @@ public class WolfSSLNameConstraintsTest {
 
     @Test
     public void testIpConstraintValueFormat() throws WolfSSLException {
-        System.out.print("\tIP constraint value format");
-
-        if (!WolfSSL.NameConstraintsEnabled()) {
-            System.out.println("\t... skipped (not compiled in)");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.NameConstraintsEnabled());
 
         WolfSSLCertificate cert = null;
         WolfSSLNameConstraints nc = null;
@@ -622,8 +528,6 @@ public class WolfSSLNameConstraintsTest {
                 value.contains("/"));
             assertEquals("Should be 192.168.1.0/255.255.255.0",
                 "192.168.1.0/255.255.255.0", value);
-
-            System.out.println("\t... passed");
         } finally {
             if (nc != null) {
                 nc.free();
@@ -636,12 +540,7 @@ public class WolfSSLNameConstraintsTest {
 
     @Test
     public void testCheckUriNoConstraint() throws WolfSSLException {
-        System.out.print("\tcheckUri() no constraint");
-
-        if (!WolfSSL.NameConstraintsEnabled()) {
-            System.out.println("\t... skipped (not compiled in)");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.NameConstraintsEnabled());
 
         WolfSSLCertificate cert = null;
         WolfSSLNameConstraints nc = null;
@@ -657,8 +556,6 @@ public class WolfSSLNameConstraintsTest {
                 nc.checkUri("https://example.com/path"));
             assertTrue("Any URI should be permitted",
                 nc.checkUri("http://wolfssl.com/test"));
-
-            System.out.println("\t... passed");
         } finally {
             if (nc != null) {
                 nc.free();
@@ -671,18 +568,10 @@ public class WolfSSLNameConstraintsTest {
 
     @Test
     public void testCheckNameGeneric() throws WolfSSLException {
-        System.out.print("\tcheckName() generic type");
-
-        if (!WolfSSL.NameConstraintsEnabled()) {
-            System.out.println("\t... skipped (not compiled in)");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.NameConstraintsEnabled());
 
         /* Skip on Windows, see testCheckIpAddressPermitted */
-        if (WolfSSLTestCommon.isWindows()) {
-            System.out.println("\t\t... skipped (Windows)");
-            return;
-        }
+        Assume.assumeFalse(WolfSSLTestCommon.isWindows());
 
         WolfSSLCertificate cert = null;
         WolfSSLNameConstraints nc = null;
@@ -701,8 +590,6 @@ public class WolfSSLNameConstraintsTest {
             /* DNS should be permitted since no DNS constraint exists */
             assertTrue("checkName with GEN_DNS should be permitted",
                 nc.checkName(WolfSSLGeneralName.GEN_DNS, "www.example.com"));
-
-            System.out.println("\t... passed");
         } finally {
             if (nc != null) {
                 nc.free();
@@ -715,18 +602,10 @@ public class WolfSSLNameConstraintsTest {
 
     @Test
     public void testIpSubnetBoundaries() throws WolfSSLException {
-        System.out.print("\tIP subnet boundary cases");
-
-        if (!WolfSSL.NameConstraintsEnabled()) {
-            System.out.println("\t... skipped (not compiled in)");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.NameConstraintsEnabled());
 
         /* Skip on Windows, see testCheckIpAddressPermitted */
-        if (WolfSSLTestCommon.isWindows()) {
-            System.out.println("\t... skipped (Windows)");
-            return;
-        }
+        Assume.assumeFalse(WolfSSLTestCommon.isWindows());
 
         WolfSSLCertificate cert = null;
         WolfSSLNameConstraints nc = null;
@@ -751,8 +630,6 @@ public class WolfSSLNameConstraintsTest {
                 nc.checkIpAddress("192.168.0.255"));
             assertFalse("192.168.2.0 should be outside range",
                 nc.checkIpAddress("192.168.2.0"));
-
-            System.out.println("\t... passed");
         } finally {
             if (nc != null) {
                 nc.free();
@@ -765,12 +642,7 @@ public class WolfSSLNameConstraintsTest {
 
     @Test
     public void testIterateAllSubtrees() throws WolfSSLException {
-        System.out.print("\tIterate all subtrees");
-
-        if (!WolfSSL.NameConstraintsEnabled()) {
-            System.out.println("\t\t... skipped (not compiled in)");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.NameConstraintsEnabled());
 
         WolfSSLCertificate cert = null;
         WolfSSLNameConstraints nc = null;
@@ -804,8 +676,6 @@ public class WolfSSLNameConstraintsTest {
             for (WolfSSLGeneralName gn : excluded) {
                 assertNotNull("Excluded GeneralName should not be null", gn);
             }
-
-            System.out.println("\t\t... passed");
         } finally {
             if (nc != null) {
                 nc.free();
@@ -818,12 +688,7 @@ public class WolfSSLNameConstraintsTest {
 
     @Test
     public void testDnsConstraintEnforcement() throws WolfSSLException {
-        System.out.print("\tDNS constraint enforcement");
-
-        if (!WolfSSL.NameConstraintsEnabled()) {
-            System.out.println("\t... skipped (not compiled in)");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.NameConstraintsEnabled());
 
         WolfSSLCertificate cert = null;
         WolfSSLNameConstraints nc = null;
@@ -854,8 +719,6 @@ public class WolfSSLNameConstraintsTest {
                 nc.checkDnsName("example.com"));
             assertFalse("notwolfssl.com should not be permitted",
                 nc.checkDnsName("notwolfssl.com"));
-
-            System.out.println("\t... passed");
         } finally {
             if (nc != null) {
                 nc.free();
@@ -868,12 +731,7 @@ public class WolfSSLNameConstraintsTest {
 
     @Test
     public void testUriConstraintEnforcement() throws WolfSSLException {
-        System.out.print("\tURI constraint enforcement");
-
-        if (!WolfSSL.NameConstraintsEnabled()) {
-            System.out.println("\t... skipped (not compiled in)");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.NameConstraintsEnabled());
 
         WolfSSLCertificate cert = null;
         WolfSSLNameConstraints nc = null;
@@ -894,8 +752,6 @@ public class WolfSSLNameConstraintsTest {
             /* URIs with other hosts should not be permitted */
             assertFalse("https://example.com should not be permitted",
                 nc.checkUri("https://example.com/path"));
-
-            System.out.println("\t... passed");
         } finally {
             if (nc != null) {
                 nc.free();
@@ -908,12 +764,7 @@ public class WolfSSLNameConstraintsTest {
 
     @Test
     public void testExcludedConstraintEnforcement() throws WolfSSLException {
-        System.out.print("\tExcluded constraint enforcement");
-
-        if (!WolfSSL.NameConstraintsEnabled()) {
-            System.out.println("\t... skipped (not compiled in)");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.NameConstraintsEnabled());
 
         WolfSSLCertificate cert = null;
         WolfSSLNameConstraints nc = null;
@@ -948,8 +799,6 @@ public class WolfSSLNameConstraintsTest {
             /* Domains outside permitted .example.com should not be allowed */
             assertFalse("www.wolfssl.com DNS should not be permitted",
                 nc.checkDnsName("www.wolfssl.com"));
-
-            System.out.println("\t... passed");
         } finally {
             if (nc != null) {
                 nc.free();
@@ -964,12 +813,7 @@ public class WolfSSLNameConstraintsTest {
     public void testMixedPermittedExcludedConstraints()
         throws WolfSSLException {
 
-        System.out.print("\tMixed permitted/excluded");
-
-        if (!WolfSSL.NameConstraintsEnabled()) {
-            System.out.println("\t... skipped (not compiled in)");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.NameConstraintsEnabled());
 
         WolfSSLCertificate cert = null;
         WolfSSLNameConstraints nc = null;
@@ -1010,8 +854,6 @@ public class WolfSSLNameConstraintsTest {
                 nc.checkDnsName("other.com"));
             assertFalse("user@other.com should not be permitted",
                 nc.checkEmail("user@other.com"));
-
-            System.out.println("\t... passed");
         } finally {
             if (nc != null) {
                 nc.free();
@@ -1024,12 +866,7 @@ public class WolfSSLNameConstraintsTest {
 
     @Test
     public void testDnsConstraintValueFormat() throws WolfSSLException {
-        System.out.print("\tDNS constraint value format");
-
-        if (!WolfSSL.NameConstraintsEnabled()) {
-            System.out.println("\t... skipped (not compiled in)");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.NameConstraintsEnabled());
 
         WolfSSLCertificate cert = null;
         WolfSSLNameConstraints nc = null;
@@ -1063,8 +900,6 @@ public class WolfSSLNameConstraintsTest {
             String value = dnsGn.getValue();
             assertNotNull("DNS value should not be null", value);
             assertEquals("Should be .wolfssl.com", ".wolfssl.com", value);
-
-            System.out.println("\t... passed");
         } finally {
             if (nc != null) {
                 nc.free();

--- a/src/test/com/wolfssl/test/WolfSSLSessionTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLSessionTest.java
@@ -21,8 +21,11 @@
 
 package com.wolfssl.test;
 
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.TestRule;
 import static org.junit.Assert.*;
 
 import java.io.ByteArrayOutputStream;
@@ -80,6 +83,9 @@ public class WolfSSLSessionTest {
      * Security property use in this test class */
     private static final Object byteBufferPoolPropertyLock = new Object();
 
+    @Rule
+    public TestRule testWatcher = TimedTestWatcher.create();
+
     @BeforeClass
     public static void loadLibrary()
         throws WolfSSLException{
@@ -109,13 +115,10 @@ public class WolfSSLSessionTest {
 
         WolfSSLSession sess = null;
 
-        System.out.print("\tWolfSSLSession()");
-
         try {
             sess = new WolfSSLSession(ctx);
 
         } catch (WolfSSLException we) {
-            System.out.println("\t... failed");
             fail("failed to create WolfSSLSession object");
 
         } finally {
@@ -123,15 +126,11 @@ public class WolfSSLSessionTest {
                 sess.freeSSL();
             }
         }
-
-        System.out.println("\t\t... passed");
     }
 
     @Test
     public void test_WolfSSLSession_useCertificateFile()
         throws WolfSSLJNIException, WolfSSLException {
-
-        System.out.print("\tuseCertificateFile()");
 
         WolfSSLSession ssl = new WolfSSLSession(ctx);
 
@@ -143,26 +142,20 @@ public class WolfSSLSessionTest {
                  "useCertificateFile(ssl, bogusFile, SSL_FILETYPE_PEM)");
 
         test_ucf("useCertificateFile", ssl, cliCert, 9999,
-                 WolfSSL.SSL_FAILURE,
-                 "useCertificateFile(ssl, cliCert, 9999)");
+                 WolfSSL.SSL_FAILURE, "useCertificateFile(ssl, cliCert, 9999)");
 
         test_ucf("useCertificateFile", ssl, cliCert,
-                 WolfSSL.SSL_FILETYPE_PEM,
-                 WolfSSL.SSL_SUCCESS,
+                 WolfSSL.SSL_FILETYPE_PEM, WolfSSL.SSL_SUCCESS,
                  "useCertificateFile(ssl, cliCert, SSL_FILETYPE_PEM)");
 
         if (ssl != null) {
             ssl.freeSSL();
         }
-
-        System.out.println("\t\t... passed");
     }
 
     @Test
     public void test_WolfSSLSession_useCertificateChainFile()
         throws WolfSSLJNIException, WolfSSLException {
-
-        System.out.print("\tuseCertificateChainFile()");
 
         WolfSSLSession ssl = new WolfSSLSession(ctx);
 
@@ -181,8 +174,6 @@ public class WolfSSLSessionTest {
         if (ssl != null) {
             ssl.freeSSL();
         }
-
-        System.out.println("\t... passed");
     }
 
     /* helper for testing WolfSSLSession.useCertificateFile() */
@@ -201,13 +192,7 @@ public class WolfSSLSessionTest {
                 fail(name + " failed");
             }
 
-            if ((result != cond) && (result != WolfSSL.NOT_COMPILED_IN))
-            {
-                if (func.equals("useCertificateFile")) {
-                    System.out.println("\t\t... failed");
-                } else {
-                    System.out.println("\t... failed");
-                }
+            if ((result != cond) && (result != WolfSSL.NOT_COMPILED_IN)) {
                 fail(name + " failed");
             }
 
@@ -225,8 +210,6 @@ public class WolfSSLSessionTest {
     @Test
     public void test_WolfSSLSession_usePrivateKeyFile()
         throws WolfSSLJNIException, WolfSSLException {
-
-        System.out.print("\tusePrivateKeyFile()");
 
         WolfSSLSession ssl = new WolfSSLSession(ctx);
 
@@ -246,8 +229,6 @@ public class WolfSSLSessionTest {
         if (ssl != null) {
             ssl.freeSSL();
         }
-
-        System.out.println("\t\t... passed");
     }
 
     /* helper for testing WolfSSLSession.usePrivateKeyFile() */
@@ -259,9 +240,7 @@ public class WolfSSLSessionTest {
         try {
 
             result = ssl.usePrivateKeyFile(filePath, type);
-            if ((result != cond) && (result != WolfSSL.NOT_COMPILED_IN))
-            {
-                System.out.println("\t\t... failed");
+            if ((result != cond) && (result != WolfSSL.NOT_COMPILED_IN)) {
                 fail(name + " failed");
             }
 
@@ -283,8 +262,9 @@ public class WolfSSLSessionTest {
                 long keyMaxLen) {
 
             /* set the client identity */
-            if (identity.length() != 0)
+            if (identity.length() != 0) {
                 return 0;
+            }
             identity.append("Client_identity");
 
             /* set the client key, max key size is key.length */
@@ -304,33 +284,25 @@ public class WolfSSLSessionTest {
 
         WolfSSLSession ssl = null;
 
-        System.out.print("\tsetPskClientCb()");
-
         try {
             TestPskClientCb pskClientCb = new TestPskClientCb();
             ssl = new WolfSSLSession(ctx);
             ssl.setPskClientCb(pskClientCb);
 
         } catch (Exception e) {
-            if (e.getMessage().equals("wolfSSL not compiled with PSK " +
-                "support")) {
-                /* Not compiled in, skip */
-                System.out.println("\t\t... skipped");
-                return;
+            String msg = e.getMessage();
+            if (msg != null &&
+                msg.equals("wolfSSL not compiled with PSK support")) {
+                Assume.assumeNoException("PSK not compiled in", e);
             }
-            else {
-                System.out.println("\t\t... failed");
-                fail("Failed setPskClientCb test");
-                e.printStackTrace();
-            }
+            e.printStackTrace();
+            fail("Failed setPskClientCb test: " + msg);
 
         } finally {
             if (ssl != null) {
                 ssl.freeSSL();
             }
         }
-
-        System.out.println("\t\t... passed");
     }
 
     class TestPskServerCb implements WolfSSLPskServerCallback
@@ -339,8 +311,9 @@ public class WolfSSLSessionTest {
                 byte[] key, long keyMaxLen) {
 
             /* check the client identity */
-            if (!identity.equals("Client_identity"))
+            if (!identity.equals("Client_identity")) {
                 return 0;
+            }
 
             /* set the server key, max key size is key.length */
             key[0] = 26;
@@ -359,33 +332,25 @@ public class WolfSSLSessionTest {
 
         WolfSSLSession ssl = null;
 
-        System.out.print("\tsetPskServerCb()");
-
         try {
             TestPskServerCb pskServerCb = new TestPskServerCb();
             ssl = new WolfSSLSession(ctx);
             ssl.setPskServerCb(pskServerCb);
 
         } catch (Exception e) {
-            if (e.getMessage().equals("wolfSSL not compiled with PSK " +
-                "support")) {
-                /* Not compiled in, skip */
-                System.out.println("\t\t... skipped");
-                return;
+            String msg = e.getMessage();
+            if (msg != null &&
+                msg.equals("wolfSSL not compiled with PSK support")) {
+                Assume.assumeNoException("PSK not compiled in", e);
             }
-            else {
-                System.out.println("\t\t... failed");
-                fail("Failed setPskServerCb test");
-                e.printStackTrace();
-            }
+            e.printStackTrace();
+            fail("Failed setPskServerCb test: " + msg);
 
         } finally {
             if (ssl != null) {
                 ssl.freeSSL();
             }
         }
-
-        System.out.println("\t\t... passed");
     }
 
     @Test
@@ -396,8 +361,6 @@ public class WolfSSLSessionTest {
         String hint = null;
         WolfSSLSession ssl = null;
 
-        System.out.print("\tuse/getPskIdentityHint()");
-
         ssl = new WolfSSLSession(ctx);
 
         try {
@@ -405,19 +368,16 @@ public class WolfSSLSessionTest {
             ret = ssl.usePskIdentityHint("wolfssl hint");
             if (ret != WolfSSL.SSL_SUCCESS &&
                 ret != WolfSSL.NOT_COMPILED_IN) {
-                System.out.println("\t... failed");
                 fail("usePskIdentityHint failed");
             }
 
             /* Get PSK identity hint */
             hint = ssl.getPskIdentityHint();
             if (hint != null && !hint.equals("wolfssl hint")) {
-                System.out.println("\t... failed");
                 fail("getPskIdentityHint failed");
             }
 
         } catch (IllegalStateException e) {
-            System.out.println("\t... failed");
             e.printStackTrace();
             fail("Failed use/getPskIdentityHint test");
 
@@ -426,8 +386,6 @@ public class WolfSSLSessionTest {
                 ssl.freeSSL();
             }
         }
-
-        System.out.println("\t... passed");
     }
 
     @Test
@@ -437,29 +395,24 @@ public class WolfSSLSessionTest {
         int ret = 0;
         WolfSSLSession ssl = null;
 
-        System.out.print("\tuseSessionTicket()");
-
         try {
             ssl = new WolfSSLSession(ctx);
 
             ret = ssl.useSessionTicket();
             if (ret != WolfSSL.SSL_SUCCESS &&
                 ret != WolfSSL.NOT_COMPILED_IN) {
-                System.out.println("\t\t... failed");
                 fail("useSessionTicket failed");
             }
 
         } catch (IllegalStateException e) {
-            System.out.println("\t\t... failed");
             e.printStackTrace();
+            fail("Failed useSessionTicket test: " + e.getMessage());
 
         } finally {
             if (ssl != null) {
                 ssl.freeSSL();
             }
         }
-
-        System.out.println("\t\t... passed");
     }
 
     @Test
@@ -471,15 +424,12 @@ public class WolfSSLSessionTest {
         byte[] ticket = null;
         byte[] retrievedTicket = null;
 
-        System.out.print("\t(get/set)SessionTicket()");
-
         try {
             ssl = new WolfSSLSession(ctx);
 
             ret = ssl.useSessionTicket();
             if (ret != WolfSSL.SSL_SUCCESS &&
                 ret != WolfSSL.NOT_COMPILED_IN) {
-                System.out.println("\t\t... failed");
                 fail("useSessionTicket failed");
             }
 
@@ -489,35 +439,30 @@ public class WolfSSLSessionTest {
             ret = ssl.setSessionTicket(ticket);
             if (ret != WolfSSL.SSL_SUCCESS &&
                 ret != WolfSSL.NOT_COMPILED_IN) {
-                System.out.println("\t... failed");
                 fail("setSessionTicket failed");
             }
 
             retrievedTicket = ssl.getSessionTicket();
 
             if (retrievedTicket == null) {
-                System.out.println("\t... failed" );
                 fail("getSessionTicket failed");
             }
 
             for (int i = 0; i < ticket.length; i++) {
                 if (ticket[i] != retrievedTicket[i]) {
-                    System.out.println("\t... failed");
                     fail("getSessionTicket failed");
                 }
             }
 
         } catch (IllegalStateException e) {
-            System.out.println("\t... failed");
             e.printStackTrace();
+            fail("Failed getSetSessionTickets test: " + e.getMessage());
 
         } finally {
             if (ssl != null) {
                 ssl.freeSSL();
             }
         }
-
-        System.out.println("\t... passed");
     }
 
     public void test_WolfSSLSession_resumeWithSessionTickets()
@@ -532,8 +477,6 @@ public class WolfSSLSessionTest {
          * must be final since used inside inner class. */
         final WolfSSLContext srvCtx;
         WolfSSLContext cliCtx;
-
-        System.out.println("\tresumeWithSessionTickets()");
 
         /* Create ServerSocket first to get ephemeral port */
         final ServerSocket srvSocket = new ServerSocket(0);
@@ -600,7 +543,6 @@ public class WolfSSLSessionTest {
             });
 
         } catch (Exception e) {
-            System.out.println("\t... failed");
             e.printStackTrace();
             fail();
         }
@@ -686,8 +628,6 @@ public class WolfSSLSessionTest {
                 srvCtx.free();
             }
         }
-
-        System.out.println("\t... passed");
     }
 
     @Test
@@ -696,15 +636,12 @@ public class WolfSSLSessionTest {
 
         WolfSSLSession ssl = null;
 
-        System.out.print("\tgetPskIdentity()");
-
         try {
             ssl = new WolfSSLSession(ctx);
             /* Not checking return, just that we don't throw an exception */
             ssl.getPskIdentity();
 
         } catch (IllegalStateException e) {
-            System.out.println("\t\t... failed");
             fail("Failed getPskIdentity test");
             e.printStackTrace();
 
@@ -713,8 +650,6 @@ public class WolfSSLSessionTest {
                 ssl.freeSSL();
             }
         }
-
-        System.out.println("\t\t... passed");
     }
 
     @Test
@@ -723,14 +658,11 @@ public class WolfSSLSessionTest {
 
         WolfSSLSession ssl = null;
 
-        System.out.print("\ttimeout()");
-
         ssl = new WolfSSLSession(ctx);
 
         try {
             ssl.setTimeout(5);
             if (ssl.getTimeout() != 5) {
-                System.out.println("\t\t\t... failed");
                 fail("Failed timeout test");
             }
 
@@ -739,8 +671,6 @@ public class WolfSSLSessionTest {
                 ssl.freeSSL();
             }
         }
-
-        System.out.println("\t\t\t... passed");
     }
 
     @Test
@@ -749,13 +679,10 @@ public class WolfSSLSessionTest {
 
         WolfSSLSession ssl = null;
 
-        System.out.print("\tstatus()");
-
         ssl = new WolfSSLSession(ctx);
 
         try {
             if (ssl.handshakeDone() == true) {
-                System.out.println("\t\t\t... failed");
                 fail("Failed status test");
             }
 
@@ -764,8 +691,6 @@ public class WolfSSLSessionTest {
                 ssl.freeSSL();
             }
         }
-
-        System.out.println("\t\t\t... passed");
     }
 
     @Test
@@ -776,17 +701,12 @@ public class WolfSSLSessionTest {
         String sniHostName = "www.example.com";
         WolfSSLSession ssl = null;
 
-        System.out.print("\tuseSNI()");
-
         ssl = new WolfSSLSession(ctx);
 
         try {
             ret = ssl.useSNI((byte)0, sniHostName.getBytes());
-            if (ret == WolfSSL.NOT_COMPILED_IN) {
-                System.out.println("\t\t\t... skipped");
-                return;
-            } else if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t\t\t... failed");
+            Assume.assumeTrue(ret != WolfSSL.NOT_COMPILED_IN);
+            if (ret != WolfSSL.SSL_SUCCESS) {
                 fail("Failed useSNI test");
             }
 
@@ -795,8 +715,6 @@ public class WolfSSLSessionTest {
                 ssl.freeSSL();
             }
         }
-
-        System.out.println("\t\t\t... passed");
     }
 
     @Test
@@ -811,8 +729,6 @@ public class WolfSSLSessionTest {
         byte[] alpnProtoBytes = http11Alpn.getBytes();
         byte[] alpnProtoBytesPacked = new byte[1 + alpnProtoBytes.length];
         WolfSSLSession ssl = null;
-
-        System.out.print("\tuseALPN()");
 
         ssl = new WolfSSLSession(ctx);
 
@@ -869,12 +785,8 @@ public class WolfSSLSessionTest {
                 }
             }
 
-            if (ret == WolfSSL.NOT_COMPILED_IN) {
-                System.out.println("\t\t\t... skipped");
-                return;
-
-            } else if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t\t\t... failed");
+            Assume.assumeTrue(ret != WolfSSL.NOT_COMPILED_IN);
+            if (ret != WolfSSL.SSL_SUCCESS) {
                 fail("Failed useALPN test");
             }
 
@@ -883,8 +795,6 @@ public class WolfSSLSessionTest {
                 ssl.freeSSL();
             }
         }
-
-        System.out.println("\t\t\t... passed");
     }
 
     /**
@@ -913,8 +823,6 @@ public class WolfSSLSessionTest {
             (byte)0xCA, (byte)0xDA, (byte)0xEA, (byte)0xFA
         };
 
-        System.out.print("\tuseALPN() GREASE");
-
         /* Create String from bytes using ISO-8859-1 to preserve byte values */
         greaseString = new String(greaseBytes, StandardCharsets.ISO_8859_1);
         alpnProtos = new String[] { greaseString };
@@ -925,20 +833,14 @@ public class WolfSSLSessionTest {
             ret = ssl.useALPN(alpnProtos,
                 WolfSSL.WOLFSSL_ALPN_CONTINUE_ON_MISMATCH);
 
-            if (ret == WolfSSL.NOT_COMPILED_IN) {
-                System.out.println("\t\t... skipped");
-                return;
-
-            } else if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t\t... failed");
+            Assume.assumeTrue(ret != WolfSSL.NOT_COMPILED_IN);
+            if (ret != WolfSSL.SSL_SUCCESS) {
                 fail("Failed useALPN GREASE test, ret = " + ret);
             }
 
         } finally {
             ssl.freeSSL();
         }
-
-        System.out.println("\t\t... passed");
     }
 
     @Test
@@ -947,21 +849,16 @@ public class WolfSSLSessionTest {
 
         WolfSSLSession ssl = null;
 
-        System.out.print("\tfreeSSL()");
-
         ssl = new WolfSSLSession(ctx);
 
         try {
             ssl.freeSSL();
 
         } catch (WolfSSLJNIException e) {
-            System.out.println("\t\t\t... failed");
             fail("Failed freeSSL test");
             e.printStackTrace();
 
         }
-
-        System.out.println("\t\t\t... passed");
     }
 
     @Test
@@ -975,8 +872,6 @@ public class WolfSSLSessionTest {
         WolfSSLContext cliCtx = null;
         ServerSocket srvSocket = null;
         ExecutorService es = null;
-
-        System.out.print("\tTesting use after free");
 
         try {
             /* Create ServerSocket first to get ephemeral port,
@@ -1084,7 +979,6 @@ public class WolfSSLSessionTest {
             /* Don't set ssl to null - we need to test use-after-free below */
 
         } catch (Exception e) {
-            System.out.println("\t\t... failed");
             fail("Failed UseAfterFree test: " + e.getMessage());
             e.printStackTrace();
             return;
@@ -1113,11 +1007,9 @@ public class WolfSSLSessionTest {
             ret = ssl.connect();
 
         } catch (IllegalStateException ise) {
-            System.out.println("\t\t... passed");
             return;
 
         } catch (SocketTimeoutException | SocketException e) {
-            System.out.println("\t\t... failed");
             fail("Failed UseAfterFree test");
             e.printStackTrace();
             return;
@@ -1125,7 +1017,6 @@ public class WolfSSLSessionTest {
 
         /* fail here means WolfSSLSession was used after free without
          * exception thrown */
-        System.out.println("\t\t... failed");
         fail("WolfSSLSession was able to be used after freed");
     }
 
@@ -1141,8 +1032,6 @@ public class WolfSSLSessionTest {
         WolfSSLContext cliCtx = null;
         ServerSocket srvSocket = null;
         ExecutorService es = null;
-
-        System.out.print("\tTesting getSessionID()");
 
         try {
             /* Create ServerSocket first to get ephemeral port, set
@@ -1266,7 +1155,6 @@ public class WolfSSLSessionTest {
             ssl.shutdownSSL();
 
         } catch (Exception e) {
-            System.out.println("\t\t... failed");
             fail("Failed getSessionID test: " + e.getMessage());
             e.printStackTrace();
             return;
@@ -1292,8 +1180,6 @@ public class WolfSSLSessionTest {
                 } catch (Exception e) { }
             }
         }
-
-        System.out.println("\t\t... passed");
     }
 
     @Test
@@ -1304,8 +1190,6 @@ public class WolfSSLSessionTest {
         WolfSSL sslLib = null;
         WolfSSLContext sslCtx = null;
         WolfSSLSession ssl = null;
-
-        System.out.print("\tTesting useSecureRenegotiation()");
 
         try {
 
@@ -1319,13 +1203,11 @@ public class WolfSSLSessionTest {
             /* test if enable call succeeds */
             ret = ssl.useSecureRenegotiation();
             if (ret != WolfSSL.SSL_SUCCESS && ret != WolfSSL.NOT_COMPILED_IN) {
-                System.out.println("... failed");
                 fail("Failed useSecureRenegotiation test");
                 return;
             }
 
         } catch (Exception e) {
-            System.out.println("... failed");
             fail("Failed useSecureRenegotiation test");
             e.printStackTrace();
             return;
@@ -1338,8 +1220,6 @@ public class WolfSSLSessionTest {
                 sslCtx.free();
             }
         }
-
-        System.out.println("... passed");
     }
 
     class TestTls13SecretCb implements WolfSSLTls13SecretCallback
@@ -1360,12 +1240,7 @@ public class WolfSSLSessionTest {
         WolfSSLSession ssl = null;
         TestTls13SecretCb cb = null;
 
-        System.out.print("\tTesting setTls13SecretCb()");
-
-        if (!WolfSSL.secretCallbackEnabled()) {
-            System.out.println("\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(WolfSSL.secretCallbackEnabled());
 
         try {
 
@@ -1384,7 +1259,6 @@ public class WolfSSLSessionTest {
             ssl.setTls13SecretCb(cb, null);
 
         } catch (Exception e) {
-            System.out.println("\t... failed");
             e.printStackTrace();
             fail("failed setTls13SecretCb() test");
             return;
@@ -1397,8 +1271,6 @@ public class WolfSSLSessionTest {
                 sslCtx.free();
             }
         }
-
-        System.out.println("\t... passed");
     }
 
     /**
@@ -1463,8 +1335,6 @@ public class WolfSSLSessionTest {
          * test shuts down. Otherwise, we will sometimes miss debug
          * messages from the server side. */
         final CountDownLatch latch = new CountDownLatch(1);
-
-        System.out.print("\tTesting wolfssljni.debug");
 
         /* Save original property value, then enable debug. Make sure
          * connection still works with debug enabled. */
@@ -1543,7 +1413,6 @@ public class WolfSSLSessionTest {
                 });
 
             } catch (Exception e) {
-                System.out.println("\t... failed");
                 e.printStackTrace();
                 fail();
             }
@@ -1580,7 +1449,6 @@ public class WolfSSLSessionTest {
                 cliSock = null;
 
             } catch (Exception e) {
-                System.out.println("\t... failed");
                 e.printStackTrace();
                 fail();
 
@@ -1621,28 +1489,22 @@ public class WolfSSLSessionTest {
 
             /* Verify we have debug output and some expected strings */
             if (outStream == null) {
-                System.out.println("\t... failed");
                 fail("outStream is null but should not be");
             }
 
             String debugOutput = outStream.toString();
             if (debugOutput == null || debugOutput.isEmpty()) {
-                System.out.println("\t... failed");
                 fail("Debug output was null or empty, but expected");
             }
             if (!debugOutput.contains("connect() ret: 1")) {
-                System.out.println("\t... failed");
                 fail("Debug output did not contain connect() success:\n" +
                      debugOutput);
             }
             if (!debugOutput.contains("accept() ret: 1")) {
-                System.out.println("\t... failed");
                 fail("Debug output did not contain accept() success:\n" +
                      debugOutput);
             }
         }
-
-        System.out.println("\t... passed");
     }
 
     @Test
@@ -1661,8 +1523,6 @@ public class WolfSSLSessionTest {
          * must be final since used inside inner class. */
         WolfSSLContext srvCtx = null;
         WolfSSLContext cliCtx = null;
-
-        System.out.print("\tTesting get/setSession()");
 
         try {
             /* Create ServerSocket first to get ephemeral port, set 10 sec
@@ -1835,8 +1695,7 @@ public class WolfSSLSessionTest {
                     err == WolfSSL.SSL_ERROR_WANT_WRITE));
 
             if (ret != WolfSSL.SSL_SUCCESS) {
-                throw new Exception(
-                    "WolfSSLSession.connect() failed: " + err);
+                throw new Exception("WolfSSLSession.connect() failed: " + err);
             }
 
             /* Get WOLFSSL_SESSION pointer, free original one first */
@@ -1853,8 +1712,7 @@ public class WolfSSLSessionTest {
 
             /* Session should be marked as resumed */
             if (cliSes.sessionReused() == 0) {
-                throw new Exception(
-                    "Second connection not resumed");
+                throw new Exception("Second connection not resumed");
             }
 
             cliSes.shutdownSSL();
@@ -1864,7 +1722,6 @@ public class WolfSSLSessionTest {
             cliSock = null;
 
         } catch (Exception e) {
-            System.out.println("\t... failed");
             e.printStackTrace();
             fail();
 
@@ -1898,8 +1755,6 @@ public class WolfSSLSessionTest {
                 } catch (Exception e) { }
             }
         }
-
-        System.out.println("\t... passed");
     }
 
     /**
@@ -1952,8 +1807,7 @@ public class WolfSSLSessionTest {
                             ret = srvSes.setFd(server);
                             if (ret != WolfSSL.SSL_SUCCESS) {
                                 throw new Exception(
-                                    "WolfSSLSession.setFd() failed: " +
-                                    ret);
+                                    "WolfSSLSession.setFd() failed: " + ret);
                             }
 
                             do {
@@ -1965,8 +1819,7 @@ public class WolfSSLSessionTest {
 
                             if (ret != WolfSSL.SSL_SUCCESS) {
                                 throw new Exception(
-                                    "WolfSSLSession.accept() failed: " +
-                                    ret);
+                                    "WolfSSLSession.accept() failed: " + ret);
                             }
 
                             srvSes.shutdownSSL();
@@ -1988,7 +1841,6 @@ public class WolfSSLSessionTest {
             });
 
         } catch (Exception e) {
-            System.out.println("\t... failed");
             e.printStackTrace();
             fail();
         }
@@ -2016,8 +1868,7 @@ public class WolfSSLSessionTest {
                     err == WolfSSL.SSL_ERROR_WANT_WRITE));
 
             if (ret != WolfSSL.SSL_SUCCESS) {
-                throw new Exception(
-                    "WolfSSLSession.connect() failed: " + err);
+                throw new Exception("WolfSSLSession.connect() failed: " + err);
             }
 
             /* Get WOLFSSL_SESSION pointer */
@@ -2032,8 +1883,7 @@ public class WolfSSLSessionTest {
             ret = WolfSSLSession.sessionIsSetup(sessionPtr);
             if ((ret != 1) && (ret != WolfSSL.NOT_COMPILED_IN)) {
                 throw new Exception(
-                    "WolfSSLSession.sessionIsSetup() did not " +
-                    "return 1: " + ret);
+                    "WolfSSLSession.sessionIsSetup() did not return 1: " + ret);
             }
 
             /* Test duplicateSession(), wraps wolfSSL_SESSION_dup() */
@@ -2044,8 +1894,7 @@ public class WolfSSLSessionTest {
             }
             if (sesDup == sessionPtr) {
                 throw new Exception(
-                    "WolfSSLSession.duplicateSession() returned " +
-                    "same pointer");
+                    "WolfSSLSession.duplicateSession() returned same pointer");
             }
             WolfSSLSession.freeSession(sesDup);
             sesDup = 0;
@@ -2084,8 +1933,7 @@ public class WolfSSLSessionTest {
                     err == WolfSSL.SSL_ERROR_WANT_WRITE));
 
             if (ret != WolfSSL.SSL_SUCCESS) {
-                throw new Exception(
-                    "WolfSSLSession.connect() failed: " + err);
+                throw new Exception("WolfSSLSession.connect() failed: " + err);
             }
 
             /* Get WOLFSSL_SESSION pointer, free original one first */
@@ -2102,8 +1950,7 @@ public class WolfSSLSessionTest {
 
             /* Session should be marked as resumed */
             if (cliSes.sessionReused() == 0) {
-                throw new Exception(
-                    "Second connection not resumed");
+                throw new Exception("Second connection not resumed");
             }
 
             cliSes.shutdownSSL();
@@ -2113,7 +1960,6 @@ public class WolfSSLSessionTest {
             cliSock = null;
 
         } catch (Exception e) {
-            System.out.println("\t... failed");
             e.printStackTrace();
             fail();
 
@@ -2143,12 +1989,10 @@ public class WolfSSLSessionTest {
     @Test
     public void test_WolfSSLSession_disableByteBufferPool() throws Exception {
 
-        System.out.print("\tByteBuffer pool disabled");
-
         synchronized (byteBufferPoolPropertyLock) {
 
-            String originalProp =
-                Security.getProperty("wolfssl.readWriteByteBufferPool.disabled");
+            String originalProp = Security.getProperty(
+                "wolfssl.readWriteByteBufferPool.disabled");
 
             try {
                 /* Disable WolfSSLSession internal direct ByteBuffer pool
@@ -2167,14 +2011,10 @@ public class WolfSSLSessionTest {
                     originalProp);
             }
         }
-
-        System.out.println("\t... passed");
     }
 
     @Test
     public void test_WolfSSLSession_byteBufferPoolSize() throws Exception {
-
-        System.out.print("\tByteBuffer pool size changes");
 
         synchronized (byteBufferPoolPropertyLock) {
 
@@ -2207,14 +2047,10 @@ public class WolfSSLSessionTest {
                     originalProp);
             }
         }
-
-        System.out.println("\t... passed");
     }
 
     @Test
     public void test_WolfSSLSession_byteBufferPoolBufferSize() throws Exception {
-
-        System.out.print("\tByteBuffer pool buffer sizes");
 
         synchronized (byteBufferPoolPropertyLock) {
 
@@ -2248,8 +2084,6 @@ public class WolfSSLSessionTest {
                     "wolfssl.readWriteByteBufferPool.bufferSize", originalProp);
             }
         }
-
-        System.out.println("\t... passed");
     }
 
     /**
@@ -2465,8 +2299,6 @@ public class WolfSSLSessionTest {
         final WolfSSLContext srvCtx;
         WolfSSLContext cliCtx;
 
-        System.out.print("\tTesting I/O CB with ByteBuffers");
-
         /* Initialize library */
         WolfSSL lib = new WolfSSL();
         assertNotNull(lib);
@@ -2516,8 +2348,7 @@ public class WolfSSLSessionTest {
                                 err == WolfSSL.SSL_ERROR_WANT_WRITE));
 
                         if (ret != WolfSSL.SSL_SUCCESS) {
-                            throw new Exception(
-                                "Server accept failed: " + err);
+                            throw new Exception("Server accept failed: " + err);
                         }
 
                         /* Read data from client */
@@ -2566,7 +2397,6 @@ public class WolfSSLSessionTest {
             });
 
         } catch (Exception e) {
-            System.out.println("\t... failed");
             e.printStackTrace();
             fail();
         }
@@ -2593,8 +2423,7 @@ public class WolfSSLSessionTest {
                     err == WolfSSL.SSL_ERROR_WANT_WRITE));
 
             if (ret != WolfSSL.SSL_SUCCESS) {
-                throw new Exception(
-                    "Client connect failed: " + err);
+                throw new Exception("Client connect failed: " + err);
             }
 
             /* Send test data */
@@ -2606,8 +2435,7 @@ public class WolfSSLSessionTest {
                       err == WolfSSL.SSL_ERROR_WANT_WRITE));
 
             if (ret != testData.length) {
-                throw new Exception(
-                    "Client write failed: " + ret);
+                throw new Exception("Client write failed: " + ret);
             }
 
             /* Read response */
@@ -2619,8 +2447,7 @@ public class WolfSSLSessionTest {
                       err == WolfSSL.SSL_ERROR_WANT_WRITE));
 
             if (bytesRead != testData.length) {
-                throw new Exception(
-                    "Client read failed: " + bytesRead);
+                throw new Exception("Client read failed: " + bytesRead);
             }
 
             /* Verify received data matches sent data using Java 8 compatible
@@ -2647,7 +2474,6 @@ public class WolfSSLSessionTest {
             cliSock = null;
 
         } catch (Exception e) {
-            System.out.println("\t... failed");
             e.printStackTrace();
             fail();
 
@@ -2667,8 +2493,6 @@ public class WolfSSLSessionTest {
             }
             es.shutdown();
         }
-
-        System.out.println("\t... passed");
     }
 
     @Test
@@ -2684,8 +2508,6 @@ public class WolfSSLSessionTest {
         /* Create client/server WolfSSLContext objects */
         final WolfSSLContext srvCtx;
         WolfSSLContext cliCtx;
-
-        System.out.print("\tTesting ByteBuffer read()");
 
         /* Create ServerSocket first to get ephemeral port */
         final ServerSocket srvSocket = new ServerSocket(0);
@@ -2763,7 +2585,6 @@ public class WolfSSLSessionTest {
             });
 
         } catch (Exception e) {
-            System.out.println("\t... failed");
             e.printStackTrace();
             fail();
         }
@@ -2833,7 +2654,6 @@ public class WolfSSLSessionTest {
             cliSock = null;
 
         } catch (Exception e) {
-            System.out.println("\t... failed");
             e.printStackTrace();
             fail();
 
@@ -2853,8 +2673,6 @@ public class WolfSSLSessionTest {
             }
             es.shutdown();
         }
-
-        System.out.println("\t... passed");
     }
 
     @Test
@@ -2868,8 +2686,6 @@ public class WolfSSLSessionTest {
         /* Create client/server WolfSSLContext objects */
         final WolfSSLContext srvCtx;
         WolfSSLContext cliCtx;
-
-        System.out.print("\tTesting read/write bounds check");
 
         /* Create ServerSocket first to get ephemeral port */
         final ServerSocket srvSocket = new ServerSocket(0);
@@ -2933,7 +2749,6 @@ public class WolfSSLSessionTest {
             });
 
         } catch (Exception e) {
-            System.out.println("\t... failed");
             e.printStackTrace();
             fail();
         }
@@ -2995,7 +2810,6 @@ public class WolfSSLSessionTest {
                 cliSock = null;
 
             } catch (Exception e) {
-                System.out.println("\t... failed");
                 e.printStackTrace();
                 fail();
 
@@ -3023,8 +2837,6 @@ public class WolfSSLSessionTest {
                 es.shutdown();
             }
         }
-
-        System.out.println("\t... passed");
     }
 
     @Test
@@ -3041,8 +2853,6 @@ public class WolfSSLSessionTest {
          * must be final since used inside inner class. */
         final WolfSSLContext srvCtx;
         WolfSSLContext cliCtx;
-
-        System.out.print("\tsessionToDer/sessionFromDer()");
 
         /* Create ServerSocket first to get ephemeral port */
         final ServerSocket srvSocket = new ServerSocket(0);
@@ -3108,7 +2918,6 @@ public class WolfSSLSessionTest {
             });
 
         } catch (Exception e) {
-            System.out.println("\t... failed");
             e.printStackTrace();
             fail();
         }
@@ -3136,17 +2945,13 @@ public class WolfSSLSessionTest {
                     err == WolfSSL.SSL_ERROR_WANT_WRITE));
 
             if (ret != WolfSSL.SSL_SUCCESS) {
-                throw new Exception(
-                    "WolfSSLSession.connect() failed: " + err);
+                throw new Exception("WolfSSLSession.connect() failed: " + err);
             }
 
             /* Convert session to DER format */
             serializedSession = cliSes.sessionToDer();
-            if (serializedSession == null) {
-                /* Feature not compiled in, skip test */
-                System.out.println("\t... skipped");
-                return;
-            }
+            /* null return indicates feature not compiled in, skip test */
+            Assume.assumeNotNull(serializedSession);
 
             if (serializedSession.length == 0) {
                 throw new Exception("DER session has zero length");
@@ -3194,14 +2999,12 @@ public class WolfSSLSessionTest {
                     err == WolfSSL.SSL_ERROR_WANT_WRITE));
 
             if (ret != WolfSSL.SSL_SUCCESS) {
-                throw new Exception(
-                    "WolfSSLSession.connect() failed: " + err);
+                throw new Exception("WolfSSLSession.connect() failed: " + err);
             }
 
             /* Check if session was resumed */
             if (cliSes.sessionReused() == 0) {
-                throw new Exception(
-                    "Session was not resumed");
+                throw new Exception("Session was not resumed");
             }
 
             cliSes.shutdownSSL();
@@ -3211,7 +3014,6 @@ public class WolfSSLSessionTest {
             cliSock = null;
 
         } catch (Exception e) {
-            System.out.println("\t... failed");
             e.printStackTrace();
             fail();
 
@@ -3232,15 +3034,11 @@ public class WolfSSLSessionTest {
                 srvCtx.free();
             }
         }
-
-        System.out.println("\t... passed");
     }
 
     @Test
     public void test_WolfSSLSession_dtlsCidMaxSize()
         throws WolfSSLJNIException {
-
-        System.out.print("\tdtlsCidMaxSize()");
 
         /* This is a static method, should work even without wolfSSL compiled
          * with DTLS CID support - may return NOT_COMPILED_IN */
@@ -3251,15 +3049,11 @@ public class WolfSSLSessionTest {
         assertTrue("dtlsCidMaxSize() should return positive value or " +
                    "NOT_COMPILED_IN",
                    maxSize > 0 || maxSize == WolfSSL.NOT_COMPILED_IN);
-
-        System.out.println("\t\t... passed");
     }
 
     @Test
     public void test_WolfSSLSession_dtlsCidParse()
         throws WolfSSLJNIException {
-
-        System.out.print("\tdtlsCidParse()");
 
         /* Test with null message - should return null */
         byte[] result = WolfSSLSession.dtlsCidParse(null, 0);
@@ -3275,8 +3069,6 @@ public class WolfSSLSessionTest {
          * compiled in or message doesn't contain valid CID) */
         result = WolfSSLSession.dtlsCidParse(testMsg, 5);
         /* Result can be null if not compiled in or no valid CID found */
-
-        System.out.println("\t\t\t... passed");
     }
 
     @Test
@@ -3287,8 +3079,6 @@ public class WolfSSLSessionTest {
         WolfSSLSession sess = null;
         int ret;
 
-        System.out.print("\tDTLS CID functions");
-
         /* Skip if DTLS not supported */
         String[] protocols = WolfSSL.getProtocols();
         boolean dtlsSupported = false;
@@ -3298,10 +3088,7 @@ public class WolfSSLSessionTest {
                 break;
             }
         }
-        if (!dtlsSupported) {
-            System.out.println("\t\t... skipped (DTLSv1.3 not enabled)");
-            return;
-        }
+        Assume.assumeTrue(dtlsSupported);
 
         try {
             /* Create DTLS context for CID testing */
@@ -3371,8 +3158,6 @@ public class WolfSSLSessionTest {
         } catch (WolfSSLException we) {
             /* Some methods may throw exceptions if DTLS CID not supported
              * or session not properly configured */
-            System.out.println("\t\t... expected exception: " +
-                               we.getMessage());
 
         } finally {
             if (sess != null) {
@@ -3382,15 +3167,11 @@ public class WolfSSLSessionTest {
                 dtlsCtx.free();
             }
         }
-
-        System.out.println("\t\t... passed");
     }
 
     @Test
     public void test_WolfSSLSession_dtlsCidClientServer()
         throws WolfSSLJNIException, WolfSSLException {
-
-        System.out.print("\tDTLS CID connection");
 
         /* Skip if DTLSv1.3 not supported - CID requires DTLSv1.3 */
         String[] protocols = WolfSSL.getProtocols();
@@ -3401,10 +3182,7 @@ public class WolfSSLSessionTest {
                 break;
             }
         }
-        if (!dtls13Supported) {
-            System.out.println("\t\t... skipped (DTLSv1.3 not enabled)");
-            return;
-        }
+        Assume.assumeTrue(dtls13Supported);
 
         WolfSSLContext serverCtx = null;
         WolfSSLContext clientCtx = null;
@@ -3431,10 +3209,7 @@ public class WolfSSLSessionTest {
 
             /* Test dtlsCidUse() - may return NOT_COMPILED_IN */
             int ret = server.dtlsCidUse();
-            if (ret == WolfSSL.NOT_COMPILED_IN) {
-                System.out.println("\t\t... skipped");
-                return;
-            }
+            Assume.assumeTrue(ret != WolfSSL.NOT_COMPILED_IN);
             assertTrue("Server dtlsCidUse() should succeed",
                        ret == WolfSSL.SSL_SUCCESS);
 
@@ -3444,12 +3219,10 @@ public class WolfSSLSessionTest {
 
             /* Test dtlsCidIsEnabled() */
             ret = server.dtlsCidIsEnabled();
-            assertTrue("Server CID should be enabled",
-                       ret == 1);
+            assertTrue("Server CID should be enabled", ret == 1);
 
             ret = client.dtlsCidIsEnabled();
-            assertTrue("Client CID should be enabled",
-                       ret == 1);
+            assertTrue("Client CID should be enabled", ret == 1);
 
             /* Set Connection IDs */
             byte[] serverCid = {0x01, 0x02, 0x03, 0x04, 0x05};
@@ -3457,15 +3230,11 @@ public class WolfSSLSessionTest {
 
             ret = server.dtlsCidSet(serverCid);
             if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t\t... skipped (Server " +
-                                   "dtlsCidSet failed: " + ret + ")");
                 return;
             }
 
             ret = client.dtlsCidSet(clientCid);
             if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t\t... skipped (Client " +
-                                   "dtlsCidSet failed: " + ret + ")");
                 return;
             }
 
@@ -3510,11 +3279,7 @@ public class WolfSSLSessionTest {
             assertTrue("Client TX CID size should be 0 (no handshake)",
                        clientTxSize == 0);
 
-            System.out.println("\t\t... passed");
-
         } catch (Exception e) {
-            System.out.println("\t\t... failed with exception: " +
-                               e.getMessage());
             throw e;
 
         } finally {
@@ -3537,8 +3302,6 @@ public class WolfSSLSessionTest {
     public void test_WolfSSLSession_dtlsCidDataExchange()
         throws WolfSSLJNIException, WolfSSLException {
 
-        System.out.print("\tDTLS CID data exchange");
-
         /* Skip if DTLSv1.3 not supported - CID requires DTLSv1.3 */
         String[] protocols = WolfSSL.getProtocols();
         boolean dtls13Supported = false;
@@ -3548,10 +3311,7 @@ public class WolfSSLSessionTest {
                 break;
             }
         }
-        if (!dtls13Supported) {
-            System.out.println("\t\t... skipped (DTLSv1.3 not enabled)");
-            return;
-        }
+        Assume.assumeTrue(dtls13Supported);
 
         WolfSSLContext serverCtx = null;
         WolfSSLContext clientCtx = null;
@@ -3574,10 +3334,7 @@ public class WolfSSLSessionTest {
 
             /* Enable CID on both sides */
             int ret = server.dtlsCidUse();
-            if (ret == WolfSSL.NOT_COMPILED_IN) {
-                System.out.println("\t\t... skipped");
-                return;
-            }
+            Assume.assumeTrue(ret != WolfSSL.NOT_COMPILED_IN);
 
             ret = client.dtlsCidUse();
             assertTrue("Client CID enable should succeed",
@@ -3589,15 +3346,11 @@ public class WolfSSLSessionTest {
 
             ret = server.dtlsCidSet(serverToClientCid);
             if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t\t... skipped (Server " +
-                                   "dtlsCidSet failed: " + ret + ")");
                 return;
             }
 
             ret = client.dtlsCidSet(clientToServerCid);
             if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t\t... skipped (Client " +
-                                   "dtlsCidSet failed: " + ret + ")");
                 return;
             }
 
@@ -3606,7 +3359,6 @@ public class WolfSSLSessionTest {
             byte[] clientRx = client.dtlsCidGetRx();
 
             if (serverRx == null || clientRx == null) {
-                System.out.println("\t\t... skipped (CID retrieval failed)");
                 return;
             }
 
@@ -3636,11 +3388,7 @@ public class WolfSSLSessionTest {
             /* parsedCid may be null - depends on DTLS message format */
             /* This tests the API works, actual parsing depends on wolfSSL */
 
-            System.out.println("\t\t... passed");
-
         } catch (Exception e) {
-            System.out.println("\t\t... failed with exception: " +
-                               e.getMessage());
             throw e;
 
         } finally {
@@ -3663,8 +3411,6 @@ public class WolfSSLSessionTest {
     public void test_WolfSSLSession_dtlsCidConnectionMigration()
         throws WolfSSLJNIException, WolfSSLException {
 
-        System.out.print("\tDTLS CID connection migration");
-
         /* Skip if DTLSv1.3 not supported - CID requires DTLSv1.3 */
         String[] protocols = WolfSSL.getProtocols();
         boolean dtls13Supported = false;
@@ -3674,10 +3420,7 @@ public class WolfSSLSessionTest {
                 break;
             }
         }
-        if (!dtls13Supported) {
-            System.out.println("\t... skipped (DTLSv1.3 not enabled)");
-            return;
-        }
+        Assume.assumeTrue(dtls13Supported);
 
         WolfSSLContext serverCtx = null;
         WolfSSLSession server1 = null;
@@ -3696,10 +3439,7 @@ public class WolfSSLSessionTest {
 
             /* Enable CID on both sessions */
             int ret1 = server1.dtlsCidUse();
-            if (ret1 == WolfSSL.NOT_COMPILED_IN) {
-                System.out.println("\t... skipped");
-                return;
-            }
+            Assume.assumeTrue(ret1 != WolfSSL.NOT_COMPILED_IN);
 
             int ret2 = server2.dtlsCidUse();
             assertTrue("Both servers should enable CID successfully",
@@ -3715,8 +3455,6 @@ public class WolfSSLSessionTest {
             ret2 = server2.dtlsCidSet(migrationCid);
 
             if (ret1 != WolfSSL.SSL_SUCCESS || ret2 != WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t... skipped (dtlsCidSet failed: " +
-                                   ret1 + ", " + ret2 + ")");
                 return;
             }
 
@@ -3725,7 +3463,6 @@ public class WolfSSLSessionTest {
             byte[] server2Rx = server2.dtlsCidGetRx();
 
             if (server1Rx == null || server2Rx == null) {
-                System.out.println("\t... skipped (CID retrieval failed)");
                 return;
             }
 
@@ -3758,11 +3495,7 @@ public class WolfSSLSessionTest {
             assertTrue("TX CID size should be 0 without handshake",
                        txSize1 == 0 && txSize2 == 0);
 
-            System.out.println("\t... passed");
-
         } catch (Exception e) {
-            System.out.println("\t... failed with exception: " +
-                               e.getMessage());
             throw e;
 
         } finally {
@@ -3785,8 +3518,6 @@ public class WolfSSLSessionTest {
         WolfSSLContext dtlsCtx = null;
         WolfSSLSession sess = null;
 
-        System.out.print("\tDTLS CID boundary sizes");
-
         /* Skip if DTLSv1.3 not supported */
         String[] protocols = WolfSSL.getProtocols();
         boolean dtls13Supported = false;
@@ -3797,10 +3528,7 @@ public class WolfSSLSessionTest {
             }
         }
 
-        if (!dtls13Supported) {
-            System.out.println("\t\t... skipped (DTLSv1.3 not enabled)");
-            return;
-        }
+        Assume.assumeTrue(dtls13Supported);
 
         try {
             /* Create DTLS context for CID testing */
@@ -3809,10 +3537,7 @@ public class WolfSSLSessionTest {
 
             /* Enable CID */
             int ret = sess.dtlsCidUse();
-            if (ret == WolfSSL.NOT_COMPILED_IN) {
-                System.out.println("\t\t... skipped");
-                return;
-            }
+            Assume.assumeTrue(ret != WolfSSL.NOT_COMPILED_IN);
 
             /* Test empty CID (0 bytes) */
             byte[] emptyCid = new byte[0];
@@ -3877,8 +3602,6 @@ public class WolfSSLSessionTest {
                              (byte)0xAA, retrieved[0]);
             }
 
-            System.out.println("\t\t... passed");
-
         } finally {
             if (sess != null) {
                 sess.freeSSL();
@@ -3896,8 +3619,6 @@ public class WolfSSLSessionTest {
         WolfSSLContext dtlsCtx = null;
         WolfSSLSession sess = null;
 
-        System.out.print("\tDTLS CID error conditions");
-
         /* Skip if DTLSv1.3 not supported */
         String[] protocols = WolfSSL.getProtocols();
         boolean dtls13Supported = false;
@@ -3908,10 +3629,7 @@ public class WolfSSLSessionTest {
             }
         }
 
-        if (!dtls13Supported) {
-            System.out.println("\t... skipped (DTLSv1.3 not enabled)");
-            return;
-        }
+        Assume.assumeTrue(dtls13Supported);
 
         try {
             /* Create DTLS context for CID testing */
@@ -3920,10 +3638,7 @@ public class WolfSSLSessionTest {
 
             /* Enable CID */
             int ret = sess.dtlsCidUse();
-            if (ret == WolfSSL.NOT_COMPILED_IN) {
-                System.out.println("\t... skipped");
-                return;
-            }
+            Assume.assumeTrue(ret != WolfSSL.NOT_COMPILED_IN);
 
             /* Test null CID - should return BAD_FUNC_ARG */
             ret = sess.dtlsCidSet(null);
@@ -3981,8 +3696,6 @@ public class WolfSSLSessionTest {
                 sess2.freeSSL();
             }
 
-            System.out.println("\t... passed");
-
         } finally {
             if (sess != null) {
                 sess.freeSSL();
@@ -4000,8 +3713,6 @@ public class WolfSSLSessionTest {
         WolfSSLContext dtlsCtx = null;
         WolfSSLSession sess = null;
 
-        System.out.print("\tDTLS CID get0 vs regular get");
-
         /* Skip if DTLSv1.3 not supported */
         String[] protocols = WolfSSL.getProtocols();
         boolean dtls13Supported = false;
@@ -4012,10 +3723,7 @@ public class WolfSSLSessionTest {
             }
         }
 
-        if (!dtls13Supported) {
-            System.out.println("\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(dtls13Supported);
 
         try {
             /* Create DTLS context for CID testing */
@@ -4024,16 +3732,12 @@ public class WolfSSLSessionTest {
 
             /* Enable CID */
             int ret = sess.dtlsCidUse();
-            if (ret == WolfSSL.NOT_COMPILED_IN) {
-                System.out.println("\t... skipped");
-                return;
-            }
+            Assume.assumeTrue(ret != WolfSSL.NOT_COMPILED_IN);
 
             /* Set a test CID */
             byte[] testCid = new byte[]{0x01, 0x02, 0x03, 0x04, 0x05};
             ret = sess.dtlsCidSet(testCid);
             if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t... skipped");
                 return;
             }
 
@@ -4070,16 +3774,12 @@ public class WolfSSLSessionTest {
             byte[] rxCid0Again = sess.dtlsCidGet0Rx();
 
             /* Should still have original value */
-            assertNotNull("Re-fetched CID should not be null",
-                          rxCidAgain);
-            assertNotNull("Re-fetched CID0 should not be null",
-                          rxCid0Again);
+            assertNotNull("Re-fetched CID should not be null", rxCidAgain);
+            assertNotNull("Re-fetched CID0 should not be null", rxCid0Again);
             assertEquals("Internal CID should not be modified by " +
-                         "external changes",
-                         originalFirstByte, rxCidAgain[0]);
+                         "external changes", originalFirstByte, rxCidAgain[0]);
             assertEquals("Internal CID should not be modified by " +
-                         "external changes",
-                         originalFirstByte, rxCid0Again[0]);
+                         "external changes", originalFirstByte, rxCid0Again[0]);
 
             /* Test TX side (before handshake, should return null or
              * empty) */
@@ -4093,8 +3793,6 @@ public class WolfSSLSessionTest {
             assertTrue("TX CID0 should be null or empty before " +
                        "handshake",
                        txCid0 == null || txCid0.length == 0);
-
-            System.out.println("\t... passed");
 
         } finally {
             if (sess != null) {
@@ -4110,8 +3808,6 @@ public class WolfSSLSessionTest {
     public void test_WolfSSLSession_dtlsCidHandshakeComplete()
         throws Exception {
 
-        System.out.print("\tDTLS CID handshake complete");
-
         /* Skip if DTLSv1.3 not supported - CID requires DTLSv1.3 */
         String[] protocols = WolfSSL.getProtocols();
         boolean dtls13Supported = false;
@@ -4122,10 +3818,7 @@ public class WolfSSLSessionTest {
             }
         }
 
-        if (!dtls13Supported) {
-            System.out.println("\t... skipped (DTLSv1.3 not enabled)");
-            return;
-        }
+        Assume.assumeTrue(dtls13Supported);
 
         WolfSSLContext serverCtx = null;
         WolfSSLContext clientCtx = null;
@@ -4134,16 +3827,12 @@ public class WolfSSLSessionTest {
 
         try {
             /* Create server and client contexts */
-            serverCtx = new WolfSSLContext(
-                WolfSSL.DTLSv1_3_ServerMethod());
-            clientCtx = new WolfSSLContext(
-                WolfSSL.DTLSv1_3_ClientMethod());
+            serverCtx = new WolfSSLContext(WolfSSL.DTLSv1_3_ServerMethod());
+            clientCtx = new WolfSSLContext(WolfSSL.DTLSv1_3_ClientMethod());
 
             /* Load certificates */
-            serverCtx.useCertificateFile(srvCert,
-                                         WolfSSL.SSL_FILETYPE_PEM);
-            serverCtx.usePrivateKeyFile(srvKey,
-                                        WolfSSL.SSL_FILETYPE_PEM);
+            serverCtx.useCertificateFile(srvCert, WolfSSL.SSL_FILETYPE_PEM);
+            serverCtx.usePrivateKeyFile(srvKey, WolfSSL.SSL_FILETYPE_PEM);
             clientCtx.loadVerifyLocations(caCert, null);
 
             /* Create sessions */
@@ -4152,15 +3841,10 @@ public class WolfSSLSessionTest {
 
             /* Enable CID on both sides */
             int ret = server.dtlsCidUse();
-            if (ret == WolfSSL.NOT_COMPILED_IN) {
-                System.out.println("\t... skipped");
-                return;
-            }
+            Assume.assumeTrue(ret != WolfSSL.NOT_COMPILED_IN);
 
             ret = client.dtlsCidUse();
             if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t... skipped (Client CID " +
-                                   "enable failed: " + ret + ")");
                 return;
             }
 
@@ -4170,15 +3854,11 @@ public class WolfSSLSessionTest {
 
             ret = server.dtlsCidSet(serverCid);
             if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t... skipped (Server " +
-                                   "dtlsCidSet failed: " + ret + ")");
                 return;
             }
 
             ret = client.dtlsCidSet(clientCid);
             if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t... skipped (Client " +
-                                   "dtlsCidSet failed: " + ret + ")");
                 return;
             }
 
@@ -4292,10 +3972,8 @@ public class WolfSSLSessionTest {
                 byte[] serverTx = server.dtlsCidGetTx();
                 byte[] clientTx = client.dtlsCidGetTx();
 
-                assertNotNull("Server TX CID should not be null",
-                              serverTx);
-                assertNotNull("Client TX CID should not be null",
-                              clientTx);
+                assertNotNull("Server TX CID should not be null", serverTx);
+                assertNotNull("Client TX CID should not be null", clientTx);
 
                 /* Server's TX CID should match client's RX CID */
                 assertArrayEquals("Server TX should match client RX",
@@ -4309,22 +3987,14 @@ public class WolfSSLSessionTest {
                 byte[] serverTx0 = server.dtlsCidGet0Tx();
                 byte[] clientTx0 = client.dtlsCidGet0Tx();
 
-                assertNotNull("Server TX CID0 should not be null",
-                              serverTx0);
-                assertNotNull("Client TX CID0 should not be null",
-                              clientTx0);
+                assertNotNull("Server TX CID0 should not be null", serverTx0);
+                assertNotNull("Client TX CID0 should not be null", clientTx0);
 
                 assertArrayEquals("Server TX0 should match TX",
                                   serverTx, serverTx0);
                 assertArrayEquals("Client TX0 should match TX",
                                   clientTx, clientTx0);
 
-                System.out.println("\t... passed");
-
-            } else {
-                System.out.println("\t... skipped (handshake failed: " +
-                                   "client=" + ret + ", server=" +
-                                   serverRet + ")");
             }
 
         } finally {
@@ -4347,8 +4017,6 @@ public class WolfSSLSessionTest {
     public void test_WolfSSLSession_dtlsCidDataExchangeAfterHandshake()
         throws Exception {
 
-        System.out.print("\tDTLS CID data exchange");
-
         /* Skip if DTLSv1.3 not supported - CID requires DTLSv1.3 */
         String[] protocols = WolfSSL.getProtocols();
         boolean dtls13Supported = false;
@@ -4359,10 +4027,7 @@ public class WolfSSLSessionTest {
             }
         }
 
-        if (!dtls13Supported) {
-            System.out.println("\t\t... skipped (DTLSv1.3 not enabled)");
-            return;
-        }
+        Assume.assumeTrue(dtls13Supported);
 
         WolfSSLContext serverCtx = null;
         WolfSSLContext clientCtx = null;
@@ -4371,16 +4036,12 @@ public class WolfSSLSessionTest {
 
         try {
             /* Create server and client contexts */
-            serverCtx = new WolfSSLContext(
-                WolfSSL.DTLSv1_3_ServerMethod());
-            clientCtx = new WolfSSLContext(
-                WolfSSL.DTLSv1_3_ClientMethod());
+            serverCtx = new WolfSSLContext(WolfSSL.DTLSv1_3_ServerMethod());
+            clientCtx = new WolfSSLContext(WolfSSL.DTLSv1_3_ClientMethod());
 
             /* Load certificates */
-            serverCtx.useCertificateFile(srvCert,
-                                         WolfSSL.SSL_FILETYPE_PEM);
-            serverCtx.usePrivateKeyFile(srvKey,
-                                        WolfSSL.SSL_FILETYPE_PEM);
+            serverCtx.useCertificateFile(srvCert, WolfSSL.SSL_FILETYPE_PEM);
+            serverCtx.usePrivateKeyFile(srvKey, WolfSSL.SSL_FILETYPE_PEM);
             clientCtx.loadVerifyLocations(caCert, null);
 
             /* Create sessions */
@@ -4389,15 +4050,10 @@ public class WolfSSLSessionTest {
 
             /* Enable CID on both sides */
             int ret = server.dtlsCidUse();
-            if (ret == WolfSSL.NOT_COMPILED_IN) {
-                System.out.println("\t\t... skipped");
-                return;
-            }
+            Assume.assumeTrue(ret != WolfSSL.NOT_COMPILED_IN);
 
             ret = client.dtlsCidUse();
             if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t\t... skipped (Client CID " +
-                                   "enable failed: " + ret + ")");
                 return;
             }
 
@@ -4407,15 +4063,11 @@ public class WolfSSLSessionTest {
 
             ret = server.dtlsCidSet(serverCid);
             if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t\t... skipped (Server " +
-                                   "dtlsCidSet failed)");
                 return;
             }
 
             ret = client.dtlsCidSet(clientCid);
             if (ret != WolfSSL.SSL_SUCCESS) {
-                System.out.println("\t\t... skipped (Client " +
-                                   "dtlsCidSet failed)");
                 return;
             }
 
@@ -4534,24 +4186,13 @@ public class WolfSSLSessionTest {
                 byte[] serverTx = server.dtlsCidGetTx();
                 byte[] clientTx = client.dtlsCidGetTx();
 
-                assertNotNull("Server TX CID should still be set",
-                              serverTx);
-                assertNotNull("Client TX CID should still be set",
-                              clientTx);
+                assertNotNull("Server TX CID should still be set", serverTx);
+                assertNotNull("Client TX CID should still be set", clientTx);
 
-                assertArrayEquals("Server TX should still match " +
-                                  "client RX",
+                assertArrayEquals("Server TX should still match client RX",
                                   clientCid, serverTx);
-                assertArrayEquals("Client TX should still match " +
-                                  "server RX",
+                assertArrayEquals("Client TX should still match server RX",
                                   serverCid, clientTx);
-
-                System.out.println("\t\t... passed");
-
-            } else {
-                System.out.println("\t\t... skipped (handshake " +
-                                   "failed: client=" + ret +
-                                   ", server=" + serverRet + ")");
             }
 
         } finally {
@@ -4569,6 +4210,5 @@ public class WolfSSLSessionTest {
             }
         }
     }
-
 }
 

--- a/src/test/com/wolfssl/test/WolfSSLTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLTest.java
@@ -21,8 +21,11 @@
 
 package com.wolfssl.test;
 
-import org.junit.Test;
+import org.junit.Assume;
 import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
 import static org.junit.Assert.*;
 
 import java.nio.charset.StandardCharsets;
@@ -36,8 +39,12 @@ import com.wolfssl.WolfSSLException;
 @SuppressWarnings("deprecation")
 public class WolfSSLTest {
 
+    @Rule
+    public TestRule testWatcher = TimedTestWatcher.create();
+
     @BeforeClass
     public static void loadLibrary() {
+        System.out.println("WolfSSL Class");
         try {
             WolfSSL.loadLibrary();
         } catch (UnsatisfiedLinkError ule) {
@@ -46,83 +53,49 @@ public class WolfSSLTest {
     }
 
     @Test
-    public void testWolfSSL() throws WolfSSLException {
-
-        WolfSSL lib = null;
-        System.out.println("WolfSSL Class");
-
-        test_WolfSSL_new(lib);
-        test_WolfSSL_protocol();
-        test_WolfSSL_getProtocolsMask();
-        test_WolfSSL_Method_Allocators(lib);
-        test_WolfSSL_getLibVersionHex();
-        test_WolfSSL_getErrno();
-        test_WolfSSL_getSNIFromBuffer();
-        testGetCiphersAvailableIana();
-        test_isLibraryLoadSkippedReturnsFalseByDefault();
-        test_SystemPropertyNotSetByDefault();
-        test_SettingPropertyAfterLoadHasNoEffect();
-    }
-
-    public void test_WolfSSL_new(WolfSSL lib) {
-
+    public void test_WolfSSL_new() {
         try {
-            System.out.print("\tWolfSSL()");
-            lib = new WolfSSL();
+            new WolfSSL();
         } catch (UnsatisfiedLinkError ule) {
-            System.out.println("\t\t\t... failed");
             fail("failed to load native JNI library");
         } catch (WolfSSLException we) {
-            System.out.println("\t\t\t... failed");
             fail("failed to create WolfSSL object");
         }
-
-        System.out.println("\t\t\t... passed");
     }
 
+    @Test
     public void test_WolfSSL_protocol() {
         String[] p = WolfSSL.getProtocols();
-
-        System.out.print("\tWolfSSL_protocol()");
         if (p == null) {
-            System.out.println("\t\t... failed");
             fail("failed to get protocols");
         }
-        System.out.println("\t\t... passed");
     }
 
+    @Test
     public void test_WolfSSL_getProtocolsMask() {
-        System.out.print("\tgetProtocolsMask()");
-
         /* Get all protocols (no mask) */
         String[] allProtocols = WolfSSL.getProtocolsMask(0);
         if (allProtocols == null) {
-            System.out.println("\t\t... failed");
             fail("getProtocolsMask(0) returned null");
         }
-        List<String> allProtoList = Arrays.asList(allProtocols);
 
         /* Test with TLSv1.3 masked off, verify TLSv1.3 not in result */
         String[] noTls13 = WolfSSL.getProtocolsMask(WolfSSL.SSL_OP_NO_TLSv1_3);
         if (noTls13 == null) {
-            System.out.println("\t\t... failed");
             fail("getProtocolsMask(SSL_OP_NO_TLSv1_3) returned null");
         }
         List<String> noTls13List = Arrays.asList(noTls13);
         if (noTls13List.contains("TLSv1.3")) {
-            System.out.println("\t\t... failed");
             fail("TLSv1.3 should not be in result when masked");
         }
 
         /* Test with TLSv1.2 masked off, verify TLSv1.2 not in result */
         String[] noTls12 = WolfSSL.getProtocolsMask(WolfSSL.SSL_OP_NO_TLSv1_2);
         if (noTls12 == null) {
-            System.out.println("\t\t... failed");
             fail("getProtocolsMask(SSL_OP_NO_TLSv1_2) returned null");
         }
         List<String> noTls12List = Arrays.asList(noTls12);
         if (noTls12List.contains("TLSv1.2")) {
-            System.out.println("\t\t... failed");
             fail("TLSv1.2 should not be in result when masked");
         }
 
@@ -130,20 +103,17 @@ public class WolfSSLTest {
         long multiMask = WolfSSL.SSL_OP_NO_TLSv1_2 | WolfSSL.SSL_OP_NO_TLSv1_3;
         String[] noTls12And13 = WolfSSL.getProtocolsMask(multiMask);
         if (noTls12And13 == null) {
-            System.out.println("\t\t... failed");
             fail("getProtocolsMask with multiple masks returned null");
         }
         List<String> noTls12And13List = Arrays.asList(noTls12And13);
         if (noTls12And13List.contains("TLSv1.2") ||
             noTls12And13List.contains("TLSv1.3")) {
-            System.out.println("\t\t... failed");
             fail("TLSv1.2 and TLSv1.3 should not be in result when masked");
         }
-
-        System.out.println("\t\t... passed");
     }
 
-    public void test_WolfSSL_Method_Allocators(WolfSSL lib) {
+    @Test
+    public void test_WolfSSL_Method_Allocators() {
         /* Get protocols compiled into native wolfSSL */
         List<String> enabledProtocols = Arrays.asList(WolfSSL.getProtocols());
 
@@ -187,30 +157,22 @@ public class WolfSSLTest {
         tstMethod(WolfSSL.SSLv23_ClientMethod(), "SSLv23_ClientMethod()");
     }
 
-    public void tstMethod(long method, String name) {
-
-        System.out.print("\t" + name);
-
+    private void tstMethod(long method, String name) {
         if (method == 0) {
-            System.out.println("\t\t... failed");
-            fail("method test failed, method was null");
+            fail(name + " method test failed, method was null");
         } else if (method != WolfSSL.NOT_COMPILED_IN) {
             WolfSSL.nativeFree(method);
         }
-        System.out.println("\t\t... passed");
     }
 
+    @Test
     public void testGetCiphersAvailableIana() {
-        System.out.print("\tgetCiphersAvailableIana()");
-
         String[] ciphers = WolfSSL.getCiphersAvailableIana(
                 WolfSSL.TLS_VERSION.SSLv23);
         if (ciphers == null) {
-            System.out.println("\t... failed");
             fail("available ciphers array was null");
         }
         if (ciphers.length == 0) {
-            System.out.println("\t... failed");
             fail("available ciphers array length was zero");
         }
 
@@ -225,48 +187,36 @@ public class WolfSSLTest {
             String[] verCiphers = WolfSSL.getCiphersAvailableIana(ver);
             if (verCiphers != null) {
                 if (verCiphers.length == 0) {
-                    System.out.println("\t... failed");
                     fail("getCiphersAvailableIana(" + ver +
                         ") returned empty array");
                 }
                 for (int i = 0; i < verCiphers.length; i++) {
                     if (verCiphers[i] == null ||
                         verCiphers[i].isEmpty()) {
-                        System.out.println("\t... failed");
                         fail("getCiphersAvailableIana(" + ver +
                             ") contains null/empty cipher at index " + i);
                     }
                 }
             }
         }
-
-        System.out.println("\t... passed");
     }
 
+    @Test
     public void test_WolfSSL_getLibVersionHex() {
-        System.out.print("\tgetLibVersionHex()");
-
         long verHex = WolfSSL.getLibVersionHex();
         if (verHex == 0 || verHex < 0) {
-            System.out.println("\t\t... failed");
             fail("getting library version hex failed");
         }
-
-        System.out.println("\t\t... passed");
     }
 
+    @Test
     public void test_WolfSSL_getErrno() {
-        System.out.print("\tgetErrno()");
-
         /* Just make sure we don't seg fault or crash here */
-        int errno = WolfSSL.getErrno();
-
-        System.out.println("\t\t\t... passed");
+        WolfSSL.getErrno();
     }
 
+    @Test
     public void test_WolfSSL_getSNIFromBuffer() throws WolfSSLException {
-        System.out.print("\tgetSNIFromBuffer()");
-
         /* Minimal TLS 1.2 ClientHello with SNI extension for "www.example.com".
          * This is a hand crafted minimal valid ClientHello message. */
         String hostname = "www.example.com";
@@ -361,19 +311,14 @@ public class WolfSSLTest {
         int ret = WolfSSL.getSNIFromBuffer(clientHello,
             (byte)WolfSSL.WOLFSSL_SNI_HOST_NAME, sniOut);
 
-        if (ret == WolfSSL.NOT_COMPILED_IN) {
-            System.out.println("\t\t... skipped");
-            return;
-        }
+        Assume.assumeTrue(ret != WolfSSL.NOT_COMPILED_IN);
 
         if (ret <= 0) {
-            System.out.println("\t\t... failed");
             fail("getSNIFromBuffer() returned: " + ret);
         }
 
         String extracted = new String(sniOut, 0, ret, StandardCharsets.UTF_8);
         if (!hostname.equals(extracted)) {
-            System.out.println("\t\t... failed");
             fail("getSNIFromBuffer() expected [" + hostname + "] got [" +
                 extracted + "]");
         }
@@ -382,7 +327,6 @@ public class WolfSSLTest {
         try {
             WolfSSL.getSNIFromBuffer(null, (byte)WolfSSL.WOLFSSL_SNI_HOST_NAME,
                 sniOut);
-            System.out.println("\t\t... failed");
             fail("Expected IllegalArgumentException for null clientHello");
         } catch (IllegalArgumentException e) {
             /* expected */
@@ -392,66 +336,40 @@ public class WolfSSLTest {
         try {
             WolfSSL.getSNIFromBuffer(clientHello,
                 (byte)WolfSSL.WOLFSSL_SNI_HOST_NAME, null);
-            System.out.println("\t\t... failed");
             fail("Expected IllegalArgumentException for null sni");
         } catch (IllegalArgumentException e) {
             /* expected */
         }
-
-        System.out.println("\t\t... passed");
     }
 
+    @Test
     public void test_isLibraryLoadSkippedReturnsFalseByDefault() {
-
-        System.out.print(
-            "\tisLibraryLoadSkipped() default");
-
         /* Library was loaded normally in @BeforeClass, so
          * isLibraryLoadSkipped() should return false */
-        assertFalse(
-            "isLibraryLoadSkipped() should be false when " +
-            "library was loaded normally",
-            WolfSSL.isLibraryLoadSkipped());
-
-        System.out.println("\t... passed");
+        assertFalse("isLibraryLoadSkipped() should be false when " +
+            "library was loaded normally", WolfSSL.isLibraryLoadSkipped());
     }
 
+    @Test
     public void test_SystemPropertyNotSetByDefault() {
-
-        System.out.print(
-            "\twolfssl.skipLibraryLoad not set");
-
         /* Verify property is not set by default in test env */
-        String val =
-            System.getProperty("wolfssl.skipLibraryLoad");
-        assertNull(
-            "wolfssl.skipLibraryLoad should not be set " +
-            "by default", val);
-
-        System.out.println("\t... passed");
+        String val = System.getProperty("wolfssl.skipLibraryLoad");
+        assertNull("wolfssl.skipLibraryLoad should not be set by default", val);
     }
 
+    @Test
     public void test_SettingPropertyAfterLoadHasNoEffect() {
-
-        System.out.print(
-            "\tskipLibraryLoad after load");
-
         /* Setting the property after library has already been
          * loaded should not change isLibraryLoadSkipped() */
         try {
-            System.setProperty(
-                "wolfssl.skipLibraryLoad", "true");
+            System.setProperty("wolfssl.skipLibraryLoad", "true");
 
-            assertFalse(
-                "isLibraryLoadSkipped() should still be " +
+            assertFalse("isLibraryLoadSkipped() should still be " +
                 "false after setting property post-load",
                 WolfSSL.isLibraryLoadSkipped());
 
         } finally {
             System.clearProperty("wolfssl.skipLibraryLoad");
         }
-
-        System.out.println("\t... passed");
     }
 }
-


### PR DESCRIPTION
This PR switches JUnit test output from tab-aligned `passed`/`failed`/`skipped` strings to per-method timing, matching wolfcrypt-jni.

Adds `TimedTestWatcher` `@Rule` and applies it across all 24 test files.  This can help surfaces slow tests if needed, and removes the brittle tab alignment of the status string.

Umbrella `@Test` methods in `WolfSSLTest`, `WolfSSLContextTest` (JNI), and `WolfSSLCertificateTest` are split into per unit `@Test` methods so timing is meaningful per helper. Early return skip paths now use `Assume.assumeTrue(...)` so JUnit properly reports them as skipped instead of silently counting them as passed.