### PR TITLE
Fenrir fixes: X.509 JNI safety, I/O callback validation, and debug-log corrections

### DIFF
--- a/examples/provider/update-keystore-pqc.sh
+++ b/examples/provider/update-keystore-pqc.sh
@@ -38,17 +38,20 @@ OUT_DIR="$(dirname "$0")"
 
 KT="${JAVA_HOME:+$JAVA_HOME/bin/}keytool"
 
+# One private scratch dir for all keytool work. mktemp -d gives it an
+# unpredictable name and mode 0700. The trap removes it on every exit.
+WORK_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/wolfssl-pqc.XXXXXXXX")"
+trap 'rm -rf -- "$WORK_ROOT"' EXIT
+
 # Verify JDK 24+
 if ! "$KT" -genkeypair -keyalg ML-DSA -alias _probe \
-        -keystore /tmp/_pqc_probe_$$.jks -storepass "$PASSWD" \
+        -keystore "$WORK_ROOT/probe.jks" -storepass "$PASSWD" \
         -dname "CN=probe" >/dev/null 2>&1; then
     echo "ERROR: keytool does not support ML-DSA. Need JDK 24+." >&2
     echo "  Tried: $KT" >&2
     "$KT" -version 2>&1 || true
-    rm -f /tmp/_pqc_probe_$$.jks
     exit 1
 fi
-rm -f /tmp/_pqc_probe_$$.jks
 
 # Generate one entity keystore (server or client) signed by the supplied
 # root. Helper used by gen_keystore() so both roles share one root.
@@ -117,13 +120,13 @@ gen_keystore() {
     local ext="$3"         # jks or p12
     local alg="ML-DSA-${level}"
     local ca_ks="${OUT_DIR}/ca-mldsa${level}.${ext}"
-    local work="/tmp/_pqc_$$_${level}_${ext}"
+    local work="${WORK_ROOT}/mldsa${level}_${ext}"
     local root_ks="${work}/root.${ext}"
 
     echo "=== Generating ML-DSA-${level} (${storetype}) cert chain ==="
 
     rm -f "$ca_ks"
-    mkdir -p "$work"
+    mkdir "$work"
 
     # 1. Root CA self-signed (kept in $work; never shipped)
     "$KT" -genkeypair -keyalg "$alg" \

--- a/native/com_wolfssl_WolfSSLCertificate.c
+++ b/native/com_wolfssl_WolfSSLCertificate.c
@@ -1069,9 +1069,8 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1load_1certific
 
     if (path != NULL) {
         x509 = wolfSSL_X509_load_certificate_file(path, format);
+        (*jenv)->ReleaseStringUTFChars(jenv, filename, path);
     }
-
-    (*jenv)->ReleaseStringUTFChars(jenv, filename, path);
 
     return (jlong)(uintptr_t)x509;
 #else
@@ -2372,6 +2371,10 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1exte
     }
 
     oid = (*jenv)->GetStringUTFChars(jenv, oidIn, 0);
+    if (oid == NULL) {
+        return NULL;
+    }
+
     nid = wolfSSL_OBJ_txt2nid(oid);
     (*jenv)->ReleaseStringUTFChars(jenv, oidIn, oid);
     if (nid == NID_undef) {
@@ -2441,6 +2444,10 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1is_1extension_1
     }
 
     oid = (*jenv)->GetStringUTFChars(jenv, oidIn, 0);
+    if (oid == NULL) {
+        return -1;
+    }
+
     nid = wolfSSL_OBJ_txt2nid(oid);
     if (nid == NID_undef) {
         (*jenv)->ReleaseStringUTFChars(jenv, oidIn, oid);

--- a/native/com_wolfssl_WolfSSLContext.c
+++ b/native/com_wolfssl_WolfSSLContext.c
@@ -1330,7 +1330,7 @@ int NativeIORecvCb(WOLFSSL *ssl, char *buf, int sz, void *ctx)
     jmethodID  recvCbMethodId;        /* internalIORecvCallback ID */
     jbyteArray inData;
 
-    if (!g_vm || !ssl || !buf || !ctx) {
+    if (!g_vm || !ssl || !buf || !ctx || sz < 0) {
         /* can't throw exception yet, just return error */
         return WOLFSSL_CBIO_ERR_GENERAL;
     }
@@ -1547,7 +1547,7 @@ int NativeIOSendCb(WOLFSSL *ssl, char *buf, int sz, void *ctx)
     jmethodID  sendCbMethodId;        /* internalIOSendCallback ID */
     jbyteArray outData;               /* jbyteArray for data to send */
 
-    if (!g_vm || !ssl || !buf || !ctx) {
+    if (!g_vm || !ssl || !buf || !ctx || sz < 0) {
         /* can't throw exception yet, just return error */
         return WOLFSSL_CBIO_ERR_GENERAL;
     }
@@ -1573,8 +1573,9 @@ int NativeIOSendCb(WOLFSSL *ssl, char *buf, int sz, void *ctx)
     if ((*jenv)->ExceptionOccurred(jenv)) {
         (*jenv)->ExceptionDescribe(jenv);
         (*jenv)->ExceptionClear(jenv);
-        if (needsDetach)
+        if (needsDetach) {
             (*g_vm)->DetachCurrentThread(g_vm);
+        }
         return WOLFSSL_CBIO_ERR_GENERAL;
     }
 
@@ -1582,10 +1583,11 @@ int NativeIOSendCb(WOLFSSL *ssl, char *buf, int sz, void *ctx)
     g_cachedSSLObj = (jobject*) wolfSSL_get_jobject((WOLFSSL*)ssl);
     if (!g_cachedSSLObj) {
         (*jenv)->ThrowNew(jenv, excClass,
-                "Can't get native WolfSSLSession object reference in "
-                "NativeIOSendCb");
-        if (needsDetach)
+            "Can't get native WolfSSLSession object reference in "
+            "NativeIOSendCb");
+        if (needsDetach) {
             (*g_vm)->DetachCurrentThread(g_vm);
+        }
         return WOLFSSL_CBIO_ERR_GENERAL;
     }
 
@@ -1594,14 +1596,15 @@ int NativeIOSendCb(WOLFSSL *ssl, char *buf, int sz, void *ctx)
     if (!sessClass) {
         (*jenv)->ThrowNew(jenv, excClass,
             "Can't get native WolfSSLSession class reference");
-        if (needsDetach)
+        if (needsDetach) {
             (*g_vm)->DetachCurrentThread(g_vm);
+        }
         return WOLFSSL_CBIO_ERR_GENERAL;
     }
 
     /* lookup WolfSSLContext private member fieldID */
     ctxFid = (*jenv)->GetFieldID(jenv, sessClass, "ctx",
-            "Lcom/wolfssl/WolfSSLContext;");
+        "Lcom/wolfssl/WolfSSLContext;");
     if (!ctxFid) {
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
@@ -1609,8 +1612,9 @@ int NativeIOSendCb(WOLFSSL *ssl, char *buf, int sz, void *ctx)
         }
         (*jenv)->ThrowNew(jenv, excClass,
             "Can't get native WolfSSLContext field ID in NativeIOSendCb");
-        if (needsDetach)
+        if (needsDetach) {
             (*g_vm)->DetachCurrentThread(g_vm);
+        }
         return WOLFSSL_CBIO_ERR_GENERAL;
     }
 
@@ -1624,22 +1628,23 @@ int NativeIOSendCb(WOLFSSL *ssl, char *buf, int sz, void *ctx)
             (*jenv)->ExceptionClear(jenv);
         }
         (*jenv)->ThrowNew(jenv, excClass,
-            "Can't get getAssociatedContextPtr() method ID in "
-            "NativeIOSendCb");
-        if (needsDetach)
+            "Can't get getAssociatedContextPtr() method ID in NativeIOSendCb");
+        if (needsDetach) {
             (*g_vm)->DetachCurrentThread(g_vm);
+        }
         return WOLFSSL_CBIO_ERR_GENERAL;
     }
 
     /* get WolfSSLContext(ctx) object from Java WolfSSLSession object */
     ctxRef = (*jenv)->CallObjectMethod(jenv, (jobject)(*g_cachedSSLObj),
-            getCtxMethodId);
+        getCtxMethodId);
     CheckException(jenv);
     if (!ctxRef) {
         (*jenv)->ThrowNew(jenv, excClass,
             "Can't get WolfSSLContext object in NativeIOSendCb");
-        if (needsDetach)
+        if (needsDetach) {
             (*g_vm)->DetachCurrentThread(g_vm);
+        }
         return WOLFSSL_CBIO_ERR_GENERAL;
     }
 
@@ -1650,75 +1655,74 @@ int NativeIOSendCb(WOLFSSL *ssl, char *buf, int sz, void *ctx)
             "Can't get native WolfSSLContext class reference in "
             "NativeIOSendCb");
         (*jenv)->DeleteLocalRef(jenv, ctxRef);
-        if (needsDetach)
+        if (needsDetach) {
             (*g_vm)->DetachCurrentThread(g_vm);
+        }
         return WOLFSSL_CBIO_ERR_GENERAL;
     }
 
-    /* call internal I/O recv callback */
+    /* call internal I/O send callback */
     sendCbMethodId = (*jenv)->GetMethodID(jenv, innerCtxClass,
-            "internalIOSendCallback",
-            "(Lcom/wolfssl/WolfSSLSession;[BI)I");
+        "internalIOSendCallback", "(Lcom/wolfssl/WolfSSLSession;[BI)I");
     if (!sendCbMethodId) {
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
             (*jenv)->ExceptionClear(jenv);
         }
         (*jenv)->ThrowNew(jenv, excClass,
-                "Error getting internalIOSendCallback method from JNI");
+            "Error getting internalIOSendCallback method from JNI");
         (*jenv)->DeleteLocalRef(jenv, ctxRef);
-        if (needsDetach)
+        if (needsDetach) {
             (*g_vm)->DetachCurrentThread(g_vm);
+        }
         return WOLFSSL_CBIO_ERR_GENERAL;
     }
 
-    if (sz >= 0)
-    {
-        /* create jbyteArray to hold received data */
-        outData = (*jenv)->NewByteArray(jenv, sz);
-        if (!outData) {
-            (*jenv)->ThrowNew(jenv, excClass,
-                    "Error getting internalIOSendCallback method from JNI");
-            (*jenv)->DeleteLocalRef(jenv, ctxRef);
-            if (needsDetach)
-                (*g_vm)->DetachCurrentThread(g_vm);
-            return WOLFSSL_CBIO_ERR_GENERAL;
+    /* create jbyteArray to hold data to send */
+    outData = (*jenv)->NewByteArray(jenv, sz);
+    if (!outData) {
+        (*jenv)->ThrowNew(jenv, excClass,
+            "Error creating jbyteArray in NativeIOSendCb");
+        (*jenv)->DeleteLocalRef(jenv, ctxRef);
+        if (needsDetach) {
+            (*g_vm)->DetachCurrentThread(g_vm);
         }
+        return WOLFSSL_CBIO_ERR_GENERAL;
+    }
 
-        (*jenv)->SetByteArrayRegion(jenv, outData, 0, sz, (jbyte*)buf);
-        if ((*jenv)->ExceptionOccurred(jenv)) {
-            (*jenv)->ExceptionDescribe(jenv);
-            (*jenv)->ExceptionClear(jenv);
-            (*jenv)->DeleteLocalRef(jenv, ctxRef);
-            (*jenv)->DeleteLocalRef(jenv, outData);
-            if (needsDetach)
-                (*g_vm)->DetachCurrentThread(g_vm);
-            return WOLFSSL_CBIO_ERR_GENERAL;
-        }
-
-        /* call Java send callback, ignore native ctx since Java
-         * handles it */
-        retval = (*jenv)->CallIntMethod(jenv, ctxRef, sendCbMethodId,
-                                (jobject)(*g_cachedSSLObj), outData, (jint)sz);
-
-        if ((*jenv)->ExceptionOccurred(jenv)) {
-            (*jenv)->ExceptionDescribe(jenv);
-            (*jenv)->ExceptionClear(jenv);
-            (*jenv)->DeleteLocalRef(jenv, ctxRef);
-            (*jenv)->DeleteLocalRef(jenv, outData);
-            if (needsDetach)
-                (*g_vm)->DetachCurrentThread(g_vm);
-            return WOLFSSL_CBIO_ERR_GENERAL;
-        }
-
-        /* delete local refs */
+    (*jenv)->SetByteArrayRegion(jenv, outData, 0, sz, (jbyte*)buf);
+    if ((*jenv)->ExceptionOccurred(jenv)) {
+        (*jenv)->ExceptionDescribe(jenv);
+        (*jenv)->ExceptionClear(jenv);
+        (*jenv)->DeleteLocalRef(jenv, ctxRef);
         (*jenv)->DeleteLocalRef(jenv, outData);
+        if (needsDetach) {
+            (*g_vm)->DetachCurrentThread(g_vm);
+        }
+        return WOLFSSL_CBIO_ERR_GENERAL;
+    }
+
+    /* call Java send callback, ignore native ctx since Java handles it */
+    retval = (*jenv)->CallIntMethod(jenv, ctxRef, sendCbMethodId,
+        (jobject)(*g_cachedSSLObj), outData, (jint)sz);
+
+    if ((*jenv)->ExceptionOccurred(jenv)) {
+        (*jenv)->ExceptionDescribe(jenv);
+        (*jenv)->ExceptionClear(jenv);
+        (*jenv)->DeleteLocalRef(jenv, ctxRef);
+        (*jenv)->DeleteLocalRef(jenv, outData);
+        if (needsDetach) {
+            (*g_vm)->DetachCurrentThread(g_vm);
+        }
+        return WOLFSSL_CBIO_ERR_GENERAL;
     }
 
     /* delete local refs, detach JNIEnv from thread */
     (*jenv)->DeleteLocalRef(jenv, ctxRef);
-    if (needsDetach)
+    (*jenv)->DeleteLocalRef(jenv, outData);
+    if (needsDetach) {
         (*g_vm)->DetachCurrentThread(g_vm);
+    }
 
     return retval;
 }

--- a/src/java/com/wolfssl/WolfSSLCertificate.java
+++ b/src/java/com/wolfssl/WolfSSLCertificate.java
@@ -414,7 +414,7 @@ public class WolfSSLCertificate implements Serializable {
         synchronized (x509Lock) {
             WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
                 WolfSSLDebug.INFO, this.x509Ptr,
-                () -> "entering getSubjectName(" + name + ")");
+                () -> "entering setSubjectName(" + name + ")");
 
             /* TODO somehow lock WolfSSLX509Name object while using pointer? */
             ret = X509_set_subject_name(this.x509Ptr,

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
@@ -1020,7 +1020,7 @@ public class WolfSSLEngine extends SSLEngine {
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                     () -> "setUseClientMode: " +
                     this.engineHelper.getUseClientMode());
-                for (i = 0; i < len; i++) {
+                for (i = ofst; i < ofst + len; i++) {
                     final int idx = i;
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                         () -> "ByteBuffer in["+idx+"].remaining(): " +
@@ -1889,7 +1889,7 @@ public class WolfSSLEngine extends SSLEngine {
                     () -> "in.position(): " + in.position());
                 WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                     () -> "in.limit(): " + in.limit());
-                for (i = 0; i < length; i++) {
+                for (i = ofst; i < ofst + length; i++) {
                     final int idx = i;
                     WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
                         () -> "out["+idx+"].remaining(): " +


### PR DESCRIPTION
This PR fixes 6 Fenrir issues:

  - **F-9125**: Generate PQC test keystores in a private mktemp workspace that a trap removes on every exit path.
  - **F-3909**: Iterate the wrap()/unwrap() exit debug loops over the requested buffer slice, matching entry loops.
  - **F-4146 / F-9120**: NULL-guard ReleaseStringUTFChars in X.509 certificate JNI entry points when GetStringUTFChars fails.
  - **F-4147**: Reject negative sz in native I/O send/recv callbacks so both return an error instead of zero-byte result.
  - **F-4618**: Log correct method name in the setSubjectName() debug output.