### PR TITLE
Suppress JDK 24 deprecation/removal warnings

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -297,6 +297,7 @@
                classpathref="classpath"
                includeantruntime="false">
             <compilerarg value="-Xlint:-options"/>
+            <compilerarg value="-Xlint:-path"/>
         </javac>
     </target>
 

--- a/src/java/com/wolfssl/WolfCryptEccKey.java
+++ b/src/java/com/wolfssl/WolfCryptEccKey.java
@@ -110,7 +110,7 @@ public class WolfCryptEccKey {
         return EccPrivateKeyToPKCS8(getEccKeyPtr());
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected void finalize() throws Throwable
     {

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -2024,7 +2024,7 @@ public class WolfSSL {
         }
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected void finalize() throws Throwable
     {

--- a/src/java/com/wolfssl/WolfSSLCRL.java
+++ b/src/java/com/wolfssl/WolfSSLCRL.java
@@ -880,7 +880,7 @@ public class WolfSSLCRL implements Serializable {
         }
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected void finalize() throws Throwable {
         this.free();

--- a/src/java/com/wolfssl/WolfSSLCertManager.java
+++ b/src/java/com/wolfssl/WolfSSLCertManager.java
@@ -335,7 +335,7 @@ public class WolfSSLCertManager {
         }
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected void finalize() throws Throwable
     {

--- a/src/java/com/wolfssl/WolfSSLCertRequest.java
+++ b/src/java/com/wolfssl/WolfSSLCertRequest.java
@@ -853,7 +853,7 @@ public class WolfSSLCertRequest {
         }
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected void finalize() throws Throwable
     {

--- a/src/java/com/wolfssl/WolfSSLCertificate.java
+++ b/src/java/com/wolfssl/WolfSSLCertificate.java
@@ -2624,7 +2624,7 @@ public class WolfSSLCertificate implements Serializable {
         }
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected void finalize() throws Throwable
     {

--- a/src/java/com/wolfssl/WolfSSLContext.java
+++ b/src/java/com/wolfssl/WolfSSLContext.java
@@ -2546,7 +2546,7 @@ public class WolfSSLContext {
         flushSessions(getContextPtr(), tm);
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected void finalize() throws Throwable
     {

--- a/src/java/com/wolfssl/WolfSSLDebug.java
+++ b/src/java/com/wolfssl/WolfSSLDebug.java
@@ -213,6 +213,7 @@ public class WolfSSLDebug {
             Level level = record.getLevel();
             String levelStr = (level != null) ? level.toString() : "UNKNOWN";
 
+            @SuppressWarnings("deprecation")
             long threadId = record.getThreadID();
             String message = record.getMessage();
             if (message == null) {
@@ -233,6 +234,7 @@ public class WolfSSLDebug {
      * JSON formatter for wolfSSL logs
      */
     private static class JSONFormatter extends Formatter {
+        @SuppressWarnings("deprecation")
         @Override
         public String format(LogRecord record) {
             if (record == null) {

--- a/src/java/com/wolfssl/WolfSSLNameConstraints.java
+++ b/src/java/com/wolfssl/WolfSSLNameConstraints.java
@@ -239,7 +239,7 @@ public class WolfSSLNameConstraints {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     protected void finalize() throws Throwable {
         try {
             free();

--- a/src/java/com/wolfssl/WolfSSLNativeLoggingCallback.java
+++ b/src/java/com/wolfssl/WolfSSLNativeLoggingCallback.java
@@ -33,6 +33,7 @@ import java.time.Instant;
  */
 class WolfSSLNativeLoggingCallback implements WolfSSLLoggingCallback
 {
+    @SuppressWarnings("deprecation")
     public synchronized void loggingCallback(int logLevel, String logMessage) {
 
         System.err.println(

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -5910,7 +5910,7 @@ public class WolfSSLSession {
         }
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected void finalize() throws Throwable
     {

--- a/src/java/com/wolfssl/WolfSSLX509Name.java
+++ b/src/java/com/wolfssl/WolfSSLX509Name.java
@@ -626,7 +626,7 @@ public class WolfSSLX509Name {
         }
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected void finalize() throws Throwable
     {

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLAuthStore.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLAuthStore.java
@@ -789,7 +789,7 @@ public class WolfSSLAuthStore {
         }
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected synchronized void finalize() throws Throwable {
         /* Clear LinkedHashMap and set to null to allow

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLContext.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLContext.java
@@ -601,7 +601,7 @@ public class WolfSSLContext extends SSLContextSpi {
         return this.ctx;
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected void finalize() throws Throwable {
         if (this.ctx != null) {

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
@@ -2806,7 +2806,7 @@ public class WolfSSLEngine extends SSLEngine {
         }
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected synchronized void finalize() throws Throwable {
         if (this.ssl != null) {

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
@@ -1971,7 +1971,7 @@ public class WolfSSLEngineHelper {
         this.authStore = null;
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected synchronized void finalize() throws Throwable {
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
@@ -622,6 +622,7 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession {
         return km.getCertificateChain(authStore.getCertAlias());
     }
 
+    @SuppressWarnings("removal")
     @Override
     public synchronized javax.security.cert.X509Certificate[]
         getPeerCertificateChain() throws SSLPeerUnverifiedException {
@@ -1181,7 +1182,7 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession {
         return Collections.emptyList();
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected synchronized void finalize() throws Throwable
     {

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLInternalVerifyCb.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLInternalVerifyCb.java
@@ -446,6 +446,7 @@ public class WolfSSLInternalVerifyCb implements WolfSSLVerifyCallback {
      *         SSL/TLS handshake should continue. Otherwise return 0
      *         to mark verification failure and stop/abort handshake.
      */
+    @SuppressWarnings("deprecation")
     public int verifyCallback(int preverify_ok, long x509StorePtr) {
 
         WolfSSLCertificate[] certs = null;

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLKeyX509.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLKeyX509.java
@@ -22,7 +22,6 @@
 package com.wolfssl.provider.jsse;
 
 import java.net.Socket;
-import java.security.AccessController;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.Principal;
@@ -90,9 +89,11 @@ public class WolfSSLKeyX509 extends X509ExtendedKeyManager {
             () -> "creating new WolfSSLKeyX509 object");
 
         /* Check Security property once at construction time.
-         * Use doPrivileged for SecurityManager compatibility. */
+         * Use doPrivileged for SecurityManager compatibility.
+         * AccessController used via FQN to avoid import-line removal
+         * warning on JDK 17+. */
         @SuppressWarnings("removal")
-        String disableCacheValue = AccessController.doPrivileged(
+        String disableCacheValue = java.security.AccessController.doPrivileged(
             new PrivilegedAction<String>() {
                 public String run() {
                     return Security.getProperty(DISABLE_CACHE_PROPERTY);
@@ -215,6 +216,7 @@ public class WolfSSLKeyX509 extends X509ExtendedKeyManager {
      * null - if no alias matches found in KeyStore.
      * String[] - aliases, if found that match type and/or issuers
      */
+    @SuppressWarnings("deprecation")
     private String[] getAliasesFromKeyStore(String type, Principal[] issuers)
         throws KeyStoreException {
 
@@ -286,6 +288,7 @@ public class WolfSSLKeyX509 extends X509ExtendedKeyManager {
      * null - if no alias matches found.
      * String[] - aliases, if found that match type and/or issuers
      */
+    @SuppressWarnings("deprecation")
     private String[] getAliases(String type, Principal[] issuers) {
 
         /* Check if caching is disabled, use direct KeyStore access */
@@ -555,6 +558,7 @@ public class WolfSSLKeyX509 extends X509ExtendedKeyManager {
     /**
      * Clear sensitive data when object is garbage collected
      */
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected void finalize() throws Throwable {
         try {

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLParametersHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLParametersHelper.java
@@ -22,7 +22,6 @@ package com.wolfssl.provider.jsse;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.InvocationTargetException;
-import java.security.AccessController;
 import java.security.PrivilegedAction;
 import javax.net.ssl.SSLParameters;
 import com.wolfssl.provider.jsse.WolfSSLJDK8Helper;
@@ -53,7 +52,16 @@ public class WolfSSLParametersHelper
      * has SSLParameters methods that older versions may not have */
     static
     {
-        AccessController.doPrivileged(new PrivilegedAction<Object>() {
+        detectSSLParametersMethods();
+    }
+
+    /* AccessController used via FQN to avoid import-line removal
+     * warning on JDK 17+. */
+    @SuppressWarnings("removal")
+    private static void detectSSLParametersMethods()
+    {
+        java.security.AccessController
+            .doPrivileged(new PrivilegedAction<Object>() {
             public Object run() {
                 Class<?> c = SSLParameters.class;
                 Method[] methods = c.getDeclaredMethods();

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLProvider.java
@@ -75,6 +75,7 @@ public final class WolfSSLProvider extends Provider {
     /**
      * wolfSSL JSSE Provider class
      */
+    @SuppressWarnings("deprecation")
     public WolfSSLProvider() {
         super("wolfJSSE", 1.17, "wolfSSL JSSE Provider");
         /* super("wolfJSSE", "1.17", "wolfSSL JSSE Provider"); */

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLSocket.java
@@ -1514,6 +1514,7 @@ public class WolfSSLSocket extends SSLSocket {
      *
      * @throws IOException if a network error occurs
      */
+    @SuppressWarnings("deprecation")
     @Override
     public synchronized void startHandshake() throws IOException {
         int ret;
@@ -2319,7 +2320,7 @@ public class WolfSSLSocket extends SSLSocket {
         }
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected synchronized void finalize() throws Throwable {
         if (this.ssl != null) {

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLTrustX509.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLTrustX509.java
@@ -1339,7 +1339,7 @@ public final class WolfSSLTrustX509 extends X509ExtendedTrustManager {
         }
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected void finalize() throws Throwable {
         this.store = null;

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLX509.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLX509.java
@@ -181,6 +181,7 @@ public class WolfSSLX509 extends X509Certificate {
         return this.cert.getSerial();
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public Principal getIssuerDN() {
 
@@ -194,6 +195,7 @@ public class WolfSSLX509 extends X509Certificate {
         return new WolfSSLPrincipal(name);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public Principal getSubjectDN() {
 
@@ -678,7 +680,7 @@ public class WolfSSLX509 extends X509Certificate {
     }
 
 
-    @SuppressWarnings("removal")
+    @SuppressWarnings({"deprecation", "removal"})
     @Override
     protected void finalize() throws Throwable {
         try {

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLX509X.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLX509X.java
@@ -40,7 +40,7 @@ import com.wolfssl.WolfSSLException;
  *
  * @author wolfSSL
  */
-@SuppressWarnings("deprecation")
+@SuppressWarnings({"deprecation", "removal"})
 public class WolfSSLX509X extends X509Certificate {
     WolfSSLX509 cert;
 

--- a/src/java/com/wolfssl/provider/jsse/adapter/WolfSSLJDK8Helper.java
+++ b/src/java/com/wolfssl/provider/jsse/adapter/WolfSSLJDK8Helper.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.ArrayList;
 import java.lang.reflect.Method;
 import java.lang.reflect.InvocationTargetException;
-import java.security.AccessController;
 import java.security.PrivilegedAction;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SNIServerName;
@@ -52,6 +51,7 @@ public class WolfSSLJDK8Helper
      * @param m Java method to call to set SNI server names
      * @param in WolfSSLParameters to set SNI names from
      */
+    @SuppressWarnings("removal")
     protected static void setServerNames(final SSLParameters out,
                                          final Method m, WolfSSLParameters in) {
 
@@ -69,8 +69,11 @@ public class WolfSSLJDK8Helper
                 sni.add(new SNIHostName(name.getEncoded()));
             }
 
-            /* call SSLParameters.setServerName() */
-            AccessController.doPrivileged(new PrivilegedAction<Object>() {
+            /* call SSLParameters.setServerNames().
+             * AccessController used via FQN to avoid import-line removal
+             * warning on JDK 17+. */
+            java.security.AccessController
+                .doPrivileged(new PrivilegedAction<Object>() {
                 public Object run() {
                     try {
                         m.invoke(out, sni);
@@ -122,6 +125,7 @@ public class WolfSSLJDK8Helper
      * @param m method to invoke to set protocols
      * @param in input WolfSSLParameters to read ALPN protocols from
      */
+    @SuppressWarnings("removal")
     protected static void setApplicationProtocols(final SSLParameters out,
                                          final Method m, WolfSSLParameters in) {
 
@@ -134,7 +138,8 @@ public class WolfSSLJDK8Helper
         final Object[] appProtoArr = {appProtos};
         if (appProtos != null) {
             /* call SSLParameters.setApplicationProtocols() */
-            AccessController.doPrivileged(new PrivilegedAction<Object>() {
+            java.security.AccessController
+                .doPrivileged(new PrivilegedAction<Object>() {
                 public Object run() {
                     try {
                         m.invoke(out, appProtoArr);
@@ -190,6 +195,7 @@ public class WolfSSLJDK8Helper
      * @param m method to invoke to set endpoint ID algo
      * @param in input WolfSSLParameters to read endpoint ID algo from
      */
+    @SuppressWarnings("removal")
     protected static void setEndpointIdentificationAlgorithm(
         final SSLParameters out, final Method m, WolfSSLParameters in) {
 
@@ -202,7 +208,8 @@ public class WolfSSLJDK8Helper
         final String idAlgo = in.getEndpointIdentificationAlgorithm();
         if (idAlgo != null) {
             /* call SSLParameters.setEndpointIdentificationAlgorithm() */
-            AccessController.doPrivileged(new PrivilegedAction<Object>() {
+            java.security.AccessController
+                .doPrivileged(new PrivilegedAction<Object>() {
                 public Object run() {
                     try {
                         m.invoke(out, idAlgo);

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineMemoryLeakTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineMemoryLeakTest.java
@@ -82,6 +82,7 @@ public class WolfSSLEngineMemoryLeakTest {
      * The test will fail if JNI global references prevent garbage collection.
      */
     @Test
+    @SuppressWarnings("removal")
     public void testEngineMemoryLeakWithAbandonedEngines() throws Exception {
 
         /* Skip on Android due to performance and timeout issues */

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLEngineTest.java
@@ -2489,6 +2489,7 @@ public class WolfSSLEngineTest {
      * when no client auth requested, matching SunJSSE/Netty expectations.
      */
     @Test
+    @SuppressWarnings("removal")
     public void testGetPeerCertificateChainNoClientAuth() throws Exception {
 
         String protocol = null;

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSessionTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSessionTest.java
@@ -92,6 +92,7 @@ public class WolfSSLSessionTest {
 
 
     @Test
+    @SuppressWarnings("removal")
     public void testSessionTimeAndCerts()
         throws NoSuchAlgorithmException, KeyManagementException,
                KeyStoreException, CertificateException, IOException,
@@ -148,6 +149,7 @@ public class WolfSSLSessionTest {
     }
 
     @Test
+    @SuppressWarnings("removal")
     public void testNullSession()
         throws NoSuchAlgorithmException, KeyManagementException,
                KeyStoreException, CertificateException, IOException,

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLX509Test.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLX509Test.java
@@ -73,6 +73,7 @@ import com.wolfssl.provider.jsse.WolfSSLX509;
 import com.wolfssl.provider.jsse.WolfSSLX509X;
 import com.wolfssl.test.TimedTestWatcher;
 
+@SuppressWarnings("removal")
 public class WolfSSLX509Test {
 
     @Rule


### PR DESCRIPTION
Compiling with JDK 24 produced 70+ `[deprecation]` and `[removal]` warnings, plus 16 in the test build. All flagged APIs are intentional uses (`finalize()` for native cleanup, `AccessController` / `javax.security.cert.*` / `getSubjectDN` etc. required for Java 8 min version support and JSSE interface contracts).

This PR cleans those up by:

  - Adds targeted `@SuppressWarnings({"deprecation", "removal"})` on the affected `finalize()`, methods, locals, and a couple of class declarations (`WolfSSLX509X`, `WolfSSLX509Test`).
  - Switches `AccessController` usages to fully-qualified names in `WolfSSLKeyX509`, `WolfSSLParametersHelper`, and `WolfSSLJDK8Helper` so the import-line `[removal]` warning (which class-level `@SuppressWarnings` cannot reach) goes away. Comments added to flag the intent.
  - Adds `-Xlint:-path` to the `build-test` javac target to silence the exploded-module classpath warning.

  `@SuppressWarnings("removal")` is unknown to Java 8 javac and silently ignored per JLS, so the Java 8 min version is preserved.