### PR TITLE
check for null name in getValue

### DIFF
--- a/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLImplementSSLSession.java
@@ -454,6 +454,9 @@ public class WolfSSLImplementSSLSession extends ExtendedSSLSession {
      * @return Object value associated with name
      */
     public Object getValue(String name) {
+        if (name == null) {
+            throw new IllegalArgumentException();
+        }
         return binding.get(name);
     }
 


### PR DESCRIPTION
`WolfSSLImplementSSLSession.getValue()` did not check for null name before attempting to access, resulting in NPE, when IllegalArgumentException was expected.

Fixes SunJSSE FixingJavadocs/SSLSessionNulls.java