### PR TITLE
Fixes for JNI callback error paths, certificate dates, CRL time init, Makefile JDK checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,15 +44,15 @@ JAVA_HOME       ?= $(shell \
 
 # Platform-specific flags
 ifeq ($(OS),Darwin)
-    JNI_INCLUDES  = -I$(JAVA_HOME)/include \
-                    -I$(JAVA_HOME)/include/darwin \
-                    -I$(WOLFSSL_INSTALL_DIR)/include
+    JNI_INCLUDES  = -I"$(JAVA_HOME)/include" \
+                    -I"$(JAVA_HOME)/include/darwin" \
+                    -I"$(WOLFSSL_INSTALL_DIR)/include"
     JNI_LIB_FLAGS = -dynamiclib
     JNI_LIB_NAME  = libwolfssljni.dylib
 else ifeq ($(OS),Linux)
-    JNI_INCLUDES  = -I$(JAVA_HOME)/include \
-                    -I$(JAVA_HOME)/include/linux \
-                    -I$(WOLFSSL_INSTALL_DIR)/include
+    JNI_INCLUDES  = -I"$(JAVA_HOME)/include" \
+                    -I"$(JAVA_HOME)/include/linux" \
+                    -I"$(WOLFSSL_INSTALL_DIR)/include"
     JNI_LIB_FLAGS = -shared
     JNI_LIB_NAME  = libwolfssljni.so
     ifneq ($(filter x86_64 aarch64,$(ARCH)),)
@@ -79,11 +79,12 @@ endif
 
 JNI_CFLAGS  = -Wall -Wextra -Werror $(FPIC) -MMD -MP $(PATCH_CFLAGS) $(CFLAGS)
 JNI_LDFLAGS = -Wall $(JNI_LIB_FLAGS) $(CFLAGS) \
-              -L$(WOLFSSL_INSTALL_DIR)/lib \
-              -L$(WOLFSSL_INSTALL_DIR)/lib64
+              -L"$(WOLFSSL_INSTALL_DIR)/lib" \
+              -L"$(WOLFSSL_INSTALL_DIR)/lib64"
 JNI_LDLIBS  = -l$(WOLFSSL_LIBNAME)
 
-.PHONY: all build check native clean-native clean install uninstall dist rpm print-config
+.PHONY: all build check native clean-native clean install uninstall dist rpm \
+        print-config check-jdk
 
 all: build
 
@@ -94,8 +95,15 @@ build: build.xml
 check: build
 	ant test
 
+# Fail with a clear message when JAVA_HOME does not point at a JDK.
+check-jdk:
+	@if [ ! -f "$(JAVA_HOME)/include/jni.h" ]; then \
+	    echo "ERROR: JAVA_HOME \"$(JAVA_HOME)\" has no include/jni.h" >&2; \
+	    exit 1; \
+	fi
+
 # Pattern rule: compile any native/*.c to native/*.o
-$(NATIVE_SRC_DIR)/%.o: $(NATIVE_SRC_DIR)/%.c | print-config
+$(NATIVE_SRC_DIR)/%.o: $(NATIVE_SRC_DIR)/%.c | print-config check-jdk
 	@echo "  CC      $<"
 	$(Q)$(CC) $(JNI_CFLAGS) -c $< -o $@ $(JNI_INCLUDES)
 

--- a/native/com_wolfssl_WolfSSLCRL.c
+++ b/native/com_wolfssl_WolfSSLCRL.c
@@ -149,7 +149,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCRL_X509_1CRL_1set_1lastUpdate
 
     timeBuf = (byte*)(*jenv)->GetByteArrayElements(jenv, time, NULL);
     timeSz = (*jenv)->GetArrayLength(jenv, time);
-    /* Ensure there is enough room for date string (32 bytes) 
+    /* Ensure there is enough room for date string (32 bytes)
        plus 4 bytes of length and 4 bytes for type. */
     if (timeBuf == NULL || timeSz < (CTC_DATE_SIZE + 8)) {
         ret = 0;
@@ -164,7 +164,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCRL_X509_1CRL_1set_1lastUpdate
             /* Copy time string and null-terminate */
             XMEMCPY(timeStr, timeBuf, timeLen);
             timeStr[timeLen] = '\0';
+
             /* Create ASN1_TIME object and set string */
+            XMEMSET(&asnTime, 0, sizeof(asnTime));
             if (wolfSSL_ASN1_TIME_set_string(&asnTime, timeStr) == 1) {
                 ret = wolfSSL_X509_CRL_set_lastUpdate(crl, &asnTime);
             }
@@ -208,7 +210,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCRL_X509_1CRL_1set_1nextUpdate
 
     timeBuf = (byte*)(*jenv)->GetByteArrayElements(jenv, time, NULL);
     timeSz = (*jenv)->GetArrayLength(jenv, time);
-    /* Ensure there is enough room for date string (32 bytes) 
+    /* Ensure there is enough room for date string (32 bytes)
        plus 4 bytes of length and 4 bytes for type. */
     if (timeBuf == NULL || timeSz < (CTC_DATE_SIZE + 8)) {
         ret = 0;
@@ -223,7 +225,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCRL_X509_1CRL_1set_1nextUpdate
             /* Copy time string and null-terminate */
             XMEMCPY(timeStr, timeBuf, timeLen);
             timeStr[timeLen] = '\0';
+
             /* Create ASN1_TIME object and set string */
+            XMEMSET(&asnTime, 0, sizeof(asnTime));
             if (wolfSSL_ASN1_TIME_set_string(&asnTime, timeStr) == 1) {
                 ret = wolfSSL_X509_CRL_set_nextUpdate(crl, &asnTime);
             }

--- a/native/com_wolfssl_WolfSSLCertificate.c
+++ b/native/com_wolfssl_WolfSSLCertificate.c
@@ -469,10 +469,15 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1set_1notBefore
     WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
     WOLFSSL_ASN1_TIME* asnBefore = NULL;
     int ret = WOLFSSL_SUCCESS;
-    time_t notBeforeTime = (time_t)(long)notBefore;
+    time_t notBeforeTime = (time_t)notBefore;
     (void)jcl;
 
     if (jenv == NULL || x509 == NULL) {
+        return WOLFSSL_FAILURE;
+    }
+
+    /* Reject values the platform time_t cannot represent */
+    if ((jlong)notBeforeTime != notBefore) {
         return WOLFSSL_FAILURE;
     }
 
@@ -509,10 +514,15 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1set_1notAfter
     WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
     WOLFSSL_ASN1_TIME* asnAfter = NULL;
     int ret = WOLFSSL_SUCCESS;
-    time_t notAfterTime = (time_t)(long)notAfter;
+    time_t notAfterTime = (time_t)notAfter;
     (void)jcl;
 
     if (jenv == NULL || x509 == NULL) {
+        return WOLFSSL_FAILURE;
+    }
+
+    /* Reject values the platform time_t cannot represent */
+    if ((jlong)notAfterTime != notAfter) {
         return WOLFSSL_FAILURE;
     }
 

--- a/native/com_wolfssl_WolfSSLContext.c
+++ b/native/com_wolfssl_WolfSSLContext.c
@@ -3903,12 +3903,13 @@ int  NativeEccSharedSecretCb(WOLFSSL* ssl, ecc_key* otherKey,
         unsigned char* out, unsigned int* outlen, int side, void* ctx)
 {
     int        ret;
+    int        cbException = 0;       /* Java callback threw an exception */
     jint       retval = 0;
 
     JNIEnv*    jenv = NULL;           /* JNI Environment */
     int        needsDetach = 0;       /* Should we explicitly detach? */
 
-    jobject* g_cachedSSLObj;           /* WolfSSLSession cached object */
+    jobject* g_cachedSSLObj;          /* WolfSSLSession cached object */
 
     jobject    ctxRef;                /* WolfSSLContext object */
     jmethodID  eccSharedSecretMethodId;
@@ -4138,12 +4139,22 @@ int  NativeEccSharedSecretCb(WOLFSSL* ssl, ecc_key* otherKey,
             (jobject)(*g_cachedSSLObj), eccKeyObject, pubKeyDerBB,
             j_pubKeyDerSz, outBB, j_outSz, (jint)side);
 
-    CheckException(jenv);
+    cbException = CheckException(jenv);
     (*jenv)->DeleteLocalRef(jenv, ctxRef);
     (*jenv)->DeleteLocalRef(jenv, eccKeyObject);
     (*jenv)->DeleteLocalRef(jenv, pubKeyDerBB);
     if (side == WOLFSSL_SERVER_END) {
         XFREE(tmpKeyDer, otherKey->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+
+    if (cbException) {
+        /* Java callback threw, do not use the undefined result */
+        (*jenv)->DeleteLocalRef(jenv, j_pubKeyDerSz);
+        (*jenv)->DeleteLocalRef(jenv, j_outSz);
+        (*jenv)->DeleteLocalRef(jenv, outBB);
+        if (needsDetach)
+            (*g_vm)->DetachCurrentThread(g_vm);
+        return -1;
     }
 
     if (retval == 0) {

--- a/native/com_wolfssl_WolfSSLContext.c
+++ b/native/com_wolfssl_WolfSSLContext.c
@@ -5888,6 +5888,14 @@ int  NativeRsaEncCb(WOLFSSL* ssl, const unsigned char* in, unsigned int inSz,
     if ((*jenv)->ExceptionOccurred(jenv)) {
         (*jenv)->ExceptionDescribe(jenv);
         (*jenv)->ExceptionClear(jenv);
+        (*jenv)->DeleteLocalRef(jenv, ctxRef);
+        (*jenv)->DeleteLocalRef(jenv, inBB);
+        (*jenv)->DeleteLocalRef(jenv, outBB);
+        (*jenv)->DeleteLocalRef(jenv, keyDerBB);
+        (*jenv)->DeleteLocalRef(jenv, j_outSz);
+        if (needsDetach)
+            (*g_vm)->DetachCurrentThread(g_vm);
+        return -1;
     }
 
     if (retval == 0) {

--- a/native/com_wolfssl_WolfSSLContext.c
+++ b/native/com_wolfssl_WolfSSLContext.c
@@ -3414,6 +3414,14 @@ int  NativeEccSignCb(WOLFSSL* ssl, const unsigned char* in, unsigned int inSz,
     if ((*jenv)->ExceptionOccurred(jenv)) {
         (*jenv)->ExceptionDescribe(jenv);
         (*jenv)->ExceptionClear(jenv);
+        (*jenv)->DeleteLocalRef(jenv, ctxRef);
+        (*jenv)->DeleteLocalRef(jenv, outBB);
+        (*jenv)->DeleteLocalRef(jenv, inBB);
+        (*jenv)->DeleteLocalRef(jenv, keyDerBB);
+        (*jenv)->DeleteLocalRef(jenv, j_outSz);
+        if (needsDetach)
+            (*g_vm)->DetachCurrentThread(g_vm);
+        return -1;
     }
 
     if (retval == 0) {

--- a/src/test/com/wolfssl/test/WolfSSLCertificateTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLCertificateTest.java
@@ -928,6 +928,66 @@ public class WolfSSLCertificateTest {
         }
     }
 
+    /* A validity date after the 2038 32-bit time_t rollover must round-trip
+     * through the notBefore and notAfter setters. */
+    @Test
+    public void test_setNotBeforeNotAfterPost2038RoundTrips()
+        throws WolfSSLException, WolfSSLJNIException, IOException {
+
+        Assume.assumeTrue(WolfSSL.FileSystemEnabled());
+
+        Date notBefore = Date.from(Instant.parse("2039-01-01T00:00:00Z"));
+        Date notAfter = Date.from(Instant.parse("2040-01-01T00:00:00Z"));
+        Date representable = Date.from(Instant.parse("2020-01-01T00:00:00Z"));
+
+        WolfSSLCertificate x509 = new WolfSSLCertificate();
+        WolfSSLX509Name name = null;
+        byte[] der;
+
+        try {
+            /* A representable date must set cleanly. Let a failure here
+             * propagate, since it is a real regression not a time_t limit. */
+            x509.setNotBefore(representable);
+
+            /* A 32-bit time_t cannot hold a post-2038 date, so the setter
+             * rejects it there. Skip rather than fail on those platforms. */
+            try {
+                x509.setNotBefore(notBefore);
+                x509.setNotAfter(notAfter);
+            } catch (WolfSSLException e) {
+                Assume.assumeNoException(
+                    "post-2038 validity dates require 64-bit time_t", e);
+            }
+
+            x509.setSerialNumber(BigInteger.valueOf(1125));
+
+            name = new WolfSSLX509Name();
+            name.setCommonName("post 2038 test");
+            x509.setSubjectName(name);
+
+            x509.setPublicKey(cliKeyPubDer, WolfSSL.RSAk,
+                WolfSSL.SSL_FILETYPE_ASN1);
+            x509.signCert(cliKeyDer, WolfSSL.RSAk,
+                WolfSSL.SSL_FILETYPE_ASN1, "SHA256");
+            der = x509.getDer();
+        } finally {
+            if (name != null) {
+                name.free();
+            }
+            x509.free();
+        }
+
+        WolfSSLCertificate cert = new WolfSSLCertificate(der);
+        try {
+            assertEquals("post-2038 notBefore must round-trip",
+                notBefore, cert.notBefore());
+            assertEquals("post-2038 notAfter must round-trip",
+                notAfter, cert.notAfter());
+        } finally {
+            cert.free();
+        }
+    }
+
     /* Generate a self-signed cert with the given CN and an optional single
      * SubjectAltName entry, return its DER encoding. */
     private byte[] genIpTestCertDer(String cn, String sanValue, int sanType)


### PR DESCRIPTION
This PR includes six Fenrir fixes:

  - **F-10744**: Cast certificate validity dates directly from `jlong` to `time_t`
  - **F-10745**: Return an error from `NativeEccSignCb` when the Java callback throws
  - **F-10746**: Same fix for `NativeEccSharedSecretCb`.
  - **F-10747**: Same fix for `NativeRsaEncCb`.
  - **F-9130**: Zero the stack `WOLFSSL_ASN1_TIME` before use in CRL `set_lastUpdate` and `set_nextUpdate` paths.
  - **F-6737**: Auto-detect `JAVA_HOME`, quote the JNI include and library paths for directories with spaces