### PR TITLE
Correctness fixes for verify callback lifecycle, session cache keying, ALPN cleanup, and IP hostname matching

### DIFF
--- a/native/com_wolfssl_WolfSSLCertificate.c
+++ b/native/com_wolfssl_WolfSSLCertificate.c
@@ -1099,9 +1099,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1check_1host
         /* peerNamePtr not used */
         ret = wolfSSL_X509_check_host(x509, hostname,
             XSTRLEN(hostname), (unsigned int)flags, NULL);
+        (*jenv)->ReleaseStringUTFChars(jenv, chk, hostname);
     }
-
-    (*jenv)->ReleaseStringUTFChars(jenv, chk, hostname);
 
     return (jint)ret;
 
@@ -1112,6 +1111,39 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1check_1host
     (void)chk;
     (void)flags;
     (void)peerNamePtr;
+    return (jint)NOT_COMPILED_IN;
+#endif
+}
+
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1check_1ip_1asc
+  (JNIEnv* jenv, jclass jcl, jlong x509Ptr, jstring ipasc, jlong flags)
+{
+#ifndef NO_ASN
+    int ret = WOLFSSL_FAILURE;
+    const char* ip = NULL;
+    WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
+    (void)jcl;
+
+    if (jenv == NULL || ipasc == NULL) {
+        return WOLFSSL_FAILURE;
+    }
+
+    /* Matches only iPAddress SAN entries. Does not fall back to Subject CN or
+       a dNSName, required for IP address ref identities (RFC 6125/2818). */
+    ip = (*jenv)->GetStringUTFChars(jenv, ipasc, 0);
+    if (ip != NULL) {
+        ret = wolfSSL_X509_check_ip_asc(x509, ip, (unsigned int)flags);
+        (*jenv)->ReleaseStringUTFChars(jenv, ipasc, ip);
+    }
+
+    return (jint)ret;
+
+#else
+    (void)jenv;
+    (void)jcl;
+    (void)x509Ptr;
+    (void)ipasc;
+    (void)flags;
     return (jint)NOT_COMPILED_IN;
 #endif
 }

--- a/native/com_wolfssl_WolfSSLCertificate.h
+++ b/native/com_wolfssl_WolfSSLCertificate.h
@@ -287,6 +287,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1check_1host
 
 /*
  * Class:     com_wolfssl_WolfSSLCertificate
+ * Method:    X509_check_ip_asc
+ * Signature: (JLjava/lang/String;J)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1check_1ip_1asc
+  (JNIEnv *, jclass, jlong, jstring, jlong);
+
+/*
+ * Class:     com_wolfssl_WolfSSLCertificate
  * Method:    X509_get_ext_d2i_name_constraints
  * Signature: (J)J
  */

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -5543,6 +5543,7 @@ int NativeALPNSelectCb(WOLFSSL *ssl, const unsigned char **out,
     peerProtosCopy = (char*)XMALLOC(peerProtosSz + 1, NULL,
         DYNAMIC_TYPE_TMP_BUFFER);
     if (peerProtosCopy == NULL) {
+        wolfSSL_ALPN_FreePeerProtocol(ssl, &peerProtos);
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
             (*jenv)->ExceptionClear(jenv);

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -111,6 +111,7 @@ int NativeSSLVerifyCallback(int preverify_ok, WOLFSSL_X509_STORE_CTX* store)
     jobjectRefType refcheck;
     SSLAppData* appData;            /* WOLFSSL app data, stored verify cb obj */
     jobject* g_verifySSLCbIfaceObj;  /* Global jobject, stored in app data */
+    jobject   verifyCbObj = NULL;    /* Local ref promoted from stored global */
 
     if (!g_vm) {
         /* we can't throw an exception yet, so just return 0 (failure) */
@@ -135,41 +136,53 @@ int NativeSSLVerifyCallback(int preverify_ok, WOLFSSL_X509_STORE_CTX* store)
 
     /* get app data to retrieve stored Java jobject callback object */
     appData = (SSLAppData*)wolfSSL_get_app_data(
-                wolfSSL_X509_STORE_CTX_get_ex_data(store, 0));
+        wolfSSL_X509_STORE_CTX_get_ex_data(store, 0));
     if (appData == NULL) {
         printf("Error getting app data from WOLFSSL\n");
-        if (needsDetach)
+        if (needsDetach) {
             (*g_vm)->DetachCurrentThread(g_vm);
+        }
         return -105;
     }
 
-    /* get global Java verify callback object */
+    /* Promote stored global callback ref to a local ref under g_verifyCbMutex
+     * so a concurrent setVerify() cannot free it mid-call. appData stays valid
+     * via jniSessLock, held by the read/write caller. */
+    (void)NativeVerifyCbLock();
     g_verifySSLCbIfaceObj = appData->g_verifySSLCbIfaceObj;
-    if (g_verifySSLCbIfaceObj == NULL || *g_verifySSLCbIfaceObj == NULL) {
+    if ((g_verifySSLCbIfaceObj != NULL) && (*g_verifySSLCbIfaceObj != NULL)) {
+        verifyCbObj = (*jenv)->NewLocalRef(jenv, *g_verifySSLCbIfaceObj);
+    }
+    (void)NativeVerifyCbUnlock();
+
+    if (verifyCbObj == NULL) {
         printf("Error getting g_verifySSLCbIfaceObj from appData\n");
-        if (needsDetach)
+        if (needsDetach) {
             (*g_vm)->DetachCurrentThread(g_vm);
+        }
         return -106;
     }
 
-    /* check if our stored object reference is valid */
-    refcheck = (*jenv)->GetObjectRefType(jenv, *g_verifySSLCbIfaceObj);
-    if (refcheck == 2) {
+    /* valid ref check: non-zero type covers local/global/weak, and verifyCbObj
+     * is a promoted local ref */
+    refcheck = (*jenv)->GetObjectRefType(jenv, verifyCbObj);
+    if (refcheck != 0) {
 
         if (!g_verifyCallbackMethodId) {
             if ((*jenv)->ExceptionOccurred(jenv)) {
                 (*jenv)->ExceptionDescribe(jenv);
                 (*jenv)->ExceptionClear(jenv);
             }
-
             throwWolfSSLJNIException(jenv,
                 "verifyCallback method ID is null in NativeSSLVerifyCallback");
-            if (needsDetach)
+            (*jenv)->DeleteLocalRef(jenv, verifyCbObj);
+            if (needsDetach) {
                 (*g_vm)->DetachCurrentThread(g_vm);
+            }
             return -107;
         }
 
-        retval = (*jenv)->CallIntMethod(jenv, *g_verifySSLCbIfaceObj,
+        retval = (*jenv)->CallIntMethod(jenv, verifyCbObj,
                 g_verifyCallbackMethodId, preverify_ok,
                 (jlong)(uintptr_t)store);
 
@@ -177,6 +190,7 @@ int NativeSSLVerifyCallback(int preverify_ok, WOLFSSL_X509_STORE_CTX* store)
             /* exception occurred on the Java side during method call */
             (*jenv)->ExceptionDescribe(jenv);
             (*jenv)->ExceptionClear(jenv);
+            (*jenv)->DeleteLocalRef(jenv, verifyCbObj);
             if (needsDetach)
                 (*g_vm)->DetachCurrentThread(g_vm);
             return -109;
@@ -190,10 +204,13 @@ int NativeSSLVerifyCallback(int preverify_ok, WOLFSSL_X509_STORE_CTX* store)
 
         throwWolfSSLJNIException(jenv,
                 "Object reference invalid in NativeSSLVerifyCallback");
+        (*jenv)->DeleteLocalRef(jenv, verifyCbObj);
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
         return -1;
     }
+
+    (*jenv)->DeleteLocalRef(jenv, verifyCbObj);
 
     if (needsDetach)
         (*g_vm)->DetachCurrentThread(g_vm);
@@ -1853,7 +1870,12 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_freeSSL
             XFREE(appData->jniSessLock, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             appData->jniSessLock = NULL;
         }
+        /* Clear the stored pointer under g_verifyCbMutex, then free the prior
+         * ref and its container after unlocking, matching setVerify(). */
+        (void)NativeVerifyCbLock();
         g_cachedVerifyCb = appData->g_verifySSLCbIfaceObj;
+        appData->g_verifySSLCbIfaceObj = NULL;
+        (void)NativeVerifyCbUnlock();
         if (g_cachedVerifyCb != NULL) {
             (*jenv)->DeleteGlobalRef(jenv, (jobject)(*g_cachedVerifyCb));
             XFREE(g_cachedVerifyCb, NULL, DYNAMIC_TYPE_TMP_BUFFER);
@@ -4837,15 +4859,18 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setVerify
         return;
     }
 
-    /* Release global reference if already set, before setting again */
+    /* Clear stored pointer under g_verifyCbMutex, then free prior ref and its
+     * container after unlocking. */
     appData = (SSLAppData*)wolfSSL_get_app_data(ssl);
     if (appData != NULL) {
+        (void)NativeVerifyCbLock();
         verifyCb = appData->g_verifySSLCbIfaceObj;
+        appData->g_verifySSLCbIfaceObj = NULL;
+        (void)NativeVerifyCbUnlock();
         if (verifyCb != NULL) {
             (*jenv)->DeleteGlobalRef(jenv, (jobject)(*verifyCb));
             XFREE(verifyCb, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             verifyCb = NULL;
-            appData->g_verifySSLCbIfaceObj = NULL;
         }
     }
 
@@ -4876,7 +4901,11 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setVerify
 		        XFREE(verifyCb, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             }
             else {
+                /* Publish under g_verifyCbMutex so a concurrent callback
+                 * reads a consistent pointer. */
+                (void)NativeVerifyCbLock();
                 appData->g_verifySSLCbIfaceObj = verifyCb;
+                (void)NativeVerifyCbUnlock();
 
                 /* set verify mode, register Java callback with wolfSSL */
                 wolfSSL_set_verify(ssl, mode, NativeSSLVerifyCallback);

--- a/src/java/com/wolfssl/WolfSSLCertificate.java
+++ b/src/java/com/wolfssl/WolfSSLCertificate.java
@@ -114,6 +114,7 @@ public class WolfSSLCertificate implements Serializable {
     static native long X509_load_certificate_file(String path, int format);
     static native int X509_check_host(long x509, String chk, long flags,
         long peerName);
+    static native int X509_check_ip_asc(long x509, String ipasc, long flags);
     static native long X509_get_ext_d2i_name_constraints(long x509);
 
     /* native functions used for X509v3 certificate generation */
@@ -2139,6 +2140,38 @@ public class WolfSSLCertificate implements Serializable {
                 flags + ")");
 
             return X509_check_host(this.x509Ptr, hostname, flags, 0);
+        }
+    }
+
+    /**
+     * Checks that the given IP address literal matches an iPAddress entry in
+     * this certificate's SubjectAltName extension.
+     *
+     * Unlike {@link #checkHost(String)}, this only matches iPAddress SAN
+     * entries. It never falls back to the Subject CommonName or a dNSName
+     * SAN, as required for IP address reference identities by RFC 6125 and
+     * RFC 2818.
+     *
+     * @param ipAddress IP address literal to check certificate against, in
+     *        text form (ex: "192.0.2.1" or "::1")
+     *
+     * @return WolfSSL.SSL_SUCCESS on successful iPAddress match,
+     *         WolfSSL.SSL_FAILURE on invalid match or error, or
+     *         WolfSSL.NOT_COMPILED_IN if native wolfSSL has been compiled
+     *         with NO_ASN defined and native API is not available.
+     *
+     * @throws IllegalStateException if WolfSSLCertificate has been freed.
+     */
+    public int checkIpAddress(String ipAddress) throws IllegalStateException {
+
+        confirmObjectIsActive();
+
+        synchronized (x509Lock) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.x509Ptr,
+                () -> "entering checkIpAddress(" + ipAddress + ")");
+
+            return X509_check_ip_asc(this.x509Ptr, ipAddress, 0);
         }
     }
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLAuthStore.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLAuthStore.java
@@ -65,7 +65,7 @@ public class WolfSSLAuthStore {
     private WolfSSLSessionContext serverCtx = null;
     private WolfSSLSessionContext clientCtx = null;
 
-    private SessionStore<Integer, WolfSSLImplementSSLSession> store = null;
+    private SessionStore<String, WolfSSLImplementSSLSession> store = null;
     private static final Object storeLock = new Object();
 
     /**
@@ -282,7 +282,7 @@ public class WolfSSLAuthStore {
      * @param side server/client side for cache resize
      */
     protected void resizeCache(int sz, int side) {
-        SessionStore<Integer, WolfSSLImplementSSLSession> newStore =
+        SessionStore<String, WolfSSLImplementSSLSession> newStore =
                 new SessionStore<>(sz);
 
         /* @TODO check for side server/client, currently a resize is for all */
@@ -328,8 +328,7 @@ public class WolfSSLAuthStore {
 
         boolean needNewSession = false;
         WolfSSLImplementSSLSession ses = null;
-        String toHash = null;
-        int hashCode = 0;
+        String cacheKey = null;
 
         if (ssl == null) {
             return null;
@@ -349,9 +348,8 @@ public class WolfSSLAuthStore {
          * Synchronizes on storeLock internally. */
         printSessionStoreStatus();
 
-        /* Generate cache key hash (host:port), outside lock */
-        toHash = host.concat(Integer.toString(port));
-        hashCode = toHash.hashCode();
+        /* Generate cache key (host:port), outside lock */
+        cacheKey = sessionCacheKey(host, port);
 
         /* Lock on static/global storeLock while getting session out of
          * store, since Java session cache table is shared between all
@@ -359,14 +357,14 @@ public class WolfSSLAuthStore {
         synchronized (storeLock) {
 
             /* Try getting session out of Java store */
-            ses = store.get(hashCode);
+            ses = store.get(cacheKey);
 
             /* Remove old entry from table. TLS 1.3 binder changes between
              * resumptions and stored session should only be used to
              * resume once. New session structure/object will be cached
              * after the resumed session completes the handshake, for
              * subsequent resumption attempts to use. */
-            store.remove(hashCode);
+            store.remove(cacheKey);
         }
 
         /* Check conditions where we need to create a new new session:
@@ -599,15 +597,30 @@ public class WolfSSLAuthStore {
     }
 
     /**
+     * Build the client session cache key from peer host and port.
+     *
+     * The key is a "host:port" String so the cache map compares hosts with
+     * String.equals() and distinct hosts never share a slot. The ':' separator
+     * keeps the port unambiguous even when the host ends in digits or is an
+     * IPv6 literal.
+     *
+     * @param host peer host name or IP literal, must not be null
+     * @param port peer port number
+     * @return session cache key String
+     */
+    private String sessionCacheKey(String host, int port) {
+        return host + ":" + Integer.toString(port);
+    }
+
+    /**
      * Add SSLSession into wolfJSSE Java session cache table, to be used
      * for session resumption.
      *
-     * Session is stored into the session table using a hash code as the key.
-     * If the peer host is not null, the hash code is based on a concatenation
-     * of the peer host and port. If the peer host is null, the hash code
-     * is based on the session ID (if ID is not null, and non-zero length).
-     * Otherwise, no hash code is generated and the session is not stored into
-     * the session cache table.
+     * Session is stored into the session table using a String key. If the
+     * peer host is not null, the key is the "host:port" String. If the peer
+     * host is null, the key is based on the session ID (if ID is not null,
+     * and non-zero length). Otherwise, no key is generated and the session is
+     * not stored into the session cache table.
      *
      * This method synchronizes on the static/global storeLock object, since
      * the session cache is global and shared amongst all threads.
@@ -617,8 +630,7 @@ public class WolfSSLAuthStore {
      */
     protected int addSession(WolfSSLImplementSSLSession session) {
 
-        String toHash;
-        final int hashCode;
+        final String cacheKey;
         final boolean haveKey;
 
         /* Don't store session if invalid (or not complete with sesPtr
@@ -640,40 +652,38 @@ public class WolfSSLAuthStore {
 
         if (session.getPeerHost() != null) {
             /* Generate key for storing into session table (host:port) */
-            toHash = session.getPeerHost().concat(Integer.toString(
-                     session.getPeerPort()));
-            hashCode = toHash.hashCode();
+            cacheKey = sessionCacheKey(session.getPeerHost(),
+                session.getPeerPort());
             haveKey = true;
         }
         else {
-            /* If no peer host is available then create hash key from
+            /* If no peer host is available then create key from
              * session ID if not null, not zero length, and not all zeros */
             byte[] sessionId = session.getId();
             if (sessionId != null && sessionId.length > 0 &&
                 (idAllZeros(sessionId) == false)) {
-                hashCode = Arrays.toString(session.getId()).hashCode();
+                cacheKey = Arrays.toString(sessionId);
                 haveKey = true;
             } else {
-                hashCode = 0;
+                cacheKey = null;
                 haveKey = false;
             }
         }
 
-        /* Only store session into cache if we have a usable key. If session
-         * already exists for hashCode, it will be overwritten with the new
-         * version. Note that hashCode == 0 is a legitimate hash value, so
-         * we use haveKey rather than hashCode == 0 to gate caching. */
+        /* Only store session into cache if we have a usable key. If a session
+         * already exists for cacheKey, it will be overwritten with the new
+         * version. */
         if (haveKey) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                 () -> "stored session in cache table (host: " +
                 session.getPeerHost() + ", port: " +
-                session.getPeerPort() + ") " + "hashCode = " + hashCode +
+                session.getPeerPort() + ") " + "cacheKey = " + cacheKey +
                 " side = " + session.getSideString());
 
             /* Lock access to store while adding new session, store is global */
             synchronized (storeLock) {
                 session.isInTable = true;
-                store.put(hashCode, session);
+                store.put(cacheKey, session);
             }
 
             printSessionStoreStatus();

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLInternalVerifyCb.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLInternalVerifyCb.java
@@ -288,22 +288,23 @@ public class WolfSSLInternalVerifyCb implements WolfSSLVerifyCallback {
             return 0;
         }
 
-        /* Verify hostname against certificate SAN/CN using native
-         * wolfSSL X509_check_host() */
+        /* Verify hostname against certificate SAN/CN using native wolfSSL.
+         * IP address literals are matched against iPAddress SANs only, never
+         * CN or a dNSName, per RFC 6125 / RFC 2818. */
         final String tmpHost = peerHost;
         WolfSSLCertificate wCert = null;
         try {
             wCert = new WolfSSLCertificate(peer.getEncoded());
-            int ret = wCert.checkHost(peerHost);
+            int ret = WolfSSLUtil.verifyHostnameOrIp(wCert, peerHost, 0);
             if (ret == WolfSSL.SSL_SUCCESS) {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    () -> "Provider-level hostname verification " +
-                        "passed for: " + tmpHost);
+                    () -> "Provider-level hostname verification passed for: " +
+                        tmpHost);
                 return 1;
             } else {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-                    () -> "Provider-level hostname verification " +
-                        "FAILED for: " + tmpHost);
+                    () -> "Provider-level hostname verification FAILED for: " +
+                        tmpHost);
                 this.verifyException = new CertificateException(
                     "Hostname verification failed for: " + tmpHost);
                 return 0;

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLTrustX509.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLTrustX509.java
@@ -751,7 +751,7 @@ public final class WolfSSLTrustX509 extends X509ExtendedTrustManager {
                     () -> "trying hostname verification against SNI: " +
                     tmpSniName);
 
-                ret = peerCert.checkHost(sniHostName);
+                ret = WolfSSLUtil.verifyHostnameOrIp(peerCert, sniHostName, 0);
                 if (ret == WolfSSL.SSL_SUCCESS) {
                     /* Hostname successfully verified against SNI name */
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
@@ -776,13 +776,12 @@ public final class WolfSSLTrustX509 extends X509ExtendedTrustManager {
                 () -> "trying hostname verification against peer host: " +
                 peerHost);
 
-            if (type == HOSTNAME_TYPE_LDAPS) {
-                /* LDAPS requires wildcard left-most matching only */
-                ret = peerCert.checkHost(peerHost,
-                        WolfSSL.WOLFSSL_LEFT_MOST_WILDCARD_ONLY);
-            } else {
-                ret = peerCert.checkHost(peerHost);
-            }
+            /* LDAPS requires wildcard left-most matching only. IP literals
+             * are matched against iPAddress SANs only, handled inside
+             * verifyHostnameOrIp(). */
+            long flags = (type == HOSTNAME_TYPE_LDAPS) ?
+                WolfSSL.WOLFSSL_LEFT_MOST_WILDCARD_ONLY : 0;
+            ret = WolfSSLUtil.verifyHostnameOrIp(peerCert, peerHost, flags);
             if (ret == WolfSSL.SSL_SUCCESS) {
                 /* Hostname successfully verified against peer host name */
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLUtil.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLUtil.java
@@ -35,6 +35,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 
 import com.wolfssl.WolfSSL;
+import com.wolfssl.WolfSSLCertificate;
 import com.wolfssl.WolfSSLDebug;
 import com.wolfssl.WolfSSLException;
 
@@ -782,5 +783,134 @@ public class WolfSSLUtil {
         return ks;
     }
 
+    /**
+     * Verify a reference identity (host name or IP address literal) against a
+     * peer certificate.
+     *
+     * IP address literals are matched only against iPAddress SAN entries, via
+     * wolfSSL_X509_check_ip_asc(). They are never matched against the Subject
+     * CommonName or a dNSName SAN, as required by RFC 6125 and RFC 2818. Host
+     * names use wolfSSL_X509_check_host(), which matches dNSName SANs with a
+     * CN fallback.
+     *
+     * @param peerCert peer certificate to check against
+     * @param name reference identity (host name or IP literal) to verify
+     * @param flags checkHost flags, applied only to host name matching
+     *
+     * @return WolfSSL.SSL_SUCCESS on match, otherwise WolfSSL.SSL_FAILURE
+     */
+    protected static int verifyHostnameOrIp(WolfSSLCertificate peerCert,
+        String name, long flags) {
+
+        if (peerCert == null || name == null) {
+            return WolfSSL.SSL_FAILURE;
+        }
+
+        if (isIpAddress(name)) {
+            /* Match against iPAddress SANs using the bracket-free form. A
+             * cert stores IPv6 addresses without the "[...]" brackets that
+             * can wrap an IPv6 literal in a URL or host:port string. */
+            return peerCert.checkIpAddress(stripIpv6Brackets(name));
+        }
+
+        return peerCert.checkHost(name, flags);
+    }
+
+    /**
+     * Return true if the given string is an IPv4 or IPv6 address literal.
+     *
+     * Does not perform DNS resolution. Used to route IP reference identities
+     * to iPAddress SAN matching, since a host name and an IP literal are
+     * verified against different certificate fields (RFC 6125).
+     *
+     * @param host string to test, may be null
+     *
+     * @return true if host is an IP address literal, otherwise false
+     */
+    protected static boolean isIpAddress(String host) {
+
+        String h;
+
+        if (host == null || host.isEmpty()) {
+            return false;
+        }
+
+        h = stripIpv6Brackets(host);
+
+        /* A DNS host name never contains ':', so any ':' means IPv6 literal. */
+        if (h.indexOf(':') != -1) {
+            return true;
+        }
+
+        return isIPv4Literal(h);
+    }
+
+    /**
+     * Strip surrounding "[...]" brackets from an IPv6 address literal, ex:
+     * "[::1]" becomes "::1". Returns the input unchanged if not bracketed.
+     * A certificate stores IPv6 iPAddress SANs without brackets, so they must
+     * be removed before matching an IP reference identity against the cert.
+     *
+     * @param host string to strip, may be null
+     *
+     * @return host with any surrounding IPv6 brackets removed
+     */
+    private static String stripIpv6Brackets(String host) {
+
+        boolean bracketed;
+
+        if (host == null || host.length() < 2) {
+            return host;
+        }
+
+        bracketed = (host.charAt(0) == '[') &&
+            (host.charAt(host.length() - 1) == ']');
+
+        if (bracketed) {
+            return host.substring(1, host.length() - 1);
+        }
+
+        return host;
+    }
+
+    /**
+     * Return true if the given string is a strict IPv4 dotted-quad literal,
+     * meaning four octets each in the range 0 to 255.
+     *
+     * @param s string to test
+     *
+     * @return true if s is an IPv4 literal, otherwise false
+     */
+    private static boolean isIPv4Literal(String s) {
+
+        int octets = 0;
+        int start = 0;
+        int len = s.length();
+
+        for (int i = 0; i <= len; i++) {
+            if (i == len || s.charAt(i) == '.') {
+                int fieldLen = i - start;
+                int val = 0;
+
+                if (fieldLen < 1 || fieldLen > 3) {
+                    return false;
+                }
+                for (int j = start; j < i; j++) {
+                    char c = s.charAt(j);
+                    if (c < '0' || c > '9') {
+                        return false;
+                    }
+                    val = (val * 10) + (c - '0');
+                }
+                if (val > 255) {
+                    return false;
+                }
+                octets++;
+                start = i + 1;
+            }
+        }
+
+        return (octets == 4);
+    }
 }
 

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLJSSETestSuite.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLJSSETestSuite.java
@@ -41,6 +41,7 @@ import org.junit.runners.Suite;
     WolfSSLServiceLoaderTest.class,
     WolfSSLParametersPskTest.class,
     WolfSSLNamedGroupsTest.class,
+    WolfSSLUtilTest.class,
     WolfSSLPQCKeyExchangeTest.class,
     WolfSSLPQCAuthenticationTest.class,
     WolfSSLPQCAuthKeyStoreTest.class,

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
@@ -2572,6 +2572,144 @@ public class WolfSSLSocketTest {
         }
     }
 
+    /* Two host labels whose "host"+"port" String.hashCode() collides must not
+     * share a client session cache slot. Otherwise one host could resume or
+     * evict another host's cached session. */
+    @Test
+    public void testSessionResumptionHostKeyedNoHashCollision()
+        throws Exception {
+
+        byte[] sessionIdAa = null;
+        byte[] sessionIdColliding = null;
+        byte[] sessionIdAaResume = null;
+        String protocol = null;
+
+        /* TLS 1.2/1.1/1.0 resume via session ID or ticket. TLS 1.3 is
+         * excluded here for the same reason as testSessionResumption(). */
+        if (WolfSSL.TLSv12Enabled()) {
+            protocol = "TLSv1.2";
+        } else if (WolfSSL.TLSv11Enabled()) {
+            protocol = "TLSv1.1";
+        } else if (WolfSSL.TLSv1Enabled()) {
+            protocol = "TLSv1.0";
+        }
+        Assume.assumeNotNull(protocol);
+
+        /* "Aa" and "BB" both contribute 2112 to String.hashCode(), so
+         * "Aa.corp.internal"+port and "BB.corp.internal"+port collide in
+         * hashCode() while differing as Strings. Both resolve to loopback via
+         * getByAddress() so the TCP connection reaches the local test server,
+         * while the hostname label used for the cache key stays distinct. */
+        byte[] loopback = new byte[]{127, 0, 0, 1};
+        InetAddress hostAa =
+            InetAddress.getByAddress("Aa.corp.internal", loopback);
+        InetAddress hostBb =
+            InetAddress.getByAddress("BB.corp.internal", loopback);
+
+        /* Make sure client session cache is enabled for this test. */
+        String originalProp = Security.getProperty(
+            "wolfjsse.clientSessionCache.disabled");
+        Security.setProperty("wolfjsse.clientSessionCache.disabled", "false");
+
+        SSLServerSocket ss = null;
+        ExecutorService es = null;
+        Future<Void> serverFuture = null;
+
+        try {
+            this.ctx = tf.createSSLContext(protocol, ctxProvider);
+
+            ss = (SSLServerSocket)ctx.getServerSocketFactory()
+                    .createServerSocket(0);
+            final int port = ss.getLocalPort();
+            final SSLServerSocket fss = ss;
+
+            SSLSocketFactory cliFactory = ctx.getSocketFactory();
+
+            /* Server accepts three sequential handshakes. */
+            es = Executors.newSingleThreadExecutor();
+            serverFuture = es.submit(new Callable<Void>() {
+                @Override
+                public Void call() throws Exception {
+                    try {
+                        for (int i = 0; i < 3; i++) {
+                            SSLSocket server = (SSLSocket)fss.accept();
+                            server.startHandshake();
+                            server.close();
+                        }
+                    } catch (SSLException e) {
+                        fail();
+                    }
+                    return null;
+                }
+            });
+
+            try {
+                /* #1: host label "Aa...", full handshake, gets cached. */
+                SSLSocket cs = (SSLSocket)cliFactory.createSocket();
+                cs.connect(new InetSocketAddress(hostAa, port));
+                cs.startHandshake();
+                sessionIdAa = cs.getSession().getId();
+                cs.close();
+
+                /* #2: colliding host label "BB...". Must not resume or evict
+                 * Aa's cached session even though "BB..."+port and
+                 * "Aa..."+port share a 32-bit hashCode. */
+                cs = (SSLSocket)cliFactory.createSocket();
+                cs.connect(new InetSocketAddress(hostBb, port));
+                cs.startHandshake();
+                sessionIdColliding = cs.getSession().getId();
+                cs.close();
+
+                /* #3: reconnect "Aa...". Its cached session must still be
+                 * present (not evicted by BB) and resume. */
+                cs = (SSLSocket)cliFactory.createSocket();
+                cs.connect(new InetSocketAddress(hostAa, port));
+                cs.startHandshake();
+                sessionIdAaResume = cs.getSession().getId();
+                cs.close();
+
+            } catch (SSLHandshakeException e) {
+                fail();
+            }
+
+            /* Surface any server-thread failure, bounded so a stuck server
+             * cannot hang the suite. */
+            serverFuture.get(10, TimeUnit.SECONDS);
+
+            /* Colliding host must get its own session, not Aa's. */
+            if (Arrays.equals(sessionIdAa, sessionIdColliding)) {
+                fail("colliding host resumed victim host's session");
+            }
+
+            /* Same host still resumes, so the String key does not break
+             * legitimate resumption and BB did not evict Aa's entry. */
+            if (!Arrays.equals(sessionIdAa, sessionIdAaResume)) {
+                fail("same host failed to resume after colliding host connect");
+            }
+
+        } finally {
+            /* Close the server socket first so any pending accept() unblocks,
+             * then tear down the executor. Runs on every path so a failure
+             * cannot leave threads or sockets behind. */
+            if (ss != null && !ss.isClosed()) {
+                try {
+                    ss.close();
+                } catch (IOException e) {
+                    /* ignore */
+                }
+            }
+            if (serverFuture != null) {
+                serverFuture.cancel(true);
+            }
+            if (es != null) {
+                es.shutdownNow();
+            }
+            /* Restore the original property state. */
+            Security.setProperty("wolfjsse.clientSessionCache.disabled",
+                originalProp == null ? "" : originalProp);
+        }
+    }
+
     @Test
     public void testSessionResumptionSysPropDisabled() throws Exception {
 

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
@@ -2028,6 +2028,16 @@ public class WolfSSLSocketTest {
          * matched the certificate IP SAN, so this subcase confirms the
          * hostname, not the resolved IP, is what verification runs against. */
         connectHttpsAndCheckVerification("wolfssl.invalid", false);
+
+        /* IP literal matching the certificate iPAddress SAN (IP:127.0.0.1)
+         * must verify. Confirms IP reference identities are still matched
+         * against iPAddress SANs after routing them away from checkHost. */
+        connectHttpsAndCheckVerification("127.0.0.1", true);
+
+        /* IP literal not present in the certificate iPAddress SAN must fail.
+         * It must not match the DNS SAN (example.com) or the Subject CN,
+         * which is what an IP identity is forbidden from doing (RFC 6125). */
+        connectHttpsAndCheckVerification("127.0.0.2", false);
     }
 
     @Test

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLUtilTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLUtilTest.java
@@ -1,0 +1,187 @@
+/* WolfSSLUtilTest.java
+ *
+ * Copyright (C) 2006-2026 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+package com.wolfssl.provider.jsse.test;
+
+import org.junit.Test;
+import org.junit.Rule;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.rules.TestRule;
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.Method;
+import java.math.BigInteger;
+import java.util.Date;
+import java.time.Instant;
+import java.time.Duration;
+
+import com.wolfssl.WolfSSL;
+import com.wolfssl.WolfSSLCertificate;
+import com.wolfssl.WolfSSLX509Name;
+import com.wolfssl.provider.jsse.WolfSSLProvider;
+import com.wolfssl.test.TimedTestWatcher;
+import com.wolfssl.test.WolfSSLTestCommon;
+
+/**
+ * Tests for com.wolfssl.provider.jsse.WolfSSLUtil helper methods.
+ */
+public class WolfSSLUtilTest {
+
+    private static String cliKeyPubDer = "examples/certs/client-keyPub.der";
+    private static String cliKeyDer = "examples/certs/client-key.der";
+
+    @Rule
+    public TestRule testWatcher = TimedTestWatcher.create();
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        System.out.println("WolfSSLUtil Class");
+        /* Instantiate wolfJSSE, loads native wolfSSL library */
+        new WolfSSLProvider();
+
+        cliKeyPubDer = WolfSSLTestCommon.getPath(cliKeyPubDer);
+        cliKeyDer = WolfSSLTestCommon.getPath(cliKeyDer);
+    }
+
+    /* Invoke the package-private static WolfSSLUtil.isIpAddress() via
+     * reflection, since this test lives in a different package. */
+    private static boolean isIpAddress(String host) throws Exception {
+
+        Method m = com.wolfssl.provider.jsse.WolfSSLUtil.class
+            .getDeclaredMethod("isIpAddress", String.class);
+        m.setAccessible(true);
+
+        return (Boolean) m.invoke(null, host);
+    }
+
+    private static void check(String host, boolean expected) throws Exception {
+        assertEquals("isIpAddress(\"" + host + "\")", expected,
+            isIpAddress(host));
+    }
+
+    /* isIpAddress() decides whether a reference identity is matched against
+     * iPAddress SANs (IP literal) or dNSName SANs and the CN (host name). */
+    @Test
+    public void test_isIpAddress() throws Exception {
+
+        /* IPv4 literals */
+        check("192.0.2.1", true);
+        check("127.0.0.1", true);
+        check("255.255.255.255", true);
+        check("0.0.0.0", true);
+
+        /* IPv6 literals, plain and bracketed */
+        check("::1", true);
+        check("2001:db8::1", true);
+        check("[::1]", true);
+        check("fe80::1", true);
+
+        /* Host names, must not be treated as IP literals */
+        check("example.com", false);
+        check("wolfssl.com", false);
+        check("localhost", false);
+        check("host-1.example.org", false);
+
+        /* Not valid IPv4 dotted-quads, treated as host names */
+        check("192.0.2", false);
+        check("192.0.2.1.5", false);
+        check("256.0.0.1", false);
+        check("192.0.2.x", false);
+        check("192.0.2.", false);
+
+        /* null and empty */
+        check(null, false);
+        check("", false);
+    }
+
+    /* Invoke the package-private static WolfSSLUtil.verifyHostnameOrIp() via
+     * reflection. */
+    private static int verifyHostnameOrIp(WolfSSLCertificate cert, String name,
+        long flags) throws Exception {
+
+        Method m = com.wolfssl.provider.jsse.WolfSSLUtil.class
+            .getDeclaredMethod("verifyHostnameOrIp",
+                WolfSSLCertificate.class, String.class, long.class);
+        m.setAccessible(true);
+
+        return (Integer) m.invoke(null, cert, name, flags);
+    }
+
+    /* Generate a certificate with a single IPv6 iPAddress SAN. */
+    private static byte[] genIpv6SanCert(String sanIp) throws Exception {
+
+        WolfSSLCertificate x509 = new WolfSSLCertificate();
+        WolfSSLX509Name name = new WolfSSLX509Name();
+
+        Instant now = Instant.now();
+        x509.setNotBefore(Date.from(now));
+        x509.setNotAfter(Date.from(now.plus(Duration.ofDays(365))));
+        x509.setSerialNumber(BigInteger.valueOf(4321));
+
+        name.setCountryName("US");
+        name.setOrganizationName("wolfSSL Inc.");
+        name.setCommonName("wolfssl.com");
+        x509.setSubjectName(name);
+
+        x509.setPublicKey(cliKeyPubDer, WolfSSL.RSAk,
+            WolfSSL.SSL_FILETYPE_ASN1);
+        x509.addAltName(sanIp, WolfSSL.ASN_IP_TYPE);
+        x509.signCert(cliKeyDer, WolfSSL.RSAk,
+            WolfSSL.SSL_FILETYPE_ASN1, "SHA256");
+
+        byte[] der = x509.getDer();
+        name.free();
+        x509.free();
+
+        return der;
+    }
+
+    /* verifyHostnameOrIp() must strip surrounding IPv6 brackets before
+     * matching, so a bracketed literal like "[::1]" still matches a cert whose
+     * iPAddress SAN stores the address without brackets. Native wolfSSL
+     * normalizes IPv6 text forms internally, so only the brackets need
+     * removing at the Java layer. */
+    @Test
+    public void test_verifyHostnameOrIp_ipv6Brackets() throws Exception {
+
+        Assume.assumeTrue(WolfSSL.FileSystemEnabled());
+
+        /* Generating an IPv6 iPAddress SAN via wolfSSL_X509_add_altname()
+         * requires wolfSSL 5.9.2 or later. The bracket-stripping fix itself is
+         * version independent, but this test's cert generation is not. */
+        Assume.assumeTrue(WolfSSL.getLibVersionHex() >= 0x05009002L);
+
+        byte[] der = genIpv6SanCert("::1");
+        WolfSSLCertificate cert = new WolfSSLCertificate(der);
+        try {
+            assertEquals("bracketed IPv6 must match iPAddress SAN",
+                WolfSSL.SSL_SUCCESS, verifyHostnameOrIp(cert, "[::1]", 0));
+            assertEquals("bare IPv6 must match iPAddress SAN",
+                WolfSSL.SSL_SUCCESS, verifyHostnameOrIp(cert, "::1", 0));
+            assertEquals("non-matching IPv6 must be rejected",
+                WolfSSL.SSL_FAILURE,
+                verifyHostnameOrIp(cert, "[2001:db8::1]", 0));
+        } finally {
+            cert.free();
+        }
+    }
+}

--- a/src/test/com/wolfssl/test/WolfSSLCertificateTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLCertificateTest.java
@@ -797,6 +797,90 @@ public class WolfSSLCertificateTest {
         }
     }
 
+    /* Generate a self-signed cert with the given CN and an optional single
+     * SubjectAltName entry, return its DER encoding. */
+    private byte[] genIpTestCertDer(String cn, String sanValue, int sanType)
+        throws WolfSSLException, WolfSSLJNIException, IOException {
+
+        WolfSSLCertificate x509 = new WolfSSLCertificate();
+        WolfSSLX509Name name = new WolfSSLX509Name();
+
+        Instant now = Instant.now();
+        x509.setNotBefore(Date.from(now));
+        x509.setNotAfter(Date.from(now.plus(Duration.ofDays(365))));
+        x509.setSerialNumber(BigInteger.valueOf(1122));
+
+        name.setCountryName("US");
+        name.setOrganizationName("wolfSSL Inc.");
+        name.setCommonName(cn);
+        x509.setSubjectName(name);
+
+        x509.setPublicKey(cliKeyPubDer, WolfSSL.RSAk,
+            WolfSSL.SSL_FILETYPE_ASN1);
+
+        if (sanValue != null) {
+            x509.addAltName(sanValue, sanType);
+        }
+
+        x509.signCert(cliKeyDer, WolfSSL.RSAk,
+            WolfSSL.SSL_FILETYPE_ASN1, "SHA256");
+
+        byte[] der = x509.getDer();
+
+        name.free();
+        x509.free();
+
+        return der;
+    }
+
+    /* An IP address reference identity must be matched only against an
+     * iPAddress SAN, never the Subject CN or a dNSName SAN (RFC 6125 /
+     * RFC 2818). checkIpAddress() must reject a cert whose only "match" is a
+     * CN equal to the IP or a dNSName SAN holding the IP as text, and accept
+     * a cert with a real iPAddress SAN. wolfSSL_X509_check_host() would accept
+     * the first two by CN or dNSName fallback, which is why IP identities use
+     * checkIpAddress() instead. */
+    @Test
+    public void test_checkIpAddress()
+        throws WolfSSLException, WolfSSLJNIException, IOException {
+
+        Assume.assumeTrue(WolfSSL.FileSystemEnabled());
+
+        /* The strict "IP identity never falls back to the Subject CN"
+         * behavior that checkIpAddress() relies on was added to native
+         * wolfSSL_X509_check_ip_asc() in wolfSSL 5.9.2. On older versions a
+         * CN=IP cert with no SAN still matches by CN. Cross-version IP
+         * matching is covered by the endpoint-identification test. */
+        Assume.assumeTrue(WolfSSL.getLibVersionHex() >= 0x05009002L);
+
+        final String ip = "192.0.2.1";
+
+        /* Case A: CN = IP, no SAN. Must be rejected (no CN fallback). */
+        byte[] derA = genIpTestCertDer(ip, null, 0);
+        WolfSSLCertificate certA = new WolfSSLCertificate(derA);
+        assertEquals("CN=IP with no SAN must not match by IP",
+            WolfSSL.SSL_FAILURE, certA.checkIpAddress(ip));
+        certA.free();
+
+        /* Case B: dNSName SAN = IP text. Must be rejected (a dNSName is not
+         * an iPAddress SAN). */
+        byte[] derB = genIpTestCertDer("wolfssl.com", ip, WolfSSL.ASN_DNS_TYPE);
+        WolfSSLCertificate certB = new WolfSSLCertificate(derB);
+        assertEquals("dNSName SAN holding an IP string must not match by IP",
+            WolfSSL.SSL_FAILURE, certB.checkIpAddress(ip));
+        certB.free();
+
+        /* Case C: iPAddress SAN = IP. Must be accepted, and a different IP
+         * must not match. */
+        byte[] derC = genIpTestCertDer("wolfssl.com", ip, WolfSSL.ASN_IP_TYPE);
+        WolfSSLCertificate certC = new WolfSSLCertificate(derC);
+        assertEquals("iPAddress SAN must match by IP",
+            WolfSSL.SSL_SUCCESS, certC.checkIpAddress(ip));
+        assertEquals("non-matching IP must be rejected",
+            WolfSSL.SSL_FAILURE, certC.checkIpAddress("198.51.100.9"));
+        certC.free();
+    }
+
     @Test
     public void testWolfSSLCertificateExtensionSetters()
         throws WolfSSLException, WolfSSLJNIException, IOException,

--- a/src/test/com/wolfssl/test/WolfSSLSessionTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLSessionTest.java
@@ -59,6 +59,7 @@ import com.wolfssl.WolfSSLPskClientCallback;
 import com.wolfssl.WolfSSLPskServerCallback;
 import com.wolfssl.WolfSSLTls13SecretCallback;
 import com.wolfssl.WolfSSLSession;
+import com.wolfssl.WolfSSLVerifyCallback;
 import com.wolfssl.WolfSSLByteBufferIORecvCallback;
 import com.wolfssl.WolfSSLByteBufferIOSendCallback;
 
@@ -4435,6 +4436,270 @@ public class WolfSSLSessionTest {
             }
             if (ctx != null) {
                 ctx.free();
+            }
+        }
+    }
+
+    /* Verify callback, one Java object (and JNI global ref) per instance, used
+     * to exercise the session-level setVerify() ref lifecycle. */
+    private static class CountingVerifyCb implements WolfSSLVerifyCallback {
+        public volatile int calls = 0;
+        public int verifyCallback(int preverify_ok, long x509StorePtr) {
+            calls++;
+            return preverify_ok;
+        }
+    }
+
+    /* Walks setVerify() install/replace/null/re-install on one session, then
+     * frees and forces GC to surface dangling-ref issues under checked JNI.
+     * No handshake, validates only the setVerify() ref bookkeeping. */
+    @Test
+    public void test_WolfSSLSession_setVerifyRefLifecycle()
+        throws WolfSSLException, WolfSSLJNIException, Exception {
+
+        WolfSSLContext localCtx = null;
+        WolfSSLSession ssl = null;
+        CountingVerifyCb cb1 = new CountingVerifyCb();
+        CountingVerifyCb cb2 = new CountingVerifyCb();
+        CountingVerifyCb cb3 = new CountingVerifyCb();
+
+        localCtx = createAndSetupWolfSSLContext(cliCert, cliKey,
+            WolfSSL.SSL_FILETYPE_PEM, caCert,
+            WolfSSL.SSLv23_ClientMethod());
+
+        try {
+            ssl = new WolfSSLSession(localCtx);
+
+            /* Install initial callback. */
+            ssl.setVerify(WolfSSL.SSL_VERIFY_PEER, cb1);
+
+            /* Replace, exercises the prior-ref release path. */
+            ssl.setVerify(WolfSSL.SSL_VERIFY_PEER, cb2);
+
+            /* Unregister the callback (null path). */
+            ssl.setVerify(WolfSSL.SSL_VERIFY_PEER, null);
+
+            /* Re-install after the null pass. */
+            ssl.setVerify(WolfSSL.SSL_VERIFY_PEER, cb3);
+
+            /* Encourage GC of the replaced callback objects. */
+            System.gc();
+
+            /* Keep callbacks strongly reachable to end of test. */
+            assertNotNull(cb1);
+            assertNotNull(cb2);
+            assertNotNull(cb3);
+
+        } finally {
+            if (ssl != null) {
+                ssl.freeSSL();
+            }
+            if (localCtx != null) {
+                localCtx.free();
+            }
+        }
+    }
+
+    /* Concurrency smoke test: many threads run setVerify()/freeSSL() cycles on
+     * their own sessions, contending on the global verify callback mutex.
+     * Checks locked paths are deadlock-free and ref-safe under sanitizers. */
+    @Test
+    public void test_WolfSSLSession_setVerifyConcurrentLifecycle()
+        throws WolfSSLException, WolfSSLJNIException, Exception {
+
+        final int numThreads = 8;
+        final int iterations = 200;
+
+        ExecutorService es = Executors.newFixedThreadPool(numThreads);
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        Future<?>[] futures = new Future<?>[numThreads];
+
+        try {
+            for (int t = 0; t < numThreads; t++) {
+                futures[t] = es.submit(new Callable<Void>() {
+                    @Override
+                    public Void call() throws Exception {
+                        WolfSSLContext threadCtx =
+                            createAndSetupWolfSSLContext(cliCert, cliKey,
+                                WolfSSL.SSL_FILETYPE_PEM, caCert,
+                                WolfSSL.SSLv23_ClientMethod());
+                        try {
+                            /* Release all threads together for contention. */
+                            startLatch.await();
+                            for (int i = 0; i < iterations; i++) {
+                                WolfSSLSession ssl =
+                                    new WolfSSLSession(threadCtx);
+                                try {
+                                    ssl.setVerify(WolfSSL.SSL_VERIFY_PEER,
+                                        new CountingVerifyCb());
+                                    ssl.setVerify(WolfSSL.SSL_VERIFY_PEER,
+                                        new CountingVerifyCb());
+                                    ssl.setVerify(WolfSSL.SSL_VERIFY_PEER,
+                                        null);
+                                    ssl.setVerify(WolfSSL.SSL_VERIFY_PEER,
+                                        new CountingVerifyCb());
+                                } finally {
+                                    ssl.freeSSL();
+                                }
+                            }
+                        } finally {
+                            threadCtx.free();
+                        }
+                        return null;
+                    }
+                });
+            }
+
+            startLatch.countDown();
+
+            for (Future<?> f : futures) {
+                f.get(60, TimeUnit.SECONDS);
+            }
+
+        } finally {
+            es.shutdownNow();
+            try {
+                es.awaitTermination(5, TimeUnit.SECONDS);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    /* Test TLS 1.2 handshake with a session-level verify callback confirms the
+     * callback fires (via the NewLocalRef promotion) and verify succeeds. */
+    @Test
+    public void test_WolfSSLSession_setVerifyHandshakeCallback()
+        throws WolfSSLException, WolfSSLJNIException, Exception {
+
+        Assume.assumeTrue(WolfSSL.RsaEnabled() && WolfSSL.FileSystemEnabled());
+        Assume.assumeTrue(WolfSSL.TLSv12Enabled());
+
+        int ret;
+        int err;
+        Socket cliSock = null;
+        WolfSSLSession ssl = null;
+        final CountingVerifyCb cliVerifyCb = new CountingVerifyCb();
+
+        WolfSSLContext srvCtx = null;
+        WolfSSLContext cliCtx = null;
+        ServerSocket srvSocket = null;
+        ExecutorService es = null;
+        Future<Void> srvFuture = null;
+
+        try {
+            srvSocket = new ServerSocket(0);
+            final int port = srvSocket.getLocalPort();
+
+            srvCtx = createAndSetupWolfSSLContext(srvCert, srvKey,
+                WolfSSL.SSL_FILETYPE_PEM, cliCert,
+                WolfSSL.TLSv1_2_ServerMethod());
+            cliCtx = createAndSetupWolfSSLContext(cliCert, cliKey,
+                WolfSSL.SSL_FILETYPE_PEM, caCert,
+                WolfSSL.TLSv1_2_ClientMethod());
+
+            es = Executors.newSingleThreadExecutor();
+
+            final ServerSocket fSrvSock = srvSocket;
+            final WolfSSLContext fSrvCtx = srvCtx;
+            srvFuture = es.submit(new Callable<Void>() {
+                @Override
+                public Void call() throws Exception {
+                    int sret;
+                    int serr;
+                    Socket server = null;
+                    WolfSSLSession srvSes = null;
+                    try {
+                        server = fSrvSock.accept();
+                        srvSes = new WolfSSLSession(fSrvCtx);
+
+                        sret = srvSes.setFd(server);
+                        if (sret != WolfSSL.SSL_SUCCESS) {
+                            throw new Exception(
+                                "server setFd() failed: " + sret);
+                        }
+
+                        do {
+                            sret = srvSes.accept();
+                            serr = srvSes.getError(sret);
+                        } while (sret != WolfSSL.SSL_SUCCESS &&
+                                 (serr == WolfSSL.SSL_ERROR_WANT_READ ||
+                                  serr == WolfSSL.SSL_ERROR_WANT_WRITE));
+
+                        if (sret != WolfSSL.SSL_SUCCESS) {
+                            throw new Exception(
+                                "server accept() failed: " + sret);
+                        }
+
+                        srvSes.shutdownSSL();
+                    } finally {
+                        if (srvSes != null) {
+                            srvSes.freeSSL();
+                        }
+                        if (server != null) {
+                            server.close();
+                        }
+                    }
+                    return null;
+                }
+            });
+
+            cliSock = new Socket("localhost", port);
+            ssl = new WolfSSLSession(cliCtx);
+
+            ret = ssl.setFd(cliSock);
+            if (ret != WolfSSL.SSL_SUCCESS) {
+                throw new Exception("client setFd() failed: " + ret);
+            }
+
+            /* Register verify callback at the session level. */
+            ssl.setVerify(WolfSSL.SSL_VERIFY_PEER, cliVerifyCb);
+
+            do {
+                ret = ssl.connect();
+                err = ssl.getError(ret);
+            } while (ret != WolfSSL.SSL_SUCCESS &&
+                     (err == WolfSSL.SSL_ERROR_WANT_READ ||
+                      err == WolfSSL.SSL_ERROR_WANT_WRITE));
+
+            if (ret != WolfSSL.SSL_SUCCESS) {
+                throw new Exception("client connect() failed: " + ret);
+            }
+
+            /* Callback must have fired during the handshake. */
+            assertTrue("session verify callback did not fire",
+                cliVerifyCb.calls > 0);
+
+            ssl.shutdownSSL();
+
+            srvFuture.get(10, TimeUnit.SECONDS);
+
+        } finally {
+            if (ssl != null) {
+                ssl.freeSSL();
+            }
+            if (cliSock != null) {
+                cliSock.close();
+            }
+            if (srvSocket != null && !srvSocket.isClosed()) {
+                srvSocket.close();
+            }
+            if (srvFuture != null) {
+                srvFuture.cancel(true);
+            }
+            if (es != null) {
+                es.shutdownNow();
+                try {
+                    es.awaitTermination(5, TimeUnit.SECONDS);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            if (cliCtx != null) {
+                cliCtx.free();
+            }
+            if (srvCtx != null) {
+                srvCtx.free();
             }
         }
     }


### PR DESCRIPTION
This PR includes four Fenrir fixes:

- **F-4310**: Serialize the session-level verify callback's global reference with the existing verify-callback mutex, and promote it to a local ref before invoking the Java callback. Prevents the reference from being freed by a concurrent `setVerify()` while a callback is in progress.

- **F-4311**: Key the client-side session cache on a `host:port` String instead of a 32-bit `String.hashCode()`. Distinct hosts no longer collide into the same cache slot, so one host cannot read or evict another host's cached session.

- **F-4312**: Free the ALPN peer-protocol buffer on the allocation-failure path in `NativeALPNSelectCb`, matching the other error paths in the same function.

- **F-4852**: Match IP address peer identities against `iPAddress` SAN entries only, via a new `wolfSSL_X509_check_ip_asc` binding. IP literals no longer fall back to the Subject CN or a `dNSName`, aligning wolfJSSE with SunJSSE and RFC 6125.