### PR TITLE
Handle NO_DH builds in min key size setters

### DIFF
--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -1079,6 +1079,19 @@ JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_RsaEnabled
 #endif
 }
 
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_DhEnabled
+  (JNIEnv* jenv, jclass jcl)
+{
+    (void)jenv;
+    (void)jcl;
+
+#ifndef NO_DH
+    return JNI_TRUE;
+#else
+    return JNI_FALSE;
+#endif
+}
+
 JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_RsaPssEnabled
   (JNIEnv* jenv, jclass jcl)
 {

--- a/native/com_wolfssl_WolfSSL.h
+++ b/native/com_wolfssl_WolfSSL.h
@@ -847,6 +847,14 @@ JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_RsaEnabled
 
 /*
  * Class:     com_wolfssl_WolfSSL
+ * Method:    DhEnabled
+ * Signature: ()Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_wolfssl_WolfSSL_DhEnabled
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_wolfssl_WolfSSL
  * Method:    RsaPssEnabled
  * Signature: ()Z
  */

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -1128,6 +1128,13 @@ public class WolfSSL {
     public static native boolean RsaEnabled();
 
     /**
+     * Tests if DH support has been compiled into the native wolfSSL library.
+     *
+     * @return true if enabled, otherwise false if not compiled in.
+     */
+    public static native boolean DhEnabled();
+
+    /**
      * Tests if RSA_PSS support has been compiled into the native wolfSSL
      * library.
      *

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLContext.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLContext.java
@@ -270,28 +270,46 @@ public class WolfSSLContext extends SSLContextSpi {
     private void enforceKeySizeLimitations() throws WolfSSLException {
 
         int minKeySize = 0;
-        int ret = 0;
 
         minKeySize = WolfSSLUtil.getDisabledAlgorithmsKeySizeLimit("RSA");
-        ret = this.ctx.setMinRSAKeySize(minKeySize);
-        if (ret != WolfSSL.SSL_SUCCESS) {
-            throw new WolfSSLException(
-                "Error setting SSLContext min RSA key size");
-        }
+        checkMinKeySizeResult("RSA", this.ctx.setMinRSAKeySize(minKeySize));
 
         minKeySize = WolfSSLUtil.getDisabledAlgorithmsKeySizeLimit("EC");
-        ret = this.ctx.setMinECCKeySize(minKeySize);
-        if (ret != WolfSSL.SSL_SUCCESS) {
-            throw new WolfSSLException(
-                "Error setting SSLContext min ECC key size");
-        }
+        checkMinKeySizeResult("ECC", this.ctx.setMinECCKeySize(minKeySize));
 
         minKeySize = WolfSSLUtil.getDisabledAlgorithmsKeySizeLimit("DH");
-        ret = this.ctx.setMinDHKeySize(minKeySize);
-        if (ret != WolfSSL.SSL_SUCCESS) {
-            throw new WolfSSLException(
-                "Error setting SSLContext min DH key size");
+        checkMinKeySizeResult("DH", this.ctx.setMinDHKeySize(minKeySize));
+    }
+
+    /**
+     * Check the return value from a native setMin*KeySize() call.
+     *
+     * NOT_COMPILED_IN means the algorithm is not compiled into the native
+     * wolfSSL library (ex: NO_DH in a FIPS build), so there is no key
+     * exchange of that type to restrict and no minimum to set. That is not
+     * an error.
+     *
+     * @param algo algorithm name for the error message (RSA, ECC, or DH)
+     * @param ret return value from the native setMin*KeySize() call
+     *
+     * @throws WolfSSLException if the minimum key size failed to set
+     */
+    private void checkMinKeySizeResult(String algo, int ret)
+        throws WolfSSLException {
+
+        if (ret == WolfSSL.SSL_SUCCESS) {
+            return;
         }
+
+        if (ret == WolfSSL.NOT_COMPILED_IN) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
+                () -> algo + " not compiled into native wolfSSL, no min " +
+                "key size to set");
+            return;
+        }
+
+        throw new WolfSSLException(
+            "Error setting SSLContext min " + algo + " key size");
     }
 
     private void LoadTrustedRootCerts() {

--- a/src/test/com/wolfssl/test/WolfSSLContextTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLContextTest.java
@@ -652,6 +652,13 @@ public class WolfSSLContextTest {
 
         int ret = 0;
 
+        /* If DH is not compiled into native wolfSSL (ex: FIPS NO_DH),
+         * setMinDHKeySize() returns NOT_COMPILED_IN in that case */
+        if (!WolfSSL.DhEnabled()) {
+            assertEquals(WolfSSL.NOT_COMPILED_IN, ctx.setMinDHKeySize(1024));
+            return;
+        }
+
         try {
             /* key length > 16000 should fail */
             ret = ctx.setMinDHKeySize(17000);


### PR DESCRIPTION
This PR fixes `ant test` failures against FIPS Ready builds, which now define `NO_DH`.

wolfSSL commit `b4a932684` ("configure.ac: fix DH dependencies for FIPS v7 (implicit --disable-dh)") from https://github.com/wolfSSL/wolfssl/pull/10920 makes FIPS Ready builds implicitly disable DH. With `NO_DH`, the JNI `setMinDhKeySz` binding returns `NOT_COMPILED_IN` (-174), causing two failures.