### PR TITLE
Fixes for date getters, comments, KeyManager alias lookup, and buffer zeroing

### DIFF
--- a/native/com_wolfssl_WolfSSL.c
+++ b/native/com_wolfssl_WolfSSL.c
@@ -2495,12 +2495,15 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSL_getEnabledCipherSuitesIana
  *        src/java/com/wolfssl/WolfSSL.java:
  *
  *        public static enum TLS_VERSION {
- *            INVALID, (0)
- *            TLSv1,   (1)
- *            TLSv1_1, (2)
- *            TLSv1_2, (3)
- *            TLSv1_3, (4)
- *            SSLv23   (5)
+ *            INVALID,  (0)
+ *            TLSv1,    (1)
+ *            TLSv1_1,  (2)
+ *            TLSv1_2,  (3)
+ *            TLSv1_3,  (4)
+ *            SSLv23,   (5)
+ *            DTLSv1,   (6)
+ *            DTLSv1_2, (7)
+ *            DTLSv1_3  (8)
  *        }
  * @returns colon-separated cipher suite string.
  */

--- a/native/com_wolfssl_WolfSSLCRL.c
+++ b/native/com_wolfssl_WolfSSLCRL.c
@@ -563,6 +563,7 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLCRL_X509_1CRL_1get_1lastUpdate
     WOLFSSL_X509_CRL* crl = (WOLFSSL_X509_CRL*)(uintptr_t)crlPtr;
     WOLFSSL_ASN1_TIME* date = NULL;
     char timeStr[CTC_DATE_SIZE];
+    char* dateStr = NULL;
     (void)jcl;
 
     if (jenv == NULL || crl == NULL) {
@@ -571,8 +572,10 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLCRL_X509_1CRL_1get_1lastUpdate
 
     date = wolfSSL_X509_CRL_get_lastUpdate(crl);
     if (date != NULL) {
-        return (*jenv)->NewStringUTF(jenv,
-            wolfSSL_ASN1_TIME_to_string(date, timeStr, sizeof(timeStr)));
+        dateStr = wolfSSL_ASN1_TIME_to_string(date, timeStr, sizeof(timeStr));
+        if (dateStr != NULL) {
+            return (*jenv)->NewStringUTF(jenv, dateStr);
+        }
     }
 
     return NULL;
@@ -591,6 +594,7 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLCRL_X509_1CRL_1get_1nextUpdate
     WOLFSSL_X509_CRL* crl = (WOLFSSL_X509_CRL*)(uintptr_t)crlPtr;
     WOLFSSL_ASN1_TIME* date = NULL;
     char timeStr[CTC_DATE_SIZE];
+    char* dateStr = NULL;
     (void)jcl;
 
     if (jenv == NULL || crl == NULL) {
@@ -599,8 +603,10 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLCRL_X509_1CRL_1get_1nextUpdate
 
     date = wolfSSL_X509_CRL_get_nextUpdate(crl);
     if (date != NULL) {
-        return (*jenv)->NewStringUTF(jenv,
-            wolfSSL_ASN1_TIME_to_string(date, timeStr, sizeof(timeStr)));
+        dateStr = wolfSSL_ASN1_TIME_to_string(date, timeStr, sizeof(timeStr));
+        if (dateStr != NULL) {
+            return (*jenv)->NewStringUTF(jenv, dateStr);
+        }
     }
 
     return NULL;

--- a/native/com_wolfssl_WolfSSLCertificate.c
+++ b/native/com_wolfssl_WolfSSLCertificate.c
@@ -1390,6 +1390,7 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1notBefore
 #endif
     WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
     char timeStr[CTC_DATE_SIZE];
+    char* dateStr = NULL;
     (void)jcl;
 
     if (jenv == NULL || x509 == NULL) {
@@ -1403,9 +1404,11 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1notBefore
 #endif
     /* returns string holding date i.e. "Thu Jan 07 08:23:09 MST 2021" */
     if (date != NULL) {
-        return (*jenv)->NewStringUTF(jenv,
-                wolfSSL_ASN1_TIME_to_string((WOLFSSL_ASN1_TIME*)date, timeStr,
-                    sizeof(timeStr)));
+        dateStr = wolfSSL_ASN1_TIME_to_string((WOLFSSL_ASN1_TIME*)date,
+            timeStr, sizeof(timeStr));
+        if (dateStr != NULL) {
+            return (*jenv)->NewStringUTF(jenv, dateStr);
+        }
     }
     return NULL;
 }
@@ -1420,6 +1423,7 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1notAfter
 #endif
     WOLFSSL_X509* x509 = (WOLFSSL_X509*)(uintptr_t)x509Ptr;
     char timeStr[CTC_DATE_SIZE];
+    char* dateStr = NULL;
     (void)jcl;
 
     if (jenv == NULL || x509 == NULL) {
@@ -1433,9 +1437,11 @@ JNIEXPORT jstring JNICALL Java_com_wolfssl_WolfSSLCertificate_X509_1notAfter
 #endif
     /* returns string holding date i.e. "Thu Jan 07 08:23:09 MST 2021" */
     if (date != NULL) {
-        return (*jenv)->NewStringUTF(jenv,
-                wolfSSL_ASN1_TIME_to_string((WOLFSSL_ASN1_TIME*)date,
-                    timeStr, sizeof(timeStr)));
+        dateStr = wolfSSL_ASN1_TIME_to_string((WOLFSSL_ASN1_TIME*)date,
+            timeStr, sizeof(timeStr));
+        if (dateStr != NULL) {
+            return (*jenv)->NewStringUTF(jenv, dateStr);
+        }
     }
     return NULL;
 }

--- a/native/com_wolfssl_WolfSSLSession.c
+++ b/native/com_wolfssl_WolfSSLSession.c
@@ -5403,9 +5403,9 @@ JNIEXPORT jbyteArray JNICALL Java_com_wolfssl_WolfSSLSession_sslGet0AlpnSelected
         return NULL;
     }
 
-    /* get ALPN protocol received from server:
+    /* get the negotiated ALPN protocol for this session:
      * WOLFSSL_SUCCESS - on success
-     * WOLFSSL_ALPN_NOT_FOUND - no ALPN received (no match with server)
+     * WOLFSSL_ALPN_NOT_FOUND - no ALPN protocol was negotiated
      * other - error case */
     err = wolfSSL_ALPN_GetProtocol(ssl, &protocol_name, &protocol_nameSz);
     if (err != WOLFSSL_SUCCESS) {

--- a/src/java/com/wolfssl/WolfSSLSession.java
+++ b/src/java/com/wolfssl/WolfSSLSession.java
@@ -131,6 +131,11 @@ public class WolfSSLSession {
     private static final ThreadLocal<ConcurrentLinkedQueue<ByteBuffer>> directBufferPool =
         ThreadLocal.withInitial(() -> new ConcurrentLinkedQueue<>());
 
+    /* Zero-filled byte array used to overwrite pooled direct ByteBuffers
+     * before reuse. Read-only after being sized, so it is read concurrently
+     * without a lock. Grown under a short class-lock in wipeDirectBuffer(). */
+    private static volatile byte[] directBufferZeroFill = new byte[0];
+
     /**
      * Check if static direct ByteBuffer pool has been disabled for
      * use in read/write() methods.
@@ -257,6 +262,34 @@ public class WolfSSLSession {
     }
 
     /**
+     * Overwrite a direct ByteBuffer's full capacity with zeros so a pooled
+     * or discarded buffer does not retain decrypted plaintext. Leaves the
+     * buffer cleared for reuse. The full-capacity copy runs without the pool
+     * lock to avoid serializing all threads on it.
+     *
+     * @param buffer direct ByteBuffer to wipe
+     */
+    private static void wipeDirectBuffer(ByteBuffer buffer) {
+
+        int cap = buffer.capacity();
+        byte[] zeros = directBufferZeroFill;
+
+        /* Grow the shared zero source under a short lock only when needed */
+        if (zeros.length < cap) {
+            synchronized (WolfSSLSession.class) {
+                if (directBufferZeroFill.length < cap) {
+                    directBufferZeroFill = new byte[cap];
+                }
+                zeros = directBufferZeroFill;
+            }
+        }
+
+        buffer.clear();
+        buffer.put(zeros, 0, cap);
+        buffer.clear();
+    }
+
+    /**
      * Get a DirectByteBuffer from the thread-local pool or allocate a new one
      * if the pool is empty.
      *
@@ -288,20 +321,26 @@ public class WolfSSLSession {
      *
      * @param buffer the buffer to return to the pool
      */
-    private static synchronized void releaseDirectBuffer(ByteBuffer buffer) {
+    private static void releaseDirectBuffer(ByteBuffer buffer) {
 
         if (buffer != null && buffer.isDirect()) {
 
-            buffer.clear();
-            ConcurrentLinkedQueue<ByteBuffer> threadPool =
-                directBufferPool.get();
+            /* Overwrite plaintext before pooling or discarding, done outside
+             * the pool lock so the full-capacity wipe does not serialize
+             * every read()/write() on the class monitor. */
+            wipeDirectBuffer(buffer);
 
-            if (threadPool.size() < MAX_POOL_SIZE) {
-                WolfSSLDebug.log(WolfSSLSession.class,
-                    WolfSSLDebug.Component.JNI, WolfSSLDebug.INFO, 0,
-                    () -> "Returning DirectByteBuffer to thread-local pool, " +
-                    "pool size: " + threadPool.size());
-                threadPool.offer(buffer);
+            synchronized (WolfSSLSession.class) {
+                ConcurrentLinkedQueue<ByteBuffer> threadPool =
+                    directBufferPool.get();
+
+                if (threadPool.size() < MAX_POOL_SIZE) {
+                    WolfSSLDebug.log(WolfSSLSession.class,
+                        WolfSSLDebug.Component.JNI, WolfSSLDebug.INFO, 0,
+                        () -> "Returning DirectByteBuffer to thread-local " +
+                        "pool, pool size: " + threadPool.size());
+                    threadPool.offer(buffer);
+                }
             }
         }
     }

--- a/src/java/com/wolfssl/provider/jsse/WolfSSLKeyX509.java
+++ b/src/java/com/wolfssl/provider/jsse/WolfSSLKeyX509.java
@@ -357,7 +357,12 @@ public class WolfSSLKeyX509 extends X509ExtendedKeyManager {
         for (String current : aliasSet) {
             X509Certificate cert = certificateCache.get(current);
 
-            if (type != null && cert != null &&
+            /* skip aliases without a cached X509Certificate */
+            if (cert == null) {
+                continue;
+            }
+
+            if (type != null &&
                 !keyTypeMatches(type, cert.getPublicKey().getAlgorithm())) {
                 /* different public key type, skip */
                 continue;
@@ -368,21 +373,19 @@ public class WolfSSLKeyX509 extends X509ExtendedKeyManager {
                 ret.add(current);
             }
             else {
-                if (cert != null) {
-                    /* search through issuers for matching issuer name */
-                    for (i = 0; i < issuers.length; i++) {
-                        String certIssuer = cert.getIssuerDN().getName();
-                        String issuerName = issuers[i].getName();
+                /* search through issuers for matching issuer name */
+                for (i = 0; i < issuers.length; i++) {
+                    String certIssuer = cert.getIssuerDN().getName();
+                    String issuerName = issuers[i].getName();
 
-                        /* normalize spaces after commas, needed on some JDKs */
-                        certIssuer = certIssuer.replaceAll(", ", ",");
-                        issuerName = issuerName.replaceAll(", ", ",");
+                    /* normalize spaces after commas, needed on some JDKs */
+                    certIssuer = certIssuer.replaceAll(", ", ",");
+                    issuerName = issuerName.replaceAll(", ", ",");
 
-                        if (certIssuer.equals(issuerName)) {
-                            /* matched issuer, add alias and continue on */
-                            ret.add(current);
-                            break;
-                        }
+                    if (certIssuer.equals(issuerName)) {
+                        /* matched issuer, add alias and continue on */
+                        ret.add(current);
+                        break;
                     }
                 }
             }

--- a/src/test/com/wolfssl/provider/jsse/test/WolfSSLKeyX509Test.java
+++ b/src/test/com/wolfssl/provider/jsse/test/WolfSSLKeyX509Test.java
@@ -22,6 +22,7 @@
 package com.wolfssl.provider.jsse.test;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -37,6 +38,8 @@ import java.security.UnrecoverableKeyException;
 import java.security.cert.X509Certificate;
 import java.security.cert.CertificateException;
 
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509ExtendedKeyManager;
@@ -48,6 +51,7 @@ import org.junit.rules.TestRule;
 
 import com.wolfssl.WolfSSLException;
 import com.wolfssl.provider.jsse.WolfSSLProvider;
+import com.wolfssl.provider.jsse.WolfSSLKeyX509;
 import com.wolfssl.test.TimedTestWatcher;
 
 public class WolfSSLKeyX509Test {
@@ -135,6 +139,42 @@ public class WolfSSLKeyX509Test {
 
         if (alias.length != 3) {
             fail("unexpected number of alias found");
+        }
+    }
+
+    @Test
+    public void testGetClientAliasesSkipsCertlessEntries() throws Exception {
+
+        /* JCEKS can hold a SecretKeyEntry (an alias with no X509Certificate),
+         * which JKS/BKS cannot. Skip where JCEKS is unavailable. */
+        KeyStore store;
+        try {
+            store = KeyStore.getInstance("JCEKS");
+        } catch (KeyStoreException e) {
+            return;
+        }
+        store.load(null, null);
+        SecretKey sk = new SecretKeySpec(new byte[16], "AES");
+        store.setKeyEntry("secretOnly", sk, "pass".toCharArray(), null);
+
+        String original =
+            Security.getProperty("wolfjsse.X509KeyManager.disableCache");
+        try {
+            /* Both cached and direct KeyStore paths must skip aliases without
+             * a cert */
+            for (String disabled : new String[] { "false", "true" }) {
+                Security.setProperty(
+                    "wolfjsse.X509KeyManager.disableCache", disabled);
+
+                WolfSSLKeyX509 km =
+                    new WolfSSLKeyX509(store, "pass".toCharArray());
+
+                assertNull(km.getClientAliases("RSA", null));
+                assertNull(km.getServerAliases("RSA", null));
+            }
+        } finally {
+            Security.setProperty("wolfjsse.X509KeyManager.disableCache",
+                original != null ? original : "");
         }
     }
 


### PR DESCRIPTION
This PR includes five Fenrir fixes:

  - **F-12683**: Null-check ASN.1 time formatting result in the certificate and CRL date getters.
  - **F-12689**: Document the DTLS protocol versions in the cipher-list comment to match the Java enum.
  - **F-12690**: Correct the ALPN getter comment to describe the negotiated protocol for either role.
  - **F-12694**: Skip cert-less aliases in the cached KeyManager alias lookup, matching direct KeyStore access.
  - **F-12695**: Zero pooled direct ByteBuffers before reuse or discard, with the wipe kept outside the pool lock.