### PR TITLE
Fenrir fixes: JNI callback error paths, key handling, DH key size validation, and comment corrections

### DIFF
--- a/native/com_wolfssl_WolfCryptECC.c
+++ b/native/com_wolfssl_WolfCryptECC.c
@@ -95,6 +95,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptECC_doSign
     int     ret;
     WC_RNG  rng;
     ecc_key myKey;
+    int     rngInit = 0;
+    int     keyInit = 0;
     unsigned int tmpOut;
     unsigned int idx = 0;
     unsigned char* inBuf = NULL;
@@ -130,8 +132,20 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptECC_doSign
     (*jenv)->GetLongArrayRegion(jenv, outSz, 0, 1, &tmp);
     tmpOut = (unsigned int)tmp;
 
-    wc_InitRng(&rng);
-    wc_ecc_init(&myKey);
+    ret = wc_InitRng(&rng);
+    if (ret != 0) {
+        printf("wc_InitRng failed, ret = %d\n", ret);
+        return ret;
+    }
+    rngInit = 1;
+
+    ret = wc_ecc_init(&myKey);
+    if (ret != 0) {
+        printf("wc_ecc_init failed, ret = %d\n", ret);
+        wc_FreeRng(&rng);
+        return ret;
+    }
+    keyInit = 1;
 
     ret = wc_EccPrivateKeyDecode(keyBuf, &idx, &myKey, (long)keySz);
     if (ret == 0) {
@@ -144,8 +158,12 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptECC_doSign
         printf("wc_EccPrivateKeyDecode failed, ret = %d\n", ret);
     }
 
-    wc_ecc_free(&myKey);
-    wc_FreeRng(&rng);
+    if (keyInit) {
+        wc_ecc_free(&myKey);
+    }
+    if (rngInit) {
+        wc_FreeRng(&rng);
+    }
 
     if (ret == 0) {
         tmp = (jlong)tmpOut;

--- a/native/com_wolfssl_WolfCryptRSA.c
+++ b/native/com_wolfssl_WolfCryptRSA.c
@@ -38,6 +38,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptRSA_doSign
     int     ret;
     WC_RNG  rng;
     RsaKey  myKey;
+    int     rngInit = 0;
+    int     keyInit = 0;
     unsigned int idx;
     unsigned int tmpOut;
     unsigned char* inBuf = NULL;
@@ -72,8 +74,20 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptRSA_doSign
     /* get output buffer size */
     (*jenv)->GetIntArrayRegion(jenv, outSz, 0, 1, (jint*)&tmpOut);
 
-    wc_InitRng(&rng);
-    wc_InitRsaKey(&myKey, NULL);
+    ret = wc_InitRng(&rng);
+    if (ret != 0) {
+        printf("wc_InitRng failed, ret = %d\n", ret);
+        return ret;
+    }
+    rngInit = 1;
+
+    ret = wc_InitRsaKey(&myKey, NULL);
+    if (ret != 0) {
+        printf("wc_InitRsaKey failed, ret = %d\n", ret);
+        wc_FreeRng(&rng);
+        return ret;
+    }
+    keyInit = 1;
 
     idx = 0;
 
@@ -91,8 +105,12 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptRSA_doSign
         printf("wc_RsaPrivateKeyDecode failed, ret = %d\n", ret);
     }
 
-    wc_FreeRsaKey(&myKey);
-    wc_FreeRng(&rng);
+    if (keyInit) {
+        wc_FreeRsaKey(&myKey);
+    }
+    if (rngInit) {
+        wc_FreeRng(&rng);
+    }
 
     return ret;
 }
@@ -159,6 +177,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptRSA_doEnc
     int     ret;
     RsaKey  myKey;
     WC_RNG  rng;
+    int     rngInit = 0;
+    int     keyInit = 0;
     unsigned int idx;
     unsigned int tmpOut;
     unsigned char* inBuf = NULL;
@@ -193,8 +213,20 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptRSA_doEnc
     /* get output buffer size */
     (*jenv)->GetIntArrayRegion(jenv, outSz, 0, 1, (jint*)&tmpOut);
 
-    wc_InitRng(&rng);
-    wc_InitRsaKey(&myKey, NULL);
+    ret = wc_InitRng(&rng);
+    if (ret != 0) {
+        printf("wc_InitRng failed, ret = %d\n", ret);
+        return ret;
+    }
+    rngInit = 1;
+
+    ret = wc_InitRsaKey(&myKey, NULL);
+    if (ret != 0) {
+        printf("wc_InitRsaKey failed, ret = %d\n", ret);
+        wc_FreeRng(&rng);
+        return ret;
+    }
+    keyInit = 1;
 
     idx = 0;
 
@@ -211,8 +243,12 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptRSA_doEnc
         printf("wc_RsaPublicKeyDecode failed, ret = %d\n", ret);
     }
 
-    wc_FreeRsaKey(&myKey);
-    wc_FreeRng(&rng);
+    if (keyInit) {
+        wc_FreeRsaKey(&myKey);
+    }
+    if (rngInit) {
+        wc_FreeRng(&rng);
+    }
 
     return ret;
 }

--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -60,8 +60,9 @@ static wolfSSL_Mutex g_loggingCbMutex;
 static int g_loggingCbMutexInit = 0;
 
 /* Tracks one-time native registration of NativeLoggingCallback and its return
- * value. We register once and never deregister: wolfssl_log reads LogFunction
- * without a lock, so clearing it while another thread logs would crash.
+ * value. We do not deregister during normal operation: wolfssl_log reads
+ * LogFunction without a lock, so clearing it while another thread logs would
+ * crash. JNI_OnUnload deregisters it after JVM execution has ended.
  * Guarded by g_loggingCbMutex. */
 static int g_loggingCbNativeReg = 0;
 static int g_loggingCbNativeRet = 0;

--- a/native/com_wolfssl_WolfSSLContext.c
+++ b/native/com_wolfssl_WolfSSLContext.c
@@ -5346,6 +5346,14 @@ int NativeRsaSignCheckCb(WOLFSSL* ssl, unsigned char* sig, unsigned int sigSz,
     if ((*jenv)->ExceptionOccurred(jenv)) {
         (*jenv)->ExceptionDescribe(jenv);
         (*jenv)->ExceptionClear(jenv);
+        (*jenv)->DeleteLocalRef(jenv, ctxRef);
+        (*jenv)->DeleteLocalRef(jenv, sigBB);
+        (*jenv)->DeleteLocalRef(jenv, outBB);
+        (*jenv)->DeleteLocalRef(jenv, keyDerBB);
+        if (needsDetach) {
+            (*g_vm)->DetachCurrentThread(g_vm);
+        }
+        return -1;
     }
 
     /* point out* to the beginning of decrypted buffer */
@@ -5575,6 +5583,14 @@ int NativeRsaPssSignCheckCb(WOLFSSL* ssl, unsigned char* sig,
     if ((*jenv)->ExceptionOccurred(jenv)) {
         (*jenv)->ExceptionDescribe(jenv);
         (*jenv)->ExceptionClear(jenv);
+        (*jenv)->DeleteLocalRef(jenv, ctxRef);
+        (*jenv)->DeleteLocalRef(jenv, sigBB);
+        (*jenv)->DeleteLocalRef(jenv, outBB);
+        (*jenv)->DeleteLocalRef(jenv, keyDerBB);
+        if (needsDetach) {
+            (*g_vm)->DetachCurrentThread(g_vm);
+        }
+        return -1;
     }
 
     /* point out* to the beginning of decrypted buffer */

--- a/native/com_wolfssl_WolfSSLContext.c
+++ b/native/com_wolfssl_WolfSSLContext.c
@@ -43,7 +43,7 @@
  * release it before calling DeleteGlobalRef on the prior ref. Any thread
  * already inside NativeVerifyCallback's local-ref window completes safely.
  *
- * Initialized in Java_com_wolfssl_WolfSSL_init, freed in JNI_OnUnload. */
+ * Initialized in JNI_OnLoad, freed in JNI_OnUnload. */
 static wolfSSL_Mutex g_verifyCbMutex;
 static int g_verifyCbMutexInit = 0;
 
@@ -138,8 +138,7 @@ static jobject g_crlCtxCbIfaceObj;
 #endif
 
 /* Process-global mutex covering both CTX-level and session-level missing CRL
- * callback jobjects. Initialized in Java_com_wolfssl_WolfSSL_init, freed in
- * JNI_OnUnload. */
+ * callback jobjects. Initialized in JNI_OnLoad, freed in JNI_OnUnload. */
 static wolfSSL_Mutex g_crlCbMutex;
 static int g_crlCbMutexInit = 0;
 

--- a/native/com_wolfssl_WolfSSLContext.c
+++ b/native/com_wolfssl_WolfSSLContext.c
@@ -2515,7 +2515,7 @@ int NativeMacEncryptCb(WOLFSSL* ssl, unsigned char* macOut,
         (*jenv)->DeleteLocalRef(jenv, ctxRef);
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
-        retval = -1;
+        return -1;
     }
 
     if (retval == 0)

--- a/native/com_wolfssl_WolfSSLContext.c
+++ b/native/com_wolfssl_WolfSSLContext.c
@@ -1112,9 +1112,13 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setCipherList
 
     cipherList = (*jenv)->GetStringUTFChars(jenv, list, 0);
 
-    ret = (jint) wolfSSL_CTX_set_cipher_list(ctx, cipherList);
-
-    (*jenv)->ReleaseStringUTFChars(jenv, list, cipherList);
+    if (cipherList == NULL) {
+        ret = (jint)SSL_FAILURE;
+    }
+    else {
+        ret = (jint) wolfSSL_CTX_set_cipher_list(ctx, cipherList);
+        (*jenv)->ReleaseStringUTFChars(jenv, list, cipherList);
+    }
 
     return ret;
 }
@@ -2249,9 +2253,13 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setOCSPOverrideUrl
 
     url = (*jenv)->GetStringUTFChars(jenv, urlString, 0);
 
-    ret = (jint) wolfSSL_CTX_SetOCSP_OverrideURL(ctx, url);
-
-    (*jenv)->ReleaseStringUTFChars(jenv, urlString, url);
+    if (url == NULL) {
+        ret = (jint)SSL_FAILURE;
+    }
+    else {
+        ret = (jint) wolfSSL_CTX_SetOCSP_OverrideURL(ctx, url);
+        (*jenv)->ReleaseStringUTFChars(jenv, urlString, url);
+    }
 
     return ret;
 #else
@@ -7068,9 +7076,13 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_set1SigAlgsList
 
     sigAlgList = (*jenv)->GetStringUTFChars(jenv, list, 0);
 
-    ret = wolfSSL_CTX_set1_sigalgs_list(ctx, sigAlgList);
-
-    (*jenv)->ReleaseStringUTFChars(jenv, list, sigAlgList);
+    if (sigAlgList == NULL) {
+        ret = WOLFSSL_FAILURE;
+    }
+    else {
+        ret = wolfSSL_CTX_set1_sigalgs_list(ctx, sigAlgList);
+        (*jenv)->ReleaseStringUTFChars(jenv, list, sigAlgList);
+    }
 
     return (jint)ret;
 #else

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -6117,7 +6117,7 @@ int NativeSessionTicketCb(WOLFSSL* ssl, const unsigned char* ticket,
 
     jobject*  g_cachedSSLObj;       /* WolfSSLSession cached object */
     jclass    sslClass;             /* WolfSSLSession class */
-    jmethodID sessTicketCbMethodId; /* internalTls13SecretCallback ID */
+    jmethodID sessTicketCbMethodId; /* internalSessionTicketCallback ID */
     jbyteArray ticketArr = NULL;
     (void)ctx;
 
@@ -6166,7 +6166,7 @@ int NativeSessionTicketCb(WOLFSSL* ssl, const unsigned char* ticket,
         return -1;
     }
 
-    /* Call internal TLS 1.3 secret callback */
+    /* Call internal session-ticket callback */
     sessTicketCbMethodId = (*jenv)->GetMethodID(jenv, sslClass,
         "internalSessionTicketCallback", "(Lcom/wolfssl/WolfSSLSession;[B)I");
     if (sessTicketCbMethodId == NULL) {

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -4492,6 +4492,22 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getKeySize
 #endif
 }
 
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getDhKeySize
+  (JNIEnv* jenv, jobject jcl, jlong ssl)
+{
+    (void)jenv;
+    (void)jcl;
+
+#ifndef NO_DH
+    /* Returns negotiated DH group size in bits, 0 if no DH suite was
+     * negotiated, or BAD_FUNC_ARG if ssl is NULL. */
+    return wolfSSL_GetDhKey_Sz((WOLFSSL*)(uintptr_t)ssl);
+#else
+    (void)ssl;
+    return NOT_COMPILED_IN;
+#endif
+}
+
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getSide
   (JNIEnv* jenv, jobject jcl, jlong ssl)
 {

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -48,6 +48,7 @@
 #endif
 
 #include <wolfssl/ssl.h>
+#include <wolfssl/wolfcrypt/memory.h>
 #include <wolfssl/error-ssl.h>
 
 #include "com_wolfssl_globals.h"
@@ -3826,13 +3827,18 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_usePrivateKeyBuffer
     if ((*jenv)->ExceptionOccurred(jenv)) {
         (*jenv)->ExceptionDescribe(jenv);
         (*jenv)->ExceptionClear(jenv);
-        XFREE(buff, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        return SSL_FAILURE;
+        ret = SSL_FAILURE;
+    }
+    else {
+        ret = wolfSSL_use_PrivateKey_buffer(ssl, buff, (long)sz, format);
     }
 
-    ret = wolfSSL_use_PrivateKey_buffer(ssl, buff, (long)sz, format);
-
+#if (LIBWOLFSSL_VERSION_HEX >= 0x05008004) && \
+    !defined(WOLFSSL_NO_FORCE_ZERO)
+    wc_ForceZero(buff, (word32)sz);
+#else
     XMEMSET(buff, 0, (word32)sz);
+#endif
     XFREE(buff, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 
     return ret;

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -6232,7 +6232,7 @@ int NativeSessionTicketCb(WOLFSSL* ssl, const unsigned char* ticket,
     return (int)retval;
 }
 
-#endif /* WOLFSSL_TLS13 && !WOLFCRYPT_ONLY && HAVE_SECRET_CALLBACK */
+#endif /* !NO_WOLFSSL_CLIENT && HAVE_SESSION_TICKET */
 
 JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useSecureRenegotiation
   (JNIEnv* jenv, jobject jcl, jlong ssl)

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -2509,11 +2509,15 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setCipherList
         return SSL_FAILURE;
     }
 
-    cipherList= (*jenv)->GetStringUTFChars(jenv, list, 0);
+    cipherList = (*jenv)->GetStringUTFChars(jenv, list, 0);
 
-    ret = (jint) wolfSSL_set_cipher_list(ssl, cipherList);
-
-    (*jenv)->ReleaseStringUTFChars(jenv, list, cipherList);
+    if (cipherList == NULL) {
+        ret = SSL_FAILURE;
+    }
+    else {
+        ret = (jint) wolfSSL_set_cipher_list(ssl, cipherList);
+        (*jenv)->ReleaseStringUTFChars(jenv, list, cipherList);
+    }
 
     return ret;
 }
@@ -6275,9 +6279,13 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_set1SigAlgsList
 
     sigAlgList = (*jenv)->GetStringUTFChars(jenv, list, 0);
 
-    ret = wolfSSL_set1_sigalgs_list(ssl, sigAlgList);
-
-    (*jenv)->ReleaseStringUTFChars(jenv, list, sigAlgList);
+    if (sigAlgList == NULL) {
+        ret = SSL_FAILURE;
+    }
+    else {
+        ret = wolfSSL_set1_sigalgs_list(ssl, sigAlgList);
+        (*jenv)->ReleaseStringUTFChars(jenv, list, sigAlgList);
+    }
 
     return (jint)ret;
 #else

--- a/native/com_wolfssl_WolfSSLSession.h
+++ b/native/com_wolfssl_WolfSSLSession.h
@@ -657,6 +657,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getKeySize
 
 /*
  * Class:     com_wolfssl_WolfSSLSession
+ * Method:    getDhKeySize
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_getDhKeySize
+  (JNIEnv *, jobject, jlong);
+
+/*
+ * Class:     com_wolfssl_WolfSSLSession
  * Method:    getSide
  * Signature: (J)I
  */

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -659,6 +659,7 @@ public class WolfSSLSession {
     private native byte[] getServerWriteKey(long ssl);
     private native byte[] getServerWriteIV(long ssl);
     private native int getKeySize(long ssl);
+    private native int getDhKeySize(long ssl);
     private native int getSide(long ssl);
     private native int isTLSv1_1(long ssl);
     private native int getBulkCipher(long ssl);
@@ -4378,6 +4379,27 @@ public class WolfSSLSession {
                 () -> "entered getKeySize()");
 
             return getKeySize(this.sslPtr);
+        }
+    }
+
+    /**
+     * Get DH group size (bits) negotiated during handshake.
+     *
+     * @return negotiated DH group size in bits, or 0 if the handshake
+     *         did not use a Diffie-Hellman cipher suite. Returns negative
+     *         error code on error (ex: NOT_COMPILED_IN, BAD_FUNC_ARG, etc).
+     * @throws IllegalStateException WolfSSLSession object has been freed
+     * @see    #getKeySize()
+     */
+    public int getDhKeySize() throws IllegalStateException {
+
+        confirmObjectIsActive();
+
+        synchronized (sslLock) {
+            WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
+                WolfSSLDebug.INFO, this.sslPtr, () -> "entered getDhKeySize()");
+
+            return getDhKeySize(this.sslPtr);
         }
     }
 

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
@@ -2164,58 +2164,40 @@ public class WolfSSLEngineHelper {
         return ret;
     }
 
+    /**
+     * Verify the Diffie-Hellman group negotiated during the handshake is at
+     * least the minimum size configured in jdk.tls.disabledAlgorithms.
+     */
     private void checkKeySize(WolfSSLSession ssl, boolean clientMode)
         throws SSLException, WolfSSLException {
 
-        int keySize = this.ssl.getKeySize();
+        /* Skip unless a DHE group was negotiated. getDhKeySize() returns 0
+         * for a non-DHE handshake and a negative code when DH is not compiled
+         * into native wolfSSL, neither of which needs checking. */
+        int dhKeySize = ssl.getDhKeySize();
+        if (dhKeySize <= 0) {
+            return;
+        }
 
-        /*
-         * Before we update the cached values, and return from the handshake,
-         * we check if we are running a legacy cipher suite, if so, we make sure
-         * that the actual key size is at least 1024 bits.
-        */
-        String[] cipherSuites = getCiphers();
+        try {
+            int minDHKeySize =
+                WolfSSLUtil.getDisabledAlgorithmsKeySizeLimit("DH");
 
-        if (containsDHECiphers(cipherSuites)) {
-            /* Get the minimum DH key size from security settings. */
-            int minDHEKeySize;
-            try {
-                minDHEKeySize =
-                    WolfSSLUtil.getDisabledAlgorithmsKeySizeLimit("DH");
-
-                /*
-                 * If we're trying to use DHE with
-                 * insufficient key size, throw early. */
-                if (isLegacyDHEnabled() && keySize < minDHEKeySize) {
-                    if (clientMode) {
-                        throw new SSLHandshakeException(
-                            "DH ServerKeyExchange does not comply to " +
-                            "algorithm constraints");
-                    } else {
-                        throw new SSLHandshakeException(
-                            "Received fatal alert: insufficient_security");
-                    }
+            /* A minimum of 0 means no limit is configured */
+            if (dhKeySize < minDHKeySize) {
+                if (clientMode) {
+                    throw new SSLHandshakeException(
+                        "DH ServerKeyExchange does not comply to " +
+                        "algorithm constraints");
+                } else {
+                    throw new SSLHandshakeException(
+                        "Received fatal alert: insufficient_security");
                 }
-            } catch (WolfSSLException e) {
-                throw new WolfSSLException(
-                    "Failed to check DH key size constraints: ", e);
             }
+        } catch (WolfSSLException e) {
+            throw new WolfSSLException(
+                "Failed to check DH key size constraints: ", e);
         }
-    }
-
-    private boolean containsDHECiphers(String[] cipherSuites) {
-        for (String suite : cipherSuites) {
-            if (suite.contains("_DHE_")) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private boolean isLegacyDHEnabled() {
-        /* Check if legacy DH is enabled through system properties. */
-        String dhKeySize = System.getProperty("jdk.tls.ephemeralDHKeySize");
-        return "legacy".equals(dhKeySize);
     }
 
     /**

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLSocketTest.java
@@ -421,6 +421,120 @@ public class WolfSSLSocketTest {
 
     }
 
+    /**
+     * A valid TLS 1.2 DHE_RSA handshake over a 2048 bit FFDHE group must
+     * complete even with the legacy jdk.tls.ephemeralDHKeySize property set.
+     * The group is above the DH minimum, so checkKeySize must not reject it.
+     */
+    @Test
+    public void testLegacyEphemeralDHKeySizeAllowsValidDheHandshake()
+        throws Exception {
+
+        Assume.assumeTrue("TLS 1.2 and RSA required in native wolfSSL",
+            WolfSSL.TLSv12Enabled() && WolfSSL.RsaEnabled());
+
+        String[] dheSuites = dheRsaIanaSuites();
+        Assume.assumeTrue("DHE_RSA cipher suites not available",
+            dheSuites.length > 0);
+
+        synchronized (WolfSSLPQCTestUtil.GROUP_PROP_LOCK) {
+            String prevWolf = WolfSSLPQCTestUtil.setCurvesProperty(null);
+            String prevJdk =
+                WolfSSLPQCTestUtil.setJdkNamedGroupsProperty("ffdhe2048");
+            String prevEphemeral =
+                System.getProperty("jdk.tls.ephemeralDHKeySize");
+            System.clearProperty("jdk.tls.ephemeralDHKeySize");
+
+            try {
+                /* Probe without legacy property first, skip if build cannot
+                 * complete ffdhe2048 DHE handshake. */
+                try {
+                    dheSocketHandshake(dheSuites);
+                } catch (Exception e) {
+                    Assume.assumeNoException(
+                        "TLS 1.2 ffdhe2048 DHE handshake not supported by " +
+                        "this build", e);
+                }
+
+                /* Legacy property must not cause checkKeySize to reject same
+                 * valid handshake. */
+                System.setProperty("jdk.tls.ephemeralDHKeySize", "legacy");
+                String suite = dheSocketHandshake(dheSuites);
+                assertTrue("negotiated cipher suite must be DHE_RSA, got: " +
+                    suite, suite.startsWith("TLS_DHE_RSA_") ||
+                    suite.startsWith("DHE-RSA-"));
+            }
+            finally {
+                if (prevEphemeral == null) {
+                    System.clearProperty("jdk.tls.ephemeralDHKeySize");
+                } else {
+                    System.setProperty("jdk.tls.ephemeralDHKeySize",
+                        prevEphemeral);
+                }
+                WolfSSLPQCTestUtil.restoreCurvesProperty(prevWolf);
+                WolfSSLPQCTestUtil.restoreJdkNamedGroupsProperty(prevJdk);
+            }
+        }
+    }
+
+    /* Complete a TLS 1.2 DHE_RSA SSLSocket handshake with the given suites
+     * and return the negotiated cipher suite. Throws on handshake failure. */
+    private String dheSocketHandshake(String[] dheSuites) throws Exception {
+        SSLContext dheCtx = tf.createSSLContext("TLSv1.2", "wolfJSSE");
+        SSLServerSocket ss = null;
+        SSLSocket cs = null;
+        SSLSocket server = null;
+        ExecutorService es = Executors.newSingleThreadExecutor();
+
+        try {
+            ss = (SSLServerSocket)dheCtx.getServerSocketFactory()
+                .createServerSocket(0);
+            ss.setEnabledCipherSuites(dheSuites);
+            ss.setEnabledProtocols(new String[] { "TLSv1.2" });
+
+            cs = (SSLSocket)dheCtx.getSocketFactory().createSocket();
+            cs.setEnabledCipherSuites(dheSuites);
+            cs.setEnabledProtocols(new String[] { "TLSv1.2" });
+            cs.connect(new InetSocketAddress(ss.getLocalPort()));
+
+            final SSLSocket server0 = (SSLSocket)ss.accept();
+            server = server0;
+
+            Future<Void> f = es.submit(() -> {
+                server0.startHandshake();
+                return null;
+            });
+
+            cs.startHandshake();
+            f.get(10, TimeUnit.SECONDS);
+
+            return cs.getSession().getCipherSuite();
+        }
+        finally {
+            es.shutdownNow();
+            if (cs != null) {
+                cs.close();
+            }
+            if (server != null) {
+                server.close();
+            }
+            if (ss != null) {
+                ss.close();
+            }
+        }
+    }
+
+    /* IANA-named DHE_RSA cipher suites compiled into native wolfSSL. */
+    private static String[] dheRsaIanaSuites() {
+        ArrayList<String> matched = new ArrayList<>();
+        for (String suite : WolfSSL.getCiphersIana()) {
+            if (suite.startsWith("TLS_DHE_RSA_")) {
+                matched.add(suite);
+            }
+        }
+        return matched.toArray(new String[matched.size()]);
+    }
+
     @Test
     public void testGetSupportedProtocols()
         throws NoSuchProviderException, NoSuchAlgorithmException {

--- a/src/test/com/wolfssl/test/WolfSSLSessionTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLSessionTest.java
@@ -706,6 +706,177 @@ public class WolfSSLSessionTest {
     }
 
     @Test
+    public void test_WolfSSLSession_getDhKeySizeBeforeHandshakeAndAfterFree()
+        throws WolfSSLJNIException, WolfSSLException {
+
+        WolfSSLSession ssl = new WolfSSLSession(ctx);
+
+        /* Before any handshake, no DH group is negotiated */
+        int dhSz = ssl.getDhKeySize();
+        assertTrue("getDhKeySize() before handshake should be <= 0, got " +
+            dhSz, dhSz <= 0);
+
+        ssl.freeSSL();
+
+        try {
+            ssl.getDhKeySize();
+            fail("getDhKeySize() after freeSSL() should throw " +
+                "IllegalStateException");
+        } catch (IllegalStateException e) {
+            /* expected */
+        }
+    }
+
+    @Test
+    public void test_WolfSSLSession_getDhKeySizeAfterDheHandshake()
+        throws Exception {
+
+        Assume.assumeTrue("TLS 1.2 not compiled into native wolfSSL",
+            WolfSSL.TLSv12Enabled());
+        Assume.assumeTrue("DHE-RSA-AES128-GCM-SHA256 not available",
+            suiteAvailable("TLS_DHE_RSA_WITH_AES_128_GCM_SHA256"));
+        Assume.assumeTrue("ffdhe2048 named group not supported",
+            ffdhe2048Supported());
+
+        final String dheSuite = "DHE-RSA-AES128-GCM-SHA256";
+        final int[] ffdhe = new int[] { WolfSSL.WOLFSSL_FFDHE_2048 };
+
+        final WolfSSLContext srvCtx = createAndSetupWolfSSLContext(
+            srvCert, srvKey, WolfSSL.SSL_FILETYPE_PEM, cliCert,
+            WolfSSL.TLSv1_2_ServerMethod());
+        WolfSSLContext cliCtx = createAndSetupWolfSSLContext(
+            cliCert, cliKey, WolfSSL.SSL_FILETYPE_PEM, caCert,
+            WolfSSL.TLSv1_2_ClientMethod());
+
+        final ServerSocket srvSocket = new ServerSocket(0);
+        final int port = srvSocket.getLocalPort();
+        Socket cliSock = null;
+        WolfSSLSession ssl = null;
+        ExecutorService es = Executors.newSingleThreadExecutor();
+
+        try {
+            final Future<Void> srvFuture = es.submit(new Callable<Void>() {
+                @Override
+                public Void call() throws Exception {
+                    Socket server = null;
+                    WolfSSLSession srvSes = null;
+                    try {
+                        server = srvSocket.accept();
+                        srvSes = new WolfSSLSession(srvCtx);
+                        assertEquals("server setCipherList",
+                            WolfSSL.SSL_SUCCESS,
+                            srvSes.setCipherList(dheSuite));
+                        assertEquals("server useSupportedCurves",
+                            WolfSSL.SSL_SUCCESS,
+                            srvSes.useSupportedCurves(ffdhe));
+                        assertEquals("server setFd", WolfSSL.SSL_SUCCESS,
+                            srvSes.setFd(server));
+
+                        int ret, err;
+                        do {
+                            ret = srvSes.accept();
+                            err = srvSes.getError(ret);
+                        } while (ret != WolfSSL.SSL_SUCCESS &&
+                                 (err == WolfSSL.SSL_ERROR_WANT_READ ||
+                                  err == WolfSSL.SSL_ERROR_WANT_WRITE));
+                    } finally {
+                        if (srvSes != null) {
+                            srvSes.shutdownSSL();
+                            srvSes.freeSSL();
+                        }
+                        if (server != null) {
+                            server.close();
+                        }
+                    }
+                    return null;
+                }
+            });
+
+            cliSock = new Socket("localhost", port);
+            ssl = new WolfSSLSession(cliCtx);
+            assertEquals("client setCipherList", WolfSSL.SSL_SUCCESS,
+                ssl.setCipherList(dheSuite));
+            assertEquals("client useSupportedCurves", WolfSSL.SSL_SUCCESS,
+                ssl.useSupportedCurves(ffdhe));
+            assertEquals("client setFd", WolfSSL.SSL_SUCCESS,
+                ssl.setFd(cliSock));
+
+            int ret, err;
+            do {
+                ret = ssl.connect();
+                err = ssl.getError(ret);
+            } while (ret != WolfSSL.SSL_SUCCESS &&
+                     (err == WolfSSL.SSL_ERROR_WANT_READ ||
+                      err == WolfSSL.SSL_ERROR_WANT_WRITE));
+
+            /* Allow for server-side exception to come through */
+            srvFuture.get(10, TimeUnit.SECONDS);
+
+            /* Skip if build cannot complete the ffdhe2048 DHE handshake */
+            Assume.assumeTrue("build cannot complete ffdhe2048 DHE handshake",
+                ret == WolfSSL.SSL_SUCCESS);
+
+            int dhSz = ssl.getDhKeySize();
+            assertTrue("getDhKeySize() after DHE handshake should be > 0, " +
+                "got " + dhSz, dhSz > 0);
+            assertEquals("ffdhe2048 handshake should report 2048 bits",
+                2048, dhSz);
+
+            ssl.shutdownSSL();
+        } finally {
+            es.shutdownNow();
+            if (ssl != null) {
+                ssl.freeSSL();
+            }
+            if (cliSock != null) {
+                cliSock.close();
+            }
+            srvSocket.close();
+            cliCtx.free();
+            srvCtx.free();
+        }
+    }
+
+    /* True if the given IANA cipher suite is compiled into native wolfSSL. */
+    private static boolean suiteAvailable(String ianaName) {
+        for (String suite : WolfSSL.getCiphersIana()) {
+            if (suite.equals(ianaName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /* True if native wolfSSL supports the ffdhe2048 named group. */
+    private static boolean ffdhe2048Supported() {
+        WolfSSLContext c = null;
+        WolfSSLSession s = null;
+        try {
+            c = new WolfSSLContext(WolfSSL.SSLv23_ClientMethod());
+            s = new WolfSSLSession(c);
+            int[] ffdhe2048 = new int[] { WolfSSL.WOLFSSL_FFDHE_2048 };
+            return s.useSupportedCurves(ffdhe2048) == WolfSSL.SSL_SUCCESS;
+        } catch (Exception e) {
+            return false;
+        } finally {
+            if (s != null) {
+                try {
+                    s.freeSSL();
+                } catch (Exception e) {
+                    /* ignore */
+                }
+            }
+            if (c != null) {
+                try {
+                    c.free();
+                } catch (Exception e) {
+                    /* ignore */
+                }
+            }
+        }
+    }
+
+    @Test
     public void test_WolfSSLSession_getPskIdentity()
         throws WolfSSLJNIException, WolfSSLException {
 


### PR DESCRIPTION
This PR includes 10 Fenrir fixes:

  - **F-3913**: Return an error from the RSA sign-check PK callbacks (`NativeRsaSignCheckCb`, `NativeRsaPssSignCheckCb`) when the Java callback throws, cleaning up local references and detaching first.
  - **F-3914**: Null-check the `GetStringUTFChars` result before use in `setCipherList`, `set1SigAlgsList`, and `setOCSPOverrideUrl` (Session and Context), skipping the wolfSSL call and `ReleaseStringUTFChars` on NULL.
  - **F-3915**: Check the `wc_InitRng`, `wc_InitRsaKey`, and `wc_ecc_init` return values in the RSA and ECC example sign paths, freeing only initialized resources on failure.
  - **F-6732**: Scrub the temporary private key copy on every exit path in Session `usePrivateKeyBuffer`
  - **F-9121**: Return after the method-lookup failure in `NativeMacEncryptCb` so cleanup does not run twice.
  - **F-9129**: Compare the negotiated DH group size in bits (new `getDhKeySize` binding over `wolfSSL_GetDhKey_Sz`) against the `jdk.tls.disabledAlgorithms` DH minimum in `checkKeySize`, replacing a byte-based symmetric key size comparison gated on `jdk.tls.ephemeralDHKeySize`.
  - **F-9457**: Note in the logging-callback comment that `JNI_OnUnload` deregisters it after JVM execution ends.
  - **F-9458**: Name `JNI_OnLoad` as the init phase in the verify and CRL mutex comments.
  - **F-9466**: Correct the `NativeSessionTicketCb` comments to name the session-ticket callback.
  - **F-9467**: Correct the `NativeSessionTicketCb` closing `#endif` comment to name its actual guard.