### PR TITLE
Reduce PR workflow time and runner usage

### DIFF
--- a/.github/actions/setup-junit/action.yml
+++ b/.github/actions/setup-junit/action.yml
@@ -1,0 +1,38 @@
+name: 'Setup JUnit'
+description: 'Cache and download the JUnit jars used by ant test, verify
+  their checksums, and export JUNIT_HOME'
+
+# shasum is used instead of sha256sum because it is available on both
+# the Linux and macOS hosted runners.
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Cache JUnit dependencies
+      id: cache-junit
+      uses: actions/cache@v4
+      with:
+        path: junit
+        key: junit-jars-v1
+
+    - name: Download junit-4.13.2.jar
+      if: steps.cache-junit.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        wget --directory-prefix=$GITHUB_WORKSPACE/junit \
+          https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar
+        echo "8e495b634469d64fb8acfa3495a065cbacc8a0fff55ce1e31007be4c16dc57d3  $GITHUB_WORKSPACE/junit/junit-4.13.2.jar" \
+          | shasum -a 256 -c -
+
+    - name: Download hamcrest-all-1.3.jar
+      if: steps.cache-junit.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        wget --directory-prefix=$GITHUB_WORKSPACE/junit \
+          https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
+        echo "4877670629ab96f34f5f90ab283125fcd9acb7e683e66319a68be6eb2cca60de  $GITHUB_WORKSPACE/junit/hamcrest-all-1.3.jar" \
+          | shasum -a 256 -c -
+
+    - name: Set JUNIT_HOME
+      shell: bash
+      run: echo "JUNIT_HOME=$GITHUB_WORKSPACE/junit" >> "$GITHUB_ENV"

--- a/.github/workflows/address-sanitizer.yml
+++ b/.github/workflows/address-sanitizer.yml
@@ -19,6 +19,13 @@ on:
 jobs:
   build_wolfssljni_asan:
     runs-on: ${{ inputs.os }}
+    # Full effective wolfSSL configure string, defined once so the
+    # build step and the cache key below cannot drift apart.
+    env:
+      WOLFSSL_CONFIGURE: >-
+        ${{ inputs.wolfssl_configure }}
+        CFLAGS="-fsanitize=address -fno-omit-frame-pointer"
+        LDFLAGS="-fsanitize=address"
     steps:
       - uses: actions/checkout@v4
 
@@ -36,15 +43,48 @@ jobs:
         if: steps.cache-junit.outputs.cache-hit != 'true'
         run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
 
+      # Cache the installed wolfSSL build, keyed on the full configure
+      # string (including sanitizer flags), wolfSSL commit and OS/arch.
+      - name: Resolve wolfSSL cache key
+        id: wolfssl-key
+        run: |
+          SHA=$(git ls-remote https://github.com/wolfSSL/wolfssl.git \
+            refs/heads/master | cut -f1)
+          if [ -z "$SHA" ]; then
+            echo "Failed to resolve wolfSSL master SHA" >&2
+            exit 1
+          fi
+          CFG_HASH=$(printf '%s' "$WOLFSSL_CONFIGURE" | \
+            shasum -a 256 | cut -c1-16)
+          KEY="wolfssl-${{ runner.os }}-${{ runner.arch }}-$SHA-$CFG_HASH"
+          echo "key=$KEY" >> "$GITHUB_OUTPUT"
+
+      - name: Restore cached wolfSSL install
+        id: cache-wolfssl
+        uses: actions/cache/restore@v4
+        with:
+          path: build-dir
+          key: ${{ steps.wolfssl-key.outputs.key }}
+
       - name: Build native wolfSSL with AddressSanitizer
+        if: steps.cache-wolfssl.outputs.cache-hit != 'true'
         uses: wolfSSL/actions-build-autotools-project@v1
         with:
           repository: wolfSSL/wolfssl
           ref: master
           path: wolfssl
-          configure: ${{ inputs.wolfssl_configure }} CFLAGS="-fsanitize=address -fno-omit-frame-pointer" LDFLAGS="-fsanitize=address"
+          configure: ${{ env.WOLFSSL_CONFIGURE }}
           check: false
           install: true
+
+      # Save right after building (not at job end) so a later test
+      # failure does not prevent the cache from being populated.
+      - name: Save wolfSSL install to cache
+        if: steps.cache-wolfssl.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: build-dir
+          key: ${{ steps.wolfssl-key.outputs.key }}
 
       - name: Setup java
         uses: actions/setup-java@v4

--- a/.github/workflows/address-sanitizer.yml
+++ b/.github/workflows/address-sanitizer.yml
@@ -46,6 +46,7 @@ jobs:
           CFG_HASH=$(printf '%s' "$WOLFSSL_CONFIGURE" | \
             shasum -a 256 | cut -c1-16)
           KEY="wolfssl-${{ runner.os }}-${{ runner.arch }}-$SHA-$CFG_HASH"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           echo "key=$KEY" >> "$GITHUB_OUTPUT"
 
       - name: Restore cached wolfSSL install
@@ -55,12 +56,14 @@ jobs:
           path: build-dir
           key: ${{ steps.wolfssl-key.outputs.key }}
 
+      # Build the exact commit the cache key was computed from so the
+      # key and contents cannot drift if master advances mid-run.
       - name: Build native wolfSSL with AddressSanitizer
         if: steps.cache-wolfssl.outputs.cache-hit != 'true'
         uses: wolfSSL/actions-build-autotools-project@v1
         with:
           repository: wolfSSL/wolfssl
-          ref: master
+          ref: ${{ steps.wolfssl-key.outputs.sha }}
           path: wolfssl
           configure: ${{ env.WOLFSSL_CONFIGURE }}
           check: false

--- a/.github/workflows/address-sanitizer.yml
+++ b/.github/workflows/address-sanitizer.yml
@@ -29,19 +29,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache JUnit dependencies
-        uses: actions/cache@v4
-        id: cache-junit
-        with:
-          path: junit
-          key: junit-jars-v1
-
-      - name: Download junit-4.13.2.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar
-      - name: Download hamcrest-all-1.3.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
+      - name: Setup JUnit
+        uses: ./.github/actions/setup-junit
 
       # Cache the installed wolfSSL build, keyed on the full configure
       # string (including sanitizer flags), wolfSSL commit and OS/arch.
@@ -98,7 +87,6 @@ jobs:
       # This will let us catch all non-leak issues.
       - name: Set environment variables
         run: |
-          echo "JUNIT_HOME=$GITHUB_WORKSPACE/junit" >> "$GITHUB_ENV"
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/build-dir/lib" >> "$GITHUB_ENV"
           echo "ASAN_OPTIONS=detect_leaks=0:abort_on_error=1:halt_on_error=1:print_stats=1" >> "$GITHUB_ENV"
 

--- a/.github/workflows/android_gradle.yml
+++ b/.github/workflows/android_gradle.yml
@@ -7,8 +7,8 @@ on:
     branches: [ 'master' ]
 
 concurrency:
-  group: android-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  group: android-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build_wolfssljni:

--- a/.github/workflows/android_gradle_fipsready.yml
+++ b/.github/workflows/android_gradle_fipsready.yml
@@ -7,8 +7,8 @@ on:
     branches: [ 'master' ]
 
 concurrency:
-  group: android-fips-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  group: android-fips-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build_wolfssljni_fipsready:

--- a/.github/workflows/check-file-lists.yml
+++ b/.github/workflows/check-file-lists.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches: [ '*' ]
 
+# Cancel superseded in-progress runs for the same PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check-file-lists:
     runs-on: ubuntu-latest

--- a/.github/workflows/comment-style-check.yml
+++ b/.github/workflows/comment-style-check.yml
@@ -8,6 +8,11 @@ on:
       - '**/*.c'
       - '**/*.h'
 
+# Cancel superseded in-progress runs for the same PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check-comment-style:
     runs-on: ubuntu-latest

--- a/.github/workflows/fips-ready-dual-provider.yml
+++ b/.github/workflows/fips-ready-dual-provider.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [ 'master' ]
 
+# Cancel superseded in-progress runs for the same PR. Runs
+# triggered by push events are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   dual-provider-fips-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/fips-ready-dual-provider.yml
+++ b/.github/workflows/fips-ready-dual-provider.yml
@@ -33,28 +33,10 @@ jobs:
           distribution: zulu
           java-version: ${{ matrix.jdk_version }}
 
-      - name: Cache JUnit dependencies
-        uses: actions/cache@v4
-        id: cache-junit
-        with:
-          path: junit
-          key: junit-jars-v1
-
-      - name: Download junit-4.13.2.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: |
-          wget --directory-prefix=$GITHUB_WORKSPACE/junit \
-            https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar
-          echo "8e495b634469d64fb8acfa3495a065cbacc8a0fff55ce1e31007be4c16dc57d3  $GITHUB_WORKSPACE/junit/junit-4.13.2.jar" \
-            | sha256sum -c -
-
-      - name: Download hamcrest-all-1.3.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: |
-          wget --directory-prefix=$GITHUB_WORKSPACE/junit \
-            https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
-          echo "4877670629ab96f34f5f90ab283125fcd9acb7e683e66319a68be6eb2cca60de  $GITHUB_WORKSPACE/junit/hamcrest-all-1.3.jar" \
-            | sha256sum -c -
+      # wolfssljni is checked out into the wolfssljni subdirectory, so
+      # the local composite action path includes that prefix.
+      - name: Setup JUnit
+        uses: ./wolfssljni/.github/actions/setup-junit
 
       # Get latest wolfSSL stable version for FIPS Ready download URL
       - name: Get latest wolfSSL stable version
@@ -116,7 +98,6 @@ jobs:
       - name: Set library paths
         run: |
           echo "LD_LIBRARY_PATH=$GITHUB_WORKSPACE/build-dir/lib:$GITHUB_WORKSPACE/wolfssljni/lib:$GITHUB_WORKSPACE/wolfcryptjni/lib" >> "$GITHUB_ENV"
-          echo "JUNIT_HOME=$GITHUB_WORKSPACE/junit" >> "$GITHUB_ENV"
 
       # Build wolfssljni (wolfJSSE)
       - name: Build wolfssljni JNI library

--- a/.github/workflows/infer.yml
+++ b/.github/workflows/infer.yml
@@ -71,8 +71,35 @@ jobs:
         if: steps.cache-junit.outputs.cache-hit != 'true'
         run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
 
+      # Cache the installed wolfSSL build. It depends only on the wolfSSL
+      # commit, configure flags, and OS/arch, so jobs across workflows
+      # can share one build.
+      - name: Resolve wolfSSL cache key
+        id: wolfssl-key
+        env:
+          WOLFSSL_CONFIGURE: ${{ inputs.wolfssl_configure }}
+        run: |
+          SHA=$(git ls-remote https://github.com/wolfSSL/wolfssl.git \
+            refs/heads/master | cut -f1)
+          if [ -z "$SHA" ]; then
+            echo "Failed to resolve wolfSSL master SHA" >&2
+            exit 1
+          fi
+          CFG_HASH=$(printf '%s' "$WOLFSSL_CONFIGURE" | \
+            shasum -a 256 | cut -c1-16)
+          KEY="wolfssl-${{ runner.os }}-${{ runner.arch }}-$SHA-$CFG_HASH"
+          echo "key=$KEY" >> "$GITHUB_OUTPUT"
+
+      - name: Restore cached wolfSSL install
+        id: cache-wolfssl
+        uses: actions/cache/restore@v4
+        with:
+          path: build-dir
+          key: ${{ steps.wolfssl-key.outputs.key }}
+
       # Build native wolfSSL
       - name: Build native wolfSSL
+        if: steps.cache-wolfssl.outputs.cache-hit != 'true'
         uses: wolfSSL/actions-build-autotools-project@v1
         with:
           repository: wolfSSL/wolfssl
@@ -81,6 +108,15 @@ jobs:
           configure: ${{ inputs.wolfssl_configure }}
           check: false
           install: true
+
+      # Save right after building (not at job end) so a later test
+      # failure does not prevent the cache from being populated.
+      - name: Save wolfSSL install to cache
+        if: steps.cache-wolfssl.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: build-dir
+          key: ${{ steps.wolfssl-key.outputs.key }}
 
       # Setup Java
       - name: Setup java

--- a/.github/workflows/infer.yml
+++ b/.github/workflows/infer.yml
@@ -12,9 +12,6 @@ on:
       jdk_version:
         required: true
         type: string
-      wolfssl_configure:
-        required: true
-        type: string
 
 jobs:
   build_wolfssljni:
@@ -22,30 +19,66 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Infer runs javac directly over the Java sources (see
+      # scripts/infer.sh), so this job does not need native wolfSSL,
+      # the JNI library, JUnit, or the test suite. Tests for this
+      # configuration run in the main CI matrix (linux-zulu-all).
+
+      # Cache the extracted Infer release (~100MB download per run).
+      - name: Restore cached Infer
+        id: cache-infer
+        uses: actions/cache/restore@v4
+        with:
+          path: infer-*-v1.2.0
+          key: infer-v1.2.0-${{ runner.os }}-${{ runner.arch }}
+
       # Download Facebook Infer (Linux)
       - name: Download Infer (Linux)
-        if: runner.os == 'Linux'
+        if: >-
+          steps.cache-infer.outputs.cache-hit != 'true' &&
+          runner.os == 'Linux'
         run: wget https://github.com/facebook/infer/releases/download/v1.2.0/infer-linux-x86_64-v1.2.0.tar.xz
       - name: Extract Infer (Linux)
-        if: runner.os == 'Linux'
+        if: >-
+          steps.cache-infer.outputs.cache-hit != 'true' &&
+          runner.os == 'Linux'
         run: tar -xvf infer-linux-x86_64-v1.2.0.tar.xz
-      - name: Symlink Infer (Linux)
-        if: runner.os == 'Linux'
-        run: ln -s "$GITHUB_WORKSPACE/infer-linux-x86_64-v1.2.0/bin/infer" /usr/local/bin/infer
 
       # Download Facebook Infer (macOS)
       - name: Download Infer (macOS x86_64)
-        if: runner.os == 'macOS' && runner.arch == 'X64'
+        if: >-
+          steps.cache-infer.outputs.cache-hit != 'true' &&
+          runner.os == 'macOS' && runner.arch == 'X64'
         run: wget https://github.com/facebook/infer/releases/download/v1.2.0/infer-osx-x86_64-v1.2.0.tar.xz
       - name: Download Infer (macOS ARM64)
-        if: runner.os == 'macOS' && runner.arch == 'ARM64'
+        if: >-
+          steps.cache-infer.outputs.cache-hit != 'true' &&
+          runner.os == 'macOS' && runner.arch == 'ARM64'
         run: wget https://github.com/facebook/infer/releases/download/v1.2.0/infer-osx-arm64-v1.2.0.tar.xz
       - name: Extract Infer (macOS x86_64)
-        if: runner.os == 'macOS' && runner.arch == 'X64'
+        if: >-
+          steps.cache-infer.outputs.cache-hit != 'true' &&
+          runner.os == 'macOS' && runner.arch == 'X64'
         run: tar -xvf infer-osx-x86_64-v1.2.0.tar.xz
       - name: Extract Infer (macOS ARM64)
-        if: runner.os == 'macOS' && runner.arch == 'ARM64'
+        if: >-
+          steps.cache-infer.outputs.cache-hit != 'true' &&
+          runner.os == 'macOS' && runner.arch == 'ARM64'
         run: tar -xvf infer-osx-arm64-v1.2.0.tar.xz
+
+      # Save right after extracting so a failed Infer run (issues
+      # found) does not prevent the cache from being populated.
+      - name: Save Infer to cache
+        if: steps.cache-infer.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: infer-*-v1.2.0
+          key: infer-v1.2.0-${{ runner.os }}-${{ runner.arch }}
+
+      # Symlink Infer into PATH
+      - name: Symlink Infer (Linux)
+        if: runner.os == 'Linux'
+        run: ln -s "$GITHUB_WORKSPACE/infer-linux-x86_64-v1.2.0/bin/infer" /usr/local/bin/infer
       - name: Symlink Infer (macOS x86_64)
         if: runner.os == 'macOS' && runner.arch == 'X64'
         run: ln -s "$GITHUB_WORKSPACE/infer-osx-x86_64-v1.2.0/bin/infer" /usr/local/bin/infer
@@ -56,105 +89,12 @@ jobs:
       - name: Test Infer get version
         run: infer --version
 
-      # Cache and Download Junit JARs
-      - name: Cache JUnit dependencies
-        uses: actions/cache@v4
-        id: cache-junit
-        with:
-          path: junit
-          key: junit-jars-v1
-
-      - name: Download junit-4.13.2.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar
-      - name: Download hamcrest-all-1.3.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
-
-      # Cache the installed wolfSSL build. It depends only on the wolfSSL
-      # commit, configure flags, and OS/arch, so jobs across workflows
-      # can share one build.
-      - name: Resolve wolfSSL cache key
-        id: wolfssl-key
-        env:
-          WOLFSSL_CONFIGURE: ${{ inputs.wolfssl_configure }}
-        run: |
-          SHA=$(git ls-remote https://github.com/wolfSSL/wolfssl.git \
-            refs/heads/master | cut -f1)
-          if [ -z "$SHA" ]; then
-            echo "Failed to resolve wolfSSL master SHA" >&2
-            exit 1
-          fi
-          CFG_HASH=$(printf '%s' "$WOLFSSL_CONFIGURE" | \
-            shasum -a 256 | cut -c1-16)
-          KEY="wolfssl-${{ runner.os }}-${{ runner.arch }}-$SHA-$CFG_HASH"
-          echo "key=$KEY" >> "$GITHUB_OUTPUT"
-
-      - name: Restore cached wolfSSL install
-        id: cache-wolfssl
-        uses: actions/cache/restore@v4
-        with:
-          path: build-dir
-          key: ${{ steps.wolfssl-key.outputs.key }}
-
-      # Build native wolfSSL
-      - name: Build native wolfSSL
-        if: steps.cache-wolfssl.outputs.cache-hit != 'true'
-        uses: wolfSSL/actions-build-autotools-project@v1
-        with:
-          repository: wolfSSL/wolfssl
-          ref: master
-          path: wolfssl
-          configure: ${{ inputs.wolfssl_configure }}
-          check: false
-          install: true
-
-      # Save right after building (not at job end) so a later test
-      # failure does not prevent the cache from being populated.
-      - name: Save wolfSSL install to cache
-        if: steps.cache-wolfssl.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: build-dir
-          key: ${{ steps.wolfssl-key.outputs.key }}
-
       # Setup Java
       - name: Setup java
         uses: actions/setup-java@v4
         with:
           distribution: ${{ inputs.jdk_distro }}
           java-version: ${{ inputs.jdk_version }}
-
-      - name: Set JUNIT_HOME
-        run: |
-          echo "JUNIT_HOME=$GITHUB_WORKSPACE/junit" >> "$GITHUB_ENV"
-
-      - name: Set LD_LIBRARY_PATH (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/build-dir/lib" >> "$GITHUB_ENV"
-
-      - name: Set DYLD_LIBRARY_PATH (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          echo "DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$GITHUB_WORKSPACE/build-dir/lib" >> "$GITHUB_ENV"
-
-      # Build wolfssljni JNI library (libwolfssljni.so)
-      - name: Build JNI library
-        run: ./java.sh $GITHUB_WORKSPACE/build-dir
-
-      # Build wolfssljni JAR (wolfssljni.jar)
-      - name: Build JAR (ant)
-        run: ant
-
-      # Run ant tests
-      - name: Run Java tests (ant test)
-        run: ant test
-
-      - name: Show logs on failure
-        if: failure() || cancelled()
-        run: |
-          cat build/reports/*.txt
 
       # Run Facebook Infer
       - name: Run Facebook Infer
@@ -163,4 +103,3 @@ jobs:
       - name: Shows Infer report on failure
         if: failure()
         run: cat infer-out/report.txt
-

--- a/.github/workflows/java-module-test.yml
+++ b/.github/workflows/java-module-test.yml
@@ -37,7 +37,34 @@ jobs:
         if: steps.cache-junit.outputs.cache-hit != 'true'
         run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
 
+      # Cache the installed wolfSSL build. The key matches the one built
+      # in linux-common.yml for the same configure flags, so this job
+      # shares the cache with the main CI matrix.
+      - name: Resolve wolfSSL cache key
+        id: wolfssl-key
+        env:
+          WOLFSSL_CONFIGURE: '--enable-jni'
+        run: |
+          SHA=$(git ls-remote https://github.com/wolfSSL/wolfssl.git \
+            refs/heads/master | cut -f1)
+          if [ -z "$SHA" ]; then
+            echo "Failed to resolve wolfSSL master SHA" >&2
+            exit 1
+          fi
+          CFG_HASH=$(printf '%s' "$WOLFSSL_CONFIGURE" | \
+            shasum -a 256 | cut -c1-16)
+          KEY="wolfssl-${{ runner.os }}-${{ runner.arch }}-$SHA-$CFG_HASH"
+          echo "key=$KEY" >> "$GITHUB_OUTPUT"
+
+      - name: Restore cached wolfSSL install
+        id: cache-wolfssl
+        uses: actions/cache/restore@v4
+        with:
+          path: build-dir
+          key: ${{ steps.wolfssl-key.outputs.key }}
+
       - name: Build native wolfSSL
+        if: steps.cache-wolfssl.outputs.cache-hit != 'true'
         uses: wolfSSL/actions-build-autotools-project@v1
         with:
           repository: wolfSSL/wolfssl
@@ -46,6 +73,15 @@ jobs:
           configure: --enable-jni
           check: false
           install: true
+
+      # Save right after building (not at job end) so a later test
+      # failure does not prevent the cache from being populated.
+      - name: Save wolfSSL install to cache
+        if: steps.cache-wolfssl.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: build-dir
+          key: ${{ steps.wolfssl-key.outputs.key }}
 
       - name: Setup Java
         uses: actions/setup-java@v4
@@ -195,7 +231,34 @@ jobs:
         if: steps.cache-junit.outputs.cache-hit != 'true'
         run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
 
+      # Cache the installed wolfSSL build. The key matches the one built
+      # in linux-common.yml for the same configure flags, so this job
+      # shares the cache with the main CI matrix.
+      - name: Resolve wolfSSL cache key
+        id: wolfssl-key
+        env:
+          WOLFSSL_CONFIGURE: '--enable-jni'
+        run: |
+          SHA=$(git ls-remote https://github.com/wolfSSL/wolfssl.git \
+            refs/heads/master | cut -f1)
+          if [ -z "$SHA" ]; then
+            echo "Failed to resolve wolfSSL master SHA" >&2
+            exit 1
+          fi
+          CFG_HASH=$(printf '%s' "$WOLFSSL_CONFIGURE" | \
+            shasum -a 256 | cut -c1-16)
+          KEY="wolfssl-${{ runner.os }}-${{ runner.arch }}-$SHA-$CFG_HASH"
+          echo "key=$KEY" >> "$GITHUB_OUTPUT"
+
+      - name: Restore cached wolfSSL install
+        id: cache-wolfssl
+        uses: actions/cache/restore@v4
+        with:
+          path: build-dir
+          key: ${{ steps.wolfssl-key.outputs.key }}
+
       - name: Build native wolfSSL
+        if: steps.cache-wolfssl.outputs.cache-hit != 'true'
         uses: wolfSSL/actions-build-autotools-project@v1
         with:
           repository: wolfSSL/wolfssl
@@ -204,6 +267,15 @@ jobs:
           configure: --enable-jni
           check: false
           install: true
+
+      # Save right after building (not at job end) so a later test
+      # failure does not prevent the cache from being populated.
+      - name: Save wolfSSL install to cache
+        if: steps.cache-wolfssl.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: build-dir
+          key: ${{ steps.wolfssl-key.outputs.key }}
 
       - name: Setup Java 8
         uses: actions/setup-java@v4

--- a/.github/workflows/java-module-test.yml
+++ b/.github/workflows/java-module-test.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [ '*' ]
 
+# Cancel superseded in-progress runs for the same PR. Runs
+# triggered by push events are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # Test Java 9+ module support (JPMS)
   # Verifies that module-info.java is properly compiled and the resulting

--- a/.github/workflows/java-module-test.yml
+++ b/.github/workflows/java-module-test.yml
@@ -28,20 +28,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache JUnit dependencies
-        uses: actions/cache@v4
-        id: cache-junit
-        with:
-          path: junit
-          key: junit-jars-v1
-
-      - name: Download junit-4.13.2.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar
-
-      - name: Download hamcrest-all-1.3.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
+      - name: Setup JUnit
+        uses: ./.github/actions/setup-junit
 
       # Cache the installed wolfSSL build. The key matches the one built
       # in linux-common.yml for the same configure flags, so this job
@@ -94,10 +82,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.jdk_version }}
-
-      - name: Set JUNIT_HOME
-        run: |
-          echo "JUNIT_HOME=$GITHUB_WORKSPACE/junit" >> "$GITHUB_ENV"
 
       - name: Set LD_LIBRARY_PATH
         run: |
@@ -222,20 +206,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache JUnit dependencies
-        uses: actions/cache@v4
-        id: cache-junit
-        with:
-          path: junit
-          key: junit-jars-v1
-
-      - name: Download junit-4.13.2.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar
-
-      - name: Download hamcrest-all-1.3.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
+      - name: Setup JUnit
+        uses: ./.github/actions/setup-junit
 
       # Cache the installed wolfSSL build. The key matches the one built
       # in linux-common.yml for the same configure flags, so this job
@@ -288,10 +260,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-
-      - name: Set JUNIT_HOME
-        run: |
-          echo "JUNIT_HOME=$GITHUB_WORKSPACE/junit" >> "$GITHUB_ENV"
 
       - name: Set LD_LIBRARY_PATH
         run: |

--- a/.github/workflows/java-module-test.yml
+++ b/.github/workflows/java-module-test.yml
@@ -48,6 +48,7 @@ jobs:
           CFG_HASH=$(printf '%s' "$WOLFSSL_CONFIGURE" | \
             shasum -a 256 | cut -c1-16)
           KEY="wolfssl-${{ runner.os }}-${{ runner.arch }}-$SHA-$CFG_HASH"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           echo "key=$KEY" >> "$GITHUB_OUTPUT"
 
       - name: Restore cached wolfSSL install
@@ -57,12 +58,14 @@ jobs:
           path: build-dir
           key: ${{ steps.wolfssl-key.outputs.key }}
 
+      # Build the exact commit the cache key was computed from so the
+      # key and contents cannot drift if master advances mid-run.
       - name: Build native wolfSSL
         if: steps.cache-wolfssl.outputs.cache-hit != 'true'
         uses: wolfSSL/actions-build-autotools-project@v1
         with:
           repository: wolfSSL/wolfssl
-          ref: master
+          ref: ${{ steps.wolfssl-key.outputs.sha }}
           path: wolfssl
           configure: --enable-jni
           check: false
@@ -226,6 +229,7 @@ jobs:
           CFG_HASH=$(printf '%s' "$WOLFSSL_CONFIGURE" | \
             shasum -a 256 | cut -c1-16)
           KEY="wolfssl-${{ runner.os }}-${{ runner.arch }}-$SHA-$CFG_HASH"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           echo "key=$KEY" >> "$GITHUB_OUTPUT"
 
       - name: Restore cached wolfSSL install
@@ -235,12 +239,14 @@ jobs:
           path: build-dir
           key: ${{ steps.wolfssl-key.outputs.key }}
 
+      # Build the exact commit the cache key was computed from so the
+      # key and contents cannot drift if master advances mid-run.
       - name: Build native wolfSSL
         if: steps.cache-wolfssl.outputs.cache-hit != 'true'
         uses: wolfSSL/actions-build-autotools-project@v1
         with:
           repository: wolfSSL/wolfssl
-          ref: master
+          ref: ${{ steps.wolfssl-key.outputs.sha }}
           path: wolfssl
           configure: --enable-jni
           check: false

--- a/.github/workflows/jni-patched-ci.yml
+++ b/.github/workflows/jni-patched-ci.yml
@@ -152,19 +152,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache JUnit dependencies
-        uses: actions/cache@v4
-        id: cache-junit
-        with:
-          path: junit
-          key: junit-jars-v1
-
-      - name: Download junit-4.13.2.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: curl -fsSL -o "$GITHUB_WORKSPACE/junit/junit-4.13.2.jar" https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar
-      - name: Download hamcrest-all-1.3.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: curl -fsSL -o "$GITHUB_WORKSPACE/junit/hamcrest-all-1.3.jar" https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
+      - name: Setup JUnit
+        uses: ./.github/actions/setup-junit
 
       - name: Build native wolfSSL
         uses: wolfSSL/actions-build-autotools-project@v1
@@ -181,10 +170,6 @@ jobs:
         with:
           distribution: zulu
           java-version: '21'
-
-      - name: Set JUNIT_HOME
-        run: |
-          echo "JUNIT_HOME=$GITHUB_WORKSPACE/junit" >> "$GITHUB_ENV"
 
       - name: Set LD_LIBRARY_PATH
         run: |

--- a/.github/workflows/jni-patched-ci.yml
+++ b/.github/workflows/jni-patched-ci.yml
@@ -11,6 +11,12 @@ on:
   pull_request:
     branches: [ 'master' ]
 
+# Cancel superseded in-progress runs for the same PR. Runs
+# triggered by push events are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   resolve_wolfssl_ref:
     runs-on: ubuntu-latest

--- a/.github/workflows/jni-patched-ci.yml
+++ b/.github/workflows/jni-patched-ci.yml
@@ -28,11 +28,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install prerequisites
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y jq curl
-
       - name: Find patch defines
         id: find_defines
         run: |

--- a/.github/workflows/line-length-check.yml
+++ b/.github/workflows/line-length-check.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches: [ '*' ]
 
+# Cancel superseded in-progress runs for the same PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   line-length-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/linux-32bit.yml
+++ b/.github/workflows/linux-32bit.yml
@@ -70,6 +70,7 @@ jobs:
             shasum -a 256 | cut -c1-16)
           KEY="wolfssl-m32-${{ runner.os }}-${{ runner.arch }}"
           KEY="$KEY-$SHA-$CFG_HASH"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           echo "key=$KEY" >> "$GITHUB_OUTPUT"
 
       - name: Restore cached wolfSSL install
@@ -79,11 +80,16 @@ jobs:
           path: wolfssl-install
           key: ${{ steps.wolfssl-key.outputs.key }}
 
+      # Fetch the exact commit the cache key was computed from so the
+      # key and contents cannot drift if master advances mid-run.
       - name: Clone and build wolfSSL (32-bit)
         if: steps.cache-wolfssl.outputs.cache-hit != 'true'
         run: |
-          git clone --depth 1 https://github.com/wolfSSL/wolfssl.git /tmp/wolfssl
+          git init /tmp/wolfssl
           cd /tmp/wolfssl
+          git fetch --depth 1 https://github.com/wolfSSL/wolfssl.git \
+            ${{ steps.wolfssl-key.outputs.sha }}
+          git checkout FETCH_HEAD
           ./autogen.sh
           ./configure ${{ matrix.wolfssl_configure }} \
             --prefix=$GITHUB_WORKSPACE/wolfssl-install \

--- a/.github/workflows/linux-32bit.yml
+++ b/.github/workflows/linux-32bit.yml
@@ -59,7 +59,34 @@ jobs:
         if: steps.cache-junit.outputs.cache-hit != 'true'
         run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
 
+      # Cache the installed wolfSSL build. The m32 key segment keeps
+      # these 32-bit builds separate from the 64-bit cache entries.
+      - name: Resolve wolfSSL cache key
+        id: wolfssl-key
+        env:
+          WOLFSSL_CONFIGURE: ${{ matrix.wolfssl_configure }}
+        run: |
+          SHA=$(git ls-remote https://github.com/wolfSSL/wolfssl.git \
+            refs/heads/master | cut -f1)
+          if [ -z "$SHA" ]; then
+            echo "Failed to resolve wolfSSL master SHA" >&2
+            exit 1
+          fi
+          CFG_HASH=$(printf '%s' "$WOLFSSL_CONFIGURE" | \
+            shasum -a 256 | cut -c1-16)
+          KEY="wolfssl-m32-${{ runner.os }}-${{ runner.arch }}"
+          KEY="$KEY-$SHA-$CFG_HASH"
+          echo "key=$KEY" >> "$GITHUB_OUTPUT"
+
+      - name: Restore cached wolfSSL install
+        id: cache-wolfssl
+        uses: actions/cache/restore@v4
+        with:
+          path: wolfssl-install
+          key: ${{ steps.wolfssl-key.outputs.key }}
+
       - name: Clone and build wolfSSL (32-bit)
+        if: steps.cache-wolfssl.outputs.cache-hit != 'true'
         run: |
           git clone --depth 1 https://github.com/wolfSSL/wolfssl.git /tmp/wolfssl
           cd /tmp/wolfssl
@@ -69,6 +96,15 @@ jobs:
             CFLAGS="-m32" LDFLAGS="-m32"
           make
           make install
+
+      # Save right after building (not at job end) so a later test
+      # failure does not prevent the cache from being populated.
+      - name: Save wolfSSL install to cache
+        if: steps.cache-wolfssl.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: wolfssl-install
+          key: ${{ steps.wolfssl-key.outputs.key }}
 
       - name: Set environment variables
         run: |

--- a/.github/workflows/linux-32bit.yml
+++ b/.github/workflows/linux-32bit.yml
@@ -50,20 +50,8 @@ jobs:
           java -version
           file $(which java)
 
-      - name: Cache JUnit dependencies
-        uses: actions/cache@v4
-        id: cache-junit
-        with:
-          path: junit
-          key: junit-jars-v1
-
-      - name: Download junit-4.13.2.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar
-
-      - name: Download hamcrest-all-1.3.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
+      - name: Setup JUnit
+        uses: ./.github/actions/setup-junit
 
       # Cache the installed wolfSSL build. The m32 key segment keeps
       # these 32-bit builds separate from the 64-bit cache entries.
@@ -114,7 +102,6 @@ jobs:
 
       - name: Set environment variables
         run: |
-          echo "JUNIT_HOME=$GITHUB_WORKSPACE/junit" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=$GITHUB_WORKSPACE/wolfssl-install/lib" >> $GITHUB_ENV
 
       - name: Build JNI library (32-bit)

--- a/.github/workflows/linux-32bit.yml
+++ b/.github/workflows/linux-32bit.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [ 'master' ]
 
+# Cancel superseded in-progress runs for the same PR. Runs
+# triggered by push events are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # Linux 32-bit build using Zulu x86 JDK
   # Tests JNI pointer handling and 32-bit specific code paths

--- a/.github/workflows/linux-common.yml
+++ b/.github/workflows/linux-common.yml
@@ -63,7 +63,7 @@ jobs:
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/build-dir/lib" >> "$GITHUB_ENV"
 
       - name: Build JNI library
-        run: CFLAGS=${{ inputs.javah_cflags }} ./java.sh $GITHUB_WORKSPACE/build-dir
+        run: CFLAGS="${{ inputs.javash_cflags }}" ./java.sh $GITHUB_WORKSPACE/build-dir
       - name: Build JAR (ant)
         run: ant
       - name: Run Java tests (ant test)

--- a/.github/workflows/linux-common.yml
+++ b/.github/workflows/linux-common.yml
@@ -45,6 +45,7 @@ jobs:
           CFG_HASH=$(printf '%s' "$WOLFSSL_CONFIGURE" | \
             shasum -a 256 | cut -c1-16)
           KEY="wolfssl-${{ runner.os }}-${{ runner.arch }}-$SHA-$CFG_HASH"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           echo "key=$KEY" >> "$GITHUB_OUTPUT"
 
       - name: Restore cached wolfSSL install
@@ -54,12 +55,14 @@ jobs:
           path: build-dir
           key: ${{ steps.wolfssl-key.outputs.key }}
 
+      # Build the exact commit the cache key was computed from so the
+      # key and contents cannot drift if master advances mid-run.
       - name: Build native wolfSSL
         if: steps.cache-wolfssl.outputs.cache-hit != 'true'
         uses: wolfSSL/actions-build-autotools-project@v1
         with:
           repository: wolfSSL/wolfssl
-          ref: master
+          ref: ${{ steps.wolfssl-key.outputs.sha }}
           path: wolfssl
           configure: ${{ inputs.wolfssl_configure }}
           check: false

--- a/.github/workflows/linux-common.yml
+++ b/.github/workflows/linux-common.yml
@@ -39,7 +39,34 @@ jobs:
         if: steps.cache-junit.outputs.cache-hit != 'true'
         run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
 
+      # Cache the installed wolfSSL build. It depends only on the wolfSSL
+      # commit, configure flags, and OS/arch, not on the JDK in use, so
+      # jobs across the matrix (and other workflows) can share one build.
+      - name: Resolve wolfSSL cache key
+        id: wolfssl-key
+        env:
+          WOLFSSL_CONFIGURE: ${{ inputs.wolfssl_configure }}
+        run: |
+          SHA=$(git ls-remote https://github.com/wolfSSL/wolfssl.git \
+            refs/heads/master | cut -f1)
+          if [ -z "$SHA" ]; then
+            echo "Failed to resolve wolfSSL master SHA" >&2
+            exit 1
+          fi
+          CFG_HASH=$(printf '%s' "$WOLFSSL_CONFIGURE" | \
+            shasum -a 256 | cut -c1-16)
+          KEY="wolfssl-${{ runner.os }}-${{ runner.arch }}-$SHA-$CFG_HASH"
+          echo "key=$KEY" >> "$GITHUB_OUTPUT"
+
+      - name: Restore cached wolfSSL install
+        id: cache-wolfssl
+        uses: actions/cache/restore@v4
+        with:
+          path: build-dir
+          key: ${{ steps.wolfssl-key.outputs.key }}
+
       - name: Build native wolfSSL
+        if: steps.cache-wolfssl.outputs.cache-hit != 'true'
         uses: wolfSSL/actions-build-autotools-project@v1
         with:
           repository: wolfSSL/wolfssl
@@ -48,6 +75,15 @@ jobs:
           configure: ${{ inputs.wolfssl_configure }}
           check: false
           install: true
+
+      # Save right after building (not at job end) so a later test
+      # failure does not prevent the cache from being populated.
+      - name: Save wolfSSL install to cache
+        if: steps.cache-wolfssl.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: build-dir
+          key: ${{ steps.wolfssl-key.outputs.key }}
 
       - name: Setup java
         uses: actions/setup-java@v4

--- a/.github/workflows/linux-common.yml
+++ b/.github/workflows/linux-common.yml
@@ -25,19 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache JUnit dependencies
-        uses: actions/cache@v4
-        id: cache-junit
-        with:
-          path: junit
-          key: junit-jars-v1
-
-      - name: Download junit-4.13.2.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar
-      - name: Download hamcrest-all-1.3.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
+      - name: Setup JUnit
+        uses: ./.github/actions/setup-junit
 
       # Cache the installed wolfSSL build. It depends only on the wolfSSL
       # commit, configure flags, and OS/arch, not on the JDK in use, so
@@ -91,9 +80,6 @@ jobs:
           distribution: ${{ inputs.jdk_distro }}
           java-version: ${{ inputs.jdk_version }}
 
-      - name: Set JUNIT_HOME
-        run: |
-          echo "JUNIT_HOME=$GITHUB_WORKSPACE/junit" >> "$GITHUB_ENV"
       - name: Set LD_LIBRARY_PATH
         run: |
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/build-dir/lib" >> "$GITHUB_ENV"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [ 'master' ]
 
+# Cancel superseded in-progress runs for the same PR. Runs
+# triggered by push events are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # Oracle JDK (Linux, Mac)
   linux-oracle:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -210,21 +210,21 @@ jobs:
       javash_cflags: ${{ matrix.javash_cflags }}
 
   # ------------------ Facebook Infer static analysis -------------------
-  # Run Facebook infer over PR code on both Linux and macOS to catch
-  # platform-specific issues.
+  # Run Facebook Infer over the Java sources on both Linux and macOS.
+  # Infer only compiles the .java files with javac, so no native
+  # wolfSSL build or test run is needed here. Tests for the equivalent
+  # configuration run in linux-zulu-all above.
   fb-infer:
     strategy:
       matrix:
         os: [ 'ubuntu-latest', 'macos-latest' ]
         jdk_version: [ '11' ]
-        wolfssl_configure: [ '--enable-jni --enable-all' ]
-    name: Facebook Infer (${{ matrix.os }} Zulu JDK ${{ matrix.jdk_version }}, ${{ matrix.wolfssl_configure }})
+    name: Facebook Infer (${{ matrix.os }} Zulu JDK ${{ matrix.jdk_version }})
     uses: ./.github/workflows/infer.yml
     with:
       os: ${{ matrix.os }}
       jdk_distro: "zulu"
       jdk_version: ${{ matrix.jdk_version }}
-      wolfssl_configure: ${{ matrix.wolfssl_configure }}
 
   # --------------------- Maven build - test pom.xml --------------------
   # Run Maven build over PR code, running on Linux and Mac with only one

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -73,6 +73,7 @@ jobs:
         with:
           distribution: ${{ inputs.jdk_distro }}
           java-version: ${{ inputs.jdk_version }}
+          cache: 'maven'
 
       - name: Set LD_LIBRARY_PATH
         run: |
@@ -81,13 +82,10 @@ jobs:
       - name: Build JNI library
         run: ./java.sh $GITHUB_WORKSPACE/build-dir
 
-      # Maven build
-      - name: mvn compile
-        run: mvn compile
-
-      - name: mvn test
-        run: mvn test
-
+      # Maven build. A single mvn package runs the compile, test, and
+      # package phases in one lifecycle pass. Separate compile, test,
+      # and package steps would run the whole test suite twice, once
+      # for the test step and again inside package.
       - name: mvn package
         run: mvn package
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,7 +22,34 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Cache the installed wolfSSL build. It depends only on the wolfSSL
+      # commit, configure flags, and OS/arch, so jobs across workflows
+      # can share one build.
+      - name: Resolve wolfSSL cache key
+        id: wolfssl-key
+        env:
+          WOLFSSL_CONFIGURE: ${{ inputs.wolfssl_configure }}
+        run: |
+          SHA=$(git ls-remote https://github.com/wolfSSL/wolfssl.git \
+            refs/heads/master | cut -f1)
+          if [ -z "$SHA" ]; then
+            echo "Failed to resolve wolfSSL master SHA" >&2
+            exit 1
+          fi
+          CFG_HASH=$(printf '%s' "$WOLFSSL_CONFIGURE" | \
+            shasum -a 256 | cut -c1-16)
+          KEY="wolfssl-${{ runner.os }}-${{ runner.arch }}-$SHA-$CFG_HASH"
+          echo "key=$KEY" >> "$GITHUB_OUTPUT"
+
+      - name: Restore cached wolfSSL install
+        id: cache-wolfssl
+        uses: actions/cache/restore@v4
+        with:
+          path: build-dir
+          key: ${{ steps.wolfssl-key.outputs.key }}
+
       - name: Build native wolfSSL
+        if: steps.cache-wolfssl.outputs.cache-hit != 'true'
         uses: wolfSSL/actions-build-autotools-project@v1
         with:
           repository: wolfSSL/wolfssl
@@ -31,6 +58,15 @@ jobs:
           configure: ${{ inputs.wolfssl_configure }}
           check: false
           install: true
+
+      # Save right after building (not at job end) so a later test
+      # failure does not prevent the cache from being populated.
+      - name: Save wolfSSL install to cache
+        if: steps.cache-wolfssl.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: build-dir
+          key: ${{ steps.wolfssl-key.outputs.key }}
 
       - name: Setup java
         uses: actions/setup-java@v4

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -39,6 +39,7 @@ jobs:
           CFG_HASH=$(printf '%s' "$WOLFSSL_CONFIGURE" | \
             shasum -a 256 | cut -c1-16)
           KEY="wolfssl-${{ runner.os }}-${{ runner.arch }}-$SHA-$CFG_HASH"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           echo "key=$KEY" >> "$GITHUB_OUTPUT"
 
       - name: Restore cached wolfSSL install
@@ -48,12 +49,14 @@ jobs:
           path: build-dir
           key: ${{ steps.wolfssl-key.outputs.key }}
 
+      # Build the exact commit the cache key was computed from so the
+      # key and contents cannot drift if master advances mid-run.
       - name: Build native wolfSSL
         if: steps.cache-wolfssl.outputs.cache-hit != 'true'
         uses: wolfSSL/actions-build-autotools-project@v1
         with:
           repository: wolfSSL/wolfssl
-          ref: master
+          ref: ${{ steps.wolfssl-key.outputs.sha }}
           path: wolfssl
           configure: ${{ inputs.wolfssl_configure }}
           check: false

--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -41,6 +41,7 @@ jobs:
           CFG_HASH=$(printf '%s' "$WOLFSSL_CONFIGURE" | \
             shasum -a 256 | cut -c1-16)
           KEY="wolfssl-${{ runner.os }}-${{ runner.arch }}-$SHA-$CFG_HASH"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           echo "key=$KEY" >> "$GITHUB_OUTPUT"
 
       - name: Restore cached wolfSSL install
@@ -50,13 +51,15 @@ jobs:
           path: build-dir
           key: ${{ steps.wolfssl-key.outputs.key }}
 
-      # Build native wolfSSL
+      # Build native wolfSSL, using the exact commit the cache key was
+      # computed from so the key and contents cannot drift if master
+      # advances mid-run.
       - name: Build native wolfSSL
         if: steps.cache-wolfssl.outputs.cache-hit != 'true'
         uses: wolfSSL/actions-build-autotools-project@v1
         with:
           repository: wolfSSL/wolfssl
-          ref: master
+          ref: ${{ steps.wolfssl-key.outputs.sha }}
           path: wolfssl
           configure: '--enable-jni --enable-all'
           check: false

--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -36,8 +36,35 @@ jobs:
         if: steps.cache-junit.outputs.cache-hit != 'true'
         run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
 
+      # Cache the installed wolfSSL build. The key matches the one built
+      # in linux-common.yml for the same configure flags, so this job
+      # shares the cache with the main CI matrix.
+      - name: Resolve wolfSSL cache key
+        id: wolfssl-key
+        env:
+          WOLFSSL_CONFIGURE: '--enable-jni --enable-all'
+        run: |
+          SHA=$(git ls-remote https://github.com/wolfSSL/wolfssl.git \
+            refs/heads/master | cut -f1)
+          if [ -z "$SHA" ]; then
+            echo "Failed to resolve wolfSSL master SHA" >&2
+            exit 1
+          fi
+          CFG_HASH=$(printf '%s' "$WOLFSSL_CONFIGURE" | \
+            shasum -a 256 | cut -c1-16)
+          KEY="wolfssl-${{ runner.os }}-${{ runner.arch }}-$SHA-$CFG_HASH"
+          echo "key=$KEY" >> "$GITHUB_OUTPUT"
+
+      - name: Restore cached wolfSSL install
+        id: cache-wolfssl
+        uses: actions/cache/restore@v4
+        with:
+          path: build-dir
+          key: ${{ steps.wolfssl-key.outputs.key }}
+
       # Build native wolfSSL
       - name: Build native wolfSSL
+        if: steps.cache-wolfssl.outputs.cache-hit != 'true'
         uses: wolfSSL/actions-build-autotools-project@v1
         with:
           repository: wolfSSL/wolfssl
@@ -46,6 +73,15 @@ jobs:
           configure: '--enable-jni --enable-all'
           check: false
           install: true
+
+      # Save right after building (not at job end) so a later test
+      # failure does not prevent the cache from being populated.
+      - name: Save wolfSSL install to cache
+        if: steps.cache-wolfssl.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: build-dir
+          key: ${{ steps.wolfssl-key.outputs.key }}
 
       # Setup Java
       - name: Setup java

--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [ '*' ]
 
+# Cancel superseded in-progress runs for the same PR. Runs
+# triggered by push events are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   scan-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -24,24 +24,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y clang-tools
 
-      # Cache Junit JARs
-      - name: Cache Junit JARs
-        uses: actions/cache@v3
-        id: cache-junit
-        with:
-          path: ${{ github.workspace }}/junit
-          key: junit-cache-${{ runner.os }}-junit-4.13.2-hamcrest-1.3
-          restore-keys: |
-            junit-cache-${{ runner.os }}-
-
-      # Download Junit JARs (needed for full build)
-      - name: Download junit-4.13.2.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar
-      - name: Download hamcrest-all-1.3.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
-
       # Cache the installed wolfSSL build. The key matches the one built
       # in linux-common.yml for the same configure flags, so this job
       # shares the cache with the main CI matrix.
@@ -96,19 +78,15 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
 
-      - name: Set JUNIT_HOME
-        run: |
-          echo "JUNIT_HOME=$GITHUB_WORKSPACE/junit" >> "$GITHUB_ENV"
-      - name: Set LD_LIBRARY_PATH
-        run: |
-          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/build-dir/lib" >> "$GITHUB_ENV"
-
-      # Run scan-build over the native JNI C files
+      # Run scan-build over the native JNI C files. scan-build only
+      # analyzes C compilations, so build the native target alone and
+      # skip the Java side of the default make target. JUnit jars and
+      # LD_LIBRARY_PATH are not needed since no tests run here.
       - name: Run scan-build
         env:
           PREFIX: ${{ github.workspace }}/build-dir
         run: |
-          scan-build --status-bugs -o scan-build-reports make
+          scan-build --status-bugs -o scan-build-reports make native
 
       # Upload scan-build results as artifacts
       - name: Upload scan-build results

--- a/.github/workflows/spotbugs.yml
+++ b/.github/workflows/spotbugs.yml
@@ -33,14 +33,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y ant
 
-      - name: Download JUnit
-        run: |
-          mkdir -p /tmp/junit
-          wget -q -P /tmp/junit \
-            "https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar"
-          EXPECTED_SHA="8e495b634469d64fb8acfa3495a065cbacc8a0fff55ce1e31007be4c16dc57d3"
-          echo "${EXPECTED_SHA}  /tmp/junit/junit-4.13.2.jar" | sha256sum -c -
-          echo "JUNIT_HOME=/tmp/junit" >> $GITHUB_ENV
+      - name: Setup JUnit
+        uses: ./.github/actions/setup-junit
 
       - name: Download and set up SpotBugs
         run: |

--- a/.github/workflows/spotbugs.yml
+++ b/.github/workflows/spotbugs.yml
@@ -8,6 +8,11 @@ on:
       - 'build.xml'
       - 'spotbugs-exclude.xml'
 
+# Cancel superseded in-progress runs for the same PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   spotbugs:
     runs-on: ubuntu-latest

--- a/.github/workflows/stable-wolfssl-releases.yml
+++ b/.github/workflows/stable-wolfssl-releases.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # First job: dynamically fetch the last 3 stable wolfSSL release tags
+  # First job: dynamically fetch the last 5 stable wolfSSL release tags
   get-stable-releases:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/stable-wolfssl-releases.yml
+++ b/.github/workflows/stable-wolfssl-releases.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches: [ 'master' ]
 
+# Cancel superseded in-progress runs for the same PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # First job: dynamically fetch the last 3 stable wolfSSL release tags
   get-stable-releases:

--- a/.github/workflows/stable-wolfssl-releases.yml
+++ b/.github/workflows/stable-wolfssl-releases.yml
@@ -53,7 +53,28 @@ jobs:
         if: steps.cache-junit.outputs.cache-hit != 'true'
         run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
 
+      # Cache the installed wolfSSL build. Stable release tags do not
+      # move, so these entries stay valid indefinitely.
+      - name: Compute wolfSSL cache key
+        id: wolfssl-key
+        env:
+          WOLFSSL_CONFIGURE: ${{ matrix.wolfssl_configure }}
+        run: |
+          CFG_HASH=$(printf '%s' "$WOLFSSL_CONFIGURE" | \
+            shasum -a 256 | cut -c1-16)
+          KEY="wolfssl-${{ runner.os }}-${{ runner.arch }}"
+          KEY="$KEY-${{ matrix.wolfssl_version }}-$CFG_HASH"
+          echo "key=$KEY" >> "$GITHUB_OUTPUT"
+
+      - name: Restore cached wolfSSL install
+        id: cache-wolfssl
+        uses: actions/cache/restore@v4
+        with:
+          path: build-dir
+          key: ${{ steps.wolfssl-key.outputs.key }}
+
       - name: Build native wolfSSL ${{ matrix.wolfssl_version }}
+        if: steps.cache-wolfssl.outputs.cache-hit != 'true'
         uses: wolfSSL/actions-build-autotools-project@v1
         with:
           repository: wolfSSL/wolfssl
@@ -62,6 +83,15 @@ jobs:
           configure: ${{ matrix.wolfssl_configure }}
           check: false
           install: true
+
+      # Save right after building (not at job end) so a later test
+      # failure does not prevent the cache from being populated.
+      - name: Save wolfSSL install to cache
+        if: steps.cache-wolfssl.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: build-dir
+          key: ${{ steps.wolfssl-key.outputs.key }}
 
       - name: Setup java
         uses: actions/setup-java@v4

--- a/.github/workflows/stable-wolfssl-releases.yml
+++ b/.github/workflows/stable-wolfssl-releases.yml
@@ -43,20 +43,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache JUnit dependencies
-        uses: actions/cache@v4
-        id: cache-junit
-        with:
-          path: junit
-          key: junit-jars-v1
-
-      - name: Download junit-4.13.2.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar
-
-      - name: Download hamcrest-all-1.3.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
+      - name: Setup JUnit
+        uses: ./.github/actions/setup-junit
 
       # Cache the installed wolfSSL build. Stable release tags do not
       # move, so these entries stay valid indefinitely.
@@ -103,10 +91,6 @@ jobs:
         with:
           distribution: zulu
           java-version: ${{ matrix.jdk_version }}
-
-      - name: Set JUNIT_HOME
-        run: |
-          echo "JUNIT_HOME=$GITHUB_WORKSPACE/junit" >> "$GITHUB_ENV"
 
       - name: Set LD_LIBRARY_PATH
         run: |

--- a/.github/workflows/undefined-sanitizer.yml
+++ b/.github/workflows/undefined-sanitizer.yml
@@ -49,6 +49,7 @@ jobs:
           CFG_HASH=$(printf '%s' "$WOLFSSL_CONFIGURE" | \
             shasum -a 256 | cut -c1-16)
           KEY="wolfssl-${{ runner.os }}-${{ runner.arch }}-$SHA-$CFG_HASH"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           echo "key=$KEY" >> "$GITHUB_OUTPUT"
 
       - name: Restore cached wolfSSL install
@@ -58,12 +59,14 @@ jobs:
           path: build-dir
           key: ${{ steps.wolfssl-key.outputs.key }}
 
+      # Build the exact commit the cache key was computed from so the
+      # key and contents cannot drift if master advances mid-run.
       - name: Build native wolfSSL with UndefinedBehaviorSanitizer
         if: steps.cache-wolfssl.outputs.cache-hit != 'true'
         uses: wolfSSL/actions-build-autotools-project@v1
         with:
           repository: wolfSSL/wolfssl
-          ref: master
+          ref: ${{ steps.wolfssl-key.outputs.sha }}
           path: wolfssl
           configure: ${{ env.WOLFSSL_CONFIGURE }}
           check: false

--- a/.github/workflows/undefined-sanitizer.yml
+++ b/.github/workflows/undefined-sanitizer.yml
@@ -32,19 +32,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache JUnit dependencies
-        uses: actions/cache@v4
-        id: cache-junit
-        with:
-          path: junit
-          key: junit-jars-v1
-
-      - name: Download junit-4.13.2.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar
-      - name: Download hamcrest-all-1.3.jar
-        if: steps.cache-junit.outputs.cache-hit != 'true'
-        run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
+      - name: Setup JUnit
+        uses: ./.github/actions/setup-junit
 
       # Cache the installed wolfSSL build, keyed on the full configure
       # string (including sanitizer flags), wolfSSL commit and OS/arch.
@@ -97,7 +86,6 @@ jobs:
 
       - name: Set environment variables
         run: |
-          echo "JUNIT_HOME=$GITHUB_WORKSPACE/junit" >> "$GITHUB_ENV"
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/build-dir/lib" >> "$GITHUB_ENV"
           echo "UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1" >> "$GITHUB_ENV"
 

--- a/.github/workflows/undefined-sanitizer.yml
+++ b/.github/workflows/undefined-sanitizer.yml
@@ -15,6 +15,13 @@ jobs:
         jdk_version: [ '21' ]
         wolfssl_configure: [ '--enable-jni --enable-debug' ]
     name: UBSan (ubuntu-latest Zulu JDK ${{ matrix.jdk_version }})
+    # Full effective wolfSSL configure string, defined once so the
+    # build step and the cache key below cannot drift apart.
+    env:
+      WOLFSSL_CONFIGURE: >-
+        ${{ matrix.wolfssl_configure }}
+        CFLAGS="-fsanitize=undefined -fno-sanitize-recover=all
+        -fno-omit-frame-pointer" LDFLAGS="-fsanitize=undefined"
 
     steps:
       - uses: actions/checkout@v4
@@ -33,15 +40,48 @@ jobs:
         if: steps.cache-junit.outputs.cache-hit != 'true'
         run: wget --directory-prefix=$GITHUB_WORKSPACE/junit https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar
 
+      # Cache the installed wolfSSL build, keyed on the full configure
+      # string (including sanitizer flags), wolfSSL commit and OS/arch.
+      - name: Resolve wolfSSL cache key
+        id: wolfssl-key
+        run: |
+          SHA=$(git ls-remote https://github.com/wolfSSL/wolfssl.git \
+            refs/heads/master | cut -f1)
+          if [ -z "$SHA" ]; then
+            echo "Failed to resolve wolfSSL master SHA" >&2
+            exit 1
+          fi
+          CFG_HASH=$(printf '%s' "$WOLFSSL_CONFIGURE" | \
+            shasum -a 256 | cut -c1-16)
+          KEY="wolfssl-${{ runner.os }}-${{ runner.arch }}-$SHA-$CFG_HASH"
+          echo "key=$KEY" >> "$GITHUB_OUTPUT"
+
+      - name: Restore cached wolfSSL install
+        id: cache-wolfssl
+        uses: actions/cache/restore@v4
+        with:
+          path: build-dir
+          key: ${{ steps.wolfssl-key.outputs.key }}
+
       - name: Build native wolfSSL with UndefinedBehaviorSanitizer
+        if: steps.cache-wolfssl.outputs.cache-hit != 'true'
         uses: wolfSSL/actions-build-autotools-project@v1
         with:
           repository: wolfSSL/wolfssl
           ref: master
           path: wolfssl
-          configure: ${{ matrix.wolfssl_configure }} CFLAGS="-fsanitize=undefined -fno-sanitize-recover=all -fno-omit-frame-pointer" LDFLAGS="-fsanitize=undefined"
+          configure: ${{ env.WOLFSSL_CONFIGURE }}
           check: false
           install: true
+
+      # Save right after building (not at job end) so a later test
+      # failure does not prevent the cache from being populated.
+      - name: Save wolfSSL install to cache
+        if: steps.cache-wolfssl.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: build-dir
+          key: ${{ steps.wolfssl-key.outputs.key }}
 
       - name: Setup java
         uses: actions/setup-java@v4

--- a/.github/workflows/undefined-sanitizer.yml
+++ b/.github/workflows/undefined-sanitizer.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [ 'master' ]
 
+# Cancel superseded in-progress runs for the same PR. Runs
+# triggered by push events are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # Run UBSan build and test on Linux only for undefined behavior detection
   ubsan:

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -830,9 +830,9 @@ enum {
 static int socketSelect(SSLAppData* appData, int sockfd, int timeout_ms, int rx,
     int shutdown)
 {
-    fd_set fds, errfds;
-    fd_set* recvfds = NULL;
-    fd_set* sendfds = NULL;
+    fd_set recvfds, sendfds, errfds;
+    fd_set* recvfdsPtr = NULL;
+    fd_set* sendfdsPtr = NULL;
     int nfds = sockfd + 1;
     int result = 0;
     struct timeval timeout;
@@ -861,15 +861,29 @@ static int socketSelect(SSLAppData* appData, int sockfd, int timeout_ms, int rx,
         timeout.tv_sec = timeout_ms / 1000;
         timeout.tv_usec = (timeout_ms % 1000) * 1000;
 
-        /* file/socket descriptors */
-        FD_ZERO(&fds);
-        FD_SET(sockfd, &fds);
+        /* Monitor the socket descriptor for readability or writability
+         * depending on the direction of the blocked I/O operation */
+        FD_ZERO(&recvfds);
+        FD_ZERO(&sendfds);
+        if (rx) {
+            FD_SET(sockfd, &recvfds);
+            recvfdsPtr = &recvfds;
+        } else {
+            FD_SET(sockfd, &sendfds);
+            sendfdsPtr = &sendfds;
+        }
+
 #ifndef USE_WINDOWS_API
+        /* The interrupt pipe read end is always monitored for
+         * readability, even when waiting for the socket to become
+         * writable. Otherwise SSLSocket.close() from another thread
+         * could not interrupt a blocked send. */
         if ((shutdown == 0) && (appData->interruptFds[0] != -1)) {
             if (appData->interruptFds[0] >= FD_SETSIZE) {
                 return WOLFJNI_IO_EVENT_ERROR;
             }
-            FD_SET(appData->interruptFds[0], &fds);
+            FD_SET(appData->interruptFds[0], &recvfds);
+            recvfdsPtr = &recvfds;
             /* nfds should be set to the highest number descriptor plus 1 */
             if (appData->interruptFds[0] > sockfd) {
                 nfds = appData->interruptFds[0] + 1;
@@ -881,36 +895,22 @@ static int socketSelect(SSLAppData* appData, int sockfd, int timeout_ms, int rx,
         FD_ZERO(&errfds);
         FD_SET(sockfd, &errfds);
 
-        if (rx) {
-            recvfds = &fds;
-        } else {
-            sendfds = &fds;
-        }
-
         incrementThreadPollCount(appData);
         if (timeout_ms == 0) {
-            result = select(nfds, recvfds, sendfds, &errfds, NULL);
+            result = select(nfds, recvfdsPtr, sendfdsPtr, &errfds, NULL);
         } else {
-            result = select(nfds, recvfds, sendfds, &errfds, &timeout);
+            result = select(nfds, recvfdsPtr, sendfdsPtr, &errfds, &timeout);
         }
         decrementThreadPollCount(appData);
 
         if (result == 0) {
             return WOLFJNI_IO_EVENT_TIMEOUT;
         } else if (result > 0) {
-            if (FD_ISSET(sockfd, &fds)) {
-                if (rx) {
-                    return WOLFJNI_IO_EVENT_RECV_READY;
-                } else {
-                    return WOLFJNI_IO_EVENT_SEND_READY;
-                }
-            }
-            else if (FD_ISSET(sockfd, &errfds)) {
-                return WOLFJNI_IO_EVENT_ERROR;
-            }
 #ifndef USE_WINDOWS_API
-            else if ((shutdown == 0) && (appData->interruptFds[0] != -1) &&
-                     (FD_ISSET(appData->interruptFds[0], &fds))) {
+            /* Check the interrupt descriptor first, matching the
+             * priority used by the socketPoll() implementation */
+            if ((shutdown == 0) && (appData->interruptFds[0] != -1) &&
+                (FD_ISSET(appData->interruptFds[0], &recvfds))) {
                 /* We got interrupted by our interrupt fd, due to a Java
                  * thread calling SSLSocket.close(). Try to read byte that
                  * was placed on our interruptFds[0] descriptor, but not
@@ -925,6 +925,15 @@ static int socketSelect(SSLAppData* appData, int sockfd, int timeout_ms, int rx,
                 return WOLFJNI_IO_EVENT_FD_CLOSED;
             }
 #endif /* !USE_WINDOWS_API */
+            if (rx && FD_ISSET(sockfd, &recvfds)) {
+                return WOLFJNI_IO_EVENT_RECV_READY;
+            }
+            else if (!rx && FD_ISSET(sockfd, &sendfds)) {
+                return WOLFJNI_IO_EVENT_SEND_READY;
+            }
+            else if (FD_ISSET(sockfd, &errfds)) {
+                return WOLFJNI_IO_EVENT_ERROR;
+            }
         }
 
 #ifndef USE_WINDOWS_API


### PR DESCRIPTION
This PR speeds up PR CI and cuts GitHub runner usage.

  ### Fixes
  - Fix `javash_cflags` input typo so `-DWOLFJNI_USE_IO_SELECT` actually reaches the compiler in the ioselect sanity jobs
  - Fix cold-cache JUnit download failure in patched JNI CI
  - Fix stale comment, stable release CI tests last 5 wolfSSL tags

  ### Optimizations
  - Cache installed native wolfSSL builds, keyed on wolfSSL commit, configure flags, and OS/arch. Around 85 jobs per PR previously each rebuilt wolfSSL from source
  - Cancel superseded in-progress runs when a PR branch is re-pushed. Push runs are never cancelled
  - Run Infer over Java sources only, dropping its redundant native build and duplicate test run, and cache the Infer release
  - Run a single `mvn package` instead of separate test and package phases, which ran the test suite twice, and cache Maven dependencies
  - Point scan-build at the native target only, it never analyzed the Java side
  - Remove redundant `jq`/`curl` install, both are preinstalled on runners
  - Consolidate copy-pasted JUnit setup into a shared composite action with SHA-256 verification on all downloads