### PR TITLE
JNI reference, resource, and error-handling fixes

### DIFF
--- a/native/com_wolfssl_WolfCryptECC.c
+++ b/native/com_wolfssl_WolfCryptECC.c
@@ -70,7 +70,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptECC_doVerify
         return -1;
     }
 
-    wc_ecc_init(&myKey);
+    ret = wc_ecc_init(&myKey);
+    if (ret != 0) {
+        printf("wc_ecc_init failed, ret = %d\n", ret);
+        return ret;
+    }
 
     ret = wc_ecc_import_x963(keyBuf, (unsigned int)keySz, &myKey);
 

--- a/native/com_wolfssl_WolfCryptRSA.c
+++ b/native/com_wolfssl_WolfCryptRSA.c
@@ -171,7 +171,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptRSA_doVerify
         return -1;
     }
 
-    wc_InitRsaKey(&myKey, NULL);
+    ret = wc_InitRsaKey(&myKey, NULL);
+    if (ret != 0) {
+        printf("wc_InitRsaKey failed, ret = %d\n", ret);
+        return ret;
+    }
     idx = 0;
 
     ret = wc_RsaPublicKeyDecode(keyBuf, &idx, &myKey, (unsigned int)keySz);
@@ -533,7 +537,11 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfCryptRSA_doDec
         return -1;
     }
 
-    wc_InitRsaKey(&myKey, NULL);
+    ret = wc_InitRsaKey(&myKey, NULL);
+    if (ret != 0) {
+        printf("wc_InitRsaKey failed, ret = %d\n", ret);
+        return ret;
+    }
     idx = 0;
 
     ret = wc_RsaPrivateKeyDecode(keyBuf, &idx, &myKey, (unsigned int)keySz);

--- a/native/com_wolfssl_WolfSSLContext.c
+++ b/native/com_wolfssl_WolfSSLContext.c
@@ -779,6 +779,27 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setVerify(JNIEnv* jenv,
     }
 }
 
+/* Delete local references created in NativeVerifyCallback */
+static void freeNativeVerifyCbLocalRefs(JNIEnv* jenv, jclass excClass,
+    jclass verifyClass, jobject verifyCbObj)
+{
+    if (jenv == NULL) {
+        return;
+    }
+
+    if (verifyClass != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, verifyClass);
+    }
+
+    if (verifyCbObj != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, verifyCbObj);
+    }
+
+    if (excClass != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, excClass);
+    }
+}
+
 int NativeVerifyCallback(int preverify_ok, WOLFSSL_X509_STORE_CTX* store)
 {
     JNIEnv*   jenv;
@@ -819,6 +840,7 @@ int NativeVerifyCallback(int preverify_ok, WOLFSSL_X509_STORE_CTX* store)
     if( (*jenv)->ExceptionOccurred(jenv)) {
         (*jenv)->ExceptionDescribe(jenv);
         (*jenv)->ExceptionClear(jenv);
+        freeNativeVerifyCbLocalRefs(jenv, excClass, verifyClass, verifyCbObj);
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
         return -103;
@@ -847,6 +869,7 @@ int NativeVerifyCallback(int preverify_ok, WOLFSSL_X509_STORE_CTX* store)
     }
     if (verifyCbObj == NULL) {
         /* No Java callback registered. Fail closed without throwing. */
+        freeNativeVerifyCbLocalRefs(jenv, excClass, verifyClass, verifyCbObj);
         if (needsDetach) {
             (*g_vm)->DetachCurrentThread(g_vm);
         }
@@ -869,6 +892,8 @@ int NativeVerifyCallback(int preverify_ok, WOLFSSL_X509_STORE_CTX* store)
 
             (*jenv)->ThrowNew(jenv, excClass,
                 "Can't get native WolfSSLVerifyCallback class reference");
+            freeNativeVerifyCbLocalRefs(jenv, excClass, verifyClass,
+                verifyCbObj);
             if (needsDetach)
                 (*g_vm)->DetachCurrentThread(g_vm);
             return -104;
@@ -884,6 +909,8 @@ int NativeVerifyCallback(int preverify_ok, WOLFSSL_X509_STORE_CTX* store)
 
             (*jenv)->ThrowNew(jenv, excClass,
                 "Error getting verifyCallback method from JNI");
+            freeNativeVerifyCbLocalRefs(jenv, excClass, verifyClass,
+                verifyCbObj);
             if (needsDetach)
                 (*g_vm)->DetachCurrentThread(g_vm);
             return -105;
@@ -896,6 +923,8 @@ int NativeVerifyCallback(int preverify_ok, WOLFSSL_X509_STORE_CTX* store)
             /* exception occurred on the Java side during method call */
             (*jenv)->ExceptionDescribe(jenv);
             (*jenv)->ExceptionClear(jenv);
+            freeNativeVerifyCbLocalRefs(jenv, excClass, verifyClass,
+                verifyCbObj);
             if (needsDetach)
                 (*g_vm)->DetachCurrentThread(g_vm);
             return -106;
@@ -909,11 +938,13 @@ int NativeVerifyCallback(int preverify_ok, WOLFSSL_X509_STORE_CTX* store)
 
         (*jenv)->ThrowNew(jenv, excClass,
                 "Object reference invalid in NativeVerifyCallback");
+        freeNativeVerifyCbLocalRefs(jenv, excClass, verifyClass, verifyCbObj);
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
         return -1;
     }
 
+    freeNativeVerifyCbLocalRefs(jenv, excClass, verifyClass, verifyCbObj);
     if (needsDetach)
         (*g_vm)->DetachCurrentThread(g_vm);
 

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -381,7 +381,15 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_newSSL
             return SSL_FAILURE;
         }
 
-        wc_InitMutex(jniSessLock);
+        if (wc_InitMutex(jniSessLock) != 0) {
+            printf("error initializing jniSessLock in newSSL\n");
+            (*jenv)->DeleteGlobalRef(jenv, *g_cachedSSLObj);
+            XFREE(jniSessLock, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(appData, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(g_cachedSSLObj, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            wolfSSL_free((WOLFSSL*)(uintptr_t)sslPtr);
+            return SSL_FAILURE;
+        }
         appData->jniSessLock = jniSessLock;
 
         /* set up interrupt pipe for SSLSocket.close() to use if/when needed.
@@ -398,13 +406,24 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_newSSL
         if (pollCountLock == NULL) {
             printf("error mallocing pollCountLock in newSSL for SSLAppData\n");
             (*jenv)->DeleteGlobalRef(jenv, *g_cachedSSLObj);
+            wc_FreeMutex(jniSessLock);
             XFREE(jniSessLock, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(appData, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(g_cachedSSLObj, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             wolfSSL_free((WOLFSSL*)(uintptr_t)sslPtr);
             return SSL_FAILURE;
         }
-        wc_InitMutex(pollCountLock);
+        if (wc_InitMutex(pollCountLock) != 0) {
+            printf("error initializing pollCountLock in newSSL\n");
+            (*jenv)->DeleteGlobalRef(jenv, *g_cachedSSLObj);
+            XFREE(pollCountLock, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            wc_FreeMutex(jniSessLock);
+            XFREE(jniSessLock, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(appData, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(g_cachedSSLObj, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            wolfSSL_free((WOLFSSL*)(uintptr_t)sslPtr);
+            return SSL_FAILURE;
+        }
         appData->pollCountLock = pollCountLock;
 
         appData->interruptFds[0] = -1;
@@ -415,7 +434,9 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_newSSL
             if (ret == -1) {
                 printf("error setting up pipe() for interruptFds[] in newSSL\n");
                 (*jenv)->DeleteGlobalRef(jenv, *g_cachedSSLObj);
+                wc_FreeMutex(pollCountLock);
                 XFREE(pollCountLock, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+                wc_FreeMutex(jniSessLock);
                 XFREE(jniSessLock, NULL, DYNAMIC_TYPE_TMP_BUFFER);
                 XFREE(appData, NULL, DYNAMIC_TYPE_TMP_BUFFER);
                 XFREE(g_cachedSSLObj, NULL, DYNAMIC_TYPE_TMP_BUFFER);
@@ -429,7 +450,9 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_newSSL
                 printf("error setting interruptFds[0] non-blocking in newSSL\n");
                 closeInterruptPipe(appData);
                 (*jenv)->DeleteGlobalRef(jenv, *g_cachedSSLObj);
+                wc_FreeMutex(pollCountLock);
                 XFREE(pollCountLock, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+                wc_FreeMutex(jniSessLock);
                 XFREE(jniSessLock, NULL, DYNAMIC_TYPE_TMP_BUFFER);
                 XFREE(appData, NULL, DYNAMIC_TYPE_TMP_BUFFER);
                 XFREE(g_cachedSSLObj, NULL, DYNAMIC_TYPE_TMP_BUFFER);
@@ -446,8 +469,10 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_newSSL
             (*jenv)->DeleteGlobalRef(jenv, *g_cachedSSLObj);
         #ifndef USE_WINDOWS_API
             closeInterruptPipe(appData);
+            wc_FreeMutex(pollCountLock);
             XFREE(pollCountLock, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         #endif
+            wc_FreeMutex(jniSessLock);
             XFREE(jniSessLock, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(appData, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(g_cachedSSLObj, NULL, DYNAMIC_TYPE_TMP_BUFFER);
@@ -462,8 +487,10 @@ JNIEXPORT jlong JNICALL Java_com_wolfssl_WolfSSLSession_newSSL
             (*jenv)->DeleteGlobalRef(jenv, *g_cachedSSLObj);
         #ifndef USE_WINDOWS_API
             closeInterruptPipe(appData);
+            wc_FreeMutex(pollCountLock);
             XFREE(pollCountLock, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         #endif
+            wc_FreeMutex(jniSessLock);
             XFREE(jniSessLock, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(appData, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(g_cachedSSLObj, NULL, DYNAMIC_TYPE_TMP_BUFFER);

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -2425,12 +2425,18 @@ public class WolfSSLSession {
             () -> "entered setSessTimeout(timeout (sec): " + t + ")");
 
         session = this.getSession();
-        if (session == 0) {
-            /* session may be null if session cache disabled, wolfSSL
-             * doesn't have session ID available, mutex function fails, etc */
-            ret = WolfSSL.JNI_SESSION_UNAVAILABLE;
-        } else {
-            ret = setSessTimeout(session, t);
+        try {
+            if (session == 0) {
+                /* session may be null if session cache disabled, no session
+                 * ID available, mutex function fails, etc */
+                ret = WolfSSL.JNI_SESSION_UNAVAILABLE;
+            } else {
+                ret = setSessTimeout(session, t);
+            }
+        } finally {
+            /* getSession() returns a get1Session() owned reference that
+             * must be released. freeSession() is a no-op when passed 0. */
+            freeSession(session);
         }
 
         WolfSSLDebug.log(getClass(), WolfSSLDebug.Component.JNI,
@@ -6121,12 +6127,17 @@ public class WolfSSLSession {
         confirmObjectIsActive();
         synchronized (sslLock) {
             WolfSSLDebug.log(WolfSSLSession.class, WolfSSLDebug.Component.JNI,
-                WolfSSLDebug.INFO, this.sslPtr,
-                () -> "entered sessionToDer()");
+                WolfSSLDebug.INFO, this.sslPtr, () -> "entered sessionToDer()");
             long sessPtr = this.getSession();
-            return sessionToDerNative(sessPtr);
-        }
 
+            try {
+                return sessionToDerNative(sessPtr);
+            } finally {
+                /* getSession() returns a get1Session() owned reference, must
+                 * be released. */
+                freeSession(sessPtr);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
This PR includes 4 Fenrir fixes:

  - **F-11872**: `NativeVerifyCallback` deletes the JNI local references it creates each invocation, so they no longer accumulate across a certificate chain.
  - **F-11877**: WolfCrypt ECC/RSA verify and decrypt helpers check the key init result before operating on or freeing the key.
  - **F-11878**: `newSSL()` checks each mutex init result and frees initialized mutexes on its construction rollback paths.
  - **F-11884**: `sessionToDer()` and `setSessTimeout()` release the owned `getSession()` reference via try/finally.