### PR TITLE
Fixes for JNI resource cleanup, NULL string handling, SAN and CertManager parsing

### DIFF
--- a/native/com_wolfssl_WolfSSLCertManager.c
+++ b/native/com_wolfssl_WolfSSLCertManager.c
@@ -116,8 +116,13 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertManager_CertManagerLoadCABuff
         return BAD_FUNC_ARG;
     }
 
+    /* number of bytes to parse and must fit within the array */
+    if (sz > (jlong)(*jenv)->GetArrayLength(jenv, in)) {
+        return BAD_FUNC_ARG;
+    }
+
     buff = (byte*)(*jenv)->GetByteArrayElements(jenv, in, NULL);
-    buffSz = (*jenv)->GetArrayLength(jenv, in);
+    buffSz = (word32)sz;
 
     if (buff != NULL) {
         ret = wolfSSL_CertManagerLoadCABuffer(cm, buff, buffSz, format);
@@ -159,8 +164,12 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLCertManager_CertManagerVerifyBuff
     if (jenv == NULL || in == NULL || (sz < 0))
         return BAD_FUNC_ARG;
 
+    /* number of bytes to parse and must fit within the array */
+    if (sz > (jlong)(*jenv)->GetArrayLength(jenv, in))
+        return BAD_FUNC_ARG;
+
     buff = (byte*)(*jenv)->GetByteArrayElements(jenv, in, NULL);
-    buffSz = (*jenv)->GetArrayLength(jenv, in);
+    buffSz = (word32)sz;
 
     if (buff != NULL) {
         ret = wolfSSL_CertManagerVerifyBuffer(cm, buff, buffSz, format);

--- a/native/com_wolfssl_WolfSSLCertificate.c
+++ b/native/com_wolfssl_WolfSSLCertificate.c
@@ -2738,12 +2738,27 @@ JNIEXPORT jobjectArray JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1su
                     strValue = (const char*)wolfSSL_ASN1_STRING_data(asn1Str);
                     strLen = wolfSSL_ASN1_STRING_length(asn1Str);
                     if ((strValue != NULL) && (strLen >= 0)) {
-                        valueStr = (*jenv)->NewStringUTF(jenv, strValue);
-                        if ((valueStr != NULL) &&
-                            !(*jenv)->ExceptionCheck(jenv)) {
-                            (*jenv)->SetObjectArrayElement(jenv, innerArray,
-                                1, valueStr);
-                            (*jenv)->DeleteLocalRef(jenv, valueStr);
+                        /* Copy exactly strLen bytes, null terminate */
+                        char* valBuf = (char*)XMALLOC((size_t)strLen + 1, NULL,
+                            DYNAMIC_TYPE_TMP_BUFFER);
+                        if (valBuf != NULL) {
+                            if (strLen > 0) {
+                                XMEMCPY(valBuf, strValue, (size_t)strLen);
+                            }
+                            valBuf[strLen] = '\0';
+
+                            /* A shorter C string means an embedded null.
+                             * Skip it so the name is not truncated there. */
+                            if (XSTRLEN(valBuf) == (size_t)strLen) {
+                                valueStr = (*jenv)->NewStringUTF(jenv, valBuf);
+                                if ((valueStr != NULL) &&
+                                    !(*jenv)->ExceptionCheck(jenv)) {
+                                    (*jenv)->SetObjectArrayElement(jenv,
+                                        innerArray, 1, valueStr);
+                                    (*jenv)->DeleteLocalRef(jenv, valueStr);
+                                }
+                            }
+                            XFREE(valBuf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
                         }
                     }
                 }

--- a/native/com_wolfssl_WolfSSLCertificate.c
+++ b/native/com_wolfssl_WolfSSLCertificate.c
@@ -1596,10 +1596,11 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1signatu
     }
 
     oidSz = wolfSSL_OBJ_obj2txt(oid, oidSz, obj, 1);
+    wolfSSL_ASN1_OBJECT_free(obj);
     if (oidSz <= 0) {
         return NULL;
     }
-    wolfSSL_ASN1_OBJECT_free(obj);
+
     return (*jenv)->NewStringUTF(jenv, oid);
 }
 

--- a/native/com_wolfssl_WolfSSLContext.c
+++ b/native/com_wolfssl_WolfSSLContext.c
@@ -439,12 +439,14 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setTmpDHFile
             return (jint)SSL_FAILURE;
         }
         (*jenv)->ThrowNew(jenv, excClass,
-                "Input WolfSSLContext object was null in "
-                "setTmpDHFile");
+            "Input WolfSSLContext object was null in setTmpDHFile");
         return (jint)SSL_FAILURE;
     }
 
     fname = (*jenv)->GetStringUTFChars(jenv, file, 0);
+    if (fname == NULL) {
+        return (jint)SSL_FAILURE;
+    }
 
     ret = wolfSSL_CTX_SetTmpDH_file(ctx, fname, format);
 
@@ -482,13 +484,15 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useCertificateFile
             (*jenv)->ExceptionClear(jenv);
         }
         /* throw NullPointerException */
-        (*jenv)->ThrowNew(jenv, excClass,
-                "Input certificate file is NULL");
+        (*jenv)->ThrowNew(jenv, excClass, "Input certificate file is NULL");
 
         return (jint)SSL_FAILURE;
     }
 
     certFile = (*jenv)->GetStringUTFChars(jenv, file, 0);
+    if (certFile == NULL) {
+        return (jint)SSL_FAILURE;
+    }
 
     ret = (jint) wolfSSL_CTX_use_certificate_file(ctx, certFile, (int)format);
 
@@ -526,13 +530,15 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_usePrivateKeyFile
             (*jenv)->ExceptionClear(jenv);
         }
         /* throw NullPointerException */
-        (*jenv)->ThrowNew(jenv, excClass,
-                "Input private key file is NULL");
+        (*jenv)->ThrowNew(jenv, excClass, "Input private key file is NULL");
 
         return (jint)SSL_FAILURE;
     }
 
     keyFile = (*jenv)->GetStringUTFChars(jenv, file, 0);
+    if (keyFile == NULL) {
+        return (jint)SSL_FAILURE;
+    }
 
     ret = (jint) wolfSSL_CTX_use_PrivateKey_file(ctx, keyFile, (int)format);
 
@@ -579,12 +585,21 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_loadVerifyLocations
 
     if (file) {
         caFile = (*jenv)->GetStringUTFChars(jenv, file, 0);
+        if (caFile == NULL) {
+            return (jint)SSL_FAILURE;
+        }
     } else {
         caFile = NULL;
     }
 
     if (path) {
         caPath = (*jenv)->GetStringUTFChars(jenv, path, 0);
+        if (caPath == NULL) {
+            if (caFile) {
+                (*jenv)->ReleaseStringUTFChars(jenv, file, caFile);
+            }
+            return (jint)SSL_FAILURE;
+        }
     } else {
         caPath = NULL;
     }
@@ -636,6 +651,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useCertificateChainFile
     }
 
     chainFile = (*jenv)->GetStringUTFChars(jenv, file, 0);
+    if (chainFile == NULL) {
+        return (jint)SSL_FAILURE;
+    }
 
     ret = (jint) wolfSSL_CTX_use_certificate_chain_file(ctx, chainFile);
 
@@ -2098,6 +2116,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_loadCRL
     }
 
     crlPath = (*jenv)->GetStringUTFChars(jenv, path, 0);
+    if (crlPath == NULL) {
+        return (jint)SSL_FAILURE;
+    }
 
     ret = wolfSSL_CTX_LoadCRL(ctx, crlPath, type, monitor);
 
@@ -7093,6 +7114,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_usePskIdentityHint
     }
 
     nativeHint = (*jenv)->GetStringUTFChars(jenv, hint, 0);
+    if (nativeHint == NULL) {
+        return (jint)SSL_FAILURE;
+    }
 
     ret = (jint)wolfSSL_CTX_use_psk_identity_hint(ctx, nativeHint);
 

--- a/native/com_wolfssl_WolfSSLContext.c
+++ b/native/com_wolfssl_WolfSSLContext.c
@@ -2193,6 +2193,31 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_setCRLCb
 
 #ifdef HAVE_CRL
 
+/* Delete JNI local references created inside NativeCtxMissingCRLCallback() */
+static void freeCtxMissingCRLCbLocalRefs(JNIEnv* jenv, jclass excClass,
+    jobject crlCbObj, jclass crlClass, jstring missingUrl)
+{
+    if (jenv == NULL) {
+        return;
+    }
+
+    if (missingUrl != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, missingUrl);
+    }
+
+    if (crlClass != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, crlClass);
+    }
+
+    if (crlCbObj != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, crlCbObj);
+    }
+
+    if (excClass != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, excClass);
+    }
+}
+
 void NativeCtxMissingCRLCallback(const char* url)
 {
     JNIEnv*   jenv;
@@ -2245,6 +2270,8 @@ void NativeCtxMissingCRLCallback(const char* url)
 
     if (crlCbObj == NULL) {
         /* No Java callback registered, drop silently. */
+        freeCtxMissingCRLCbLocalRefs(jenv, excClass, crlCbObj, crlClass,
+            missingUrl);
         if (needsDetach) {
             (*g_vm)->DetachCurrentThread(g_vm);
         }
@@ -2261,6 +2288,8 @@ void NativeCtxMissingCRLCallback(const char* url)
         if (!crlClass) {
             (*jenv)->ThrowNew(jenv, excClass,
                 "Can't get native WolfSSLMissingCRLCallback class reference");
+            freeCtxMissingCRLCbLocalRefs(jenv, excClass, crlCbObj, crlClass,
+                missingUrl);
             if (needsDetach)
                 (*g_vm)->DetachCurrentThread(g_vm);
             return;
@@ -2277,6 +2306,8 @@ void NativeCtxMissingCRLCallback(const char* url)
 
             (*jenv)->ThrowNew(jenv, excClass,
                 "Error getting missingCRLCallback method from JNI");
+            freeCtxMissingCRLCbLocalRefs(jenv, excClass, crlCbObj, crlClass,
+                missingUrl);
             if (needsDetach)
                 (*g_vm)->DetachCurrentThread(g_vm);
             return;
@@ -2302,6 +2333,9 @@ void NativeCtxMissingCRLCallback(const char* url)
         (*jenv)->ThrowNew(jenv, excClass,
                 "Object reference invalid in NativeMissingCRLCallback");
     }
+
+    freeCtxMissingCRLCbLocalRefs(jenv, excClass, crlCbObj, crlClass,
+        missingUrl);
 
     if (needsDetach)
         (*g_vm)->DetachCurrentThread(g_vm);

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -639,6 +639,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useCertificateFile
     }
 
     certFile = (*jenv)->GetStringUTFChars(jenv, file, 0);
+    if (certFile == NULL) {
+        return SSL_FAILURE;
+    }
 
     ret = (jint) wolfSSL_use_certificate_file(ssl, certFile, (int)format);
 
@@ -673,6 +676,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_usePrivateKeyFile
     }
 
     keyFile = (*jenv)->GetStringUTFChars(jenv, file, 0);
+    if (keyFile == NULL) {
+        return SSL_FAILURE;
+    }
 
     ret = (jint) wolfSSL_use_PrivateKey_file(ssl, keyFile, (int)format);
 
@@ -707,6 +713,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useCertificateChainFile
     }
 
     chainFile = (*jenv)->GetStringUTFChars(jenv, file, 0);
+    if (chainFile == NULL) {
+        return SSL_FAILURE;
+    }
 
     ret = (jint) wolfSSL_use_certificate_chain_file(ssl, chainFile);
 
@@ -3647,6 +3656,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_checkDomainName
     }
 
     dname = (*jenv)->GetStringUTFChars(jenv, dn, 0);
+    if (dname == NULL) {
+        return SSL_FAILURE;
+    }
 
     ret = wolfSSL_check_domain_name(ssl, dname);
 
@@ -3745,6 +3757,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setTmpDHFile
     }
 
     fname = (*jenv)->GetStringUTFChars(jenv, file, 0);
+    if (fname == NULL) {
+        return SSL_FAILURE;
+    }
 
     ret = wolfSSL_SetTmpDH_file(ssl, fname, format);
 
@@ -4016,6 +4031,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_loadCRL
     }
 
     crlPath = (*jenv)->GetStringUTFChars(jenv, path, 0);
+    if (crlPath == NULL) {
+        return SSL_FAILURE;
+    }
 
     ret = wolfSSL_LoadCRL(ssl, crlPath, type, monitor);
 
@@ -4926,6 +4944,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_usePskIdentityHint
     }
 
     nativeHint = (*jenv)->GetStringUTFChars(jenv, hint, 0);
+    if (nativeHint == NULL) {
+        return SSL_FAILURE;
+    }
 
     ret = (jint)wolfSSL_use_psk_identity_hint(ssl, nativeHint);
 

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -2680,6 +2680,9 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_dtlsSetPeer
         (*jenv)->ExceptionDescribe(jenv);
         (*jenv)->ExceptionClear(jenv);
     }
+    if (addrObj == NULL) {
+        return SSL_FAILURE;
+    }
 
     /* is this a wildcard address, ie: INADDR_ANY? */
     isAnyID = (*jenv)->GetMethodID(jenv, inetaddr, "isAnyLocalAddress", "()Z");
@@ -2715,9 +2718,15 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_dtlsSetPeer
             (*jenv)->ExceptionDescribe(jenv);
             (*jenv)->ExceptionClear(jenv);
         }
+        if (ipAddr == NULL) {
+            return SSL_FAILURE;
+        }
 
         /* convert IP string to char* */
         ipAddress = (*jenv)->GetStringUTFChars(jenv, ipAddr, 0);
+        if (ipAddress == NULL) {
+            return SSL_FAILURE;
+        }
     }
 
     /* build sockaddr_in */

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -4123,6 +4123,27 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setCRLCb
 
 #ifdef HAVE_CRL
 
+/* Delete JNI local references created inside NativeMissingCRLCallback() */
+static void freeMissingCRLCbLocalRefs(JNIEnv* jenv, jobject crlCbObj,
+    jclass crlClass, jstring missingUrl)
+{
+    if (jenv == NULL) {
+        return;
+    }
+
+    if (missingUrl != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, missingUrl);
+    }
+
+    if (crlClass != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, crlClass);
+    }
+
+    if (crlCbObj != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, crlCbObj);
+    }
+}
+
 void NativeMissingCRLCallback(const char* url)
 {
     JNIEnv*   jenv;
@@ -4178,6 +4199,7 @@ void NativeMissingCRLCallback(const char* url)
         if (!crlClass) {
             throwWolfSSLException(jenv,
                 "Can't get native WolfSSLMissingCRLCallback class reference");
+            freeMissingCRLCbLocalRefs(jenv, crlCbObj, crlClass, missingUrl);
             if (needsDetach)
                 (*g_vm)->DetachCurrentThread(g_vm);
             return;
@@ -4194,6 +4216,7 @@ void NativeMissingCRLCallback(const char* url)
 
             throwWolfSSLException(jenv,
                 "Error getting missingCRLCallback method from JNI");
+            freeMissingCRLCbLocalRefs(jenv, crlCbObj, crlClass, missingUrl);
             if (needsDetach)
                 (*g_vm)->DetachCurrentThread(g_vm);
             return;
@@ -4218,6 +4241,8 @@ void NativeMissingCRLCallback(const char* url)
         throwWolfSSLException(jenv,
             "Object reference invalid in NativeMissingCRLCallback");
     }
+
+    freeMissingCRLCbLocalRefs(jenv, crlCbObj, crlClass, missingUrl);
 
     if (needsDetach)
         (*g_vm)->DetachCurrentThread(g_vm);

--- a/native/com_wolfssl_WolfSSLX509StoreCtx.c
+++ b/native/com_wolfssl_WolfSSLX509StoreCtx.c
@@ -63,6 +63,9 @@ JNIEXPORT jobjectArray JNICALL Java_com_wolfssl_WolfSSLX509StoreCtx_X509_1STORE_
     skNum = wolfSSL_sk_X509_num(sk);
 
     if (sk == NULL || skNum == 0) {
+        if (sk != NULL) {
+            wolfSSL_sk_X509_pop_free(sk, NULL);
+        }
         return NULL;
     }
 

--- a/src/java/com/wolfssl/WolfSSLCertManager.java
+++ b/src/java/com/wolfssl/WolfSSLCertManager.java
@@ -116,12 +116,14 @@ public class WolfSSLCertManager {
      * Load CA into CertManager from byte array
      *
      * @param in byte array holding X.509 certificate to load
-     * @param sz size of input byte array, bytes
+     * @param sz number of bytes to parse from the start of in.
+     *           Must not exceed in.length.
      * @param format format of input certificate, either
      *               WolfSSL.SSL_FILETYPE_PEM (PEM formatted) or
      *               WolfSSL.SSL_FILETYPE_ASN1 (ASN.1/DER).
      *
-     * @return WolfSSL.SSL_SUCCESS on success, negative on error
+     * @return WolfSSL.SSL_SUCCESS on success, negative on error including
+     *         BAD_FUNC_ARG when sz exceeds in.length
      * @throws IllegalStateException WolfSSLContext has been freed
      */
     public synchronized int CertManagerLoadCABuffer(
@@ -225,13 +227,15 @@ public class WolfSSLCertManager {
      * Verify X.509 certificate held in byte array
      *
      * @param in input X.509 certificate as byte array
-     * @param sz size of input certificate array, bytes
+     * @param sz number of bytes to parse from the start of in.
+     *           Must not exceed in.length.
      * @param format format of input certificate, either
      *               WolfSSL.SSL_FILETYPE_PEM (PEM formatted) or
      *               WolfSSL.SSL_FILETYPE_ASN1 (ASN.1/DER).
      *
      * @return WolfSSL.SSL_SUCCESS on successful verification, otherwise
-     *         negative on error.
+     *         negative on error including BAD_FUNC_ARG when sz exceeds
+     *         in.length.
      * @throws IllegalStateException WolfSSLContext has been freed
      */
     public synchronized int CertManagerVerifyBuffer(

--- a/src/java/com/wolfssl/WolfSSLCertificate.java
+++ b/src/java/com/wolfssl/WolfSSLCertificate.java
@@ -2204,6 +2204,9 @@ public class WolfSSLCertificate implements Serializable {
      * getSubjectAltNamesExtended() which returns the OID and ASN.1
      * encoded value bytes.
      *
+     * A SAN entry whose value contains an embedded null byte is omitted,
+     * so it is never returned truncated at the null.
+     *
      * @return immutable Collection of subject alternative names, or null
      *
      * @throws IllegalStateException if WolfSSLCertificate has been freed.
@@ -2315,6 +2318,9 @@ public class WolfSSLCertificate implements Serializable {
      * }
      * </pre>
      *
+     * A SAN entry whose value contains an embedded null byte is omitted,
+     * so it is never returned truncated at the null.
+     *
      * @return immutable Collection of subject alternative names with extended
      *         data, or null if no SANs present or native method not available
      *
@@ -2399,6 +2405,9 @@ public class WolfSSLCertificate implements Serializable {
      * }
      * </pre>
      *
+     * A SAN entry whose value contains an embedded null byte is omitted,
+     * so it is never returned truncated at the null.
+     *
      * @return array of WolfSSLAltName objects, or null if no SANs present
      *         or native method not available
      *
@@ -2416,7 +2425,7 @@ public class WolfSSLCertificate implements Serializable {
                 () -> "entering getSubjectAltNamesArray()");
 
             WolfSSLAltName[] cached = getAltNamesArrayInternal();
-            if (cached == null) {
+            if (cached == null || cached.length == 0) {
                 return null;
             }
 
@@ -2506,7 +2515,8 @@ public class WolfSSLCertificate implements Serializable {
         }
 
         if (count == 0) {
-            return null;
+            this.altNamesArray = new WolfSSLAltName[0];
+            return this.altNamesArray;
         }
 
         /* Trim array if needed and cache result */

--- a/src/java/com/wolfssl/WolfSSLDebug.java
+++ b/src/java/com/wolfssl/WolfSSLDebug.java
@@ -28,6 +28,7 @@ import java.util.logging.*;
 import java.util.logging.Formatter;
 import java.util.logging.Handler;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 
 /**
  * Central location for all debugging messages
@@ -105,6 +106,31 @@ public class WolfSSLDebug {
 
     /** Info level debug message */
     public static final String INFO = "INFO";
+
+    /** Characters removed from externally-influenced log values: CR, LF,
+     * other C0 control characters, DEL, and double quote. */
+    private static final Pattern LOG_UNSAFE_CHARS =
+        Pattern.compile("[\\x00-\\x1F\\x7F\"]");
+
+    /**
+     * Sanitize input string: replaces CR, LF, other C0 control characters,
+     * DEL, and double quote with underscore.
+     *
+     * Used by callers to sanitize values that come from network or remote
+     * peers before placing them in a log message, so uncontrolled input
+     * cannot forge or split log entries.
+     *
+     * @param value string to sanitize, may be null
+     * @return sanitized string, or null if value was null
+     */
+    public static String sanitizeForLog(String value) {
+
+        if (value == null) {
+            return null;
+        }
+
+        return LOG_UNSAFE_CHARS.matcher(value).replaceAll("_");
+    }
 
     /**
      * Native wolfSSL logging callback.
@@ -231,6 +257,47 @@ public class WolfSSLDebug {
     }
 
     /**
+     * Escape a string for safe inclusion as a JSON string value. Handles
+     * backslash, double quote, control characters.
+     *
+     * @param value string to escape, may be null
+     * @return JSON-escaped string, empty string if value was null
+     */
+    private static String jsonEscape(String value) {
+
+        StringBuilder sb;
+
+        if (value == null) {
+            return "";
+        }
+
+        sb = new StringBuilder(value.length());
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '\\': sb.append("\\\\"); break;
+                case '"':  sb.append("\\\""); break;
+                case '\n': sb.append("\\n");  break;
+                case '\r': sb.append("\\r");  break;
+                case '\t': sb.append("\\t");  break;
+                case '\b': sb.append("\\b");  break;
+                case '\f': sb.append("\\f");  break;
+                default:
+                    /* other control chars have no shorthand, emit as a
+                     * unicode escape */
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    }
+                    else {
+                        sb.append(c);
+                    }
+            }
+        }
+
+        return sb.toString();
+    }
+
+    /**
      * JSON formatter for wolfSSL logs
      */
     private static class JSONFormatter extends Formatter {
@@ -270,10 +337,10 @@ public class WolfSSLDebug {
                 "    \"thread_id\": \"%d\"\n" +
                 "}\n",
                 TIME_FORMATTER.format(Instant.ofEpochMilli(record.getMillis())),
-                levelStr,
-                component,
-                message,
-                threadName,
+                jsonEscape(levelStr),
+                jsonEscape(component),
+                jsonEscape(message),
+                jsonEscape(threadName),
                 record.getThreadID());
         }
     }

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLEngineHelper.java
@@ -874,7 +874,8 @@ public class WolfSSLEngineHelper {
         String proto = ssl.getAlpnSelectedString();
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.INFO,
-            () -> "selected ALPN protocol = " + proto);
+            () -> "selected ALPN protocol = " +
+                WolfSSLDebug.sanitizeForLog(proto));
 
         if (proto == null && this.ssl.handshakeDone()) {
             /* ALPN not used if proto is null and handshake is done */

--- a/src/test/com/wolfssl/test/WolfSSLCertManagerTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLCertManagerTest.java
@@ -565,6 +565,56 @@ public class WolfSSLCertManagerTest {
         }
     }
 
+    /* The buffer load/verify calls must parse exactly sz bytes from the start
+     * of the array. A sz beyond the array is rejected instead of being
+     * ignored and the whole backing array parsed. */
+    @Test
+    public void testCertManagerBufferHonorsSz() throws Exception {
+
+        WolfSSLCertManager cm = null;
+
+        try {
+            byte[] caCertPem =
+                Files.readAllBytes(new File(ocspRootCaCert).toPath());
+            byte[] peerPem = Files.readAllBytes(new File(serverCert).toPath());
+
+            cm = new WolfSSLCertManager();
+
+            /* Exact length is the normal, supported call. */
+            assertEquals("exact-length load should succeed",
+                WolfSSL.SSL_SUCCESS,
+                cm.CertManagerLoadCABuffer(caCertPem, caCertPem.length,
+                    WolfSSL.SSL_FILETYPE_PEM));
+
+            assertEquals("load sz past end of array must be rejected",
+                WolfSSL.BAD_FUNC_ARG,
+                cm.CertManagerLoadCABuffer(caCertPem, caCertPem.length + 1,
+                    WolfSSL.SSL_FILETYPE_PEM));
+
+            assertEquals("verify sz past end of array must be rejected",
+                WolfSSL.BAD_FUNC_ARG,
+                cm.CertManagerVerifyBuffer(peerPem, peerPem.length + 1,
+                    WolfSSL.SSL_FILETYPE_PEM));
+
+            /* A shorter sz must parse only the first sz bytes, not the whole
+             * array. Half the PEM is malformed, so the load must fail. The
+             * old code ignored sz and parsed the full array, succeeding. */
+            assertTrue("a shorter sz must not parse the whole array",
+                cm.CertManagerLoadCABuffer(caCertPem, caCertPem.length / 2,
+                    WolfSSL.SSL_FILETYPE_PEM) != WolfSSL.SSL_SUCCESS);
+
+            /* sz of zero parses nothing and must not succeed. */
+            assertTrue("sz of zero must not succeed",
+                cm.CertManagerLoadCABuffer(caCertPem, 0,
+                    WolfSSL.SSL_FILETYPE_PEM) != WolfSSL.SSL_SUCCESS);
+
+        } finally {
+            if (cm != null) {
+                cm.free();
+            }
+        }
+    }
+
     @Test
     public void testCertManagerCheckOCSPResponse()
         throws Exception {

--- a/src/test/com/wolfssl/test/WolfSSLCertificateTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLCertificateTest.java
@@ -26,6 +26,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Date;
@@ -1024,6 +1025,86 @@ public class WolfSSLCertificateTest {
         return der;
     }
 
+    /* Generate a self-signed cert carrying two dNSName SubjectAltName entries,
+     * return its DER encoding. */
+    private byte[] genCertWithTwoDnsSans(String san1, String san2)
+        throws WolfSSLException, WolfSSLJNIException, IOException {
+
+        WolfSSLCertificate x509 = new WolfSSLCertificate();
+        WolfSSLX509Name name = new WolfSSLX509Name();
+
+        Instant now = Instant.now();
+        x509.setNotBefore(Date.from(now));
+        x509.setNotAfter(Date.from(now.plus(Duration.ofDays(365))));
+        x509.setSerialNumber(BigInteger.valueOf(1123));
+
+        name.setCountryName("US");
+        name.setOrganizationName("wolfSSL Inc.");
+        name.setCommonName("Embedded NUL SAN Test");
+        x509.setSubjectName(name);
+
+        x509.setPublicKey(cliKeyPubDer, WolfSSL.RSAk,
+            WolfSSL.SSL_FILETYPE_ASN1);
+
+        x509.addAltName(san1, WolfSSL.ASN_DNS_TYPE);
+        x509.addAltName(san2, WolfSSL.ASN_DNS_TYPE);
+
+        x509.signCert(cliKeyDer, WolfSSL.RSAk,
+            WolfSSL.SSL_FILETYPE_ASN1, "SHA256");
+
+        byte[] der = x509.getDer();
+
+        name.free();
+        x509.free();
+
+        return der;
+    }
+
+    /* Index of the first occurrence of needle in haystack, or -1. */
+    private static int indexOf(byte[] haystack, byte[] needle) {
+        for (int i = 0; i + needle.length <= haystack.length; i++) {
+            int j = 0;
+            while (j < needle.length && haystack[i + j] == needle[j]) {
+                j++;
+            }
+            if (j == needle.length) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /* True if sans holds a dNSName entry whose value equals value. */
+    private static boolean hasDnsSan(Collection<List<?>> sans, String value) {
+        if (sans == null) {
+            return false;
+        }
+        for (List<?> san : sans) {
+            if (san.size() < 2) {
+                continue;
+            }
+            int type = (Integer)san.get(0);
+            if (type == WolfSSL.ASN_DNS_TYPE && value.equals(san.get(1))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /* True if sans holds any entry, of any type, whose value equals value. */
+    private static boolean hasSanValue(Collection<List<?>> sans,
+        String value) {
+        if (sans == null) {
+            return false;
+        }
+        for (List<?> san : sans) {
+            if (san.size() >= 2 && value.equals(san.get(1))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /* An IP address reference identity must be matched only against an
      * iPAddress SAN, never the Subject CN or a dNSName SAN (RFC 6125 /
      * RFC 2818). checkIpAddress() must reject a cert whose only "match" is a
@@ -1070,6 +1151,95 @@ public class WolfSSLCertificateTest {
         assertEquals("non-matching IP must be rejected",
             WolfSSL.SSL_FAILURE, certC.checkIpAddress("198.51.100.9"));
         certC.free();
+    }
+
+    /* A SubjectAltName with an embedded null must not be returned truncated
+     * at that null. The parser drops such an entry. Build a cert with a valid
+     * dNSName plus one holding a placeholder byte, then overwrite that byte
+     * with a raw null in the DER, keeping all ASN.1 lengths unchanged. */
+    @Test
+    public void test_getSubjectAltNames_EmbeddedNulNotTruncated()
+        throws WolfSSLException, WolfSSLJNIException, IOException {
+
+        Assume.assumeTrue(WolfSSL.FileSystemEnabled());
+
+        final String prefix = "example.com";
+        final String marker = prefix + "X.evil.com";
+        final String valid = "good.example";
+
+        byte[] der = genCertWithTwoDnsSans(valid, marker);
+
+        /* Unpatched, both names round-trip in full. */
+        WolfSSLCertificate before = new WolfSSLCertificate(der);
+        Collection<List<?>> sansBefore = before.getSubjectAltNames();
+        assertTrue("valid dNSName missing before patch",
+            hasDnsSan(sansBefore, valid));
+        assertTrue("marker dNSName missing before patch",
+            hasDnsSan(sansBefore, marker));
+        before.free();
+
+        int at = indexOf(der, marker.getBytes(StandardCharsets.UTF_8));
+        assertTrue("marker not found in generated DER", at >= 0);
+        der[at + prefix.length()] = 0x00;
+
+        WolfSSLCertificate after = null;
+        try {
+            after = new WolfSSLCertificate(der);
+        } catch (WolfSSLException e) {
+            Assume.assumeNoException(
+                "build rejects embedded-null cert at parse", e);
+        }
+        Collection<List<?>> sansAfter = after.getSubjectAltNames();
+
+        /* The valid name still returns, the embedded null name is dropped
+         * rather than truncated to its pre null prefix. */
+        assertTrue("valid dNSName must survive", hasDnsSan(sansAfter, valid));
+        assertFalse("embedded null dNSName must not truncate to a prefix",
+            hasDnsSan(sansAfter, prefix));
+        after.free();
+    }
+
+    /* When the embedded-null SAN is the only SAN, the entry must still be
+     * dropped, not returned truncated through the legacy getSubjectAltNames()
+     * fallback that runs when no typed SAN entry survives. All three SAN
+     * accessors must agree. The native handling is shared across dNSName,
+     * rfc822Name, and URI. */
+    @Test
+    public void test_getSubjectAltNames_EmbeddedNulSingleSanDropped()
+        throws WolfSSLException, WolfSSLJNIException, IOException {
+
+        Assume.assumeTrue(WolfSSL.FileSystemEnabled());
+
+        final String prefix = "example.com";
+        final String marker = prefix + "X.evil.com";
+
+        byte[] der = genIpTestCertDer("Embedded NUL SAN Test", marker,
+            WolfSSL.ASN_DNS_TYPE);
+
+        int at = indexOf(der, marker.getBytes(StandardCharsets.UTF_8));
+        assertTrue("marker not found in generated DER", at >= 0);
+        der[at + prefix.length()] = 0x00;
+
+        WolfSSLCertificate cert = null;
+        try {
+            cert = new WolfSSLCertificate(der);
+        } catch (WolfSSLException e) {
+            Assume.assumeNoException(
+                "build rejects embedded-null cert at parse", e);
+        }
+
+        /* Legacy accessor must not fall back and return the value truncated
+         * at the null. */
+        assertFalse("truncated value returned via getSubjectAltNames",
+            hasSanValue(cert.getSubjectAltNames(), prefix));
+
+        /* With the sole entry dropped, the typed accessors return null. */
+        assertNull("getSubjectAltNamesArray",
+            cert.getSubjectAltNamesArray());
+        assertNull("getSubjectAltNamesExtended",
+            cert.getSubjectAltNamesExtended());
+
+        cert.free();
     }
 
     @Test

--- a/src/test/com/wolfssl/test/WolfSSLSessionTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLSessionTest.java
@@ -3855,6 +3855,56 @@ public class WolfSSLSessionTest {
         /* Result can be null if not compiled in or no valid CID found */
     }
 
+    /* dtlsSetPeer() with an unresolved InetSocketAddress must fail cleanly.
+     * getAddress() returns null there, so the native code must not invoke
+     * InetAddress methods on a null object reference. */
+    @Test
+    public void test_WolfSSLSession_dtlsSetPeerUnresolved()
+        throws WolfSSLJNIException, WolfSSLException {
+
+        String[] protocols = WolfSSL.getProtocols();
+        String dtlsProto = null;
+        for (String p : protocols) {
+            if (p.startsWith("DTLS")) {
+                dtlsProto = p;
+                break;
+            }
+        }
+        Assume.assumeTrue(dtlsProto != null);
+
+        long method;
+        if (dtlsProto.equals("DTLSv1.3")) {
+            method = WolfSSL.DTLSv1_3_ClientMethod();
+        }
+        else if (dtlsProto.equals("DTLSv1.2")) {
+            method = WolfSSL.DTLSv1_2_ClientMethod();
+        }
+        else {
+            method = WolfSSL.DTLSv1_ClientMethod();
+        }
+        /* Skip if the selected DTLS method is not compiled in. */
+        Assume.assumeTrue(method != 0);
+
+        WolfSSLContext dtlsCtx = null;
+        WolfSSLSession sess = null;
+        try {
+            dtlsCtx = new WolfSSLContext(method);
+            sess = new WolfSSLSession(dtlsCtx);
+
+            InetSocketAddress unresolved =
+                InetSocketAddress.createUnresolved("host.invalid", 11111);
+            assertEquals("unresolved peer address must fail",
+                WolfSSL.SSL_FAILURE, sess.dtlsSetPeer(unresolved));
+        } finally {
+            if (sess != null) {
+                sess.freeSSL();
+            }
+            if (dtlsCtx != null) {
+                dtlsCtx.free();
+            }
+        }
+    }
+
     @Test
     public void test_WolfSSLSession_dtlsCidFunctions()
         throws WolfSSLJNIException, WolfSSLException {


### PR DESCRIPTION
This PR includes 10 Fenrir fixes:

  - **F-4151**: Guard against a NULL host address and string in `dtlsSetPeer`.
  - **F-4152**: Release JNI local refs on all exit paths in `NativeMissingCRLCallback`.
  - **F-4153**: Release JNI local refs on all exit paths in `NativeCtxMissingCRLCallback`.
  - **F-4619**: Free the owned `WOLFSSL_STACK` on the empty branch in `getDerCerts`.
  - **F-4620**: Return an error when `GetStringUTFChars` yields NULL in the file, hint, cipher, and sig-alg setters.
  - **F-4851 / F-5065**: Honor the caller-supplied `sz` and bound it to the array in the CertManager buffer loaders.
  - **F-5027**: Sanitize the peer ALPN value and JSON-escape debug log fields.
  - **F-5636**: Honor the ASN.1 string length for SAN values and drop entries containing an embedded null.
  - **F-6304**: Free the signature `ASN1_OBJECT` when `OBJ_obj2txt` fails in `getSignatureOID`.