### PR TITLE
JNI callback hardening: exception paths, leaks, and missing checks

### DIFF
--- a/native/com_wolfssl_WolfCryptECC.c
+++ b/native/com_wolfssl_WolfCryptECC.c
@@ -93,6 +93,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptECC_doSign
    jlongArray outSz, jobject keyDer, jlong keySz)
 {
     int     ret;
+    int     rngInit = 0;
+    int     keyInit = 0;
     WC_RNG  rng;
     ecc_key myKey;
     unsigned int tmpOut;
@@ -130,8 +132,20 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptECC_doSign
     (*jenv)->GetLongArrayRegion(jenv, outSz, 0, 1, &tmp);
     tmpOut = (unsigned int)tmp;
 
-    wc_InitRng(&rng);
-    wc_ecc_init(&myKey);
+    ret = wc_InitRng(&rng);
+    if (ret != 0) {
+        printf("wc_InitRng failed, ret = %d\n", ret);
+        return ret;
+    }
+    rngInit = 1;
+
+    ret = wc_ecc_init(&myKey);
+    if (ret != 0) {
+        printf("wc_ecc_init failed, ret = %d\n", ret);
+        wc_FreeRng(&rng);
+        return ret;
+    }
+    keyInit = 1;
 
     ret = wc_EccPrivateKeyDecode(keyBuf, &idx, &myKey, (long)keySz);
     if (ret == 0) {
@@ -144,8 +158,12 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptECC_doSign
         printf("wc_EccPrivateKeyDecode failed, ret = %d\n", ret);
     }
 
-    wc_ecc_free(&myKey);
-    wc_FreeRng(&rng);
+    if (keyInit) {
+        wc_ecc_free(&myKey);
+    }
+    if (rngInit) {
+        wc_FreeRng(&rng);
+    }
 
     if (ret == 0) {
         tmp = (jlong)tmpOut;

--- a/native/com_wolfssl_WolfCryptRSA.c
+++ b/native/com_wolfssl_WolfCryptRSA.c
@@ -36,6 +36,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptRSA_doSign
    jintArray outSz, jobject keyDer, jlong keySz)
 {
     int     ret;
+    int     rngInit = 0;
+    int     keyInit = 0;
     WC_RNG  rng;
     RsaKey  myKey;
     unsigned int idx;
@@ -72,8 +74,20 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptRSA_doSign
     /* get output buffer size */
     (*jenv)->GetIntArrayRegion(jenv, outSz, 0, 1, (jint*)&tmpOut);
 
-    wc_InitRng(&rng);
-    wc_InitRsaKey(&myKey, NULL);
+    ret = wc_InitRng(&rng);
+    if (ret != 0) {
+        printf("wc_InitRng failed, ret = %d\n", ret);
+        return ret;
+    }
+    rngInit = 1;
+
+    ret = wc_InitRsaKey(&myKey, NULL);
+    if (ret != 0) {
+        printf("wc_InitRsaKey failed, ret = %d\n", ret);
+        wc_FreeRng(&rng);
+        return ret;
+    }
+    keyInit = 1;
 
     idx = 0;
 
@@ -91,8 +105,12 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptRSA_doSign
         printf("wc_RsaPrivateKeyDecode failed, ret = %d\n", ret);
     }
 
-    wc_FreeRsaKey(&myKey);
-    wc_FreeRng(&rng);
+    if (keyInit) {
+        wc_FreeRsaKey(&myKey);
+    }
+    if (rngInit) {
+        wc_FreeRng(&rng);
+    }
 
     return ret;
 }
@@ -157,6 +175,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptRSA_doEnc
    jintArray outSz, jobject keyDer, jlong keySz)
 {
     int     ret;
+    int     rngInit = 0;
+    int     keyInit = 0;
     RsaKey  myKey;
     WC_RNG  rng;
     unsigned int idx;
@@ -193,8 +213,20 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptRSA_doEnc
     /* get output buffer size */
     (*jenv)->GetIntArrayRegion(jenv, outSz, 0, 1, (jint*)&tmpOut);
 
-    wc_InitRng(&rng);
-    wc_InitRsaKey(&myKey, NULL);
+    ret = wc_InitRng(&rng);
+    if (ret != 0) {
+        printf("wc_InitRng failed, ret = %d\n", ret);
+        return ret;
+    }
+    rngInit = 1;
+
+    ret = wc_InitRsaKey(&myKey, NULL);
+    if (ret != 0) {
+        printf("wc_InitRsaKey failed, ret = %d\n", ret);
+        wc_FreeRng(&rng);
+        return ret;
+    }
+    keyInit = 1;
 
     idx = 0;
 
@@ -211,8 +243,12 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptRSA_doEnc
         printf("wc_RsaPublicKeyDecode failed, ret = %d\n", ret);
     }
 
-    wc_FreeRsaKey(&myKey);
-    wc_FreeRng(&rng);
+    if (keyInit) {
+        wc_FreeRsaKey(&myKey);
+    }
+    if (rngInit) {
+        wc_FreeRng(&rng);
+    }
 
     return ret;
 }

--- a/native/com_wolfssl_WolfSSLContext.c
+++ b/native/com_wolfssl_WolfSSLContext.c
@@ -859,6 +859,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setCipherList
     }
 
     cipherList = (*jenv)->GetStringUTFChars(jenv, list, 0);
+    if (cipherList == NULL) {
+        return (jint)MEMORY_E;
+    }
 
     ret = (jint) wolfSSL_CTX_set_cipher_list(ctx, cipherList);
 
@@ -1179,6 +1182,7 @@ int NativeIORecvCb(WOLFSSL *ssl, char *buf, int sz, void *ctx)
     if (!g_sslIORecvMethodId) {
         (*jenv)->ThrowNew(jenv, excClass,
             "Cached recv callback method ID is null in NativeIORecvCb");
+        (*jenv)->DeleteLocalRef(jenv, ctxRef);
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
         return WOLFSSL_CBIO_ERR_GENERAL;
@@ -1782,9 +1786,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setCRLCb
             }
             (*jenv)->ThrowNew(jenv, excClass,
                     "error storing global missing CTX CRL callback interface");
+            return (jint)SSL_FAILURE;
         }
 
         ret = wolfSSL_CTX_SetCRL_Cb(ctx, NativeCtxMissingCRLCallback);
+    }
+    else {
+        /* clear native callback when Java side is disabling */
+        ret = wolfSSL_CTX_SetCRL_Cb(ctx, NULL);
     }
 
     return (jint)ret;
@@ -1952,6 +1961,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setOCSPOverrideUrl
     }
 
     url = (*jenv)->GetStringUTFChars(jenv, urlString, 0);
+    if (url == NULL) {
+        return (jint)MEMORY_E;
+    }
 
     ret = (jint) wolfSSL_CTX_SetOCSP_OverrideURL(ctx, url);
 
@@ -6766,6 +6778,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_set1SigAlgsList
     }
 
     sigAlgList = (*jenv)->GetStringUTFChars(jenv, list, 0);
+    if (sigAlgList == NULL) {
+        return (jint)MEMORY_E;
+    }
 
     ret = wolfSSL_CTX_set1_sigalgs_list(ctx, sigAlgList);
 

--- a/native/com_wolfssl_WolfSSLContext.c
+++ b/native/com_wolfssl_WolfSSLContext.c
@@ -4754,6 +4754,14 @@ int  NativeRsaVerifyCb(WOLFSSL* ssl, unsigned char* sig, unsigned int sigSz,
     if ((*jenv)->ExceptionOccurred(jenv)) {
         (*jenv)->ExceptionDescribe(jenv);
         (*jenv)->ExceptionClear(jenv);
+        (*jenv)->DeleteLocalRef(jenv, ctxRef);
+        (*jenv)->DeleteLocalRef(jenv, sigBB);
+        (*jenv)->DeleteLocalRef(jenv, outBB);
+        (*jenv)->DeleteLocalRef(jenv, keyDerBB);
+        if (needsDetach) {
+            (*g_vm)->DetachCurrentThread(g_vm);
+        }
+        return -1;
     }
 
     /* point out* to the beginning of our decrypted buffer */
@@ -5042,6 +5050,14 @@ int NativeRsaSignCheckCb(WOLFSSL* ssl, unsigned char* sig, unsigned int sigSz,
     if ((*jenv)->ExceptionOccurred(jenv)) {
         (*jenv)->ExceptionDescribe(jenv);
         (*jenv)->ExceptionClear(jenv);
+        (*jenv)->DeleteLocalRef(jenv, ctxRef);
+        (*jenv)->DeleteLocalRef(jenv, sigBB);
+        (*jenv)->DeleteLocalRef(jenv, outBB);
+        (*jenv)->DeleteLocalRef(jenv, keyDerBB);
+        if (needsDetach) {
+            (*g_vm)->DetachCurrentThread(g_vm);
+        }
+        return -1;
     }
 
     /* point out* to the beginning of decrypted buffer */
@@ -5271,6 +5287,14 @@ int NativeRsaPssSignCheckCb(WOLFSSL* ssl, unsigned char* sig,
     if ((*jenv)->ExceptionOccurred(jenv)) {
         (*jenv)->ExceptionDescribe(jenv);
         (*jenv)->ExceptionClear(jenv);
+        (*jenv)->DeleteLocalRef(jenv, ctxRef);
+        (*jenv)->DeleteLocalRef(jenv, sigBB);
+        (*jenv)->DeleteLocalRef(jenv, outBB);
+        (*jenv)->DeleteLocalRef(jenv, keyDerBB);
+        if (needsDetach) {
+            (*g_vm)->DetachCurrentThread(g_vm);
+        }
+        return -1;
     }
 
     /* point out* to the beginning of decrypted buffer */

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -2470,6 +2470,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setCipherList
     }
 
     cipherList= (*jenv)->GetStringUTFChars(jenv, list, 0);
+    if (cipherList == NULL) {
+        return (jint)MEMORY_E;
+    }
 
     ret = (jint) wolfSSL_set_cipher_list(ssl, cipherList);
 
@@ -6380,6 +6383,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_set1SigAlgsList
     }
 
     sigAlgList = (*jenv)->GetStringUTFChars(jenv, list, 0);
+    if (sigAlgList == NULL) {
+        return (jint)MEMORY_E;
+    }
 
     ret = wolfSSL_set1_sigalgs_list(ssl, sigAlgList);
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
@@ -851,7 +851,7 @@ public class WolfSSLEngine extends SSLEngine {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                 () -> "setUseClientMode: " +
                 this.engineHelper.getUseClientMode());
-            for (i = 0; i < len; i++) {
+            for (i = ofst; i < ofst + len; i++) {
                 final int idx = i;
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                     () -> "ByteBuffer in["+idx+"].remaining(): " +
@@ -996,7 +996,7 @@ public class WolfSSLEngine extends SSLEngine {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                     () -> "setUseClientMode: " +
                     this.engineHelper.getUseClientMode());
-                for (i = 0; i < len; i++) {
+                for (i = ofst; i < ofst + len; i++) {
                     final int idx = i;
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                         () -> "ByteBuffer in["+idx+"].remaining(): " +
@@ -1370,7 +1370,7 @@ public class WolfSSLEngine extends SSLEngine {
                 () -> "in.position(): " + in.position());
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                 () -> "in.limit(): " + in.limit());
-            for (i = 0; i < length; i++) {
+            for (i = ofst; i < ofst + length; i++) {
                 final int idx = i;
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                     () -> "out["+idx+"].remaining(): " +
@@ -1796,7 +1796,7 @@ public class WolfSSLEngine extends SSLEngine {
                     () -> "in.position(): " + in.position());
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                     () -> "in.limit(): " + in.limit());
-                for (i = 0; i < length; i++) {
+                for (i = ofst; i < ofst + length; i++) {
                     final int idx = i;
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                         () -> "out["+idx+"].remaining(): " +


### PR DESCRIPTION
Fixes F-3909, F-3910, F-3912, F-3913, F-3914, F-3915, F-3916

- RsaVerifyCb, RsaSignCheckCb, RsaPssSignCheckCb: return -1 after CallIntMethod raises (was: continued with undefined retval, could surface success)
- WolfSSLEngine wrap/unwrap exit debug loops: iterate ofst..ofst+len instead of 0..len so logging never reads outside the requested slice
- Null-check GetStringUTFChars in setCipherList/set1SigAlgsList/setOCSPOverrideUrl (Session + Context) and return MEMORY_E on failure
- setCRLCb: bail when NewGlobalRef fails; clear native callback when caller passes NULL
- WolfCryptRSA doSign/doEnc and WolfCryptECC doSign: check wc_InitRng / key init returns, track init flags, free only on success (matches doPssSign)
- NativeIORecvCb: DeleteLocalRef(ctxRef) on g_sslIORecvMethodId-null branch (matches NativeIOSendCb)