### PR TITLE
Fixes for JNI buffer-size validation and JSSE/RMI example corrections

### DIFF
--- a/examples/provider/DtlsClientEngine.java
+++ b/examples/provider/DtlsClientEngine.java
@@ -37,7 +37,6 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLEngineResult;
 import javax.net.ssl.SSLEngineResult.HandshakeStatus;
 import javax.net.ssl.SSLException;
-import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManagerFactory;
 
@@ -273,15 +272,6 @@ public class DtlsClientEngine {
         /* Create SSLEngine */
         engine = ctx.createSSLEngine(host, port);
         engine.setUseClientMode(true);
-
-        /* Enable endpoint identification if available */
-        try {
-            SSLParameters params = engine.getSSLParameters();
-            engine.setSSLParameters(params);
-        } catch (Exception e) {
-            System.out.println(
-                "DEBUG: Exception setting SSL parameters: " + e.getMessage());
-        }
 
         System.out.println("DTLS 1.3 Client Engine created");
     }

--- a/examples/provider/DualProviderFIPSTest.java
+++ b/examples/provider/DualProviderFIPSTest.java
@@ -113,6 +113,9 @@ public class DualProviderFIPSTest {
                     (SSLServerSocket)ctx.getServerSocketFactory()
                         .createServerSocket(port)) {
 
+                    /* Require client auth */
+                    ss.setNeedClientAuth(true);
+
                     /* Signal client that server is ready */
                     serverReady.countDown();
 

--- a/examples/provider/ThreadedSSLSocketClientServer.java
+++ b/examples/provider/ThreadedSSLSocketClientServer.java
@@ -75,7 +75,7 @@ public class ThreadedSSLSocketClientServer
                 TrustManagerFactory tm = TrustManagerFactory
                     .getInstance(tmfType, tmfProv);
                 tm.init(cert);
-                
+
                 KeyManagerFactory km = KeyManagerFactory
                     .getInstance(kmfType, kmfProv);
                 km.init(pKey, ksPass);
@@ -85,6 +85,9 @@ public class ThreadedSSLSocketClientServer
 
                 SSLServerSocket ss = (SSLServerSocket)ctx
                     .getServerSocketFactory().createServerSocket(srvPort);
+
+                /* Require client auth */
+                ss.setNeedClientAuth(true);
 
                 SSLSocket sock = (SSLSocket)ss.accept();
                 sock.startHandshake();
@@ -119,11 +122,11 @@ public class ThreadedSSLSocketClientServer
                 pKey.load(new FileInputStream(keyStorePath), ksPass);
                 KeyStore cert = KeyStore.getInstance("JKS");
                 cert.load(new FileInputStream(trustStorePath), tsPass);
-                
+
                 TrustManagerFactory tm = TrustManagerFactory
                     .getInstance(tmfType, tmfProv);
                 tm.init(cert);
-                
+
                 KeyManagerFactory km = KeyManagerFactory
                     .getInstance(kmfType, kmfProv);
                 km.init(pKey, ksPass);

--- a/examples/provider/rmi/RmiClient.java
+++ b/examples/provider/rmi/RmiClient.java
@@ -36,7 +36,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicIntegerArray;
 
-import java.net.InetAddress;
 import java.rmi.server.RMIClientSocketFactory;
 import java.rmi.registry.LocateRegistry;
 import java.rmi.registry.Registry;
@@ -267,8 +266,9 @@ public class RmiClient
         }
 
         try {
-            /* Server hostname, null indicates localhost */
-            String host = InetAddress.getLocalHost().getHostName();
+            /* Connect over loopback, matches a SAN in the server cert so
+             * endpoint identification passes */
+            String host = "127.0.0.1";
 
             /* Make single first client connection in order to get the
              * list of registry ports that have been created. Then we can

--- a/examples/provider/rmi/RmiServer.java
+++ b/examples/provider/rmi/RmiServer.java
@@ -77,7 +77,7 @@ public class RmiServer extends UnicastRemoteObject implements RmiRemoteInterface
     /* Keystore files and passwords, holding certs/keys/CAs */
     private static String clientJKS = "../provider/client.jks";
     private static String clientCaJKS = "../provider/ca-server.jks";
-    private static String serverJKS = "../provider/server.jks";
+    private static String serverJKS = "../provider/server-rsa.jks";
     private static String serverCaJKS = "../provider/ca-client.jks";
     private static String jksPass = "wolfSSL test";
 
@@ -268,6 +268,10 @@ public class RmiServer extends UnicastRemoteObject implements RmiRemoteInterface
         }
 
         try {
+            /* Export RMI stubs on loopback so address matches a SAN
+             * in the server certificate the client verifies */
+            System.setProperty("java.rmi.server.hostname", "127.0.0.1");
+
             /* Create one SocketFactory for server and one for client */
             SocketFactory cliSF = createClientSocketFactory();
             SSLServerSocketFactory srvSF = createServerSocketFactory();

--- a/examples/provider/rmi/RmiTLSClientSocketFactory.java
+++ b/examples/provider/rmi/RmiTLSClientSocketFactory.java
@@ -27,6 +27,7 @@ import java.security.KeyStore;
 import java.net.Socket;
 import javax.net.SocketFactory;
 import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManagerFactory;
@@ -47,7 +48,15 @@ public class RmiTLSClientSocketFactory
         }
 
         System.out.println("Creating client Socket");
-        return sf.createSocket(host, port);
+
+        /* Enable endpoint identification to verify the server cert against
+         * host/IP connecting to */
+        SSLSocket s = (SSLSocket)sf.createSocket(host, port);
+        SSLParameters p = s.getSSLParameters();
+        p.setEndpointIdentificationAlgorithm("HTTPS");
+        s.setSSLParameters(p);
+
+        return s;
     }
 
     public int hashCode() {

--- a/examples/provider/rmi/RmiTLSServerSocketFactory.java
+++ b/examples/provider/rmi/RmiTLSServerSocketFactory.java
@@ -26,6 +26,7 @@ import java.security.KeyStore;
 import java.net.ServerSocket;
 import javax.net.SocketFactory;
 import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLServerSocketFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.KeyManagerFactory;
@@ -47,8 +48,12 @@ public class RmiTLSServerSocketFactory implements RMIServerSocketFactory
         }
 
         System.out.println("Creating server Socket");
-        return (ServerSocket)sf.createServerSocket(port);
 
+        /* Require client cert auth */
+        SSLServerSocket ss = (SSLServerSocket)sf.createServerSocket(port);
+        ss.setNeedClientAuth(true);
+
+        return ss;
     }
 
     public int hashCode() {

--- a/native/com_wolfssl_WolfCryptECC.c
+++ b/native/com_wolfssl_WolfCryptECC.c
@@ -64,6 +64,12 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptECC_doVerify
         return -1;
     }
 
+    if ((sigSz  > (*jenv)->GetDirectBufferCapacity(jenv, sig)) ||
+        (hashSz > (*jenv)->GetDirectBufferCapacity(jenv, hash)) ||
+        (keySz  > (*jenv)->GetDirectBufferCapacity(jenv, keyDer))) {
+        return -1;
+    }
+
     wc_ecc_init(&myKey);
 
     ret = wc_ecc_import_x963(keyBuf, (unsigned int)keySz, &myKey);
@@ -129,8 +135,20 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptECC_doSign
     }
 
     /* set previous value of outSz */
+    if ((*jenv)->GetArrayLength(jenv, outSz) < 1) {
+        return -1;
+    }
     (*jenv)->GetLongArrayRegion(jenv, outSz, 0, 1, &tmp);
     tmpOut = (unsigned int)tmp;
+
+    /* Reject a negative output size or any size larger than the backing
+     * direct buffer */
+    if ((tmp < 0) ||
+        (inSz  > (*jenv)->GetDirectBufferCapacity(jenv, in)) ||
+        (keySz > (*jenv)->GetDirectBufferCapacity(jenv, keyDer)) ||
+        (tmp   > (*jenv)->GetDirectBufferCapacity(jenv, out))) {
+        return -1;
+    }
 
     ret = wc_InitRng(&rng);
     if (ret != 0) {

--- a/native/com_wolfssl_WolfCryptRSA.c
+++ b/native/com_wolfssl_WolfCryptRSA.c
@@ -42,6 +42,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptRSA_doSign
     int     keyInit = 0;
     unsigned int idx;
     unsigned int tmpOut;
+    jint outSzVal = 0;
     unsigned char* inBuf = NULL;
     unsigned char* outBuf = NULL;
     unsigned char* keyBuf = NULL;
@@ -72,7 +73,19 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptRSA_doSign
     }
 
     /* get output buffer size */
-    (*jenv)->GetIntArrayRegion(jenv, outSz, 0, 1, (jint*)&tmpOut);
+    if ((*jenv)->GetArrayLength(jenv, outSz) < 1) {
+        return -1;
+    }
+    (*jenv)->GetIntArrayRegion(jenv, outSz, 0, 1, &outSzVal);
+
+    /* Reject negative output size or size larger than backing buffer */
+    if ((outSzVal < 0) ||
+        (inSz  > (*jenv)->GetDirectBufferCapacity(jenv, in)) ||
+        (keySz > (*jenv)->GetDirectBufferCapacity(jenv, keyDer)) ||
+        ((jlong)outSzVal > (*jenv)->GetDirectBufferCapacity(jenv, out))) {
+        return -1;
+    }
+    tmpOut = (unsigned int)outSzVal;
 
     ret = wc_InitRng(&rng);
     if (ret != 0) {
@@ -97,8 +110,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptRSA_doSign
                 &myKey, &rng);
         if (ret > 0) {
             /* save and convert to 0 for success */
-            tmpOut = ret;
-            (*jenv)->SetIntArrayRegion(jenv, outSz, 0, 1, (jint*)&tmpOut);
+            outSzVal = ret;
+            (*jenv)->SetIntArrayRegion(jenv, outSz, 0, 1, &outSzVal);
             ret = 0;
         }
     } else {
@@ -151,6 +164,13 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptRSA_doVerify
         return -1;
     }
 
+    /* Reject sizes larger than their backing direct buffers */
+    if ((sigSz > (*jenv)->GetDirectBufferCapacity(jenv, sig)) ||
+        (keySz > (*jenv)->GetDirectBufferCapacity(jenv, keyDer)) ||
+        (outSz > (*jenv)->GetDirectBufferCapacity(jenv, out))) {
+        return -1;
+    }
+
     wc_InitRsaKey(&myKey, NULL);
     idx = 0;
 
@@ -181,6 +201,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptRSA_doEnc
     int     keyInit = 0;
     unsigned int idx;
     unsigned int tmpOut;
+    jint outSzVal = 0;
     unsigned char* inBuf = NULL;
     unsigned char* outBuf = NULL;
     unsigned char* keyBuf = NULL;
@@ -211,7 +232,19 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptRSA_doEnc
     }
 
     /* get output buffer size */
-    (*jenv)->GetIntArrayRegion(jenv, outSz, 0, 1, (jint*)&tmpOut);
+    if ((*jenv)->GetArrayLength(jenv, outSz) < 1) {
+        return -1;
+    }
+    (*jenv)->GetIntArrayRegion(jenv, outSz, 0, 1, &outSzVal);
+
+    /* Reject negative output size or size larger than backing buffer */
+    if ((outSzVal < 0) ||
+        (inSz  > (*jenv)->GetDirectBufferCapacity(jenv, in)) ||
+        (keySz > (*jenv)->GetDirectBufferCapacity(jenv, keyDer)) ||
+        ((jlong)outSzVal > (*jenv)->GetDirectBufferCapacity(jenv, out))) {
+        return -1;
+    }
+    tmpOut = (unsigned int)outSzVal;
 
     ret = wc_InitRng(&rng);
     if (ret != 0) {
@@ -236,7 +269,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptRSA_doEnc
                 &myKey, &rng);
         if (ret > 0) {
             /* save and convert to 0 for success */
-            (*jenv)->SetIntArrayRegion(jenv, outSz, 0, 1, (jint*)&ret);
+            outSzVal = ret;
+            (*jenv)->SetIntArrayRegion(jenv, outSz, 0, 1, &outSzVal);
             ret = 0;
         }
     } else {
@@ -264,6 +298,7 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptRSA_doPssSign
     int     keyInit = 0;
     unsigned int idx = 0;
     unsigned int tmpOut;
+    jint outSzVal = 0;
     unsigned char* inBuf = NULL;
     unsigned char* outBuf = NULL;
     unsigned char* keyBuf = NULL;
@@ -299,7 +334,19 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptRSA_doPssSign
     }
 
     /* get output buffer size */
-    (*jenv)->GetIntArrayRegion(jenv, outSz, 0, 1, (jint*)&tmpOut);
+    if ((*jenv)->GetArrayLength(jenv, outSz) < 1) {
+        return -1;
+    }
+    (*jenv)->GetIntArrayRegion(jenv, outSz, 0, 1, &outSzVal);
+
+    /* Reject negative output size or size larger than backing buffer */
+    if ((outSzVal < 0) ||
+        (inSz  > (*jenv)->GetDirectBufferCapacity(jenv, in)) ||
+        (keySz > (*jenv)->GetDirectBufferCapacity(jenv, keyDer)) ||
+        ((jlong)outSzVal > (*jenv)->GetDirectBufferCapacity(jenv, out))) {
+        return -1;
+    }
+    tmpOut = (unsigned int)outSzVal;
 
     ret = wc_InitRng(&rng);
     if (ret != 0) {
@@ -322,8 +369,8 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptRSA_doPssSign
         ret = wc_RsaPSS_Sign(inBuf, (unsigned int)inSz, outBuf, tmpOut,
             hashType, mgf, &myKey, &rng);
         if (ret > 0) {
-            tmpOut = ret;
-            (*jenv)->SetIntArrayRegion(jenv, outSz, 0, 1, (jint*)&tmpOut);
+            outSzVal = ret;
+            (*jenv)->SetIntArrayRegion(jenv, outSz, 0, 1, &outSzVal);
             ret = 0;
         }
     } else {
@@ -391,6 +438,13 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptRSA_doPssVerify
     hashType = wc_OidGetHash(hash);
     if (hashType == WC_HASH_TYPE_NONE) {
         printf("doPssVerify: unsupported hash OID %d\n", hash);
+        return -1;
+    }
+
+    /* Reject sizes larger than their backing direct buffers */
+    if ((sigSz > (*jenv)->GetDirectBufferCapacity(jenv, sig)) ||
+        (keySz > (*jenv)->GetDirectBufferCapacity(jenv, keyDer)) ||
+        (outSz > (*jenv)->GetDirectBufferCapacity(jenv, out))) {
         return -1;
     }
 
@@ -469,6 +523,13 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptRSA_doDec
     keyBuf = (*jenv)->GetDirectBufferAddress(jenv, keyDer);
     if (keyBuf == NULL) {
         printf("problem getting key buffer address\n");
+        return -1;
+    }
+
+    /* Reject sizes larger than their backing direct buffers */
+    if ((inSz  > (*jenv)->GetDirectBufferCapacity(jenv, in)) ||
+        (keySz > (*jenv)->GetDirectBufferCapacity(jenv, keyDer)) ||
+        (outSz > (*jenv)->GetDirectBufferCapacity(jenv, out))) {
         return -1;
     }
 

--- a/native/com_wolfssl_WolfSSLContext.c
+++ b/native/com_wolfssl_WolfSSLContext.c
@@ -1128,20 +1128,21 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_loadVerifyBuffer
 {
     int ret = WOLFSSL_FAILURE;
     byte* buff = NULL;
-    word32 buffSz = 0;
     WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
-    (void)sz;
 
     if (jenv == NULL || ctx == NULL || in == NULL) {
         return (jint)BAD_FUNC_ARG;
     }
 
-    buff = (byte*)(*jenv)->GetByteArrayElements(jenv, in, NULL);
-    buffSz = (*jenv)->GetArrayLength(jenv, in);
+    if (sz <= 0 || sz > (jlong)(*jenv)->GetArrayLength(jenv, in)) {
+        return (jint)BAD_FUNC_ARG;
+    }
 
-    if (buff != NULL && buffSz > 0) {
-        ret = wolfSSL_CTX_load_verify_buffer(ctx, buff, buffSz, format);
+    buff = (byte*)(*jenv)->GetByteArrayElements(jenv, in, NULL);
+
+    if (buff != NULL) {
+        ret = wolfSSL_CTX_load_verify_buffer(ctx, buff, (long)sz, format);
     }
 
     if (buff != NULL) {
@@ -1157,20 +1158,21 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useCertificateBuffer
 {
     int ret = WOLFSSL_FAILURE;
     byte* buff = NULL;
-    word32 buffSz = 0;
     WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
-    (void)sz;
 
     if (jenv == NULL || ctx == NULL || in == NULL) {
         return (jint)BAD_FUNC_ARG;
     }
 
-    buff = (byte*)(*jenv)->GetByteArrayElements(jenv, in, NULL);
-    buffSz = (*jenv)->GetArrayLength(jenv, in);
+    if (sz <= 0 || sz > (jlong)(*jenv)->GetArrayLength(jenv, in)) {
+        return (jint)BAD_FUNC_ARG;
+    }
 
-    if (buff != NULL && buffSz > 0) {
-        ret = wolfSSL_CTX_use_certificate_buffer(ctx, buff, buffSz, format);
+    buff = (byte*)(*jenv)->GetByteArrayElements(jenv, in, NULL);
+
+    if (buff != NULL) {
+        ret = wolfSSL_CTX_use_certificate_buffer(ctx, buff, (long)sz, format);
     }
 
     if (buff != NULL) {
@@ -1186,30 +1188,33 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_usePrivateKeyBuffer
 {
     int ret = WOLFSSL_FAILURE;
     byte* buff = NULL;
-    word32 buffSz = 0;
+    jsize inLen = 0;
     jboolean isCopy = JNI_FALSE;
     WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
-    (void)sz;
 
     if (jenv == NULL || ctx == NULL || in == NULL) {
         return (jint)BAD_FUNC_ARG;
     }
 
-    buff = (byte*)(*jenv)->GetByteArrayElements(jenv, in, &isCopy);
-    buffSz = (*jenv)->GetArrayLength(jenv, in);
+    inLen = (*jenv)->GetArrayLength(jenv, in);
+    if (sz <= 0 || sz > (jlong)inLen) {
+        return (jint)BAD_FUNC_ARG;
+    }
 
-    if (buff != NULL && buffSz > 0) {
-        ret = wolfSSL_CTX_use_PrivateKey_buffer(ctx, buff, buffSz, format);
+    buff = (byte*)(*jenv)->GetByteArrayElements(jenv, in, &isCopy);
+
+    if (buff != NULL) {
+        ret = wolfSSL_CTX_use_PrivateKey_buffer(ctx, buff, (long)sz, format);
     }
 
     /* Only zero if JVM made a copy */
     if (buff != NULL && isCopy == JNI_TRUE) {
     #if (LIBWOLFSSL_VERSION_HEX >= 0x05008004) && \
         !defined(WOLFSSL_NO_FORCE_ZERO)
-        wc_ForceZero(buff, buffSz);
+        wc_ForceZero(buff, (word32)inLen);
     #else
-        XMEMSET(buff, 0, buffSz);
+        XMEMSET(buff, 0, (word32)inLen);
     #endif
     }
     if (buff != NULL) {
@@ -1224,20 +1229,21 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useCertificateChainBuffer
 {
     int ret = WOLFSSL_FAILURE;
     byte* buff = NULL;
-    word32 buffSz = 0;
     WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
-    (void)sz;
 
     if (jenv == NULL || ctx == NULL || in == NULL) {
         return (jint)BAD_FUNC_ARG;
     }
 
-    buff = (byte*)(*jenv)->GetByteArrayElements(jenv, in, NULL);
-    buffSz = (*jenv)->GetArrayLength(jenv, in);
+    if (sz <= 0 || sz > (jlong)(*jenv)->GetArrayLength(jenv, in)) {
+        return (jint)BAD_FUNC_ARG;
+    }
 
-    if (buff != NULL && buffSz > 0) {
-        ret = wolfSSL_CTX_use_certificate_chain_buffer(ctx, buff, buffSz);
+    buff = (byte*)(*jenv)->GetByteArrayElements(jenv, in, NULL);
+
+    if (buff != NULL) {
+        ret = wolfSSL_CTX_use_certificate_chain_buffer(ctx, buff, (long)sz);
     }
 
     if (buff != NULL) {
@@ -1252,21 +1258,22 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLContext_useCertificateChainBuffer
 {
     int ret = WOLFSSL_FAILURE;
     byte* buff = NULL;
-    word32 buffSz = 0;
     WOLFSSL_CTX* ctx = (WOLFSSL_CTX*)(uintptr_t)ctxPtr;
     (void)jcl;
-    (void)sz;
 
     if (jenv == NULL || ctx == NULL || in == NULL) {
         return (jint)BAD_FUNC_ARG;
     }
 
-    buff = (byte*)(*jenv)->GetByteArrayElements(jenv, in, NULL);
-    buffSz = (*jenv)->GetArrayLength(jenv, in);
+    if (sz <= 0 || sz > (jlong)(*jenv)->GetArrayLength(jenv, in)) {
+        return (jint)BAD_FUNC_ARG;
+    }
 
-    if (buff != NULL && buffSz > 0) {
+    buff = (byte*)(*jenv)->GetByteArrayElements(jenv, in, NULL);
+
+    if (buff != NULL) {
         ret = wolfSSL_CTX_use_certificate_chain_buffer_format(
-                ctx, buff, buffSz, format);
+                ctx, buff, (long)sz, format);
     }
 
     if (buff != NULL) {

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -3904,21 +3904,22 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_useCertificateChainBuffer
 {
     int ret = WOLFSSL_FAILURE;
     byte* buff = NULL;
-    word32 buffSz = 0;
     WOLFSSL* ssl = (WOLFSSL*)(uintptr_t)sslPtr;
     (void)jcl;
-    (void)sz;
 
     if (jenv == NULL || ssl == NULL || in == NULL) {
         return (jint)BAD_FUNC_ARG;
     }
 
-    buff = (byte*)(*jenv)->GetByteArrayElements(jenv, in, NULL);
-    buffSz = (*jenv)->GetArrayLength(jenv, in);
+    if (sz <= 0 || sz > (jlong)(*jenv)->GetArrayLength(jenv, in)) {
+        return (jint)BAD_FUNC_ARG;
+    }
 
-    if (buff != NULL && buffSz > 0) {
+    buff = (byte*)(*jenv)->GetByteArrayElements(jenv, in, NULL);
+
+    if (buff != NULL) {
         ret = wolfSSL_use_certificate_chain_buffer_format(
-                ssl, buff, buffSz, format);
+                ssl, buff, (long)sz, format);
     }
 
     if (buff != NULL) {

--- a/src/test/com/wolfssl/test/WolfCryptECCTest.java
+++ b/src/test/com/wolfssl/test/WolfCryptECCTest.java
@@ -21,12 +21,17 @@
 
 package com.wolfssl.test;
 
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
 
+import java.nio.ByteBuffer;
+
+import com.wolfssl.WolfSSL;
 import com.wolfssl.WolfSSLException;
 import com.wolfssl.WolfCryptECC;
 
@@ -36,12 +41,52 @@ public class WolfCryptECCTest {
     public TestRule testWatcher = TimedTestWatcher.create();
 
     @BeforeClass
-    public static void beforeClass() {
+    public static void beforeClass() throws WolfSSLException {
         System.out.println("WolfCryptECC Class");
+        WolfSSL.loadLibrary();
     }
 
     @Test
     public void testECCNew() throws WolfSSLException {
         assertNotNull(new WolfCryptECC());
+    }
+
+    /* doVerify must reject a size larger than its backing direct buffer */
+    @Test
+    public void testDoVerifyRejectsOversizedSz() {
+        Assume.assumeTrue(WolfSSL.EccEnabled());
+        WolfCryptECC ecc = new WolfCryptECC();
+        ByteBuffer sig  = ByteBuffer.allocateDirect(64);
+        ByteBuffer hash = ByteBuffer.allocateDirect(32);
+        ByteBuffer key  = ByteBuffer.allocateDirect(32);
+        int[] result = new int[1];
+
+        /* sigSz / hashSz over their buffers (import fails before use) */
+        assertEquals(-1, ecc.doVerify(sig, 65, hash, 32, key, 32, result));
+        assertEquals(-1, ecc.doVerify(sig, 64, hash, 33, key, 32, result));
+
+        /* keySz above the key buffer and above UINT_MAX */
+        assertEquals(-1,
+            ecc.doVerify(sig, 64, hash, 32, key, 0x100000000L + 16, result));
+    }
+
+    /* doSign must reject a size larger than its backing direct buffer */
+    @Test
+    public void testDoSignRejectsOversizedSz() {
+        Assume.assumeTrue(WolfSSL.EccEnabled());
+        WolfCryptECC ecc = new WolfCryptECC();
+        ByteBuffer in  = ByteBuffer.allocateDirect(32);
+        ByteBuffer out = ByteBuffer.allocateDirect(128);
+        ByteBuffer key = ByteBuffer.allocateDirect(64);
+
+        /* inSz / outSz over their buffers (key decode fails before use) */
+        assertEquals(-1, ecc.doSign(in, 33, out, new long[]{128}, key, 64));
+        assertEquals(-1, ecc.doSign(in, 32, out, new long[]{129}, key, 64));
+
+        /* negative outSz[0] must be rejected, not reinterpreted as huge */
+        assertEquals(-1, ecc.doSign(in, 32, out, new long[]{-1}, key, 64));
+
+        /* keySz above the key buffer */
+        assertEquals(-1, ecc.doSign(in, 32, out, new long[]{128}, key, 65));
     }
 }

--- a/src/test/com/wolfssl/test/WolfCryptRSATest.java
+++ b/src/test/com/wolfssl/test/WolfCryptRSATest.java
@@ -21,12 +21,17 @@
 
 package com.wolfssl.test;
 
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
 
+import java.nio.ByteBuffer;
+
+import com.wolfssl.WolfSSL;
 import com.wolfssl.WolfSSLException;
 import com.wolfssl.WolfCryptRSA;
 
@@ -36,12 +41,129 @@ public class WolfCryptRSATest {
     public TestRule testWatcher = TimedTestWatcher.create();
 
     @BeforeClass
-    public static void beforeClass() {
+    public static void beforeClass() throws WolfSSLException {
         System.out.println("WolfCryptRSA Class");
+        WolfSSL.loadLibrary();
     }
 
     @Test
     public void testRSANew() throws WolfSSLException {
         assertNotNull(new WolfCryptRSA());
+    }
+
+    /* A size larger than its backing direct buffer must be rejected */
+    @Test
+    public void testDoSignRejectsOversizedSz() {
+        Assume.assumeTrue(WolfSSL.RsaEnabled());
+        WolfCryptRSA rsa = new WolfCryptRSA();
+        ByteBuffer in  = ByteBuffer.allocateDirect(64);
+        ByteBuffer out = ByteBuffer.allocateDirect(256);
+        ByteBuffer key = ByteBuffer.allocateDirect(128);
+
+        assertEquals(-1, rsa.doSign(in, 65, out, new int[]{256}, key, 128));
+        assertEquals(-1, rsa.doSign(in, 64, out, new int[]{257}, key, 128));
+        assertEquals(-1,
+            rsa.doSign(in, 64, out, new int[]{256}, key, 0x100000000L + 16));
+    }
+
+    @Test
+    public void testDoEncRejectsOversizedSz() {
+        Assume.assumeTrue(WolfSSL.RsaEnabled());
+        WolfCryptRSA rsa = new WolfCryptRSA();
+        ByteBuffer in  = ByteBuffer.allocateDirect(64);
+        ByteBuffer out = ByteBuffer.allocateDirect(256);
+        ByteBuffer key = ByteBuffer.allocateDirect(128);
+
+        assertEquals(-1, rsa.doEnc(in, 65, out, new int[]{256}, key, 128));
+        assertEquals(-1, rsa.doEnc(in, 64, out, new int[]{257}, key, 128));
+        assertEquals(-1,
+            rsa.doEnc(in, 64, out, new int[]{256}, key, 0x100000000L + 16));
+    }
+
+    @Test
+    public void testDoVerifyRejectsOversizedSz() {
+        Assume.assumeTrue(WolfSSL.RsaEnabled());
+        WolfCryptRSA rsa = new WolfCryptRSA();
+        ByteBuffer sig = ByteBuffer.allocateDirect(64);
+        ByteBuffer out = ByteBuffer.allocateDirect(256);
+        ByteBuffer key = ByteBuffer.allocateDirect(128);
+
+        assertEquals(-1, rsa.doVerify(sig, 65, out, 256, key, 128));
+        assertEquals(-1, rsa.doVerify(sig, 64, out, 257, key, 128));
+        assertEquals(-1,
+            rsa.doVerify(sig, 64, out, 256, key, 0x100000000L + 16));
+    }
+
+    @Test
+    public void testDoDecRejectsOversizedSz() {
+        Assume.assumeTrue(WolfSSL.RsaEnabled());
+        WolfCryptRSA rsa = new WolfCryptRSA();
+        ByteBuffer in  = ByteBuffer.allocateDirect(64);
+        ByteBuffer out = ByteBuffer.allocateDirect(256);
+        ByteBuffer key = ByteBuffer.allocateDirect(128);
+
+        assertEquals(-1, rsa.doDec(in, 65, out, 256, key, 128));
+        assertEquals(-1, rsa.doDec(in, 64, out, 257, key, 128));
+        assertEquals(-1,
+            rsa.doDec(in, 64, out, 256, key, 0x100000000L + 16));
+    }
+
+    /* SHA-256 hash OID sum, which wolfSSL encodes two ways depending on the
+     * build: current default, or the legacy WOLFSSL_OLD_OID_SUM value
+     * (see wolfSSL oid_sum.h). */
+    private static final int SHA256_OID     = 0x7cb37afb;
+    private static final int SHA256_OID_OLD = 414;
+
+    /* Return a SHA-256 hash OID wc_OidGetHash accepts, or -1 if none
+     * (PSS not compiled, or an OID-sum scheme we do not know). */
+    private static int findPssHashOid(WolfCryptRSA rsa) {
+        ByteBuffer b = ByteBuffer.allocateDirect(64);
+        int[] candidates = { SHA256_OID, SHA256_OID_OLD };
+        for (int oid : candidates) {
+            int ret = rsa.doPssVerify(b, 64, b, 64, oid, 0, b, 64);
+            if (ret != -1 && ret != WolfSSL.NOT_COMPILED_IN) {
+                return oid;
+            }
+        }
+        return -1;
+    }
+
+    @Test
+    public void testDoPssSignRejectsOversizedSz() {
+        Assume.assumeTrue(WolfSSL.RsaEnabled());
+        WolfCryptRSA rsa = new WolfCryptRSA();
+        int oid = findPssHashOid(rsa);
+        Assume.assumeTrue("PSS unavailable or unknown hash OID scheme",
+            oid != -1);
+
+        ByteBuffer in  = ByteBuffer.allocateDirect(64);
+        ByteBuffer out = ByteBuffer.allocateDirect(256);
+        ByteBuffer key = ByteBuffer.allocateDirect(128);
+
+        assertEquals(-1,
+            rsa.doPssSign(in, 65, out, new int[]{256}, oid, 0, key, 128));
+        assertEquals(-1,
+            rsa.doPssSign(in, 64, out, new int[]{257}, oid, 0, key, 128));
+        assertEquals(-1,
+            rsa.doPssSign(in, 64, out, new int[]{256}, oid, 0, key,
+                0x100000000L + 16));
+    }
+
+    @Test
+    public void testDoPssVerifyRejectsOversizedSz() {
+        Assume.assumeTrue(WolfSSL.RsaEnabled());
+        WolfCryptRSA rsa = new WolfCryptRSA();
+        int oid = findPssHashOid(rsa);
+        Assume.assumeTrue("PSS unavailable or unknown hash OID scheme",
+            oid != -1);
+
+        ByteBuffer sig = ByteBuffer.allocateDirect(64);
+        ByteBuffer out = ByteBuffer.allocateDirect(256);
+        ByteBuffer key = ByteBuffer.allocateDirect(128);
+
+        assertEquals(-1, rsa.doPssVerify(sig, 65, out, 256, oid, 0, key, 128));
+        assertEquals(-1, rsa.doPssVerify(sig, 64, out, 257, oid, 0, key, 128));
+        assertEquals(-1,
+            rsa.doPssVerify(sig, 64, out, 256, oid, 0, key, 0x100000000L + 16));
     }
 }

--- a/src/test/com/wolfssl/test/WolfSSLContextTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLContextTest.java
@@ -30,7 +30,9 @@ import org.junit.Test;
 import org.junit.rules.TestRule;
 import static org.junit.Assert.*;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.ServerSocket;
@@ -249,6 +251,43 @@ public class WolfSSLContextTest {
                 fail(name + " threw unexpected NullPointerException");
             }
         }
+    }
+
+    @Test
+    public void test_WolfSSLContext_loadBufferHonorsSz()
+        throws WolfSSLException, WolfSSLJNIException, IOException {
+
+        int ret;
+        byte[] caPem = Files.readAllBytes(new File(caCert).toPath());
+
+        /* Exact size loads the CA as a trust anchor. Tolerate
+         * NOT_COMPILED_IN on reduced native builds. */
+        ret = ctx.loadVerifyBuffer(caPem, caPem.length,
+            WolfSSL.SSL_FILETYPE_PEM);
+        if (ret != WolfSSL.SSL_SUCCESS && ret != WolfSSL.NOT_COMPILED_IN) {
+            fail("loadVerifyBuffer failed, ret = " + ret);
+        }
+
+        /* Non-positive and oversized lengths are rejected */
+        assertEquals(WolfSSL.BAD_FUNC_ARG,
+            ctx.loadVerifyBuffer(caPem, -1, WolfSSL.SSL_FILETYPE_PEM));
+        assertEquals(WolfSSL.BAD_FUNC_ARG,
+            ctx.loadVerifyBuffer(caPem, 0, WolfSSL.SSL_FILETYPE_PEM));
+        assertEquals(WolfSSL.BAD_FUNC_ARG,
+            ctx.loadVerifyBuffer(caPem, caPem.length + 1,
+                WolfSSL.SSL_FILETYPE_PEM));
+
+        /* Same size validation on the sibling buffer loaders */
+        assertEquals(WolfSSL.BAD_FUNC_ARG,
+            ctx.useCertificateBuffer(caPem, 0, WolfSSL.SSL_FILETYPE_PEM));
+        assertEquals(WolfSSL.BAD_FUNC_ARG,
+            ctx.usePrivateKeyBuffer(caPem, caPem.length + 1,
+                WolfSSL.SSL_FILETYPE_PEM));
+        assertEquals(WolfSSL.BAD_FUNC_ARG,
+            ctx.useCertificateChainBuffer(caPem, -1));
+        assertEquals(WolfSSL.BAD_FUNC_ARG,
+            ctx.useCertificateChainBufferFormat(caPem, 0,
+                WolfSSL.SSL_FILETYPE_PEM));
     }
 
     @Test

--- a/src/test/com/wolfssl/test/WolfSSLSessionTest.java
+++ b/src/test/com/wolfssl/test/WolfSSLSessionTest.java
@@ -288,6 +288,9 @@ public class WolfSSLSessionTest {
             ssl.usePrivateKeyBuffer(null, 0, WolfSSL.SSL_FILETYPE_PEM));
         assertEquals(WolfSSL.BAD_FUNC_ARG,
             ssl.useCertificateChainBuffer(null, 0));
+        assertEquals(WolfSSL.BAD_FUNC_ARG,
+            ssl.useCertificateChainBufferFormat(null, 0,
+                WolfSSL.SSL_FILETYPE_PEM));
         ssl.freeSSL();
 
         /* correct sz loads, zero/oversized rejected, sub-array (sz < len)
@@ -327,6 +330,19 @@ public class WolfSSLSessionTest {
             ssl.useCertificateChainBuffer(certPem, 0));
         assertEquals(WolfSSL.BAD_FUNC_ARG,
             ssl.useCertificateChainBuffer(certPem, certBadSz));
+        ssl.freeSSL();
+
+        /* useCertificateChainBufferFormat: correct sz loads, others rejected */
+        ssl = new WolfSSLSession(ctx);
+        assertUseBufferOk("useCertificateChainBufferFormat",
+            ssl.useCertificateChainBufferFormat(certPem, certPem.length,
+                WolfSSL.SSL_FILETYPE_PEM));
+        assertEquals(WolfSSL.BAD_FUNC_ARG,
+            ssl.useCertificateChainBufferFormat(certPem, 0,
+                WolfSSL.SSL_FILETYPE_PEM));
+        assertEquals(WolfSSL.BAD_FUNC_ARG,
+            ssl.useCertificateChainBufferFormat(certPem, certBadSz,
+                WolfSSL.SSL_FILETYPE_PEM));
         ssl.freeSSL();
     }
 


### PR DESCRIPTION
This PR includes 10 Fenrir fixes:

  - **F-5210**: Call `setNeedClientAuth(true)` in the RMI TLS server socket factory so the loaded client CA trust store require a client certificate.

  - **F-5211**: Enable HTTPS endpoint identification in the RMI TLS client, and align the example server certificate and loopback address so the client verifies the server hostname.

  - **F-5212 / F-5269**: Honor the caller-supplied size in the `WolfSSLContext` buffer load JNI functions, rejecting a non-positive or too large size and passing the caller size through to wolfSSL instead of always using the full backing array.

  - **F-5268**: Honor the caller-supplied size in `WolfSSLSession.useCertificateChainBufferFormat`, matching the sibling buffer loaders.

  - **F-5270**: Call `setNeedClientAuth(true)` in the `ThreadedSSLSocketClientServer` example so its client CA trust store requires a client certificate.

  - **F-5271**: Call `setNeedClientAuth(true)` in the `DualProviderFIPSTest` example server so its client CA trust store requires a client certificate.

  - **F-5273**: Remove the no-op endpoint-identification block and its misleading comment from the `DtlsClientEngine` example.

  - **F-5275**: Validate the ECC sign/verify buffer sizes against `DirectByteBuffer` capacity before passing them to wolfCrypt.

  - **F-5637**: Validate the RSA sign/verify/encrypt/decrypt buffer sizes against `DirectByteBuffer` capacity before passing them to wolfCrypt.