### PR TITLE
Map select() EBADF to a closed-fd event in socketSelect()

### DIFF
--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -938,9 +938,15 @@ static int socketSelect(SSLAppData* appData, int sockfd, int timeout_ms, int rx,
 
 #ifndef USE_WINDOWS_API
     } while ((result == -1) && ((errno == EINTR) || (errno == EAGAIN)));
+
+    /* POSIX select() returns EBADF for any invalid fd in the sets.
+     * Expected cause is the socket or interrupt descriptor being closed
+     * concurrently. Report as a closed fd, matching socketPoll() POLLNVAL. */
+    if ((result == -1) && (errno == EBADF)) {
+        return WOLFJNI_IO_EVENT_FD_CLOSED;
+    }
 #endif
 
-    /* Return on error, unless errno EINTR or EAGAIN, try again above */
     return WOLFJNI_IO_EVENT_FAIL;
 }
 


### PR DESCRIPTION
This PR fixes a difference in how the two socket I/O backends report a descriptor closed by another thread mid-wait. `poll()` (the default build) maps a closed fd's `POLLNVAL` to `WOLFJNI_IO_EVENT_FD_CLOSED`, which the Java read/write layer treats as a clean close. `select()` (the `WOLFJNI_USE_IO_SELECT` build) instead fails with `EBADF`, which `socketSelect()` collapsed into a generic `WOLFJNI_IO_EVENT_FAIL` that the Java layer does not recognize as a close. This made `testSocketCloseInterruptsRead` fail intermittently on the `WOLFJNI_USE_IO_SELECT` CI job.

The fix maps `select()` `EBADF` to `WOLFJNI_IO_EVENT_FD_CLOSED` so both backends report a concurrent close identically. The change stays inside the existing POSIX and select-only compile guards, so the poll and Windows backends are unaffected.