### PR TITLE
Fenrir fixes for resource cleanup, JNI type handling, and protocol/key-size validation

### DIFF
--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -2644,15 +2644,17 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSL_getAvailableCipherSuitesIana
             ianaName = cipherName;
         #endif
             if (ianaName != NULL) {
-                /* colon separated list */
-                if (i != 0 && (XSTRLEN(cipherList) + 1) < sizeof(cipherList)) {
+                /* colon separated list, only prepend separator once cipherList
+                 * already holds a name */
+                if (cipherList[0] != '\0' &&
+                    (XSTRLEN(cipherList) + 1) < sizeof(cipherList)) {
                     XSTRNCAT(cipherList, ":",
-                             sizeof(cipherList) - XSTRLEN(cipherList) - 1);
+                        sizeof(cipherList) - XSTRLEN(cipherList) - 1);
                 }
                 if ((XSTRLEN(ianaName) + XSTRLEN(cipherList) + 1) <
-                        sizeof(cipherList)) {
+                    sizeof(cipherList)) {
                     XSTRNCAT(cipherList, ianaName,
-                             sizeof(cipherList) - XSTRLEN(cipherList) - 1);
+                        sizeof(cipherList) - XSTRLEN(cipherList) - 1);
                 }
             }
         }

--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -2916,7 +2916,7 @@ JNIEXPORT jobjectArray JNICALL Java_com_wolfssl_WolfSSL_getProtocolsMask
     }
 #endif /* WOLFSSL_ALLOW_TLSv10 */
 #endif /* !NO_OLD_TLS */
-#ifdef WOLFSSL_ALLOW_SSLv3
+#ifdef WOLFSSL_ALLOW_SSLV3
     if(!(mask & SSL_OP_NO_SSLv3)) {
         numProtocols += 1;
     }
@@ -2979,7 +2979,7 @@ JNIEXPORT jobjectArray JNICALL Java_com_wolfssl_WolfSSL_getProtocolsMask
 #endif /* WOLFSSL_ALLOW_TLSv10 */
 #endif /* !NO_OLD_TLS */
 
-#ifdef WOLFSSL_ALLOW_SSLv3
+#ifdef WOLFSSL_ALLOW_SSLV3
     if(!(mask & SSL_OP_NO_SSLv3)) {
         (*jenv)->SetObjectArrayElement(jenv, ret, idx++,
                 (*jenv)->NewStringUTF(jenv, "SSLv3"));

--- a/native/com_wolfssl_WolfSSLCertRequest.c
+++ b/native/com_wolfssl_WolfSSLCertRequest.c
@@ -509,6 +509,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLCertRequest_X509_1REQ_1get_
     if (derArr == NULL) {
         throwWolfSSLJNIException(jenv,
             "Failed to create byte array in native X509_REQ_get_der");
+        XFREE(der, NULL, DYNAMIC_TYPE_OPENSSL);
         return NULL;
     }
 

--- a/native/com_wolfssl_WolfSSLCertificate.c
+++ b/native/com_wolfssl_WolfSSLCertificate.c
@@ -2886,7 +2886,7 @@ JNIEXPORT jobjectArray JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1su
     /* If we got fewer entries than expected, create a trimmed array */
     if (idx < numNames) {
         jobjectArray trimmedArray = (*jenv)->NewObjectArray(jenv, idx,
-            objectClass, NULL);
+            objectArrayClass, NULL);
         if (trimmedArray != NULL && !(*jenv)->ExceptionCheck(jenv)) {
             for (i = 0; i < idx; i++) {
                 jobject elem = (*jenv)->GetObjectArrayElement(jenv,

--- a/native/com_wolfssl_WolfSSLContext.c
+++ b/native/com_wolfssl_WolfSSLContext.c
@@ -7088,8 +7088,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setMinDhKeySz
     WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)obj;
 
-    /* wolfSSL_CTX_SetMinDhKey_Sz() sanitizes ctx and keySzBits */
+    /* wolfSSL_CTX_SetMinDhKey_Sz() sanitizes ctx */
     if (jenv == NULL) {
+        return (jint)BAD_FUNC_ARG;
+    }
+
+    /* Validate range before narrowing to word16, otherwise out of range
+     * value can wrap to a smaller key size */
+    if ((keySzBits < 0) || (keySzBits > (jint)WOLFSSL_MAX_16BIT)) {
         return (jint)BAD_FUNC_ARG;
     }
 
@@ -7110,8 +7116,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setMinRsaKeySz
     WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)obj;
 
-    /* wolfSSL_CTX_SetMinRsaKey_Sz() sanitizes ctx and keySzBits */
+    /* wolfSSL_CTX_SetMinRsaKey_Sz() sanitizes ctx */
     if (jenv == NULL) {
+        return (jint)BAD_FUNC_ARG;
+    }
+
+    /* Validate range before narrowing to short, otherwise out of range value
+     * can wrap to a smaller key size */
+    if ((keySzBits < 0) || (keySzBits > INT16_MAX)) {
         return (jint)BAD_FUNC_ARG;
     }
 
@@ -7132,8 +7144,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setMinEccKeySz
     WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)obj;
 
-    /* wolfSSL_CTX_SetMinEccKey_Sz() sanitizes ctx and keySzBits */
+    /* wolfSSL_CTX_SetMinEccKey_Sz() sanitizes ctx */
     if (jenv == NULL) {
+        return (jint)BAD_FUNC_ARG;
+    }
+
+    /* Validate range before narrowing to short, otherwise out of range value
+     * can wrap to a smaller key size */
+    if ((keySzBits < 0) || (keySzBits > INT16_MAX)) {
         return (jint)BAD_FUNC_ARG;
     }
 

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -3569,6 +3569,9 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLSession_getPeerX509AltName
     }
 
     altname = wolfSSL_X509_get_next_altname(x509);
+    if (altname == NULL) {
+        return NULL;
+    }
 
     retString = (*jenv)->NewStringUTF(jenv, altname);
     return retString;

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -4997,7 +4997,8 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setVerify
             *verifyCb = (*jenv)->NewGlobalRef(jenv, callbackIface);
             if (*verifyCb == NULL) {
                 printf("error storing global callback interface\n");
-		        XFREE(verifyCb, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+                XFREE(verifyCb, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+                verifyCb = NULL;
             }
             else {
                 /* Publish under g_verifyCbMutex so a concurrent callback
@@ -5009,6 +5010,11 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLSession_setVerify
                 /* set verify mode, register Java callback with wolfSSL */
                 wolfSSL_set_verify(ssl, mode, NativeSSLVerifyCallback);
             }
+        }
+
+        /* If callback could not be registered, still apply requested mode */
+        if ((appData == NULL) || (verifyCb == NULL)) {
+            wolfSSL_set_verify(ssl, mode, NULL);
         }
     }
 }

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -1556,6 +1556,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_read__J_3BIII
              * 0 is used here to both commit and free */
             (*jenv)->ReleaseByteArrayElements(jenv, raw, (jbyte*)data, 0);
         }
+    } else {
+        return BAD_FUNC_ARG;
     }
 
     return size;

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngine.java
@@ -2672,14 +2672,14 @@ public class WolfSSLEngine extends SSLEngine {
                 return 0;
             }
 
-            /* If we have more data than internal static buffer,
-             * grow buffer 2x (or up to sz needed) and copy data over */
+            /* If we have more data than internal static buffer, grow buffer
+             * 2x (or up to offset + sz needed) and copy data over */
             if ((this.internalIOSendBufSz -
                     this.internalIOSendBufOffset) < sz) {
-                /* Allocate new buffer to hold data to be sent */
+                int needed = this.internalIOSendBufOffset + sz;
                 int newSz = this.internalIOSendBufSz * 2;
-                if (newSz < sz) {
-                    newSz = sz;
+                if (newSz < needed) {
+                    newSz = needed;
                 }
                 byte[] newBuf = new byte[newSz];
                 System.arraycopy(this.internalIOSendBuf, 0,

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLUtil.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLUtil.java
@@ -94,6 +94,10 @@ public class WolfSSLUtil {
         WolfSSLDebug.log(WolfSSLUtil.class, WolfSSLDebug.INFO,
             () -> "jdk.tls.disabledAlgorithms: " + tmpDisabledAlgos);
 
+        if (disabledAlgos == null) {
+            disabledAlgos = "";
+        }
+
         /*
          * WolfJSSE only supports DTLSv1.3, automatically add DTLSv1,
          * and DTLSv1.2 to disabled algorithms for now */

--- a/src/test/com/wolfssl/test/WolfSSLContextTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLContextTest.java
@@ -762,6 +762,13 @@ public class WolfSSLContextTest {
                 fail("setMinRSAKeySize should fail with negative key size");
             }
 
+            /* value that wraps across the 16-bit boundary should fail,
+             * 66560 wraps to 1024. */
+            ret = ctx.setMinRSAKeySize(66560);
+            if (ret != WolfSSL.BAD_FUNC_ARG) {
+                fail("setMinRSAKeySize should fail for out-of-range value");
+            }
+
             /* key length not % 8 should fail */
             ret = ctx.setMinRSAKeySize(1023);
             if (ret != WolfSSL.BAD_FUNC_ARG) {
@@ -812,6 +819,13 @@ public class WolfSSLContextTest {
             ret = ctx.setMinECCKeySize(-1);
             if (ret != WolfSSL.BAD_FUNC_ARG) {
                 fail("setMinECCKeySize should fail with negative key size");
+            }
+
+            /* value that wraps across the 16-bit boundary should fail,
+             * 66048 narrows to 512. */
+            ret = ctx.setMinECCKeySize(66048);
+            if (ret != WolfSSL.BAD_FUNC_ARG) {
+                fail("setMinECCKeySize should fail for out-of-range value");
             }
 
             /* valid key length should succeed */
@@ -866,6 +880,13 @@ public class WolfSSLContextTest {
             ret = ctx.setMinDHKeySize(17000);
             if (ret != WolfSSL.BAD_FUNC_ARG) {
                 fail("setMinDHKeySize should fail with key size too large");
+            }
+
+            /* value that wraps across the 16-bit boundary should fail,
+             * 66560 narrows to 1024. */
+            ret = ctx.setMinDHKeySize(66560);
+            if (ret != WolfSSL.BAD_FUNC_ARG) {
+                fail("setMinDHKeySize should fail for out-of-range value");
             }
 
             /* key length not % 8 should fail */


### PR DESCRIPTION
This PR includes 10 Fenrir fixes:

  - **F-6548**: Create the trimmed subject-alternative-name array with the Object[][] element class so it matches the declared return type.
  - **F-6549**: Free the DER buffer on the NewByteArray failure path in X509_REQ_get_der, matching the function's other exit paths.
  - **F-6733**: Size the internalSendCb grow buffer to include the existing offset so the appended record always fits.
  - **F-6734**: Treat an unset jdk.tls.disabledAlgorithms property as an empty string in sanitizeProtocols so no literal "null" token is appended.
  - **F-7010**: Base the IANA cipher-suite separator on whether the accumulator already holds data rather than on the loop index.
  - **F-9115**: Gate SSLv3 in getProtocolsMask on the correctly spelled WOLFSSL_ALLOW_SSLV3 macro so it is listed when the build allows it.
  - **F-9116**: Apply the requested verify mode in setVerify when the callback cannot be registered, rather than returning without setting it.
  - **F-9117**: Guard against a NULL altname before NewStringUTF in getPeerX509AltName, matching the certificate-level sibling.
  - **F-9118**: Return BAD_FUNC_ARG from native read() on a negative offset or length instead of a zero-length result.
  - **F-9119**: Validate the min key size range before narrowing to word16/short so an out-of-range value is rejected instead of wrapping to a smaller minimum.