### PR TITLE
Fixes for JNI callback locking, buffer sizing, and JSSE example updates

### DIFF
--- a/examples/provider/ClientSSLSocket.java
+++ b/examples/provider/ClientSSLSocket.java
@@ -105,6 +105,13 @@ public class ClientSSLSocket {
             SSLSocketFactory sf = ctx.getSocketFactory();
             SSLSocket sock = (SSLSocket)sf.createSocket(host, port);
 
+            /* Enable hostname verification against the peer certificate. A
+             * raw SSLSocket does not check that the certificate matches the
+             * host unless the endpoint identification algorithm is set. */
+            SSLParameters params = sock.getSSLParameters();
+            params.setEndpointIdentificationAlgorithm("HTTPS");
+            sock.setSSLParameters(params);
+
             sock.startHandshake();
 
             sock.close();

--- a/examples/provider/MultiThreadedSSLServer.java
+++ b/examples/provider/MultiThreadedSSLServer.java
@@ -66,7 +66,7 @@ public class MultiThreadedSSLServer
             /* Set up CA TrustManagerFactory */
             KeyStore caKeyStore = KeyStore.getInstance("JKS");
             caKeyStore.load(new FileInputStream(serverTS), psw);
-            
+
             TrustManagerFactory tm = TrustManagerFactory
                 .getInstance("SunX509", jsseProv);
             tm.init(caKeyStore);
@@ -76,6 +76,10 @@ public class MultiThreadedSSLServer
 
             SSLServerSocket ss = (SSLServerSocket)ctx
                 .getServerSocketFactory().createServerSocket(serverPort);
+
+            /* Require client authentication, the ca-client.jks trust store
+             * loaded above validates the client certificate. */
+            ss.setNeedClientAuth(true);
 
             while (true) {
                 SSLSocket sock = (SSLSocket)ss.accept();

--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -54,6 +54,73 @@ JavaVM*  g_vm;
 /* global object refs for logging callbacks */
 static jobject g_loggingCbIfaceObj;
 
+/* Serializes g_loggingCbIfaceObj reads/updates between NativeLoggingCallback
+ * and cleanup()/setLoggingCb(). Init in JNI_OnLoad, freed JNI_OnUnload. */
+static wolfSSL_Mutex g_loggingCbMutex;
+static int g_loggingCbMutexInit = 0;
+
+/* Tracks one-time native registration of NativeLoggingCallback and its return
+ * value. We register once and never deregister: wolfssl_log reads LogFunction
+ * without a lock, so clearing it while another thread logs would crash.
+ * Guarded by g_loggingCbMutex. */
+static int g_loggingCbNativeReg = 0;
+static int g_loggingCbNativeRet = 0;
+
+static int NativeLoggingCbMutexInit(void)
+{
+    if (g_loggingCbMutexInit) {
+        return 0;
+    }
+
+    if (wc_InitMutex(&g_loggingCbMutex) != 0) {
+        return -1;
+    }
+
+    g_loggingCbMutexInit = 1;
+
+    return 0;
+}
+
+static void NativeLoggingCbMutexFree(void)
+{
+    if (g_loggingCbMutexInit) {
+        wc_FreeMutex(&g_loggingCbMutex);
+        g_loggingCbMutexInit = 0;
+    }
+}
+
+static int NativeLoggingCbLock(void)
+{
+    int rc;
+
+    if (!g_loggingCbMutexInit) {
+        return 0;
+    }
+
+    rc = wc_LockMutex(&g_loggingCbMutex);
+    if (rc != 0) {
+        WOLFSSL_MSG("Failed to lock logging callback mutex");
+    }
+
+    return rc;
+}
+
+static int NativeLoggingCbUnlock(void)
+{
+    int rc;
+
+    if (!g_loggingCbMutexInit) {
+        return 0;
+    }
+
+    rc = wc_UnLockMutex(&g_loggingCbMutex);
+    if (rc != 0) {
+        WOLFSSL_MSG("Failed to unlock logging callback mutex");
+    }
+
+    return rc;
+}
+
 /* global method IDs we can cache for performance */
 jmethodID g_sslIORecvMethodId = NULL;
 jmethodID g_sslIORecvMethodId_BB = NULL;
@@ -232,6 +299,13 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved)
         return JNI_ERR;
     }
 
+    /* Initialize the logging callback mutex. */
+    if (NativeLoggingCbMutexInit() != 0) {
+        NativeVerifyCbMutexFree();
+        NativeCrlCbMutexFree();
+        return JNI_ERR;
+    }
+
     return JNI_VERSION_1_6;
 }
 
@@ -256,6 +330,21 @@ JNIEXPORT void JNICALL JNI_OnUnload(JavaVM* vm, void* reserved)
 
     /* Free the missing-CRL callback synchronization mutex. */
     NativeCrlCbMutexFree();
+
+    /* Deregister the native logging callback */
+    if (g_loggingCbNativeReg) {
+        wolfSSL_SetLoggingCb(NULL);
+        g_loggingCbNativeReg = 0;
+    }
+
+    /* Release logging callback global ref. */
+    if (g_loggingCbIfaceObj != NULL) {
+        (*env)->DeleteGlobalRef(env, g_loggingCbIfaceObj);
+        g_loggingCbIfaceObj = NULL;
+    }
+
+    /* Free the logging callback mutex. */
+    NativeLoggingCbMutexFree();
 
     /* Clear cached method ID */
     g_sslIORecvMethodId = NULL;
@@ -1629,6 +1718,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_cleanup
   (JNIEnv* jenv, jclass jcl)
 {
     int ret = WOLFSSL_SUCCESS;
+    jobject loggingCbPrior = NULL;
     (void)jenv;
     (void)jcl;
 
@@ -1637,9 +1727,13 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_cleanup
     ret = wolfSSL_Cleanup();
 
     /* release global logging callback object if registered */
-    if (g_loggingCbIfaceObj != NULL) {
-        (*jenv)->DeleteGlobalRef(jenv, g_loggingCbIfaceObj);
+    if (NativeLoggingCbLock() == 0) {
+        loggingCbPrior = g_loggingCbIfaceObj;
         g_loggingCbIfaceObj = NULL;
+        (void)NativeLoggingCbUnlock();
+    }
+    if (loggingCbPrior != NULL) {
+        (*jenv)->DeleteGlobalRef(jenv, loggingCbPrior);
     }
 
 #ifdef HAVE_FIPS
@@ -1680,6 +1774,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_setLoggingCb
   (JNIEnv* jenv, jclass jcl, jobject callback)
 {
     int ret = 0;
+    jobject newCbObj = NULL;
+    jobject priorCbObj = NULL;
 
     (void)jcl;
 
@@ -1687,25 +1783,41 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_setLoggingCb
         return BAD_FUNC_ARG;
     }
 
-    /* release existing logging callback object if registered */
-    if (g_loggingCbIfaceObj != NULL) {
-        (*jenv)->DeleteGlobalRef(jenv, g_loggingCbIfaceObj);
-        g_loggingCbIfaceObj = NULL;
-    }
-
     if (callback != NULL) {
         /* store Java logging callback Interface object */
-        g_loggingCbIfaceObj = (*jenv)->NewGlobalRef(jenv, callback);
-        if (g_loggingCbIfaceObj == NULL) {
+        newCbObj = (*jenv)->NewGlobalRef(jenv, callback);
+        if (newCbObj == NULL) {
             printf("error storing global logging callback interface\n");
             return SSL_FAILURE;
         }
-
-        ret = wolfSSL_SetLoggingCb(NativeLoggingCallback);
     }
-    else {
-        /* reset back to null */
-        ret = wolfSSL_SetLoggingCb(NULL);
+
+    /* Swap in new ref and register NativeLoggingCallback once */
+    if (NativeLoggingCbLock() != 0) {
+        /* Lock failed, free the new global ref and ret without unlocking */
+        if (newCbObj != NULL) {
+            (*jenv)->DeleteGlobalRef(jenv, newCbObj);
+        }
+        return SSL_FAILURE;
+    }
+    priorCbObj = g_loggingCbIfaceObj;
+    g_loggingCbIfaceObj = newCbObj;
+    if (!g_loggingCbNativeReg) {
+        if (newCbObj != NULL) {
+            g_loggingCbNativeRet = wolfSSL_SetLoggingCb(NativeLoggingCallback);
+            g_loggingCbNativeReg = 1;
+        }
+        else {
+            /* Clearing before any registration. */
+            g_loggingCbNativeRet = wolfSSL_SetLoggingCb(NULL);
+        }
+    }
+    ret = g_loggingCbNativeRet;
+    (void)NativeLoggingCbUnlock();
+
+    /* free prior ref outside the lock */
+    if (priorCbObj != NULL) {
+        (*jenv)->DeleteGlobalRef(jenv, priorCbObj);
     }
 
     return ret;
@@ -1728,6 +1840,7 @@ void NativeLoggingCallback(const int logLevel, const char *const logMessage)
     jstring   logMsg;
     int       needsDetach = 0;  /* Should we explicitly detach? */
     jobjectRefType refcheck;
+    jobject   localCbObj = NULL;
 
     /* get JNIEnv from JavaVM */
     vmret = (int)((*g_vm)->GetEnv(g_vm, (void**) &jenv, JNI_VERSION_1_6));
@@ -1744,27 +1857,36 @@ void NativeLoggingCallback(const int logLevel, const char *const logMessage)
         return;
     }
 
-    /* if g_loggingCbIfaceObj has been released (part of wolfSSL_Cleanup()),
-     * just return and skip this log */
-    if (g_loggingCbIfaceObj == NULL) {
+    /* Store global into local ref under mutex so a concurrent cleanup() or
+     * setLoggingCb() can't free it while we call into Java. */
+    if (NativeLoggingCbLock() == 0) {
+        if (g_loggingCbIfaceObj != NULL) {
+            localCbObj = (*jenv)->NewLocalRef(jenv, g_loggingCbIfaceObj);
+        }
+        (void)NativeLoggingCbUnlock();
+    }
+
+    /* callback released (part of wolfSSL_Cleanup()), skip this log */
+    if (localCbObj == NULL) {
         if (needsDetach == 1) {
             (*g_vm)->DetachCurrentThread(g_vm);
         }
         return;
     }
 
-    /* check if our stored object reference is valid */
-    refcheck = (*jenv)->GetObjectRefType(jenv, g_loggingCbIfaceObj);
-    if (refcheck == 2) {
+    /* Defensive check on localCbObj ref validity */
+    refcheck = (*jenv)->GetObjectRefType(jenv, localCbObj);
+    if (refcheck != JNIInvalidRefType) {
 
-        /* lookup WolfSSLLoggingCallback class from global object ref */
-        logClass = (*jenv)->GetObjectClass(jenv, g_loggingCbIfaceObj);
+        /* lookup WolfSSLLoggingCallback class from object ref */
+        logClass = (*jenv)->GetObjectClass(jenv, localCbObj);
         if (!logClass) {
             if ((*jenv)->ExceptionOccurred(jenv)) {
                 (*jenv)->ExceptionDescribe(jenv);
                 (*jenv)->ExceptionClear(jenv);
             }
 
+            (*jenv)->DeleteLocalRef(jenv, localCbObj);
             if (needsDetach == 1) {
                 (*g_vm)->DetachCurrentThread(g_vm);
             }
@@ -1774,11 +1896,14 @@ void NativeLoggingCallback(const int logLevel, const char *const logMessage)
         logMethod = (*jenv)->GetMethodID(jenv, logClass,
                                             "loggingCallback",
                                             "(ILjava/lang/String;)V");
+        /* done with logClass, release it now */
+        (*jenv)->DeleteLocalRef(jenv, logClass);
         if (logMethod == 0) {
             if ((*jenv)->ExceptionOccurred(jenv)) {
                 (*jenv)->ExceptionDescribe(jenv);
                 (*jenv)->ExceptionClear(jenv);
             }
+            (*jenv)->DeleteLocalRef(jenv, localCbObj);
             if (needsDetach == 1) {
                 (*g_vm)->DetachCurrentThread(g_vm);
             }
@@ -1788,8 +1913,11 @@ void NativeLoggingCallback(const int logLevel, const char *const logMessage)
         /* create jstring from char* */
         logMsg = (*jenv)->NewStringUTF(jenv, logMessage);
 
-        (*jenv)->CallVoidMethod(jenv, g_loggingCbIfaceObj, logMethod,
+        (*jenv)->CallVoidMethod(jenv, localCbObj, logMethod,
                 logLevel, logMsg);
+
+        /* done with logMsg, release it now */
+        (*jenv)->DeleteLocalRef(jenv, logMsg);
 
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
@@ -1799,6 +1927,7 @@ void NativeLoggingCallback(const int logLevel, const char *const logMessage)
              * Otherwise, our non-important exception here could cause
              * bad things to happen at the Java level - ie, causing the
              * certificate verify callback to fail unnecessarily. */
+            (*jenv)->DeleteLocalRef(jenv, localCbObj);
             if (needsDetach == 1) {
                 (*g_vm)->DetachCurrentThread(g_vm);
             }
@@ -1807,6 +1936,7 @@ void NativeLoggingCallback(const int logLevel, const char *const logMessage)
 
     }
 
+    (*jenv)->DeleteLocalRef(jenv, localCbObj);
     if (needsDetach == 1) {
         (*g_vm)->DetachCurrentThread(g_vm);
     }

--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -145,6 +145,66 @@ int g_verifyCbCtxExDataIdx = -1;
 #ifdef HAVE_FIPS
 /* global object ref for FIPS error callback */
 static jobject g_fipsCbIfaceObj;
+
+/* Serializes g_fipsCbIfaceObj reads/updates between NativeFIPSErrorCallback
+ * and cleanup()/setFIPSCb(). Init in JNI_OnLoad, freed JNI_OnUnload. */
+static wolfSSL_Mutex g_fipsCbMutex;
+static int g_fipsCbMutexInit = 0;
+
+static int NativeFipsCbMutexInit(void)
+{
+    if (g_fipsCbMutexInit) {
+        return 0;
+    }
+
+    if (wc_InitMutex(&g_fipsCbMutex) != 0) {
+        return -1;
+    }
+
+    g_fipsCbMutexInit = 1;
+
+    return 0;
+}
+
+static void NativeFipsCbMutexFree(void)
+{
+    if (g_fipsCbMutexInit) {
+        wc_FreeMutex(&g_fipsCbMutex);
+        g_fipsCbMutexInit = 0;
+    }
+}
+
+static int NativeFipsCbLock(void)
+{
+    int rc;
+
+    if (!g_fipsCbMutexInit) {
+        return 0;
+    }
+
+    rc = wc_LockMutex(&g_fipsCbMutex);
+    if (rc != 0) {
+        WOLFSSL_MSG("Failed to lock FIPS callback mutex");
+    }
+
+    return rc;
+}
+
+static int NativeFipsCbUnlock(void)
+{
+    int rc;
+
+    if (!g_fipsCbMutexInit) {
+        return 0;
+    }
+
+    rc = wc_UnLockMutex(&g_fipsCbMutex);
+    if (rc != 0) {
+        WOLFSSL_MSG("Failed to unlock FIPS callback mutex");
+    }
+
+    return rc;
+}
 #endif
 
 /* custom native fn prototypes */
@@ -306,6 +366,16 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved)
         return JNI_ERR;
     }
 
+#ifdef HAVE_FIPS
+    /* Initialize the FIPS callback mutex. */
+    if (NativeFipsCbMutexInit() != 0) {
+        NativeVerifyCbMutexFree();
+        NativeCrlCbMutexFree();
+        NativeLoggingCbMutexFree();
+        return JNI_ERR;
+    }
+#endif
+
     return JNI_VERSION_1_6;
 }
 
@@ -345,6 +415,20 @@ JNIEXPORT void JNICALL JNI_OnUnload(JavaVM* vm, void* reserved)
 
     /* Free the logging callback mutex. */
     NativeLoggingCbMutexFree();
+
+#ifdef HAVE_FIPS
+    /* Deregister the native FIPS callback for the same reason. */
+    wolfCrypt_SetCb_fips(NULL);
+
+    /* Release FIPS callback global ref. */
+    if (g_fipsCbIfaceObj != NULL) {
+        (*env)->DeleteGlobalRef(env, g_fipsCbIfaceObj);
+        g_fipsCbIfaceObj = NULL;
+    }
+
+    /* Free the FIPS callback mutex. */
+    NativeFipsCbMutexFree();
+#endif
 
     /* Clear cached method ID */
     g_sslIORecvMethodId = NULL;
@@ -1719,6 +1803,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_cleanup
 {
     int ret = WOLFSSL_SUCCESS;
     jobject loggingCbPrior = NULL;
+#ifdef HAVE_FIPS
+    jobject fipsCbPrior = NULL;
+#endif
     (void)jenv;
     (void)jcl;
 
@@ -1740,10 +1827,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_cleanup
     /* Deregister native FIPS callback from wolfCrypt before releasing */
     wolfCrypt_SetCb_fips(NULL);
 
-    /* release existing FIPS callback object if set */
-    if (g_fipsCbIfaceObj != NULL) {
-        (*jenv)->DeleteGlobalRef(jenv, g_fipsCbIfaceObj);
+    /* release global FIPS error callback object if registered */
+    if (NativeFipsCbLock() == 0) {
+        fipsCbPrior = g_fipsCbIfaceObj;
         g_fipsCbIfaceObj = NULL;
+        (void)NativeFipsCbUnlock();
+    }
+    if (fipsCbPrior != NULL) {
+        (*jenv)->DeleteGlobalRef(jenv, fipsCbPrior);
     }
 #endif
 
@@ -1953,6 +2044,7 @@ void NativeFIPSErrorCallback(const int ok, const int err,
     jobjectRefType refcheck;
     jstring hashString;
     int needsDetach = 0;
+    jobject localCbObj = NULL;
 
     /* get JNIEnv from JavaVM */
     vmret = (int)((*g_vm)->GetEnv(g_vm, (void**) &jenv, JNI_VERSION_1_6));
@@ -1973,33 +2065,45 @@ void NativeFIPSErrorCallback(const int ok, const int err,
         return;
     }
 
+    /* Store global into local ref under the mutex so a concurrent cleanup()
+     * or setFIPSCb() can't free it while we call into Java. */
+    if (NativeFipsCbLock() == 0) {
+        if (g_fipsCbIfaceObj != NULL) {
+            localCbObj = (*jenv)->NewLocalRef(jenv, g_fipsCbIfaceObj);
+        }
+        (void)NativeFipsCbUnlock();
+    }
+
     /* Just return if stored callback object reference is NULL/invalid */
-    if (g_fipsCbIfaceObj == NULL) {
+    if (localCbObj == NULL) {
         if (needsDetach) {
             (*g_vm)->DetachCurrentThread(g_vm);
         }
         return;
     }
 
-    refcheck = (*jenv)->GetObjectRefType(jenv, g_fipsCbIfaceObj);
-    if (refcheck != JNIGlobalRefType) {
+    /* Defensive check on localCbObj ref validity */
+    refcheck = (*jenv)->GetObjectRefType(jenv, localCbObj);
+    if (refcheck == JNIInvalidRefType) {
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
             (*jenv)->ExceptionClear(jenv);
         }
+        (*jenv)->DeleteLocalRef(jenv, localCbObj);
         if (needsDetach) {
             (*g_vm)->DetachCurrentThread(g_vm);
         }
         return;
     }
 
-    /* lookup WolfSSLFIPSErrorCallback class from global object ref */
-    fipsCbClass = (*jenv)->GetObjectClass(jenv, g_fipsCbIfaceObj);
+    /* lookup WolfSSLFIPSErrorCallback class from object ref */
+    fipsCbClass = (*jenv)->GetObjectClass(jenv, localCbObj);
     if (!fipsCbClass) {
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
             (*jenv)->ExceptionClear(jenv);
         }
+        (*jenv)->DeleteLocalRef(jenv, localCbObj);
         if (needsDetach) {
             (*g_vm)->DetachCurrentThread(g_vm);
         }
@@ -2008,11 +2112,14 @@ void NativeFIPSErrorCallback(const int ok, const int err,
 
     errorMethod = (*jenv)->GetMethodID(jenv, fipsCbClass, "errorCallback",
                                        "(IILjava/lang/String;)V");
+    /* done with fipsCbClass, release it now */
+    (*jenv)->DeleteLocalRef(jenv, fipsCbClass);
     if (errorMethod == 0) {
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
             (*jenv)->ExceptionClear(jenv);
         }
+        (*jenv)->DeleteLocalRef(jenv, localCbObj);
         if (needsDetach) {
             (*g_vm)->DetachCurrentThread(g_vm);
         }
@@ -2022,11 +2129,12 @@ void NativeFIPSErrorCallback(const int ok, const int err,
     /* create jstring from char* */
     hashString = (*jenv)->NewStringUTF(jenv, hash);
 
-    (*jenv)->CallVoidMethod(jenv, g_fipsCbIfaceObj, errorMethod,
+    (*jenv)->CallVoidMethod(jenv, localCbObj, errorMethod,
                             ok, err, hashString);
 
-    /* release local reference to jstring, since returning to native */
+    /* release local references, since returning to native */
     (*jenv)->DeleteLocalRef(jenv, hashString);
+    (*jenv)->DeleteLocalRef(jenv, localCbObj);
 
     if ((*jenv)->ExceptionOccurred(jenv)) {
         (*jenv)->ExceptionDescribe(jenv);
@@ -2047,6 +2155,10 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_setFIPSCb
   (JNIEnv* jenv, jclass jcl, jobject callback)
 {
     int ret = NOT_COMPILED_IN;
+#ifdef HAVE_FIPS
+    jobject newCbObj = NULL;
+    jobject priorCbObj = NULL;
+#endif
     (void)jcl;
 
 #ifdef HAVE_FIPS
@@ -2054,32 +2166,42 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSL_setFIPSCb
         return BAD_FUNC_ARG;
     }
 
-    /* release existing FIPS callback object if set */
-    if (g_fipsCbIfaceObj != NULL) {
-        (*jenv)->DeleteGlobalRef(jenv, g_fipsCbIfaceObj);
-        g_fipsCbIfaceObj = NULL;
-    }
-
     if (callback != NULL) {
         /* store Java FIPS callback Interface object */
-        g_fipsCbIfaceObj = (*jenv)->NewGlobalRef(jenv, callback);
-        if (g_fipsCbIfaceObj == NULL) {
+        newCbObj = (*jenv)->NewGlobalRef(jenv, callback);
+        if (newCbObj == NULL) {
             printf("error storing global wolfCrypt FIPS callback interface\n");
             return SSL_FAILURE;
         }
+    }
 
+    /* Swap in the new ref and register/deregister the native FIPS callback,
+     * both under the mutex. */
+    if (NativeFipsCbLock() != 0) {
+        /* Lock failed, free the new global ref and ret without unlocking */
+        if (newCbObj != NULL) {
+            (*jenv)->DeleteGlobalRef(jenv, newCbObj);
+        }
+        return SSL_FAILURE;
+    }
+    priorCbObj = g_fipsCbIfaceObj;
+    g_fipsCbIfaceObj = newCbObj;
+    if (callback != NULL) {
         /* register NativeFIPSErrorCallback, wraps Java callback */
         ret = wolfCrypt_SetCb_fips(NativeFIPSErrorCallback);
-        if (ret == 0) {
-            ret = SSL_SUCCESS;
-        }
     }
     else {
         /* NULL callback, deregister native FIPS callback */
         ret = wolfCrypt_SetCb_fips(NULL);
-        if (ret == 0) {
-            ret = SSL_SUCCESS;
-        }
+    }
+    (void)NativeFipsCbUnlock();
+    if (ret == 0) {
+        ret = SSL_SUCCESS;
+    }
+
+    /* free the prior ref outside the lock */
+    if (priorCbObj != NULL) {
+        (*jenv)->DeleteGlobalRef(jenv, priorCbObj);
     }
 #else
     (void)jenv;

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -3677,13 +3677,17 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useCertificateBuffer
         return SSL_FAILURE;
     }
 
-    buff = (unsigned char*)XMALLOC((int)sz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (sz <= 0 || sz > (jlong)(*jenv)->GetArrayLength(jenv, in)) {
+        return BAD_FUNC_ARG;
+    }
+
+    buff = (unsigned char*)XMALLOC((word32)sz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if (buff == NULL) {
         return MEMORY_E;
     }
-    XMEMSET(buff, 0, (int)sz);
+    XMEMSET(buff, 0, (word32)sz);
 
-    (*jenv)->GetByteArrayRegion(jenv, in, 0, (long)sz, (jbyte*)buff);
+    (*jenv)->GetByteArrayRegion(jenv, in, 0, (jsize)sz, (jbyte*)buff);
     if ((*jenv)->ExceptionOccurred(jenv)) {
         (*jenv)->ExceptionDescribe(jenv);
         (*jenv)->ExceptionClear(jenv);
@@ -3717,13 +3721,17 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_usePrivateKeyBuffer
         return SSL_FAILURE;
     }
 
-    buff = (unsigned char*)XMALLOC((long)sz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (sz <= 0 || sz > (jlong)(*jenv)->GetArrayLength(jenv, in)) {
+        return BAD_FUNC_ARG;
+    }
+
+    buff = (unsigned char*)XMALLOC((word32)sz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if (buff == NULL) {
         return MEMORY_E;
     }
-    XMEMSET(buff, 0, (long)sz);
+    XMEMSET(buff, 0, (word32)sz);
 
-    (*jenv)->GetByteArrayRegion(jenv, in, 0, (long)sz, (jbyte*)buff);
+    (*jenv)->GetByteArrayRegion(jenv, in, 0, (jsize)sz, (jbyte*)buff);
     if ((*jenv)->ExceptionOccurred(jenv)) {
         (*jenv)->ExceptionDescribe(jenv);
         (*jenv)->ExceptionClear(jenv);
@@ -3733,7 +3741,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_usePrivateKeyBuffer
 
     ret = wolfSSL_use_PrivateKey_buffer(ssl, buff, (long)sz, format);
 
-    XMEMSET(buff, 0, (long)sz);
+    XMEMSET(buff, 0, (word32)sz);
     XFREE(buff, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 
     return ret;
@@ -3758,13 +3766,17 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useCertificateChainBuffer
         return SSL_FAILURE;
     }
 
-    buff = (unsigned char*)XMALLOC((long)sz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (sz <= 0 || sz > (jlong)(*jenv)->GetArrayLength(jenv, in)) {
+        return BAD_FUNC_ARG;
+    }
+
+    buff = (unsigned char*)XMALLOC((word32)sz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if (buff == NULL) {
         return MEMORY_E;
     }
-    XMEMSET(buff, 0, (long)sz);
+    XMEMSET(buff, 0, (word32)sz);
 
-    (*jenv)->GetByteArrayRegion(jenv, in, 0, (long)sz, (jbyte*)buff);
+    (*jenv)->GetByteArrayRegion(jenv, in, 0, (jsize)sz, (jbyte*)buff);
     if ((*jenv)->ExceptionOccurred(jenv)) {
         (*jenv)->ExceptionDescribe(jenv);
         (*jenv)->ExceptionClear(jenv);

--- a/src/java/com/wolfssl/WolfSSL.java
+++ b/src/java/com/wolfssl/WolfSSL.java
@@ -1674,10 +1674,14 @@ public class WolfSSL {
     /**
      * Registers the callback to be used for Logging debug and trace
      * messages.
+     * <p>
+     * Once a callback has been registered, passing null stops delivery to it
+     * and native debug output is discarded, not reverted to wolfSSL's default
+     * output.
      *
-     * @param cb    Callback to be used for logging debug messages
+     * @param cb    Callback to be used for logging debug messages, or null to
+     *              stop delivering messages to a previously registered callback
      * @return      <b><code>SSL_ERROR_NONE</code></b> upon success,
-     *              <b><code>BAD_FUNC_ARG</code></b> if input is null,
      *              <b><code>NOT_COMPILED_IN</code></b> if wolfSSL was not
      *              compiled with debugging support enabled.
      * @see         #debuggingON()

--- a/src/test/com/wolfssl/test/WolfSSLSessionTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLSessionTest.java
@@ -29,7 +29,10 @@ import org.junit.rules.TestRule;
 import static org.junit.Assert.*;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.net.Socket;
 import java.net.ServerSocket;
 import java.net.DatagramSocket;
@@ -254,6 +257,75 @@ public class WolfSSLSessionTest {
         }
 
         return;
+    }
+
+    private void assertUseBufferOk(String name, int ret) {
+        if (ret != WolfSSL.SSL_SUCCESS && ret != WolfSSL.NOT_COMPILED_IN) {
+            fail(name + " failed, ret = " + ret);
+        }
+    }
+
+    /* The use*Buffer methods must reject a sz that is non-positive or larger
+     * than the array, while still honoring a sz smaller than the array. */
+    @Test
+    public void test_WolfSSLSession_useBufferRejectsBadSz()
+        throws WolfSSLJNIException, WolfSSLException, IOException {
+
+        byte[] certPem = Files.readAllBytes(Paths.get(cliCert));
+        byte[] keyPem  = Files.readAllBytes(Paths.get(cliKey));
+
+        /* sz with non-zero upper 32 bits, lower 32 bits == array length */
+        final long certBadSz = 0x100000000L | certPem.length;
+        final long keyBadSz  = 0x100000000L | keyPem.length;
+
+        /* null buffer returns BAD_FUNC_ARG on all three */
+        WolfSSLSession ssl = new WolfSSLSession(ctx);
+        assertEquals(WolfSSL.BAD_FUNC_ARG,
+            ssl.useCertificateBuffer(null, 0, WolfSSL.SSL_FILETYPE_PEM));
+        assertEquals(WolfSSL.BAD_FUNC_ARG,
+            ssl.usePrivateKeyBuffer(null, 0, WolfSSL.SSL_FILETYPE_PEM));
+        assertEquals(WolfSSL.BAD_FUNC_ARG,
+            ssl.useCertificateChainBuffer(null, 0));
+        ssl.freeSSL();
+
+        /* correct sz loads, zero/oversized rejected, sub-array (sz < len)
+         * still loads the first sz bytes */
+        ssl = new WolfSSLSession(ctx);
+        assertUseBufferOk("useCertificateBuffer",
+            ssl.useCertificateBuffer(certPem, certPem.length,
+                WolfSSL.SSL_FILETYPE_PEM));
+        assertEquals(WolfSSL.BAD_FUNC_ARG,
+            ssl.useCertificateBuffer(certPem, 0, WolfSSL.SSL_FILETYPE_PEM));
+        assertEquals(WolfSSL.BAD_FUNC_ARG,
+            ssl.useCertificateBuffer(certPem, certBadSz,
+                WolfSSL.SSL_FILETYPE_PEM));
+        byte[] certPadded = Arrays.copyOf(certPem, certPem.length + 32);
+        assertUseBufferOk("useCertificateBuffer subArray",
+            ssl.useCertificateBuffer(certPadded, certPem.length,
+                WolfSSL.SSL_FILETYPE_PEM));
+        ssl.freeSSL();
+
+        /* usePrivateKeyBuffer: correct sz loads, zero and oversized rejected */
+        ssl = new WolfSSLSession(ctx);
+        assertUseBufferOk("usePrivateKeyBuffer",
+            ssl.usePrivateKeyBuffer(keyPem, keyPem.length,
+                WolfSSL.SSL_FILETYPE_PEM));
+        assertEquals(WolfSSL.BAD_FUNC_ARG,
+            ssl.usePrivateKeyBuffer(keyPem, 0, WolfSSL.SSL_FILETYPE_PEM));
+        assertEquals(WolfSSL.BAD_FUNC_ARG,
+            ssl.usePrivateKeyBuffer(keyPem, keyBadSz,
+                WolfSSL.SSL_FILETYPE_PEM));
+        ssl.freeSSL();
+
+        /* useCertificateChainBuffer: correct sz loads, others rejected */
+        ssl = new WolfSSLSession(ctx);
+        assertUseBufferOk("useCertificateChainBuffer",
+            ssl.useCertificateChainBuffer(certPem, certPem.length));
+        assertEquals(WolfSSL.BAD_FUNC_ARG,
+            ssl.useCertificateChainBuffer(certPem, 0));
+        assertEquals(WolfSSL.BAD_FUNC_ARG,
+            ssl.useCertificateChainBuffer(certPem, certBadSz));
+        ssl.freeSSL();
     }
 
     class TestPskClientCb implements WolfSSLPskClientCallback

--- a/src/test/com/wolfssl/test/WolfSSLTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLTest.java
@@ -31,9 +31,12 @@ import static org.junit.Assert.*;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.wolfssl.WolfSSL;
 import com.wolfssl.WolfSSLException;
+import com.wolfssl.WolfSSLLoggingCallback;
 
 /* suppress SSLv3 deprecation warnings, meant for end user not tests */
 @SuppressWarnings("deprecation")
@@ -576,5 +579,123 @@ public class WolfSSLTest {
         if (mlkem || mldsa || oldIds) {
             /* nothing */
         }
+    }
+
+    /* Logging callback used by the setLoggingCb test. Uses a shared static
+     * counter so invocations across swapped instances accumulate. */
+    static class TestLoggingCallback implements WolfSSLLoggingCallback {
+        static final AtomicLong count = new AtomicLong(0);
+        public void loggingCallback(int logLevel, String logMessage) {
+            count.incrementAndGet();
+        }
+    }
+
+    @Test
+    public void test_WolfSSL_setLoggingCb() throws InterruptedException {
+
+        int ret;
+
+        /* Return is SSL_ERROR_NONE on a debug build, else NOT_COMPILED_IN. */
+        ret = WolfSSL.setLoggingCb(new TestLoggingCallback());
+        if (ret != WolfSSL.SSL_ERROR_NONE && ret != WolfSSL.NOT_COMPILED_IN) {
+            fail("WolfSSL.setLoggingCb() returned unexpected value: " + ret);
+        }
+
+        /* Re-register a different callback, releases the prior ref. */
+        ret = WolfSSL.setLoggingCb(new TestLoggingCallback());
+        if (ret != WolfSSL.SSL_ERROR_NONE && ret != WolfSSL.NOT_COMPILED_IN) {
+            fail("WolfSSL.setLoggingCb() re-register returned: " + ret);
+        }
+
+        ret = WolfSSL.setLoggingCb(null);
+        if (ret != WolfSSL.SSL_ERROR_NONE && ret != WolfSSL.NOT_COMPILED_IN) {
+            fail("WolfSSL.setLoggingCb(null) returned unexpected value: " +
+                ret);
+        }
+
+        WolfSSL.debuggingON();
+
+        /* Concurrency stress: writers swap and clear the callback while drivers
+         * make native calls that log, firing NativeLoggingCallback during the
+         * swap/free. Exercises both the g_loggingCbIfaceObj mutex (no jobject
+         * UAF) and one-time native registration (setLoggingCb(null) never nulls
+         * native LogFunction). Passing with no JVM abort is the assertion. */
+        final int numThreads = 8;
+        final int iterations = 500;
+        final AtomicReference<Throwable> firstError =
+            new AtomicReference<Throwable>();
+        Thread[] threads = new Thread[numThreads];
+
+        for (int i = 0; i < numThreads; i++) {
+            final int id = i;
+            threads[i] = new Thread(new Runnable() {
+                public void run() {
+                    String role = ((id % 2) == 0) ? "writer" : "driver";
+                    try {
+                        for (int j = 0; j < iterations; j++) {
+                            if ((id % 2) == 0) {
+                                /* writer: swap in a callback, then clear it */
+                                WolfSSL.setLoggingCb(new TestLoggingCallback());
+                                WolfSSL.setLoggingCb(null);
+                            }
+                            else {
+                                /* driver: native call that logs on debug */
+                                long m = WolfSSL.SSLv23_ClientMethod();
+                                if (m != 0 && m != WolfSSL.NOT_COMPILED_IN) {
+                                    WolfSSL.nativeFree(m);
+                                }
+                            }
+                        }
+                    } catch (Throwable t) {
+                        firstError.compareAndSet(null,
+                            new Exception("in " + role + " thread", t));
+                    }
+                }
+            });
+        }
+
+        for (int i = 0; i < numThreads; i++) {
+            threads[i].start();
+        }
+        for (int i = 0; i < numThreads; i++) {
+            threads[i].join();
+        }
+
+        WolfSSL.debuggingOFF();
+
+        /* leave unregistered for other tests */
+        WolfSSL.setLoggingCb(null);
+
+        Throwable err = firstError.get();
+        if (err != null) {
+            AssertionError ae = new AssertionError(
+                "concurrent setLoggingCb() threw " + err.getMessage());
+            ae.initCause(err);
+            throw ae;
+        }
+    }
+
+    /* Test that NativeLoggingCallback dispatches to Java. Skips on builds
+     * without debug logging, or where WOLFSSL_ENTER trace messages are
+     * compiled out (ex: WOLFSSL_DEBUG_ERRORS_ONLY), rather than failing. */
+    @Test
+    public void test_WolfSSL_setLoggingCbDispatch() {
+
+        int ret = WolfSSL.setLoggingCb(new TestLoggingCallback());
+        Assume.assumeTrue("debug logging not compiled in",
+            ret == WolfSSL.SSL_ERROR_NONE);
+
+        WolfSSL.debuggingON();
+        TestLoggingCallback.count.set(0);
+        long m = WolfSSL.SSLv23_ClientMethod();
+        if (m != 0 && m != WolfSSL.NOT_COMPILED_IN) {
+            WolfSSL.nativeFree(m);
+        }
+        WolfSSL.debuggingOFF();
+        WolfSSL.setLoggingCb(null);
+
+        /* No message means this build compiled out trace logging, skip. */
+        Assume.assumeTrue("no trace messages emitted by this build",
+            TestLoggingCallback.count.get() > 0);
     }
 }

--- a/src/test/com/wolfssl/test/WolfSSLTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLTest.java
@@ -37,6 +37,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import com.wolfssl.WolfSSL;
 import com.wolfssl.WolfSSLException;
 import com.wolfssl.WolfSSLLoggingCallback;
+import com.wolfssl.WolfSSLFIPSErrorCallback;
 
 /* suppress SSLv3 deprecation warnings, meant for end user not tests */
 @SuppressWarnings("deprecation")
@@ -697,5 +698,34 @@ public class WolfSSLTest {
         /* No message means this build compiled out trace logging, skip. */
         Assume.assumeTrue("no trace messages emitted by this build",
             TestLoggingCallback.count.get() > 0);
+    }
+
+    /* FIPS error callback used by the setFIPSCb test. */
+    static class TestFIPSErrorCallback implements WolfSSLFIPSErrorCallback {
+        public void errorCallback(int ok, int err, String hash) {
+        }
+    }
+
+    /* setFIPSCb() must register, re-register (freeing prior global ref under
+     * the FIPS callback mutex), and deregister without error. */
+    @Test
+    public void test_WolfSSL_setFIPSCb() {
+
+        int ret = WolfSSL.setFIPSCb(new TestFIPSErrorCallback());
+        if (ret != WolfSSL.SSL_SUCCESS && ret != WolfSSL.NOT_COMPILED_IN) {
+            fail("WolfSSL.setFIPSCb() returned unexpected value: " + ret);
+        }
+
+        /* re-register a different callback, releases the prior ref */
+        ret = WolfSSL.setFIPSCb(new TestFIPSErrorCallback());
+        if (ret != WolfSSL.SSL_SUCCESS && ret != WolfSSL.NOT_COMPILED_IN) {
+            fail("WolfSSL.setFIPSCb() re-register returned: " + ret);
+        }
+
+        /* deregister for other tests */
+        ret = WolfSSL.setFIPSCb(null);
+        if (ret != WolfSSL.SSL_SUCCESS && ret != WolfSSL.NOT_COMPILED_IN) {
+            fail("WolfSSL.setFIPSCb(null) returned: " + ret);
+        }
     }
 }


### PR DESCRIPTION
This PR includes five Fenrir fixes:

- **F-5064**: Serialize access to the global logging callback object with a dedicated mutex, and register the native logging callback once instead of toggling it, so lookups and updates stay consistent across threads.

- **F-5206**: Bound the staging buffer in WolfSSLSession useCertificateBuffer, usePrivateKeyBuffer, and useCertificateChainBuffer by validating the caller sz against the byte array length before use.

- **F-5207**: Serialize access to the global FIPS error callback object with a dedicated mutex, mirroring the logging callback handling.

- **F-5208**: Call setNeedClientAuth(true) in the MultiThreadedSSLServer example so the loaded client CA trust store is applied, matching the other server examples.

- **F-5209**: Set the endpoint identification algorithm to HTTPS in the ClientSSLSocket example so the peer certificate is checked against the connected host.