### PR TITLE
Fixes for JNI callback cleanup, EKU getter, session I/O, and equals symmetry

### DIFF
--- a/native/com_wolfssl_WolfSSLCertificate.c
+++ b/native/com_wolfssl_WolfSSLCertificate.c
@@ -2221,6 +2221,9 @@ JNIEXPORT jobjectArray JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1ex
     unsigned int ekuBits = 0;
     int ekuCount = 0;
     int idx = 0;
+    int i = 0;
+    jobjectArray trimmed = NULL;
+    jobject elem = NULL;
     WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
     (void)jcl;
 
@@ -2273,8 +2276,34 @@ JNIEXPORT jobjectArray JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1get_1ex
     idx = addEkuOid(jenv, ret, idx, ekuBits, XKU_OCSP_SIGN,
         EKU_OCSP_SIGN_OID);
     /* NID_anyExtendedKeyUsage used here since no EKU_*_OID sum for anyEKU */
-    (void)addEkuOid(jenv, ret, idx, ekuBits, XKU_ANYEKU,
+    idx = addEkuOid(jenv, ret, idx, ekuBits, XKU_ANYEKU,
         NID_anyExtendedKeyUsage);
+
+    /* Fewer OIDs than counted are written only if a conversion was skipped.
+     * Throw when none converted so this is distinguishable from "not present"
+     * null returned above. Otherwise trim off the trailing nulls. */
+    if (idx == 0) {
+        (*jenv)->DeleteLocalRef(jenv, stringClass);
+        (*jenv)->DeleteLocalRef(jenv, ret);
+        throwWolfSSLJNIException(jenv,
+            "Failed to convert any EKU OID in X509_get_extended_key_usage");
+        return NULL;
+    }
+    if (idx < ekuCount) {
+        trimmed = (*jenv)->NewObjectArray(jenv, idx, stringClass, NULL);
+        if (trimmed == NULL) {
+            (*jenv)->DeleteLocalRef(jenv, stringClass);
+            (*jenv)->DeleteLocalRef(jenv, ret);
+            return NULL;
+        }
+        for (i = 0; i < idx; i++) {
+            elem = (*jenv)->GetObjectArrayElement(jenv, ret, i);
+            (*jenv)->SetObjectArrayElement(jenv, trimmed, i, elem);
+            (*jenv)->DeleteLocalRef(jenv, elem);
+        }
+        (*jenv)->DeleteLocalRef(jenv, ret);
+        ret = trimmed;
+    }
 
     (*jenv)->DeleteLocalRef(jenv, stringClass);
 

--- a/native/com_wolfssl_WolfSSLContext.c
+++ b/native/com_wolfssl_WolfSSLContext.c
@@ -2459,6 +2459,48 @@ JNIEXPORT void JNICALL Java_com_wolfssl_WolfSSLContext_setVerifyDecryptCb
 
 #ifdef ATOMIC_USER
 
+/* Delete JNI local references created inside NativeMacEncryptCb() */
+static void freeMacEncryptCbLocalRefs(JNIEnv* jenv, jclass excClass,
+    jclass sessClass, jobject ctxRef, jclass innerCtxClass, jobject macOutBB,
+    jbyteArray j_macIn, jobject encOutBB, jobject encInBB)
+{
+    if (jenv == NULL) {
+        return;
+    }
+
+    if (macOutBB != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, macOutBB);
+    }
+
+    if (j_macIn != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, j_macIn);
+    }
+
+    if (encOutBB != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, encOutBB);
+    }
+
+    if (encInBB != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, encInBB);
+    }
+
+    if (innerCtxClass != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, innerCtxClass);
+    }
+
+    if (ctxRef != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, ctxRef);
+    }
+
+    if (sessClass != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, sessClass);
+    }
+
+    if (excClass != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, excClass);
+    }
+}
+
 int NativeMacEncryptCb(WOLFSSL* ssl, unsigned char* macOut,
         const unsigned char* macIn, unsigned int macInSz, int macContent,
         int macVerify, unsigned char* encOut, const unsigned char* encIn,
@@ -2468,16 +2510,16 @@ int NativeMacEncryptCb(WOLFSSL* ssl, unsigned char* macOut,
     jint       vmret  = 0;
 
     JNIEnv*    jenv;                  /* JNI environment */
-    jclass     excClass;              /* WolfSSLJNIException class */
+    jclass     excClass = NULL;       /* WolfSSLJNIException class */
     int        needsDetach = 0;       /* Should we explicitly detach? */
 
     jobject* g_cachedSSLObj;           /* WolfSSLSession cached object */
-    jclass     sessClass;             /* WolfSSLSession class */
+    jclass     sessClass = NULL;      /* WolfSSLSession class */
     jfieldID   ctxFid;                /* WolfSSLSession->ctx FieldID */
     jmethodID  getCtxMethodId;        /* WolfSSLSession->getAssCtxPtr() ID */
 
-    jobject    ctxRef;                /* WolfSSLContext object */
-    jclass     innerCtxClass;         /* WolfSSLContext class */
+    jobject    ctxRef = NULL;         /* WolfSSLContext object */
+    jclass     innerCtxClass = NULL;  /* WolfSSLContext class */
     jmethodID  macEncryptMethodId;    /* internalMacEncryptCallback ID */
 
     jobject    macOutBB = NULL;
@@ -2485,7 +2527,7 @@ int NativeMacEncryptCb(WOLFSSL* ssl, unsigned char* macOut,
     jobject    encInBB = NULL;
 
     int        hmacSize;
-    jbyteArray j_macIn;
+    jbyteArray j_macIn = NULL;
 
     (void)ctx;
 
@@ -2514,6 +2556,8 @@ int NativeMacEncryptCb(WOLFSSL* ssl, unsigned char* macOut,
     if ((*jenv)->ExceptionOccurred(jenv)) {
         (*jenv)->ExceptionDescribe(jenv);
         (*jenv)->ExceptionClear(jenv);
+        freeMacEncryptCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+            innerCtxClass, macOutBB, j_macIn, encOutBB, encInBB);
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
         return -1;
@@ -2525,6 +2569,8 @@ int NativeMacEncryptCb(WOLFSSL* ssl, unsigned char* macOut,
         (*jenv)->ThrowNew(jenv, excClass,
                 "Can't get native WolfSSLSession object reference in "
                 "NativeMacEncryptCb");
+        freeMacEncryptCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+            innerCtxClass, macOutBB, j_macIn, encOutBB, encInBB);
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
         return -1;
@@ -2536,6 +2582,8 @@ int NativeMacEncryptCb(WOLFSSL* ssl, unsigned char* macOut,
         (*jenv)->ThrowNew(jenv, excClass,
             "Can't get native WolfSSLSession class reference in "
             "NativeMacEncryptCb");
+        freeMacEncryptCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+            innerCtxClass, macOutBB, j_macIn, encOutBB, encInBB);
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
         return -1;
@@ -2552,6 +2600,8 @@ int NativeMacEncryptCb(WOLFSSL* ssl, unsigned char* macOut,
         (*jenv)->ThrowNew(jenv, excClass,
             "Can't get native WolfSSLContext field ID in "
             "NativeMacEncryptCb");
+        freeMacEncryptCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+            innerCtxClass, macOutBB, j_macIn, encOutBB, encInBB);
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
         return -1;
@@ -2569,6 +2619,8 @@ int NativeMacEncryptCb(WOLFSSL* ssl, unsigned char* macOut,
         (*jenv)->ThrowNew(jenv, excClass,
             "Can't get getAssociatedContextPtr() method ID in "
             "NativeMacEncryptCb");
+        freeMacEncryptCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+            innerCtxClass, macOutBB, j_macIn, encOutBB, encInBB);
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
         return -1;
@@ -2582,6 +2634,8 @@ int NativeMacEncryptCb(WOLFSSL* ssl, unsigned char* macOut,
     if (!ctxRef) {
         (*jenv)->ThrowNew(jenv, excClass,
             "Can't get WolfSSLContext object in NativeMacEncryptCb");
+        freeMacEncryptCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+            innerCtxClass, macOutBB, j_macIn, encOutBB, encInBB);
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
         return -1;
@@ -2593,7 +2647,8 @@ int NativeMacEncryptCb(WOLFSSL* ssl, unsigned char* macOut,
         (*jenv)->ThrowNew(jenv, excClass,
             "Can't get native WolfSSLContext class reference in "
             "NativeMacEncryptCb");
-        (*jenv)->DeleteLocalRef(jenv, ctxRef);
+        freeMacEncryptCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+            innerCtxClass, macOutBB, j_macIn, encOutBB, encInBB);
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
         return -1;
@@ -2612,7 +2667,8 @@ int NativeMacEncryptCb(WOLFSSL* ssl, unsigned char* macOut,
         }
         (*jenv)->ThrowNew(jenv, excClass,
                 "Error getting internalMacEncryptCallback method from JNI");
-        (*jenv)->DeleteLocalRef(jenv, ctxRef);
+        freeMacEncryptCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+            innerCtxClass, macOutBB, j_macIn, encOutBB, encInBB);
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
         return -1;
@@ -2627,7 +2683,8 @@ int NativeMacEncryptCb(WOLFSSL* ssl, unsigned char* macOut,
         if (!macOutBB) {
             (*jenv)->ThrowNew(jenv, excClass,
                     "failed to create macOut ByteBuffer");
-            (*jenv)->DeleteLocalRef(jenv, ctxRef);
+            freeMacEncryptCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+                innerCtxClass, macOutBB, j_macIn, encOutBB, encInBB);
             if (needsDetach)
                 (*g_vm)->DetachCurrentThread(g_vm);
             return -1;
@@ -2638,8 +2695,8 @@ int NativeMacEncryptCb(WOLFSSL* ssl, unsigned char* macOut,
         if (!j_macIn) {
             (*jenv)->ThrowNew(jenv, excClass,
                     "failed to create macIn ByteBuffer");
-            (*jenv)->DeleteLocalRef(jenv, ctxRef);
-            (*jenv)->DeleteLocalRef(jenv, macOutBB);
+            freeMacEncryptCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+                innerCtxClass, macOutBB, j_macIn, encOutBB, encInBB);
             if (needsDetach)
                 (*g_vm)->DetachCurrentThread(g_vm);
             return -1;
@@ -2650,9 +2707,8 @@ int NativeMacEncryptCb(WOLFSSL* ssl, unsigned char* macOut,
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
             (*jenv)->ExceptionClear(jenv);
-            (*jenv)->DeleteLocalRef(jenv, ctxRef);
-            (*jenv)->DeleteLocalRef(jenv, macOutBB);
-            (*jenv)->DeleteLocalRef(jenv, j_macIn);
+            freeMacEncryptCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+                innerCtxClass, macOutBB, j_macIn, encOutBB, encInBB);
             if (needsDetach)
                 (*g_vm)->DetachCurrentThread(g_vm);
             return -1;
@@ -2663,9 +2719,8 @@ int NativeMacEncryptCb(WOLFSSL* ssl, unsigned char* macOut,
         if (!encOutBB) {
             (*jenv)->ThrowNew(jenv, excClass,
                     "failed to create encOut ByteBuffer");
-            (*jenv)->DeleteLocalRef(jenv, ctxRef);
-            (*jenv)->DeleteLocalRef(jenv, macOutBB);
-            (*jenv)->DeleteLocalRef(jenv, j_macIn);
+            freeMacEncryptCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+                innerCtxClass, macOutBB, j_macIn, encOutBB, encInBB);
             if (needsDetach)
                 (*g_vm)->DetachCurrentThread(g_vm);
             return -1;
@@ -2679,10 +2734,8 @@ int NativeMacEncryptCb(WOLFSSL* ssl, unsigned char* macOut,
         if (!encInBB) {
             (*jenv)->ThrowNew(jenv, excClass,
                     "failed to create encIn ByteBuffer");
-            (*jenv)->DeleteLocalRef(jenv, ctxRef);
-            (*jenv)->DeleteLocalRef(jenv, macOutBB);
-            (*jenv)->DeleteLocalRef(jenv, j_macIn);
-            (*jenv)->DeleteLocalRef(jenv, encOutBB);
+            freeMacEncryptCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+                innerCtxClass, macOutBB, j_macIn, encOutBB, encInBB);
             if (needsDetach)
                 (*g_vm)->DetachCurrentThread(g_vm);
             return -1;
@@ -2698,29 +2751,59 @@ int NativeMacEncryptCb(WOLFSSL* ssl, unsigned char* macOut,
             (*jenv)->ExceptionClear(jenv);
             (*jenv)->ThrowNew(jenv, excClass,
                 "Call to Java callback failed in NativeMacEncryptCb");
-            (*jenv)->DeleteLocalRef(jenv, ctxRef);
-            (*jenv)->DeleteLocalRef(jenv, macOutBB);
-            (*jenv)->DeleteLocalRef(jenv, j_macIn);
-            (*jenv)->DeleteLocalRef(jenv, encOutBB);
-            (*jenv)->DeleteLocalRef(jenv, encInBB);
+            freeMacEncryptCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+                innerCtxClass, macOutBB, j_macIn, encOutBB, encInBB);
             if (needsDetach)
                 (*g_vm)->DetachCurrentThread(g_vm);
             return -1;
         }
-
-        /* delete local refs */
-        (*jenv)->DeleteLocalRef(jenv, macOutBB);
-        (*jenv)->DeleteLocalRef(jenv, j_macIn);
-        (*jenv)->DeleteLocalRef(jenv, encOutBB);
-        (*jenv)->DeleteLocalRef(jenv, encInBB);
     }
 
-    /* detach JNIEnv from thread */
-    (*jenv)->DeleteLocalRef(jenv, ctxRef);
+    /* delete local refs, detach JNIEnv from thread */
+    freeMacEncryptCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+        innerCtxClass, macOutBB, j_macIn, encOutBB, encInBB);
     if (needsDetach)
         (*g_vm)->DetachCurrentThread(g_vm);
 
     return retval;
+}
+
+/* Delete JNI local references created inside NativeDecryptVerifyCb() */
+static void freeDecryptVerifyCbLocalRefs(JNIEnv* jenv, jclass excClass,
+    jclass sessClass, jobject ctxRef, jclass innerCtxClass, jobject decOutBB,
+    jbyteArray j_decIn, jlongArray j_padSz)
+{
+    if (jenv == NULL) {
+        return;
+    }
+
+    if (decOutBB != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, decOutBB);
+    }
+
+    if (j_decIn != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, j_decIn);
+    }
+
+    if (j_padSz != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, j_padSz);
+    }
+
+    if (innerCtxClass != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, innerCtxClass);
+    }
+
+    if (ctxRef != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, ctxRef);
+    }
+
+    if (sessClass != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, sessClass);
+    }
+
+    if (excClass != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, excClass);
+    }
 }
 
 int  NativeDecryptVerifyCb(WOLFSSL* ssl, unsigned char* decOut,
@@ -2731,20 +2814,20 @@ int  NativeDecryptVerifyCb(WOLFSSL* ssl, unsigned char* decOut,
     jint       vmret  = 0;
 
     JNIEnv*    jenv;                  /* JNI environment */
-    jclass     excClass;              /* WolfSSLJNIException class */
+    jclass     excClass = NULL;       /* WolfSSLJNIException class */
     int        needsDetach = 0;       /* Should we explicitly detach? */
 
     jobject* g_cachedSSLObj;           /* WolfSSLSession cached object */
-    jclass     sessClass;             /* WolfSSLSession class */
+    jclass     sessClass = NULL;      /* WolfSSLSession class */
     jfieldID   ctxFid;                /* WolfSSLSession->ctx FieldID */
     jmethodID  getCtxMethodId;        /* WolfSSLSession->getAssCtxPtr() ID */
 
-    jobject    ctxRef;                /* WolfSSLContext object */
-    jclass     innerCtxClass;         /* WolfSSLContext class */
+    jobject    ctxRef = NULL;         /* WolfSSLContext object */
+    jclass     innerCtxClass = NULL;  /* WolfSSLContext class */
     jmethodID  decryptVerifyMethodId;
 
-    jbyteArray j_decIn;
-    jlongArray j_padSz;
+    jbyteArray j_decIn = NULL;
+    jlongArray j_padSz = NULL;
 
     jobject    decOutBB = NULL;
     jlong      tmpVal = 0;
@@ -2776,6 +2859,8 @@ int  NativeDecryptVerifyCb(WOLFSSL* ssl, unsigned char* decOut,
     if ((*jenv)->ExceptionOccurred(jenv)) {
         (*jenv)->ExceptionDescribe(jenv);
         (*jenv)->ExceptionClear(jenv);
+        freeDecryptVerifyCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+            innerCtxClass, decOutBB, j_decIn, j_padSz);
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
         return -1;
@@ -2786,7 +2871,9 @@ int  NativeDecryptVerifyCb(WOLFSSL* ssl, unsigned char* decOut,
     if (!g_cachedSSLObj) {
         (*jenv)->ThrowNew(jenv, excClass,
                 "Can't get native WolfSSLSession object reference in "
-                "NativeMacEncryptCb");
+                "NativeDecryptVerifyCb");
+        freeDecryptVerifyCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+            innerCtxClass, decOutBB, j_decIn, j_padSz);
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
         return -1;
@@ -2797,7 +2884,9 @@ int  NativeDecryptVerifyCb(WOLFSSL* ssl, unsigned char* decOut,
     if (!sessClass) {
         (*jenv)->ThrowNew(jenv, excClass,
             "Can't get native WolfSSLSession class reference in "
-            "NativeMacEncryptCb");
+            "NativeDecryptVerifyCb");
+        freeDecryptVerifyCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+            innerCtxClass, decOutBB, j_decIn, j_padSz);
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
         return -1;
@@ -2814,6 +2903,8 @@ int  NativeDecryptVerifyCb(WOLFSSL* ssl, unsigned char* decOut,
         (*jenv)->ThrowNew(jenv, excClass,
             "Can't get native WolfSSLContext field ID "
             "in NativeDecryptVerifyCb");
+        freeDecryptVerifyCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+            innerCtxClass, decOutBB, j_decIn, j_padSz);
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
         return -1;
@@ -2831,6 +2922,8 @@ int  NativeDecryptVerifyCb(WOLFSSL* ssl, unsigned char* decOut,
         (*jenv)->ThrowNew(jenv, excClass,
             "Can't get getAssociatedContextPtr() method ID "
             "in NativeDecryptVerifyCb");
+        freeDecryptVerifyCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+            innerCtxClass, decOutBB, j_decIn, j_padSz);
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
         return -1;
@@ -2843,6 +2936,8 @@ int  NativeDecryptVerifyCb(WOLFSSL* ssl, unsigned char* decOut,
     if (!ctxRef) {
         (*jenv)->ThrowNew(jenv, excClass,
             "Can't get WolfSSLContext object in NativeDecryptVerifyCb");
+        freeDecryptVerifyCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+            innerCtxClass, decOutBB, j_decIn, j_padSz);
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
         return -1;
@@ -2854,7 +2949,8 @@ int  NativeDecryptVerifyCb(WOLFSSL* ssl, unsigned char* decOut,
         (*jenv)->ThrowNew(jenv, excClass,
             "Can't get native WolfSSLContext class reference "
             "in NativeDecryptVerifyCb");
-        (*jenv)->DeleteLocalRef(jenv, ctxRef);
+        freeDecryptVerifyCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+            innerCtxClass, decOutBB, j_decIn, j_padSz);
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
         return -1;
@@ -2873,7 +2969,8 @@ int  NativeDecryptVerifyCb(WOLFSSL* ssl, unsigned char* decOut,
         (*jenv)->ThrowNew(jenv, excClass,
                 "Error getting internalDecryptVerifyCallback method "
                 "from JNI");
-        (*jenv)->DeleteLocalRef(jenv, ctxRef);
+        freeDecryptVerifyCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+            innerCtxClass, decOutBB, j_decIn, j_padSz);
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
         return -1;
@@ -2886,7 +2983,8 @@ int  NativeDecryptVerifyCb(WOLFSSL* ssl, unsigned char* decOut,
         if (!decOutBB) {
             (*jenv)->ThrowNew(jenv, excClass,
                     "failed to create decOut ByteBuffer");
-            (*jenv)->DeleteLocalRef(jenv, ctxRef);
+            freeDecryptVerifyCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+                innerCtxClass, decOutBB, j_decIn, j_padSz);
             if (needsDetach)
                 (*g_vm)->DetachCurrentThread(g_vm);
             return -1;
@@ -2897,8 +2995,8 @@ int  NativeDecryptVerifyCb(WOLFSSL* ssl, unsigned char* decOut,
         if (!j_decIn) {
             (*jenv)->ThrowNew(jenv, excClass,
                     "failed to create decIn ByteArray");
-            (*jenv)->DeleteLocalRef(jenv, ctxRef);
-            (*jenv)->DeleteLocalRef(jenv, decOutBB);
+            freeDecryptVerifyCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+                innerCtxClass, decOutBB, j_decIn, j_padSz);
             if (needsDetach)
                 (*g_vm)->DetachCurrentThread(g_vm);
             return -1;
@@ -2908,9 +3006,8 @@ int  NativeDecryptVerifyCb(WOLFSSL* ssl, unsigned char* decOut,
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
             (*jenv)->ExceptionClear(jenv);
-            (*jenv)->DeleteLocalRef(jenv, ctxRef);
-            (*jenv)->DeleteLocalRef(jenv, decOutBB);
-            (*jenv)->DeleteLocalRef(jenv, j_decIn);
+            freeDecryptVerifyCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+                innerCtxClass, decOutBB, j_decIn, j_padSz);
             if (needsDetach)
                 (*g_vm)->DetachCurrentThread(g_vm);
             return -1;
@@ -2922,9 +3019,8 @@ int  NativeDecryptVerifyCb(WOLFSSL* ssl, unsigned char* decOut,
         if (!j_padSz) {
             (*jenv)->ThrowNew(jenv, excClass,
                     "failed to create padSz longArray");
-            (*jenv)->DeleteLocalRef(jenv, ctxRef);
-            (*jenv)->DeleteLocalRef(jenv, decOutBB);
-            (*jenv)->DeleteLocalRef(jenv, j_decIn);
+            freeDecryptVerifyCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+                innerCtxClass, decOutBB, j_decIn, j_padSz);
             if (needsDetach)
                 (*g_vm)->DetachCurrentThread(g_vm);
             return -1;
@@ -2939,10 +3035,8 @@ int  NativeDecryptVerifyCb(WOLFSSL* ssl, unsigned char* decOut,
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
             (*jenv)->ExceptionClear(jenv);
-            (*jenv)->DeleteLocalRef(jenv, ctxRef);
-            (*jenv)->DeleteLocalRef(jenv, decOutBB);
-            (*jenv)->DeleteLocalRef(jenv, j_decIn);
-            (*jenv)->DeleteLocalRef(jenv, j_padSz);
+            freeDecryptVerifyCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+                innerCtxClass, decOutBB, j_decIn, j_padSz);
             if (needsDetach)
                 (*g_vm)->DetachCurrentThread(g_vm);
             return -1;
@@ -2954,29 +3048,61 @@ int  NativeDecryptVerifyCb(WOLFSSL* ssl, unsigned char* decOut,
             if ((*jenv)->ExceptionOccurred(jenv)) {
                 (*jenv)->ExceptionDescribe(jenv);
                 (*jenv)->ExceptionClear(jenv);
-                (*jenv)->DeleteLocalRef(jenv, ctxRef);
-                (*jenv)->DeleteLocalRef(jenv, decOutBB);
-                (*jenv)->DeleteLocalRef(jenv, j_decIn);
-                (*jenv)->DeleteLocalRef(jenv, j_padSz);
+                freeDecryptVerifyCbLocalRefs(jenv, excClass, sessClass,
+                    ctxRef, innerCtxClass, decOutBB, j_decIn, j_padSz);
                 if (needsDetach)
                     (*g_vm)->DetachCurrentThread(g_vm);
                 return -1;
             }
             *padSz = (unsigned int)tmpVal;
         }
-
-        /* delete local refs */
-        (*jenv)->DeleteLocalRef(jenv, decOutBB);
-        (*jenv)->DeleteLocalRef(jenv, j_decIn);
-        (*jenv)->DeleteLocalRef(jenv, j_padSz);
     }
 
     /* delete local refs, detach JNIEnv from thread */
-    (*jenv)->DeleteLocalRef(jenv, ctxRef);
+    freeDecryptVerifyCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+        innerCtxClass, decOutBB, j_decIn, j_padSz);
     if (needsDetach)
         (*g_vm)->DetachCurrentThread(g_vm);
 
     return retval;
+}
+
+/* Delete JNI local references created inside NativeVerifyDecryptCb() */
+static void freeVerifyDecryptCbLocalRefs(JNIEnv* jenv, jclass excClass,
+    jclass sessClass, jobject ctxRef, jclass innerCtxClass, jobject decOutBB,
+    jbyteArray j_decIn, jlongArray j_padSz)
+{
+    if (jenv == NULL) {
+        return;
+    }
+
+    if (decOutBB != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, decOutBB);
+    }
+
+    if (j_decIn != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, j_decIn);
+    }
+
+    if (j_padSz != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, j_padSz);
+    }
+
+    if (innerCtxClass != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, innerCtxClass);
+    }
+
+    if (ctxRef != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, ctxRef);
+    }
+
+    if (sessClass != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, sessClass);
+    }
+
+    if (excClass != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, excClass);
+    }
 }
 
 int NativeVerifyDecryptCb(WOLFSSL* ssl, unsigned char* decOut,
@@ -2987,21 +3113,21 @@ int NativeVerifyDecryptCb(WOLFSSL* ssl, unsigned char* decOut,
     jint       vmret  = 0;
 
     JNIEnv*    jenv;                  /* JNI environment */
-    jclass     excClass;              /* WolfSSLJNIException class */
+    jclass     excClass = NULL;       /* WolfSSLJNIException class */
     int        needsDetach = 0;       /* Should we explicitly detach? */
     int        hmacSize = 0;          /* WOLFSSL HMAC digest size */
 
     jobject* g_cachedSSLObj;           /* WolfSSLSession cached object */
-    jclass     sessClass;             /* WolfSSLSession class */
+    jclass     sessClass = NULL;      /* WolfSSLSession class */
     jfieldID   ctxFid;                /* WolfSSLSession->ctx FieldID */
     jmethodID  getCtxMethodId;        /* WolfSSLSession->getAssCtxPtr() ID */
 
-    jobject    ctxRef;                /* WolfSSLContext object */
-    jclass     innerCtxClass;         /* WolfSSLContext class */
+    jobject    ctxRef = NULL;         /* WolfSSLContext object */
+    jclass     innerCtxClass = NULL;  /* WolfSSLContext class */
     jmethodID  verifyDecryptMethodId;
 
-    jbyteArray j_decIn;
-    jlongArray j_padSz;
+    jbyteArray j_decIn = NULL;
+    jlongArray j_padSz = NULL;
 
     jobject    decOutBB = NULL;
     jlong      tmpVal = 0;
@@ -3033,6 +3159,8 @@ int NativeVerifyDecryptCb(WOLFSSL* ssl, unsigned char* decOut,
     if ((*jenv)->ExceptionOccurred(jenv)) {
         (*jenv)->ExceptionDescribe(jenv);
         (*jenv)->ExceptionClear(jenv);
+        freeVerifyDecryptCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+            innerCtxClass, decOutBB, j_decIn, j_padSz);
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
         return -1;
@@ -3044,6 +3172,8 @@ int NativeVerifyDecryptCb(WOLFSSL* ssl, unsigned char* decOut,
         (*jenv)->ThrowNew(jenv, excClass,
                 "Can't get native WolfSSLSession object reference in "
                 "NativeVerifyDecryptCb");
+        freeVerifyDecryptCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+            innerCtxClass, decOutBB, j_decIn, j_padSz);
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
         return -1;
@@ -3055,6 +3185,8 @@ int NativeVerifyDecryptCb(WOLFSSL* ssl, unsigned char* decOut,
         (*jenv)->ThrowNew(jenv, excClass,
             "Can't get native WolfSSLSession class reference in "
             "NativeVerifyDecryptCb");
+        freeVerifyDecryptCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+            innerCtxClass, decOutBB, j_decIn, j_padSz);
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
         return -1;
@@ -3071,6 +3203,8 @@ int NativeVerifyDecryptCb(WOLFSSL* ssl, unsigned char* decOut,
         (*jenv)->ThrowNew(jenv, excClass,
             "Can't get native WolfSSLContext field ID "
             "in NativeVerifyDecryptCb");
+        freeVerifyDecryptCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+            innerCtxClass, decOutBB, j_decIn, j_padSz);
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
         return -1;
@@ -3088,6 +3222,8 @@ int NativeVerifyDecryptCb(WOLFSSL* ssl, unsigned char* decOut,
         (*jenv)->ThrowNew(jenv, excClass,
             "Can't get getAssociatedContextPtr() method ID "
             "in NativeVerifyDecryptCb");
+        freeVerifyDecryptCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+            innerCtxClass, decOutBB, j_decIn, j_padSz);
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
         return -1;
@@ -3100,6 +3236,8 @@ int NativeVerifyDecryptCb(WOLFSSL* ssl, unsigned char* decOut,
     if (!ctxRef) {
         (*jenv)->ThrowNew(jenv, excClass,
             "Can't get WolfSSLContext object in NativeVerifyDecryptCb");
+        freeVerifyDecryptCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+            innerCtxClass, decOutBB, j_decIn, j_padSz);
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
         return -1;
@@ -3111,7 +3249,8 @@ int NativeVerifyDecryptCb(WOLFSSL* ssl, unsigned char* decOut,
         (*jenv)->ThrowNew(jenv, excClass,
             "Can't get native WolfSSLContext class reference "
             "in NativeVerifyDecryptCb");
-        (*jenv)->DeleteLocalRef(jenv, ctxRef);
+        freeVerifyDecryptCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+            innerCtxClass, decOutBB, j_decIn, j_padSz);
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
         return -1;
@@ -3130,7 +3269,8 @@ int NativeVerifyDecryptCb(WOLFSSL* ssl, unsigned char* decOut,
         (*jenv)->ThrowNew(jenv, excClass,
                 "Error getting internalVerifyDecryptCallback method "
                 "from JNI");
-        (*jenv)->DeleteLocalRef(jenv, ctxRef);
+        freeVerifyDecryptCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+            innerCtxClass, decOutBB, j_decIn, j_padSz);
         if (needsDetach)
             (*g_vm)->DetachCurrentThread(g_vm);
         return -1;
@@ -3146,7 +3286,8 @@ int NativeVerifyDecryptCb(WOLFSSL* ssl, unsigned char* decOut,
         if (!decOutBB) {
             (*jenv)->ThrowNew(jenv, excClass,
                     "failed to create decOut ByteBuffer");
-            (*jenv)->DeleteLocalRef(jenv, ctxRef);
+            freeVerifyDecryptCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+                innerCtxClass, decOutBB, j_decIn, j_padSz);
             if (needsDetach)
                 (*g_vm)->DetachCurrentThread(g_vm);
             return -1;
@@ -3157,8 +3298,8 @@ int NativeVerifyDecryptCb(WOLFSSL* ssl, unsigned char* decOut,
         if (!j_decIn) {
             (*jenv)->ThrowNew(jenv, excClass,
                     "failed to create decIn ByteArray");
-            (*jenv)->DeleteLocalRef(jenv, ctxRef);
-            (*jenv)->DeleteLocalRef(jenv, decOutBB);
+            freeVerifyDecryptCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+                innerCtxClass, decOutBB, j_decIn, j_padSz);
             if (needsDetach)
                 (*g_vm)->DetachCurrentThread(g_vm);
             return -1;
@@ -3168,9 +3309,8 @@ int NativeVerifyDecryptCb(WOLFSSL* ssl, unsigned char* decOut,
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
             (*jenv)->ExceptionClear(jenv);
-            (*jenv)->DeleteLocalRef(jenv, ctxRef);
-            (*jenv)->DeleteLocalRef(jenv, decOutBB);
-            (*jenv)->DeleteLocalRef(jenv, j_decIn);
+            freeVerifyDecryptCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+                innerCtxClass, decOutBB, j_decIn, j_padSz);
             if (needsDetach)
                 (*g_vm)->DetachCurrentThread(g_vm);
             return -1;
@@ -3182,9 +3322,8 @@ int NativeVerifyDecryptCb(WOLFSSL* ssl, unsigned char* decOut,
         if (!j_padSz) {
             (*jenv)->ThrowNew(jenv, excClass,
                     "failed to create padSz longArray");
-            (*jenv)->DeleteLocalRef(jenv, ctxRef);
-            (*jenv)->DeleteLocalRef(jenv, decOutBB);
-            (*jenv)->DeleteLocalRef(jenv, j_decIn);
+            freeVerifyDecryptCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+                innerCtxClass, decOutBB, j_decIn, j_padSz);
             if (needsDetach)
                 (*g_vm)->DetachCurrentThread(g_vm);
             return -1;
@@ -3199,10 +3338,8 @@ int NativeVerifyDecryptCb(WOLFSSL* ssl, unsigned char* decOut,
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
             (*jenv)->ExceptionClear(jenv);
-            (*jenv)->DeleteLocalRef(jenv, ctxRef);
-            (*jenv)->DeleteLocalRef(jenv, decOutBB);
-            (*jenv)->DeleteLocalRef(jenv, j_decIn);
-            (*jenv)->DeleteLocalRef(jenv, j_padSz);
+            freeVerifyDecryptCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+                innerCtxClass, decOutBB, j_decIn, j_padSz);
             if (needsDetach)
                 (*g_vm)->DetachCurrentThread(g_vm);
             return -1;
@@ -3214,25 +3351,19 @@ int NativeVerifyDecryptCb(WOLFSSL* ssl, unsigned char* decOut,
             if ((*jenv)->ExceptionOccurred(jenv)) {
                 (*jenv)->ExceptionDescribe(jenv);
                 (*jenv)->ExceptionClear(jenv);
-                (*jenv)->DeleteLocalRef(jenv, ctxRef);
-                (*jenv)->DeleteLocalRef(jenv, decOutBB);
-                (*jenv)->DeleteLocalRef(jenv, j_decIn);
-                (*jenv)->DeleteLocalRef(jenv, j_padSz);
+                freeVerifyDecryptCbLocalRefs(jenv, excClass, sessClass,
+                    ctxRef, innerCtxClass, decOutBB, j_decIn, j_padSz);
                 if (needsDetach)
                     (*g_vm)->DetachCurrentThread(g_vm);
                 return -1;
             }
             *padSz = (unsigned int)tmpVal;
         }
-
-        /* delete local refs */
-        (*jenv)->DeleteLocalRef(jenv, decOutBB);
-        (*jenv)->DeleteLocalRef(jenv, j_decIn);
-        (*jenv)->DeleteLocalRef(jenv, j_padSz);
     }
 
     /* delete local refs, detach JNIEnv from thread */
-    (*jenv)->DeleteLocalRef(jenv, ctxRef);
+    freeVerifyDecryptCbLocalRefs(jenv, excClass, sessClass, ctxRef,
+        innerCtxClass, decOutBB, j_decIn, j_padSz);
     if (needsDetach)
         (*g_vm)->DetachCurrentThread(g_vm);
 

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -6021,6 +6021,23 @@ JNIEXPORT jint JNICALL Java_com_wolfssl_WolfSSLSession_setSessionTicketCb
 #if defined(WOLFSSL_TLS13) && !defined(WOLFCRYPT_ONLY) && \
     defined(HAVE_SECRET_CALLBACK)
 
+/* Delete JNI local references created inside NativeTls13SecretCb() */
+static void freeTls13SecretCbLocalRefs(JNIEnv* jenv, jclass sslClass,
+    jbyteArray secretArr)
+{
+    if (jenv == NULL) {
+        return;
+    }
+
+    if (secretArr != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, secretArr);
+    }
+
+    if (sslClass != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, sslClass);
+    }
+}
+
 int NativeTls13SecretCb(WOLFSSL *ssl, int id, const unsigned char* secret,
     int secretSz, void* ctx)
 {
@@ -6030,7 +6047,7 @@ int NativeTls13SecretCb(WOLFSSL *ssl, int id, const unsigned char* secret,
     jint    vmret = 0;
 
     jobject*  g_cachedSSLObj;       /* WolfSSLSession cached object */
-    jclass    sslClass;             /* WolfSSLSession class */
+    jclass    sslClass = NULL;      /* WolfSSLSession class */
     jmethodID tls13SecretMethodId;  /* internalTls13SecretCallback ID */
     jbyteArray secretArr = NULL;
 
@@ -6061,6 +6078,7 @@ int NativeTls13SecretCb(WOLFSSL *ssl, int id, const unsigned char* secret,
         throwWolfSSLJNIException(jenv,
             "Can't get native WolfSSLSession object reference in "
             "NativeTls13SecretCb");
+        freeTls13SecretCbLocalRefs(jenv, sslClass, secretArr);
         if (needsDetach) {
             (*g_vm)->DetachCurrentThread(g_vm);
         }
@@ -6073,6 +6091,7 @@ int NativeTls13SecretCb(WOLFSSL *ssl, int id, const unsigned char* secret,
         throwWolfSSLJNIException(jenv,
             "Can't get native WolfSSLSession class reference in "
             "NativeTls13SecretCb");
+        freeTls13SecretCbLocalRefs(jenv, sslClass, secretArr);
         if (needsDetach) {
             (*g_vm)->DetachCurrentThread(g_vm);
         }
@@ -6089,6 +6108,7 @@ int NativeTls13SecretCb(WOLFSSL *ssl, int id, const unsigned char* secret,
         }
         throwWolfSSLJNIException(jenv,
             "Error getting internalTls13SecretCallback method from JNI");
+        freeTls13SecretCbLocalRefs(jenv, sslClass, secretArr);
         if (needsDetach) {
             (*g_vm)->DetachCurrentThread(g_vm);
         }
@@ -6101,6 +6121,7 @@ int NativeTls13SecretCb(WOLFSSL *ssl, int id, const unsigned char* secret,
         if (secretArr == NULL) {
             throwWolfSSLJNIException(jenv,
                 "Error creating new jbyteArray in NativeTls13SecretCb");
+            freeTls13SecretCbLocalRefs(jenv, sslClass, secretArr);
             if (needsDetach) {
                 (*g_vm)->DetachCurrentThread(g_vm);
             }
@@ -6112,6 +6133,7 @@ int NativeTls13SecretCb(WOLFSSL *ssl, int id, const unsigned char* secret,
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
             (*jenv)->ExceptionClear(jenv);
+            freeTls13SecretCbLocalRefs(jenv, sslClass, secretArr);
             if (needsDetach) {
                 (*g_vm)->DetachCurrentThread(g_vm);
             }
@@ -6128,17 +6150,16 @@ int NativeTls13SecretCb(WOLFSSL *ssl, int id, const unsigned char* secret,
             (*jenv)->ExceptionClear(jenv);
             throwWolfSSLJNIException(jenv,
                 "Exception while calling internalTls13SecretCallback()");
+            freeTls13SecretCbLocalRefs(jenv, sslClass, secretArr);
             if (needsDetach) {
                 (*g_vm)->DetachCurrentThread(g_vm);
             }
             return TLS13_SECRET_CB_E;
         }
-
-        /* Delete local refs */
-        (*jenv)->DeleteLocalRef(jenv, secretArr);
     }
 
-    /* Detach JNIEnv from thread */
+    /* Delete local refs, detach JNIEnv from thread */
+    freeTls13SecretCbLocalRefs(jenv, sslClass, secretArr);
     if (needsDetach) {
         (*g_vm)->DetachCurrentThread(g_vm);
     }
@@ -6150,6 +6171,23 @@ int NativeTls13SecretCb(WOLFSSL *ssl, int id, const unsigned char* secret,
 
 #if !defined(NO_WOLFSSL_CLIENT) && defined(HAVE_SESSION_TICKET)
 
+/* Delete JNI local references created inside NativeSessionTicketCb() */
+static void freeSessionTicketCbLocalRefs(JNIEnv* jenv, jclass sslClass,
+    jbyteArray ticketArr)
+{
+    if (jenv == NULL) {
+        return;
+    }
+
+    if (ticketArr != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, ticketArr);
+    }
+
+    if (sslClass != NULL) {
+        (*jenv)->DeleteLocalRef(jenv, sslClass);
+    }
+}
+
 int NativeSessionTicketCb(WOLFSSL* ssl, const unsigned char* ticket,
     int ticketLen, void* ctx)
 {
@@ -6159,7 +6197,7 @@ int NativeSessionTicketCb(WOLFSSL* ssl, const unsigned char* ticket,
     jint    vmret = 0;
 
     jobject*  g_cachedSSLObj;       /* WolfSSLSession cached object */
-    jclass    sslClass;             /* WolfSSLSession class */
+    jclass    sslClass = NULL;      /* WolfSSLSession class */
     jmethodID sessTicketCbMethodId; /* internalSessionTicketCallback ID */
     jbyteArray ticketArr = NULL;
     (void)ctx;
@@ -6191,6 +6229,7 @@ int NativeSessionTicketCb(WOLFSSL* ssl, const unsigned char* ticket,
         throwWolfSSLJNIException(jenv,
             "Can't get native WolfSSLSession object reference in "
             "NativeSessionTicketCb");
+        freeSessionTicketCbLocalRefs(jenv, sslClass, ticketArr);
         if (needsDetach) {
             (*g_vm)->DetachCurrentThread(g_vm);
         }
@@ -6203,6 +6242,7 @@ int NativeSessionTicketCb(WOLFSSL* ssl, const unsigned char* ticket,
         throwWolfSSLJNIException(jenv,
             "Can't get native WolfSSLSession class reference in "
             "NativeSessionTicketCb");
+        freeSessionTicketCbLocalRefs(jenv, sslClass, ticketArr);
         if (needsDetach) {
             (*g_vm)->DetachCurrentThread(g_vm);
         }
@@ -6219,6 +6259,7 @@ int NativeSessionTicketCb(WOLFSSL* ssl, const unsigned char* ticket,
         }
         throwWolfSSLJNIException(jenv,
             "Error getting internalSessionTicketCallback method from JNI");
+        freeSessionTicketCbLocalRefs(jenv, sslClass, ticketArr);
         if (needsDetach) {
             (*g_vm)->DetachCurrentThread(g_vm);
         }
@@ -6231,6 +6272,7 @@ int NativeSessionTicketCb(WOLFSSL* ssl, const unsigned char* ticket,
         if (ticketArr == NULL) {
             throwWolfSSLJNIException(jenv,
                 "Error creating new jbyteArray in NativeSessionTicketCb");
+            freeSessionTicketCbLocalRefs(jenv, sslClass, ticketArr);
             if (needsDetach) {
                 (*g_vm)->DetachCurrentThread(g_vm);
             }
@@ -6242,6 +6284,7 @@ int NativeSessionTicketCb(WOLFSSL* ssl, const unsigned char* ticket,
         if ((*jenv)->ExceptionOccurred(jenv)) {
             (*jenv)->ExceptionDescribe(jenv);
             (*jenv)->ExceptionClear(jenv);
+            freeSessionTicketCbLocalRefs(jenv, sslClass, ticketArr);
             if (needsDetach) {
                 (*g_vm)->DetachCurrentThread(g_vm);
             }
@@ -6257,17 +6300,16 @@ int NativeSessionTicketCb(WOLFSSL* ssl, const unsigned char* ticket,
             (*jenv)->ExceptionClear(jenv);
             throwWolfSSLJNIException(jenv,
                 "Exception while calling internalSessionTicketCallback()");
+            freeSessionTicketCbLocalRefs(jenv, sslClass, ticketArr);
             if (needsDetach) {
                 (*g_vm)->DetachCurrentThread(g_vm);
             }
             return -1;
         }
-
-        /* Delete local refs */
-        (*jenv)->DeleteLocalRef(jenv, ticketArr);
     }
 
-    /* Detach JNIEnv from thread */
+    /* Delete local refs, detach JNIEnv from thread */
+    freeSessionTicketCbLocalRefs(jenv, sslClass, ticketArr);
     if (needsDetach) {
         (*g_vm)->DetachCurrentThread(g_vm);
     }

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -6559,7 +6559,7 @@ int NativeSSLIORecvCb(WOLFSSL *ssl, char *buf, int sz, void *ctx)
     jobject    directBuf;
     jboolean   useByteBuffer = 0;      /* ByteBuffer or byte[] I/O callbacks */
 
-    if (g_vm == NULL || ssl == NULL || buf == NULL || ctx == NULL) {
+    if (g_vm == NULL || ssl == NULL || buf == NULL || ctx == NULL || sz < 0) {
         /* can't throw exception yet, just return error */
         return WOLFSSL_CBIO_ERR_GENERAL;
     }
@@ -6735,7 +6735,7 @@ int NativeSSLIOSendCb(WOLFSSL *ssl, char *buf, int sz, void *ctx)
     jobject    directBuf;
     jboolean   useByteBuffer = 0;     /* ByteBuffer I/O callbacks */
 
-    if (g_vm == NULL || ssl == NULL || buf == NULL || ctx == NULL) {
+    if (g_vm == NULL || ssl == NULL || buf == NULL || ctx == NULL || sz < 0) {
         /* can't throw exception yet, just return error */
         return WOLFSSL_CBIO_ERR_GENERAL;
     }

--- a/src/java/com/wolfssl/WolfSSLAltName.java
+++ b/src/java/com/wolfssl/WolfSSLAltName.java
@@ -25,6 +25,7 @@ import java.io.Serializable;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * Represents a Subject Alternative Name (SAN) entry from an X.509 certificate.
@@ -374,18 +375,21 @@ public final class WolfSSLAltName implements Serializable {
             return false;
         }
         WolfSSLAltName other = (WolfSSLAltName) obj;
+
         if (type != other.type) {
             return false;
         }
-        if (stringValue != null) {
-            return stringValue.equals(other.stringValue);
+        if (!Objects.equals(stringValue, other.stringValue)) {
+            return false;
         }
-        if (bytesValue != null) {
-            return Arrays.equals(bytesValue, other.bytesValue);
+        if (!Arrays.equals(bytesValue, other.bytesValue)) {
+            return false;
         }
-        if (otherNameOID != null) {
-            return otherNameOID.equals(other.otherNameOID) &&
-                   Arrays.equals(otherNameValue, other.otherNameValue);
+        if (!Objects.equals(otherNameOID, other.otherNameOID)) {
+            return false;
+        }
+        if (!Arrays.equals(otherNameValue, other.otherNameValue)) {
+            return false;
         }
         return true;
     }


### PR DESCRIPTION
This PR includes five Fenrir fixes:

  - **F-12676**: Release all JNI local references in the TLS secret and session ticket callbacks.
  - **F-12677**: Reject negative sizes in the session-level I/O callbacks.
  - **F-12680**: Size the getExtendedKeyUsage result to the OIDs actually written, and throw when none convert.
  - **F-12681**: Release all JNI local references in the ATOMIC_USER callbacks.
  - **F-12682**: Compare all fields symmetrically in WolfSSLAltName.equals.