### PR TITLE
JNI: release JNI local refs in NativeALPNSelectCb()

### DIFF
--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -5526,19 +5526,50 @@ JNIEXPORT int JNICALL Java_com_wolfssl_WolfSSLSession_setALPNSelectCb
 
 #ifdef HAVE_ALPN
 
+/* Delete JNI local references created inside NativeALPNSelectCb() */
+static void freeALPNSelectCbLocalRefs(JNIEnv* jenv, jclass sslClass,
+    jclass stringClass, jobjectArray peerProtosArr, jobjectArray outProtoArr,
+    jstring selectedProto)
+{
+    if (jenv == NULL) {
+        return;
+    }
+
+    if (selectedProto != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, selectedProto);
+    }
+
+    if (outProtoArr != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, outProtoArr);
+    }
+
+    if (peerProtosArr != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, peerProtosArr);
+    }
+
+    if (stringClass != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, stringClass);
+    }
+
+    if (sslClass != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, sslClass);
+    }
+}
+
 int NativeALPNSelectCb(WOLFSSL *ssl, const unsigned char **out,
     unsigned char *outlen, const unsigned char *in,
     unsigned int inlen, void *arg)
 {
-    JNIEnv* jenv;                   /* JNI environment */
-    int     needsDetach = 0;        /* Should we explicitly detach? */
+    JNIEnv* jenv;                        /* JNI environment */
+    int     needsDetach = 0;             /* Should we explicitly detach? */
     jint    vmret = 0;
 
-    jobject*  g_cachedSSLObj;       /* WolfSSLSession cached object */
-    jclass    sslClass;             /* WolfSSLSession class */
-    jmethodID alpnSelectMethodId;   /* internalAlpnSelectCallback ID */
+    jobject*  g_cachedSSLObj;            /* WolfSSLSession cached object */
+    jclass    sslClass = NULL;           /* WolfSSLSession class */
+    jclass    stringClass = NULL;        /* java/lang/String class */
+    jmethodID alpnSelectMethodId = NULL; /* internalAlpnSelectCallback */
 
-    int ret = 0;
+    int ret = SSL_TLSEXT_ERR_OK;
     unsigned int idx = 0;
     int peerProtoCount = 0;
     char* peerProtos = NULL;
@@ -5550,6 +5581,7 @@ int NativeALPNSelectCb(WOLFSSL *ssl, const unsigned char **out,
     jobjectArray peerProtosArr = NULL;
     jobjectArray outProtoArr = NULL;
     int outProtoArrSz = 0;
+    jstring protoStr = NULL;
     jstring selectedProto = NULL;
     const char* selectedProtoCharArr = NULL;
     int selectedProtoCharArrSz = 0;
@@ -5578,213 +5610,212 @@ int NativeALPNSelectCb(WOLFSSL *ssl, const unsigned char **out,
 
     /* get stored WolfSSLSession object */
     g_cachedSSLObj = (jobject*) wolfSSL_get_jobject(ssl);
-    if (!g_cachedSSLObj) {
+    if (g_cachedSSLObj == NULL) {
         throwWolfSSLJNIException(jenv,
-            "Can't get native WolfSSLSession object reference in "
-            "NativeALPNSelectCb");
-        if (needsDetach) {
-            (*g_vm)->DetachCurrentThread(g_vm);
-        }
-        return SSL_TLSEXT_ERR_ALERT_FATAL;
+            "Can't get native WolfSSLSession object ref in NativeALPNSelectCb");
+        ret = SSL_TLSEXT_ERR_ALERT_FATAL;
     }
 
-    /* lookup WolfSSLSession class from object */
-    sslClass = (*jenv)->GetObjectClass(jenv, (jobject)(*g_cachedSSLObj));
-    if (sslClass == NULL) {
-        throwWolfSSLJNIException(jenv,
-            "Can't get native WolfSSLSession class reference in "
-            "NativeALPNSelectCb");
-        if (needsDetach) {
-            (*g_vm)->DetachCurrentThread(g_vm);
-        }
-        return SSL_TLSEXT_ERR_ALERT_FATAL;
-    }
-
-    /* call internal ALPN select callback */
-    alpnSelectMethodId = (*jenv)->GetMethodID(jenv, sslClass,
-        "internalAlpnSelectCallback",
-        "(Lcom/wolfssl/WolfSSLSession;[Ljava/lang/String;[Ljava/lang/String;)I");
-    if (alpnSelectMethodId == NULL) {
-        if ((*jenv)->ExceptionOccurred(jenv)) {
-            (*jenv)->ExceptionDescribe(jenv);
-            (*jenv)->ExceptionClear(jenv);
-        }
-        throwWolfSSLJNIException(jenv,
-            "Error getting internalAlpnSelectCallback method from JNI");
-        if (needsDetach) {
-            (*g_vm)->DetachCurrentThread(g_vm);
-        }
-        return SSL_TLSEXT_ERR_ALERT_FATAL;
-    }
-
-    /* Use wolfSSL_ALPN_GetPeerProtocol() here to get ALPN protocols sent
-     * by the peer instead of directly using in/inlen, since this API
-     * splits/formats into a comma-separated list. peerProtosSz does not
-     * include the null terminator byte in the size. It is only the size
-     * of the ALPN list chars proper.*/
-    ret = wolfSSL_ALPN_GetPeerProtocol(ssl, &peerProtos, &peerProtosSz);
-    if (ret != WOLFSSL_SUCCESS) {
-        if ((*jenv)->ExceptionOccurred(jenv)) {
-            (*jenv)->ExceptionDescribe(jenv);
-            (*jenv)->ExceptionClear(jenv);
-        }
-        throwWolfSSLJNIException(jenv,
-            "Error in wolfSSL_ALPN_GetPeerProtocol()");
-        if (needsDetach) {
-            (*g_vm)->DetachCurrentThread(g_vm);
-        }
-        return SSL_TLSEXT_ERR_ALERT_FATAL;
-    }
-
-    /* Make a copy of peer protos since we have to scan through it first
-     * to get total number of tokens. Allocate peerProtosSz+1 to make
-     * sure our list is null terminated for XSTRTOK(). */
-    peerProtosCopy = (char*)XMALLOC(peerProtosSz + 1, NULL,
-        DYNAMIC_TYPE_TMP_BUFFER);
-    if (peerProtosCopy == NULL) {
-        wolfSSL_ALPN_FreePeerProtocol(ssl, &peerProtos);
-        if ((*jenv)->ExceptionOccurred(jenv)) {
-            (*jenv)->ExceptionDescribe(jenv);
-            (*jenv)->ExceptionClear(jenv);
-        }
-        throwWolfSSLJNIException(jenv,
-            "Error allocating memory for peer protocols array");
-        if (needsDetach) {
-            (*g_vm)->DetachCurrentThread(g_vm);
-        }
-        return SSL_TLSEXT_ERR_ALERT_FATAL;
-    }
-    XMEMSET(peerProtosCopy, 0, peerProtosSz + 1);
-    XMEMCPY(peerProtosCopy, peerProtos, peerProtosSz);
-
-    /* get count of protocols, used to create Java array of proper size */
-    curr = XSTRTOK(peerProtosCopy, ",", &ptr);
-    while (curr != NULL) {
-        peerProtoCount++;
-        curr = XSTRTOK(NULL, ",", &ptr);
-    }
-    XFREE(peerProtosCopy, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    peerProtosCopy = NULL;
-
-    if (peerProtoCount == 0) {
-        wolfSSL_ALPN_FreePeerProtocol(ssl, &peerProtos);
-        if ((*jenv)->ExceptionOccurred(jenv)) {
-            (*jenv)->ExceptionDescribe(jenv);
-            (*jenv)->ExceptionClear(jenv);
-        }
-        throwWolfSSLJNIException(jenv,
-            "ALPN peer protocol list size is 0");
-        if (needsDetach) {
-            (*g_vm)->DetachCurrentThread(g_vm);
-        }
-        return SSL_TLSEXT_ERR_ALERT_FATAL;
-    }
-
-    /* create Java String[] of size peerProtoCount */
-    peerProtosArr = (*jenv)->NewObjectArray(jenv, peerProtoCount,
-        (*jenv)->FindClass(jenv, "java/lang/String"), NULL);
-    if (peerProtosArr == NULL) {
-        wolfSSL_ALPN_FreePeerProtocol(ssl, &peerProtos);
-        if ((*jenv)->ExceptionOccurred(jenv)) {
-            (*jenv)->ExceptionDescribe(jenv);
-            (*jenv)->ExceptionClear(jenv);
-        }
-        throwWolfSSLJNIException(jenv,
-            "Failed to create JNI String[] for ALPN protocols");
-        if (needsDetach) {
-            (*g_vm)->DetachCurrentThread(g_vm);
-        }
-        return SSL_TLSEXT_ERR_ALERT_FATAL;
-    }
-
-    /* add each char* to String[] for call to Java callback method */
-    curr = XSTRTOK(peerProtos, ",", &ptr);
-    while (curr != NULL) {
-        (*jenv)->SetObjectArrayElement(jenv, peerProtosArr, idx++,
-            (*jenv)->NewStringUTF(jenv, curr));
-        if ((*jenv)->ExceptionOccurred(jenv)) {
-            (*jenv)->ExceptionDescribe(jenv);
-            (*jenv)->ExceptionClear(jenv);
-
-            wolfSSL_ALPN_FreePeerProtocol(ssl, &peerProtos);
+    if (ret == SSL_TLSEXT_ERR_OK) {
+        /* lookup WolfSSLSession class from object */
+        sslClass = (*jenv)->GetObjectClass(jenv, (jobject)(*g_cachedSSLObj));
+        if (sslClass == NULL) {
             throwWolfSSLJNIException(jenv,
-                "Failed to add String to JNI String[] for ALPN protocols");
-            if (needsDetach) {
-                (*g_vm)->DetachCurrentThread(g_vm);
-            }
-            return SSL_TLSEXT_ERR_ALERT_FATAL;
+                "Can't get native WolfSSLSession class reference in "
+                "NativeALPNSelectCb");
+            ret = SSL_TLSEXT_ERR_ALERT_FATAL;
         }
+    }
 
-        curr = XSTRTOK(NULL, ",", &ptr);
+    if (ret == SSL_TLSEXT_ERR_OK) {
+        /* get method ID for internalAlpnSelectCallback() */
+        alpnSelectMethodId = (*jenv)->GetMethodID(jenv, sslClass,
+            "internalAlpnSelectCallback",
+            "(Lcom/wolfssl/WolfSSLSession;[Ljava/lang/String;"
+            "[Ljava/lang/String;)I");
+        if (alpnSelectMethodId == NULL) {
+            if ((*jenv)->ExceptionCheck(jenv)) {
+                (*jenv)->ExceptionDescribe(jenv);
+                (*jenv)->ExceptionClear(jenv);
+            }
+            throwWolfSSLJNIException(jenv,
+                "Error getting internalAlpnSelectCallback method from JNI");
+            ret = SSL_TLSEXT_ERR_ALERT_FATAL;
+        }
+    }
+
+    if (ret == SSL_TLSEXT_ERR_OK) {
+        /* Use wolfSSL_ALPN_GetPeerProtocol() here to get ALPN protocols sent
+         * by the peer instead of directly using in/inlen, since this API
+         * splits/formats into a comma-separated list. peerProtosSz does not
+         * include the null terminator byte in the size. It is only the size of
+         * the ALPN list chars proper. */
+        if (wolfSSL_ALPN_GetPeerProtocol(ssl, &peerProtos,
+                &peerProtosSz) != WOLFSSL_SUCCESS) {
+            throwWolfSSLJNIException(jenv,
+                "Error in wolfSSL_ALPN_GetPeerProtocol()");
+            ret = SSL_TLSEXT_ERR_ALERT_FATAL;
+        }
+    }
+
+    if (ret == SSL_TLSEXT_ERR_OK) {
+        /* Make a copy of peer protos since we have to scan through it first
+         * to get total number of tokens. Allocate peerProtosSz+1 to make sure
+         * our list is null terminated for XSTRTOK(). */
+        peerProtosCopy = (char*)XMALLOC(peerProtosSz + 1, NULL,
+            DYNAMIC_TYPE_TMP_BUFFER);
+        if (peerProtosCopy == NULL) {
+            throwWolfSSLJNIException(jenv,
+                "Error allocating memory for peer protocols array");
+            ret = SSL_TLSEXT_ERR_ALERT_FATAL;
+        }
+    }
+
+    if (ret == SSL_TLSEXT_ERR_OK) {
+        XMEMSET(peerProtosCopy, 0, peerProtosSz + 1);
+        XMEMCPY(peerProtosCopy, peerProtos, peerProtosSz);
+
+        /* get count of protocols, used to create Java array of proper size */
+        curr = XSTRTOK(peerProtosCopy, ",", &ptr);
+        while (curr != NULL) {
+            peerProtoCount++;
+            curr = XSTRTOK(NULL, ",", &ptr);
+        }
+        XFREE(peerProtosCopy, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        peerProtosCopy = NULL;
+
+        if (peerProtoCount == 0) {
+            throwWolfSSLJNIException(jenv, "ALPN peer protocol list size is 0");
+            ret = SSL_TLSEXT_ERR_ALERT_FATAL;
+        }
+    }
+
+    if (ret == SSL_TLSEXT_ERR_OK) {
+        /* find java/lang/String class, used to create String[] below */
+        stringClass = (*jenv)->FindClass(jenv, "java/lang/String");
+        if (stringClass == NULL) {
+            if ((*jenv)->ExceptionCheck(jenv)) {
+                (*jenv)->ExceptionDescribe(jenv);
+                (*jenv)->ExceptionClear(jenv);
+            }
+            throwWolfSSLJNIException(jenv,
+                "Error finding java/lang/String class in NativeALPNSelectCb");
+            ret = SSL_TLSEXT_ERR_ALERT_FATAL;
+        }
+    }
+
+    if (ret == SSL_TLSEXT_ERR_OK) {
+        /* create Java String[] of size peerProtoCount */
+        peerProtosArr = (*jenv)->NewObjectArray(jenv, peerProtoCount,
+            stringClass, NULL);
+        if (peerProtosArr == NULL) {
+            if ((*jenv)->ExceptionCheck(jenv)) {
+                (*jenv)->ExceptionDescribe(jenv);
+                (*jenv)->ExceptionClear(jenv);
+            }
+            throwWolfSSLJNIException(jenv,
+                "Failed to create JNI String[] for ALPN protocols");
+            ret = SSL_TLSEXT_ERR_ALERT_FATAL;
+        }
+    }
+
+    if (ret == SSL_TLSEXT_ERR_OK) {
+        /* add each char* to String[] for call to Java callback method */
+        curr = XSTRTOK(peerProtos, ",", &ptr);
+        while (curr != NULL) {
+            protoStr = (*jenv)->NewStringUTF(jenv, curr);
+            if (protoStr == NULL) {
+                if ((*jenv)->ExceptionCheck(jenv)) {
+                    (*jenv)->ExceptionDescribe(jenv);
+                    (*jenv)->ExceptionClear(jenv);
+                }
+                throwWolfSSLJNIException(jenv,
+                    "Failed to create String for ALPN peer protocol");
+                ret = SSL_TLSEXT_ERR_ALERT_FATAL;
+                break;
+            }
+
+            (*jenv)->SetObjectArrayElement(jenv, peerProtosArr, idx++,
+                protoStr);
+            (*jenv)->DeleteLocalRef(jenv, protoStr);
+            protoStr = NULL;
+            if ((*jenv)->ExceptionCheck(jenv)) {
+                (*jenv)->ExceptionDescribe(jenv);
+                (*jenv)->ExceptionClear(jenv);
+                throwWolfSSLJNIException(jenv,
+                    "Failed to add String to JNI String[] for ALPN protocols");
+                ret = SSL_TLSEXT_ERR_ALERT_FATAL;
+                break;
+            }
+
+            curr = XSTRTOK(NULL, ",", &ptr);
+        }
     }
 
     /* free native peer protocol list, no longer needed */
-    wolfSSL_ALPN_FreePeerProtocol(ssl, &peerProtos);
-
-    /* create new String[1] to let Java callback put output selection into
-     * first array offset, ie String[0] */
-    outProtoArr = (*jenv)->NewObjectArray(jenv, 1,
-        (*jenv)->FindClass(jenv, "java/lang/String"), NULL);
-    if (outProtoArr == NULL) {
-        if ((*jenv)->ExceptionOccurred(jenv)) {
-            (*jenv)->ExceptionDescribe(jenv);
-            (*jenv)->ExceptionClear(jenv);
-        }
-        throwWolfSSLJNIException(jenv,
-            "Failed to create JNI String[1] for output ALPN protocol");
-        if (needsDetach) {
-            (*g_vm)->DetachCurrentThread(g_vm);
-        }
-        return SSL_TLSEXT_ERR_ALERT_FATAL;
+    if (peerProtos != NULL) {
+        wolfSSL_ALPN_FreePeerProtocol(ssl, &peerProtos);
     }
 
-    /* call Java callback */
-    ret = (*jenv)->CallIntMethod(jenv, (jobject)(*g_cachedSSLObj),
-       alpnSelectMethodId, (jobject)(*g_cachedSSLObj), outProtoArr,
-       peerProtosArr);
-    if ((*jenv)->ExceptionOccurred(jenv)) {
-        (*jenv)->ExceptionDescribe(jenv);
-        (*jenv)->ExceptionClear(jenv);
-        throwWolfSSLJNIException(jenv,
-            "Exception while calling internalAlpnSelectCallback()");
-        if (needsDetach) {
-            (*g_vm)->DetachCurrentThread(g_vm);
+    if (ret == SSL_TLSEXT_ERR_OK) {
+        /* create new String[1] to let Java callback put output selection
+         * into first array offset, ie String[0] */
+        outProtoArr = (*jenv)->NewObjectArray(jenv, 1, stringClass, NULL);
+        if (outProtoArr == NULL) {
+            if ((*jenv)->ExceptionCheck(jenv)) {
+                (*jenv)->ExceptionDescribe(jenv);
+                (*jenv)->ExceptionClear(jenv);
+            }
+            throwWolfSSLJNIException(jenv,
+                "Failed to create JNI String[1] for output ALPN protocol");
+            ret = SSL_TLSEXT_ERR_ALERT_FATAL;
         }
-        return SSL_TLSEXT_ERR_ALERT_FATAL;
+    }
+
+    if (ret == SSL_TLSEXT_ERR_OK) {
+        /* call Java callback */
+        ret = (*jenv)->CallIntMethod(jenv, (jobject)(*g_cachedSSLObj),
+            alpnSelectMethodId, (jobject)(*g_cachedSSLObj), outProtoArr,
+            peerProtosArr);
+        if ((*jenv)->ExceptionCheck(jenv)) {
+            (*jenv)->ExceptionDescribe(jenv);
+            (*jenv)->ExceptionClear(jenv);
+            throwWolfSSLJNIException(jenv,
+                "Exception while calling internalAlpnSelectCallback()");
+            ret = SSL_TLSEXT_ERR_ALERT_FATAL;
+        }
     }
 
     if (ret == SSL_TLSEXT_ERR_OK) {
         /* convert returned String[0] into char* */
         outProtoArrSz = (*jenv)->GetArrayLength(jenv, outProtoArr);
         if (outProtoArrSz != 1) {
-            if ((*jenv)->ExceptionOccurred(jenv)) {
+            if ((*jenv)->ExceptionCheck(jenv)) {
                 (*jenv)->ExceptionDescribe(jenv);
                 (*jenv)->ExceptionClear(jenv);
             }
             throwWolfSSLJNIException(jenv,
                 "Output String[] for ALPN result not size 1");
-            if (needsDetach) {
-                (*g_vm)->DetachCurrentThread(g_vm);
-            }
-            return SSL_TLSEXT_ERR_ALERT_FATAL;
+            ret = SSL_TLSEXT_ERR_ALERT_FATAL;
         }
+    }
 
+    if (ret == SSL_TLSEXT_ERR_OK) {
         /* get jstring from String[0] */
         selectedProto = (jstring)(*jenv)->GetObjectArrayElement(
             jenv, outProtoArr, 0);
         if (selectedProto == NULL) {
-            if ((*jenv)->ExceptionOccurred(jenv)) {
+            if ((*jenv)->ExceptionCheck(jenv)) {
                 (*jenv)->ExceptionDescribe(jenv);
                 (*jenv)->ExceptionClear(jenv);
             }
             throwWolfSSLJNIException(jenv,
                 "Selected ALPN protocol in String[] is NULL");
-            if (needsDetach) {
-                (*g_vm)->DetachCurrentThread(g_vm);
-            }
-            return SSL_TLSEXT_ERR_ALERT_FATAL;
+            ret = SSL_TLSEXT_ERR_ALERT_FATAL;
         }
+    }
 
+    if (ret == SSL_TLSEXT_ERR_OK) {
         /* get char* from jstring */
         selectedProtoCharArr = (*jenv)->GetStringUTFChars(jenv,
             selectedProto, 0);
@@ -5811,17 +5842,19 @@ int NativeALPNSelectCb(WOLFSSL *ssl, const unsigned char **out,
             if (idx >= inlen && ret != SSL_TLSEXT_ERR_ALERT_FATAL) {
                 ret = SSL_TLSEXT_ERR_ALERT_FATAL;
             }
+            (*jenv)->ReleaseStringUTFChars(jenv, selectedProto,
+                selectedProtoCharArr);
         }
         else {
             /* Not able to get selected ALPN protocol from Java, fatal error */
             ret = SSL_TLSEXT_ERR_ALERT_FATAL;
         }
-
-        if (selectedProtoCharArr != NULL) {
-            (*jenv)->ReleaseStringUTFChars(jenv, selectedProto,
-                selectedProtoCharArr);
-        }
     }
+
+    /* delete local refs created above, no longer needed. Selected protocol
+     * (*out) points into native in[] array, not Java memory */
+    freeALPNSelectCbLocalRefs(jenv, sslClass, stringClass, peerProtosArr,
+        outProtoArr, selectedProto);
 
     if (needsDetach) {
         (*g_vm)->DetachCurrentThread(g_vm);

--- a/src/test/com/wolfssl/test/WolfSSLSessionTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLSessionTest.java
@@ -54,6 +54,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.Security;
 
 import com.wolfssl.WolfSSL;
+import com.wolfssl.WolfSSLALPNSelectCallback;
 import com.wolfssl.WolfSSLDebug;
 import com.wolfssl.WolfSSLCertificate;
 import com.wolfssl.WolfSSLContext;
@@ -933,6 +934,326 @@ public class WolfSSLSessionTest {
             e.printStackTrace();
 
         }
+    }
+
+    /* Run one client/server TLS handshake over localhost, with the server
+     * using the provided ALPN select callback and the client offering
+     * cliProtos via useALPN(). Returns int[2] containing the server
+     * accept() and client connect() return values. If the handshake
+     * succeeds, the ALPN protocol selected is placed into selectedOut[0]
+     * (server side) and selectedOut[1] (client side). Returns null if
+     * setAlpnSelectCb() is not compiled into native wolfSSL. */
+    private int[] runAlpnSelectHandshake(final WolfSSLALPNSelectCallback cb,
+        final String[] cliProtos, final String[] selectedOut)
+        throws Exception {
+
+        int ret, err;
+        final int[] results = new int[2];
+        Socket cliSock = null;
+        WolfSSLSession cliSes = null;
+        WolfSSLContext srvCtx = null;
+        WolfSSLContext cliCtx = null;
+        ServerSocket srvSocket = null;
+        ExecutorService es = null;
+        final int[] srvAcceptRet = new int[1];
+        final String[] srvSelected = new String[1];
+
+        try {
+            /* Create ServerSocket first to get ephemeral port, set
+             * 10 sec timeout on accept() to prevent test hangs. */
+            srvSocket = new ServerSocket(0);
+            srvSocket.setSoTimeout(10000);
+
+            final int port = srvSocket.getLocalPort();
+            final ServerSocket finalSrvSocket = srvSocket;
+
+            /* Setup server and client contexts */
+            srvCtx = createAndSetupWolfSSLContext(srvCert, srvKey,
+                WolfSSL.SSL_FILETYPE_PEM, caCert,
+                WolfSSL.TLSv1_2_ServerMethod());
+            cliCtx = createAndSetupWolfSSLContext(cliCert, cliKey,
+                WolfSSL.SSL_FILETYPE_PEM, caCert,
+                WolfSSL.TLSv1_2_ClientMethod());
+            final WolfSSLContext finalSrvCtx = srvCtx;
+
+            /* Check native ALPN select callback support before starting
+             * handshake threads. setAlpnSelectCb() returns NOT_COMPILED_IN
+             * if support not available in native wolfSSL. */
+            WolfSSLSession tmpSes = new WolfSSLSession(srvCtx);
+            ret = tmpSes.setAlpnSelectCb(cb, null);
+            tmpSes.freeSSL();
+            if (ret == WolfSSL.NOT_COMPILED_IN) {
+                return null;
+            }
+            else if (ret != WolfSSL.SSL_SUCCESS) {
+                throw new Exception("setAlpnSelectCb() failed: " + ret);
+            }
+
+            /* Latch to signal when server is ready to accept */
+            final CountDownLatch serverReady = new CountDownLatch(1);
+
+            /* Start server thread */
+            es = Executors.newSingleThreadExecutor();
+            Future<Void> serverFuture = es.submit(new Callable<Void>() {
+                @Override
+                public Void call() throws Exception {
+                    int ret;
+                    int err;
+                    Socket server = null;
+                    WolfSSLSession srvSes = null;
+
+                    try {
+                        /* Signal that we're ready to accept */
+                        serverReady.countDown();
+                        server = finalSrvSocket.accept();
+                        srvSes = new WolfSSLSession(finalSrvCtx);
+
+                        ret = srvSes.setAlpnSelectCb(cb, null);
+                        if (ret != WolfSSL.SSL_SUCCESS) {
+                            throw new Exception(
+                                "setAlpnSelectCb() failed: " + ret);
+                        }
+
+                        ret = srvSes.setFd(server);
+                        if (ret != WolfSSL.SSL_SUCCESS) {
+                            throw new Exception(
+                                "WolfSSLSession.setFd() failed: " + ret);
+                        }
+
+                        try {
+                            do {
+                                ret = srvSes.accept();
+                                err = srvSes.getError(ret);
+                            } while (ret != WolfSSL.SSL_SUCCESS &&
+                                     (err == WolfSSL.SSL_ERROR_WANT_READ ||
+                                      err == WolfSSL.SSL_ERROR_WANT_WRITE));
+                        } catch (Exception e) {
+                            /* Exception from inside ALPN select callback
+                             * may propagate out of accept(), treat as
+                             * handshake failure */
+                            ret = WolfSSL.SSL_FAILURE;
+                        }
+
+                        /* Store result instead of throwing, accept()
+                         * failure is expected in some test scenarios */
+                        srvAcceptRet[0] = ret;
+
+                        if (ret == WolfSSL.SSL_SUCCESS) {
+                            srvSelected[0] = srvSes.getAlpnSelectedString();
+                            srvSes.shutdownSSL();
+                        }
+
+                    } finally {
+                        if (srvSes != null) {
+                            srvSes.freeSSL();
+                        }
+                        if (server != null) {
+                            server.close();
+                        }
+                        finalSrvSocket.close();
+                    }
+
+                    return null;
+                }
+            });
+
+            /* Wait for server thread to be ready before connecting */
+            serverReady.await(2, TimeUnit.SECONDS);
+
+            /* Client connects to local server */
+            cliSock = new Socket("localhost", port);
+            cliSes = new WolfSSLSession(cliCtx);
+
+            ret = cliSes.useALPN(cliProtos,
+                WolfSSL.WOLFSSL_ALPN_CONTINUE_ON_MISMATCH);
+            if (ret != WolfSSL.SSL_SUCCESS) {
+                throw new Exception("useALPN() failed: " + ret);
+            }
+
+            ret = cliSes.setFd(cliSock);
+            if (ret != WolfSSL.SSL_SUCCESS) {
+                throw new Exception("setFd() failed: " + ret);
+            }
+
+            do {
+                ret = cliSes.connect();
+                err = cliSes.getError(ret);
+            } while (ret != WolfSSL.SSL_SUCCESS &&
+                     (err == WolfSSL.SSL_ERROR_WANT_READ ||
+                      err == WolfSSL.SSL_ERROR_WANT_WRITE));
+
+            /* Store result, connect() failure is expected in some
+             * test scenarios */
+            results[1] = ret;
+
+            if (ret == WolfSSL.SSL_SUCCESS) {
+                selectedOut[1] = cliSes.getAlpnSelectedString();
+                cliSes.shutdownSSL();
+            }
+
+            /* Wait for server thread to finish */
+            serverFuture.get(10, TimeUnit.SECONDS);
+
+            results[0] = srvAcceptRet[0];
+            selectedOut[0] = srvSelected[0];
+
+        } finally {
+            if (cliSes != null) {
+                cliSes.freeSSL();
+            }
+            if (cliSock != null) {
+                try { cliSock.close(); } catch (Exception e) { }
+            }
+            if (srvSocket != null) {
+                try { srvSocket.close(); } catch (Exception e) { }
+            }
+            if (cliCtx != null) {
+                cliCtx.free();
+            }
+            if (srvCtx != null) {
+                srvCtx.free();
+            }
+            if (es != null) {
+                es.shutdown();
+                try {
+                    es.awaitTermination(5, TimeUnit.SECONDS);
+                } catch (Exception e) { }
+            }
+        }
+
+        return results;
+    }
+
+    @Test
+    public void test_WolfSSLSession_alpnSelectCallback() throws Exception {
+
+        int[] ret = null;
+        String[] selected = null;
+        final boolean[] cbFired = new boolean[1];
+        final boolean[] peerListOk = new boolean[1];
+
+        /* Scenario 1: callback selects "h2" from peer list. Handshake should
+         * succeed with "h2" negotiated on both peers, and the callback should
+         * receive the full client protocol list. */
+        selected = new String[2];
+        ret = runAlpnSelectHandshake(new WolfSSLALPNSelectCallback() {
+            @Override
+            public int alpnSelectCallback(WolfSSLSession ssl,
+                String[] out, String[] in, Object arg) {
+                int found = 0;
+                cbFired[0] = true;
+                for (String proto : in) {
+                    if (proto.equals("http/1.1") ||
+                        proto.equals("h2")) {
+                        found++;
+                    }
+                }
+                peerListOk[0] = (in.length == 2 && found == 2);
+                out[0] = "h2";
+                return WolfSSL.SSL_TLSEXT_ERR_OK;
+            }
+        }, new String[] { "http/1.1", "h2" }, selected);
+
+        /* Skip test if setAlpnSelectCb() not compiled into native wolfSSL
+         * (helper returns null on NOT_COMPILED_IN) */
+        Assume.assumeTrue(ret != null);
+
+        /* Skip test if native wolfSSL registered the callback but does not
+         * invoke it. Invocation requires native wolfSSL to be compiled with
+         * OPENSSL_ALL, WOLFSSL_NGINX, or WOLFSSL_HAPROXY */
+        Assume.assumeTrue(cbFired[0]);
+
+        assertEquals("server accept() failed in ALPN select test",
+            WolfSSL.SSL_SUCCESS, ret[0]);
+        assertEquals("client connect() failed in ALPN select test",
+            WolfSSL.SSL_SUCCESS, ret[1]);
+        assertTrue("ALPN callback did not receive expected peer " +
+            "protocol list", peerListOk[0]);
+        assertEquals("server did not negotiate expected ALPN protocol",
+            "h2", selected[0]);
+        assertEquals("client did not negotiate expected ALPN protocol",
+            "h2", selected[1]);
+
+        /* Scenario 2: callback returns NOACK. Handshake should succeed with no
+         * ALPN protocol negotiated on either peer. */
+        selected = new String[2];
+        ret = runAlpnSelectHandshake(new WolfSSLALPNSelectCallback() {
+            @Override
+            public int alpnSelectCallback(WolfSSLSession ssl,
+                String[] out, String[] in, Object arg) {
+                return WolfSSL.SSL_TLSEXT_ERR_NOACK;
+            }
+        }, new String[] { "http/1.1", "h2" }, selected);
+
+        assertNotNull(ret);
+        assertEquals("server accept() failed in ALPN NOACK test",
+            WolfSSL.SSL_SUCCESS, ret[0]);
+        assertEquals("client connect() failed in ALPN NOACK test",
+            WolfSSL.SSL_SUCCESS, ret[1]);
+        assertNull("no ALPN protocol should be selected on server",
+            selected[0]);
+        assertNull("no ALPN protocol should be selected on client",
+            selected[1]);
+
+        /* Scenario 3: callback selects protocol not offered by the peer.
+         * Native callback wrapper should reject the selection and the
+         * handshake should fail on both peers. */
+        selected = new String[2];
+        ret = runAlpnSelectHandshake(new WolfSSLALPNSelectCallback() {
+            @Override
+            public int alpnSelectCallback(WolfSSLSession ssl,
+                String[] out, String[] in, Object arg) {
+                out[0] = "badproto";
+                return WolfSSL.SSL_TLSEXT_ERR_OK;
+            }
+        }, new String[] { "http/1.1", "h2" }, selected);
+
+        assertNotNull(ret);
+        assertTrue("server accept() should fail when ALPN callback " +
+            "selects protocol not in peer list",
+            ret[0] != WolfSSL.SSL_SUCCESS);
+        assertTrue("client connect() should fail when ALPN callback " +
+            "selects protocol not in peer list",
+            ret[1] != WolfSSL.SSL_SUCCESS);
+
+        /* Scenario 4: callback returns ALERT_FATAL directly. Handshake should
+         * fail on both peers. */
+        selected = new String[2];
+        ret = runAlpnSelectHandshake(new WolfSSLALPNSelectCallback() {
+            @Override
+            public int alpnSelectCallback(WolfSSLSession ssl,
+                String[] out, String[] in, Object arg) {
+                return WolfSSL.SSL_TLSEXT_ERR_ALERT_FATAL;
+            }
+        }, new String[] { "http/1.1", "h2" }, selected);
+
+        assertNotNull(ret);
+        assertTrue("server accept() should fail when ALPN callback " +
+            "returns SSL_TLSEXT_ERR_ALERT_FATAL",
+            ret[0] != WolfSSL.SSL_SUCCESS);
+        assertTrue("client connect() should fail when ALPN callback " +
+            "returns SSL_TLSEXT_ERR_ALERT_FATAL",
+            ret[1] != WolfSSL.SSL_SUCCESS);
+
+        /* Scenario 5: callback throws RuntimeException. Native wrapper detects
+         * the pending exception after calling into Java, cleans up local refs
+         * with the exception pending, and fails the handshake on both peers
+         * without crashing the JVM. */
+        selected = new String[2];
+        ret = runAlpnSelectHandshake(new WolfSSLALPNSelectCallback() {
+            @Override
+            public int alpnSelectCallback(WolfSSLSession ssl,
+                String[] out, String[] in, Object arg) {
+                throw new RuntimeException(
+                    "test exception from ALPN select callback");
+            }
+        }, new String[] { "http/1.1", "h2" }, selected);
+
+        assertNotNull(ret);
+        assertTrue("server accept() should fail when ALPN callback " +
+            "throws exception", ret[0] != WolfSSL.SSL_SUCCESS);
+        assertTrue("client connect() should fail when ALPN callback " +
+            "throws exception", ret[1] != WolfSSL.SSL_SUCCESS);
     }
 
     @Test


### PR DESCRIPTION
`NativeALPNSelectCb()` created JNI local references (`jclass`, `String[]` arrays, per-protocol `jstring`'s) without calling `DeleteLocalRef()`. This PR:

  - Deletes each per-protocol `jstring` after it is added to the array
  - Deletes all remaining local refs once on a shared exit path
  - Reworks flow into cascading `if (ret == SSL_TLSEXT_ERR_OK)` blocks with a single exit point, consolidating duplicated `wolfSSL_ALPN_FreePeerProtocol()` and thread detach handling
  - Calls `FindClass()` once, with NULL check, instead of twice inline
 
Fixes #391